### PR TITLE
add build scripts to eslinting

### DIFF
--- a/build/.eslintrc
+++ b/build/.eslintrc
@@ -1,0 +1,21 @@
+{
+  // TODO: most of these overrides should be removed,
+  // but for now this documents the exceptions used by the code in this dir
+  "rules": {
+    "import/no-commonjs": "off",
+    "flowtype/require-valid-file-annotation": [0],
+    "prefer-arrow-callback": "off",
+    "no-var": "off",
+    "strict": "off",
+    "no-restricted-properties": "off",
+    "no-unused-vars": "off",
+    "prefer-template": "off",
+    "camelcase": "off",
+    "prefer-const": "off",
+    "indent": "off",
+    "no-case-declarations": "off",
+    "semi": "off",
+    "object-curly-spacing": "off",
+    "no-undef": "off"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -144,7 +144,7 @@
     "start-release": "run-s build-token build-prod-min build-css print-release-url start-server",
     "diff-tarball": "cross-env build/run-node build/diff-tarball && echo \"Please confirm the above is correct [y/n]? \"; read answer; if [ \"$answer\" = \"${answer#[Yy]}\" ]; then false; fi",
     "prepare-publish": "git clean -fdx && yarn install",
-    "lint": "eslint --cache --ignore-path .gitignore src test bench debug/*.html",
+    "lint": "eslint --cache --ignore-path .gitignore src test bench build debug/*.html",
     "lint-docs": "documentation lint src/index.js",
     "lint-css": "stylelint 'src/css/maplibre-gl.css'",
     "test": "run-s lint lint-css lint-docs test-flow test-unit",


### PR DESCRIPTION
Document the eslint overrides used by the build scripts.
Most of them should be removed during the future cleanup.