### PR TITLE
Remove mapbox specifics and branding from .github

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -11,11 +11,11 @@ Hello! Thanks for contributing.  For the fastest response and resolution, please
  - Include a link to a minimal demonstration of the bug. We recommend using https://jsbin.com.
  - Ensure you can reproduce the bug using the latest release.
  - Check the console for relevant errors and warnings
- - Only post to report a bug. For feature requests, please use https://github.com/mapbox/mapbox-gl-js/issues/new?template=Feature_request.md instead.  Direct all other questions to https://stackoverflow.com/questions/tagged/mapbox-gl-js
+ - Only post to report a bug. For feature requests, please use https://github.com/maplibre/maplibre-gl-js/issues/new?template=Feature_request.md instead.  Direct all other questions to https://stackoverflow.com/questions/tagged/maplibre-gl-js
 
 -->
 
-**mapbox-gl-js version**:
+**maplibre-gl-js version**:
 
 **browser**:
 

--- a/.github/ISSUE_TEMPLATE/Question.md
+++ b/.github/ISSUE_TEMPLATE/Question.md
@@ -7,18 +7,13 @@ about: Report a question that isn't answered in our docs
 <!--
 Hello! Thanks for contributing.
 
-The answers to many "how do I...?" questions can be found in our [help documentation](https://mapbox.com/help). If you can't find the answer there, the best place to ask is either [Stack Overflow](https://stackoverflow.com/questions/tagged/mapbox-gl-js) or [Mapbox support](https://mapbox.com/contact/).
+The answers to many "how do I...?" questions can be found hopefully in our documentation in the future. Until then, the best place to ask is either [Stack Overflow](https://stackoverflow.com/questions/tagged/maplibre-gl-js) or here.
 
-However, if you have a question that isn't addressed in the documentation but should be, please do let us know by filling out the template below!  As a general rule, if a question is about _how Mapbox GL JS works_ rather than your specific use case, we will try to address it here or by improving the documentation.  Otherwise, we might close the issue here and instead recommend asking on Stack Overflow or contacting support.
+If you have a question, please do let us know by filling out the template below!  As a general rule, if a question is about _how MapLibre GL JS works_ rather than your specific use case, we will try to address it here or by improving the documentation.  Otherwise, we might close the issue here and instead recommend asking on Stack Overflow or contacting support.
 
 -->
 
-**mapbox-gl-js version**:
+**maplibre-gl-js version**:
 
 ### Question
 
-
-
-### Links to related documentation
-
-<!-- Include links to the specific section(s) of the documentation where you would have expected to find an answer to this question. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,7 +8,5 @@
  - [ ] document any changes to public APIs
  - [ ] post benchmark scores
  - [ ] manually test the debug page
- - [ ] tagged `@mapbox/map-design-team` `@mapbox/static-apis` if this PR includes style spec API or visual changes
- - [ ] tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port
  - [ ] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
- - [ ] add an entry inside this element for inclusion in the `mapbox-gl-js` changelog: `<changelog></changelog>`
+ - [ ] add an entry inside this element for inclusion in the `maplibre-gl-js` changelog: `<changelog></changelog>`


### PR DESCRIPTION
Just text editing, did not touch .workflow to avoid breaking things too soon.