### PR TITLE
Fix ImageSource for Firefox and Safari

### DIFF
--- a/src/util/ajax.js
+++ b/src/util/ajax.js
@@ -282,7 +282,7 @@ function arrayBufferToImage(data: ArrayBuffer, callback: (err: ?Error, image: ?H
         URL.revokeObjectURL(img.src);
         // prevent image dataURI memory leak in Safari
         img.onload = null;
-        img.src = transparentPngUrl;
+        window.requestAnimationFrame(() => { img.src = transparentPngUrl; });
     };
     img.onerror = () => callback(new Error('Could not load image. Please make sure to use a supported image type such as PNG or JPEG. Note that SVGs are not supported.'));
     const blob: Blob = new window.Blob([new Uint8Array(data)], {type: 'image/png'});


### PR DESCRIPTION
Closes #51.
This PR fixes that ImageSources are not shown on Firefox and Safari.
Fix taken from mapbox/mapbox-gl-js#10230 
Fix is too simple to be copyrightable.

## Launch Checklist
 - [x] manually test the debug page