### PR TITLE
upload artifact with build info

### DIFF
--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -27,7 +27,6 @@ jobs:
       - name: Download branch artifact
         uses: dawidd6/action-download-artifact@v2
         with:
-          github_token: "${{ secrets.GITHUB_TOKEN }}"
           workflow: ${{ github.event.workflow_run.workflow_id }}
           name: dist
           path: after
@@ -35,23 +34,20 @@ jobs:
       - name: Download branch build info
         uses: dawidd6/action-download-artifact@v2
         with:
-          github_token: "${{ secrets.GITHUB_TOKEN }}"
           workflow: ${{ github.event.workflow_run.workflow_id }}
           name: build-info
           path: build-info
           repo: maplibre/maplibre-gl-js
-      - name: Get PR number
-        id: pr_number
-        run: echo "::set-output name=pr_number::$(cat build-info/pull_request_number)"
-      - name: Get Base SHA
-        id: base_sha
-        run: echo "::set-output name=base_sha::$(cat build-info/base_sha)"
+      - name: Get build info
+        id: build_info
+        run: |
+          echo "::set-output name=pr_number::$(cat build-info/pull_request_number)"
+          echo "::set-output name=base_sha::$(cat build-info/base_sha)"
       - name: Download base artifact
         uses: dawidd6/action-download-artifact@v2
         with:
-          github_token: "${{ secrets.GITHUB_TOKEN }}"
           workflow: build.yml
-          commit: ${{ steps.base_sha.outputs.base_sha }}
+          commit: ${{ steps.build_info.outputs.base_sha }}
           name: dist
           path: before
           repo: maplibre/maplibre-gl-js
@@ -64,7 +60,6 @@ jobs:
 
       - uses: marocchino/sticky-pull-request-comment@v2
         with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           path: comment-body.txt
           header: bundle-size-report
-          number: ${{ github.event.workflow_run.pull_requests[0].number }}
+          number: ${{ steps.build_info.outputs.pr_number }}

--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -15,6 +15,9 @@ jobs:
     if: ${{ github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success' }}
     timeout-minutes: 20
     steps:
+      # report status back to pull request
+      - uses: haya14busa/action-workflow_run-status@v1
+      - uses: hmarr/debug-action@v1.0.0
       - uses: actions/checkout@v2
       - name: Use Node.js 10 x64
         uses: actions/setup-node@v2-beta

--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -60,6 +60,7 @@ jobs:
 
       - uses: marocchino/sticky-pull-request-comment@v2
         with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           path: comment-body.txt
           header: bundle-size-report
           number: ${{ steps.build_info.outputs.pr_number }}

--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -17,7 +17,6 @@ jobs:
     steps:
       # report status back to pull request
       - uses: haya14busa/action-workflow_run-status@v1
-      - uses: hmarr/debug-action@v1.0.0
       - uses: actions/checkout@v2
       - name: Use Node.js 10 x64
         uses: actions/setup-node@v2-beta
@@ -33,12 +32,26 @@ jobs:
           name: dist
           path: after
           repo: maplibre/maplibre-gl-js
+      - name: Download branch build info
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          github_token: "${{ secrets.GITHUB_TOKEN }}"
+          workflow: ${{ github.event.workflow_run.workflow_id }}
+          name: build-info
+          path: build-info
+          repo: maplibre/maplibre-gl-js
+      - name: Get PR number
+        id: pr_number
+        run: echo "::set-output name=pr_number::$(cat build-info/pull_request_number)"
+      - name: Get Base SHA
+        id: base_sha
+        run: echo "::set-output name=base_sha::$(cat build-info/base_sha)"
       - name: Download base artifact
         uses: dawidd6/action-download-artifact@v2
         with:
           github_token: "${{ secrets.GITHUB_TOKEN }}"
           workflow: build.yml
-          commit: ${{ github.event.workflow_run.pull_requests[0].base.sha }}
+          commit: ${{ steps.base_sha.outputs.base_sha }}
           name: dist
           path: before
           repo: maplibre/maplibre-gl-js

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,11 +27,20 @@ jobs:
       - run: yarn run build-flow-types
       - run: yarn run test-build
       - run: find dist
+      - run: mkdir build-info
+      - name: Store build info
+        run: |
+          echo "${{ github.event.pull_request.base.sha }}" > build-info/base_sha
+          echo "${{ github.event.number }}" > build-info/pull_request_number
 
       - uses: actions/upload-artifact@v2
         with:
           name: dist
           path: ./dist
+      - uses: actions/upload-artifact@v2
+        with:
+          name: build-info
+          path: ./build-info
       - uses: actions/upload-artifact@v2
         with:
           path: ./test/release

--- a/build/check-bundle-size.js
+++ b/build/check-bundle-size.js
@@ -31,7 +31,7 @@ console.log(`
 | Output file | Before | After | Change |
 | :--- | :---: | :---: | :---: |
 | mapbox-gl.js | ${prettyBytes(beforejs.gzipped)} | ${prettyBytes(afterjs.gzipped)} | ${prettyBytes(afterjs.gzipped - beforejs.gzipped, { signed: true })} |
-| mapbox-gl.css | ${prettyBytes(beforejs.gzipped)} | ${prettyBytes(aftercss.gzipped)} | ${prettyBytes(aftercss.gzipped - beforecss.gzipped, { signed: true })} |`);
+| mapbox-gl.css | ${prettyBytes(beforecss.gzipped)} | ${prettyBytes(aftercss.gzipped)} | ${prettyBytes(aftercss.gzipped - beforecss.gzipped, { signed: true })} |`);
 
 const before = {};
 beforeSourcemap.results.forEach(result => {


### PR DESCRIPTION
It looks like the `workflow_run` job can't tell what the pull request number or base sha are. Follow examples from https://github.com/search?l=&q=%22workflow_run%22+%22marocchino%2Fsticky-pull-request-comment%22&type=code which store an artifact from `pull_request` job containing those variables and then use them in the downstream `workflow_run` job.

Also add `haya14busa/action-workflow_run-status@v1` which reports status of the workflow run job back to the original pull request.