### PR TITLE
Try to fix CI - remove flow

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -34,4 +34,4 @@ jobs:
         node-version: ${{ matrix.node_version }}
         architecture: ${{ matrix.architecture }}
     - run: yarn install --frozen-lockfile
-    - run: yarn test
+    - run: yarn test-ci

--- a/package.json
+++ b/package.json
@@ -146,6 +146,7 @@
     "lint-docs": "documentation lint src/index.js",
     "lint-css": "stylelint 'src/css/mapbox-gl.css'",
     "test": "run-s lint lint-css lint-docs test-flow test-unit",
+    "test-ci": "run-s lint lint-css lint-docs test-unit",
     "test-suite": "run-s test-render test-query test-expressions",
     "test-suite-clean": "find test/integration/{render,query, expressions}-tests -mindepth 2 -type d -exec test -e \"{}/actual.png\" \\; -not \\( -exec test -e \"{}/style.json\" \\; \\) -print | xargs -t rm -r",
     "test-unit": "build/run-tap --reporter classic --no-coverage test/unit",


### PR DESCRIPTION
Seems like the flow server keeps crashing in github actions
for an unknown reason (out of memory?).

This pr creates a dedicated target `test-ci` that for the moment
removes flow tests.