### PR TITLE
fix changelog unit tests

### DIFF
--- a/test/unit/changelog.js
+++ b/test/unit/changelog.js
@@ -6,7 +6,7 @@ import {version} from '../../package.json';
 test('changelog', (t) => {
     const changelog = fs.readFileSync(path.join(__dirname, '../../CHANGELOG.md'), 'utf8');
     t.test('latest version is in changelog', (t) => {
-        if (version.indexOf('-dev') <= 0) {
+        if (version.indexOf('-dev') <= 0 && version.indexOf('-rc') <= 0) {
             const versionString = `## ${version}\n`;
             t.ok(changelog.indexOf(versionString) >= 0);
         }


### PR DESCRIPTION
The changelog unit test currently verifies that the version in package.json exists in the changelog, unless the version contains the `-dev` string. We have been using `-rc` string in the version which will now also be ignored.

This is required before enabling CI testing