### PR TITLE
Document MapLibre specific items

### DIFF
--- a/CODE-OF-CONDUCT.md
+++ b/CODE-OF-CONDUCT.md
@@ -1,7 +1,5 @@
 # Code of conduct
 
-Everyone is invited to participate in [Mapbox’s open source projects](https://github.com/mapbox) and public discussions: we want to create a welcoming and friendly environment. Harassment of participants or other unethical and unprofessional behavior will not be tolerated in our spaces.
+A formal code of conduct may be selected by the MapLibre project shortly, until then:
 
-The [Contributor Covenant](https://contributor-covenant.org) applies to all projects under the Mapbox organization and we ask that you please read [the full text](https://www.contributor-covenant.org/version/2/0/code_of_conduct.html).
-
-Please report any instances of behavior violating this code to conduct@mapbox.com. Our team will handle any such report confidentially, and promptly review and investigate the situation and act to [enforce](https://www.contributor-covenant.org/version/2/0/code_of_conduct#enforcement) this code of conduct as needed. 
+Be kind, thoughtful and respectul to everyone. Give other people the benefit of the doubt.

--- a/docs/making-a-release.md
+++ b/docs/making-a-release.md
@@ -9,5 +9,5 @@ is following to make the `v1.13.0-rc` releases from his local machine:
 - `yarn test` (note: this appears to sporadically sometimes fail with a JSON parse error of `babylon/package.json`, not sure why its not deterministic in this respect)
 - `yarn prepublishOnly` (this will be run automatically by `yarn publish` too, but it can help to debug this relatively-complex step separately until it works on your machine reliably, and you're happy with the result)
 - Update `package.json` to increment the `-rc.____` version, note that we don't use yarns auto-increment feature in `yarn publish` presently, because it struggles with patch release incrementing, and the `-rc.` approach is important to a smooth first `v1.13.0`
-- `yarn publish`, when prompted for a new version number, enter the same one you set in `package.json` in the previous step (or just press enter!)
+- `npm publish`, note that we are using npm publish here, not yarn, I have yet to get `yarn publish` working
 - Check `https://www.npmjs.com/package/maplibre-gl` for the new version, and ideally test the new version until we build more confidence from repitition, and automate this procedure (I use a simple jsfiddle pointing at an unpkg url for quick "does it load" final validation)

--- a/docs/making-a-release.md
+++ b/docs/making-a-release.md
@@ -1,0 +1,13 @@
+Until we draft more formal docs, get CI going, and develop our own
+release process suited to our needs, here are the steps Seth
+is following to make the `v1.13.0-rc` releases from his local machine:
+
+- verify that `yarn --version` >= 1.22
+- `git clone https://github.com/maplibre/maplibre-gl-js.git`
+- `cd maplibre-gl-js`
+- `yarn install`
+- `yarn test` (note: this appears to sporadically sometimes fail with a JSON parse error of `babylon/package.json`, not sure why its not deterministic in this respect)
+- `yarn prepublishOnly` (this will be run automatically by `yarn publish` too, but it can help to debug this relatively-complex step separately until it works on your machine reliably, and you're happy with the result)
+- Update `package.json` to increment the `-rc.____` version, note that we don't use yarns auto-increment feature in `yarn publish` presently, because it struggles with patch release incrementing, and the `-rc.` approach is important to a smooth first `v1.13.0`
+- `yarn publish`, when prompted for a new version number, enter the same one you set in `package.json` in the previous step (or just press enter!)
+- Check `https://www.npmjs.com/package/maplibre-gl` for the new version, and ideally test the new version until we build more confidence from repitition, and automate this procedure (I use a simple jsfiddle pointing at an unpkg url for quick "does it load" final validation)


### PR DESCRIPTION
As we start as a project, it can be debilitating in early days to live inside a previous project's docs, but of course many of them are extremely valuable and will be re-used. This PR adds a `docs/` subdir where we can start documenting our own less formally refined notes.... better rough docs that are accurate than polished docs that are wrong!

- Replace the /very/ Mapbox-legal specific CODEOFCONDUCT.md with a placeholder, indicating basic decency and that we will probably select a formal code of conduct shortly
- Document the actual series of steps Seth has been using to build+publish maps-gl releases to npm