### PR TITLE
Avoid map repaint when setting same parameter value that is already being used

### DIFF
--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -4,7 +4,7 @@ import LngLat from './lng_lat';
 import LngLatBounds from './lng_lat_bounds';
 import MercatorCoordinate, {mercatorXfromLng, mercatorYfromLat, mercatorZfromAltitude} from './mercator_coordinate';
 import Point from '@mapbox/point-geometry';
-import {wrap, clamp} from '../util/util';
+import {deepEqual, wrap, clamp} from '../util/util';
 import {number as interpolate} from '../style-spec/util/interpolate';
 import EXTENT from '../data/extent';
 import {vec4, mat4, mat2, vec2} from 'gl-matrix';
@@ -565,16 +565,24 @@ class Transform {
     /**
      * Sets or clears the map's geographical constraints.
      * @param {LngLatBounds} bounds A {@link LngLatBounds} object describing the new geographic boundaries of the map.
+     * @returns {boolean} true if any changes were made; false otherwise
      */
-    setMaxBounds(bounds?: LngLatBounds) {
-        if (bounds) {
-            this.lngRange = [bounds.getWest(), bounds.getEast()];
-            this.latRange = [bounds.getSouth(), bounds.getNorth()];
-            this._constrain();
-        } else {
-            this.lngRange = null;
-            this.latRange = [-this.maxValidLatitude, this.maxValidLatitude];
+    setMaxBounds(bounds?: LngLatBounds): boolean {
+        const lngRange = bounds ? [bounds.getWest(), bounds.getEast()] : null;
+        const latRange = bounds ? [bounds.getSouth(), bounds.getNorth()] : [-this.maxValidLatitude, this.maxValidLatitude];
+
+        if (deepEqual(this.lngRange, lngRange) && deepEqual(this.latRange, latRange)) {
+            return false;
         }
+
+        this.lngRange = lngRange;
+        this.latRange = latRange;
+
+        if (bounds) {
+            this._constrain();
+        }
+
+        return true;
     }
 
     /**

--- a/src/source/source_cache.js
+++ b/src/source/source_cache.js
@@ -891,11 +891,12 @@ class SourceCache extends Evented {
 
     /**
      * Resets the value of a particular state key for a feature
+     * @returns {boolean} true if any changes were made; false otherwise
      * @private
      */
-    removeFeatureState(sourceLayer?: string, featureId?: number | string, key?: string) {
+    removeFeatureState(sourceLayer?: string, featureId?: number | string, key?: string): boolean {
         sourceLayer = sourceLayer || '_geojsonTileLayer';
-        this._state.removeFeatureState(sourceLayer, featureId, key);
+        return this._state.removeFeatureState(sourceLayer, featureId, key);
     }
 
     /**

--- a/src/source/source_state.js
+++ b/src/source/source_state.js
@@ -52,11 +52,15 @@ class SourceFeatureState {
                 }
             }
         }
+
     }
 
-    removeFeatureState(sourceLayer: string, featureId?: number | string, key?: string) {
+    /**
+     * @returns {boolean} true if any changes were made; false otherwise
+     */
+    removeFeatureState(sourceLayer: string, featureId?: number | string, key?: string): boolean {
         const sourceLayerDeleted = this.deletedStates[sourceLayer] === null;
-        if (sourceLayerDeleted) return;
+        if (sourceLayerDeleted) return false;
 
         const feature = String(featureId);
 
@@ -80,6 +84,7 @@ class SourceFeatureState {
             this.deletedStates[sourceLayer] = null;
         }
 
+        return true;
     }
 
     getState(sourceLayer: string, featureId: number | string) {

--- a/src/ui/camera.js
+++ b/src/ui/camera.js
@@ -710,9 +710,11 @@ class Camera extends Evented {
         this.stop();
 
         const tr = this.transform;
-        let zoomChanged = false,
+        let centerChanged = false,
+            zoomChanged = false,
             bearingChanged = false,
-            pitchChanged = false;
+            pitchChanged = false,
+            paddingChanged = false;
 
         if ('zoom' in options && tr.zoom !== +options.zoom) {
             zoomChanged = true;
@@ -720,7 +722,11 @@ class Camera extends Evented {
         }
 
         if (options.center !== undefined) {
-            tr.center = LngLat.convert(options.center);
+            const lngLatCenter = LngLat.convert(options.center);
+            if (tr.center.lng !== lngLatCenter.lng || tr.center.lat !== lngLatCenter.lat) {
+                centerChanged = true;
+                tr.center = lngLatCenter;
+            }
         }
 
         if ('bearing' in options && tr.bearing !== +options.bearing) {
@@ -734,7 +740,13 @@ class Camera extends Evented {
         }
 
         if (options.padding != null && !tr.isPaddingEqual(options.padding)) {
+            paddingChanged = true;
             tr.padding = options.padding;
+        }
+
+        const changed = centerChanged || zoomChanged || bearingChanged || pitchChanged || paddingChanged;
+        if (!changed) {
+            return this;
         }
 
         this.fire(new Event('movestart', eventData))

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -656,7 +656,9 @@ class Map extends Camera {
      * map.setMaxBounds(bounds);
      */
     setMaxBounds(bounds: LngLatBoundsLike) {
-        this.transform.setMaxBounds(LngLatBounds.convert(bounds));
+        if (!this.transform.setMaxBounds(LngLatBounds.convert(bounds))) {
+            return this;
+        }
         return this._update();
     }
 
@@ -681,6 +683,10 @@ class Map extends Camera {
         minZoom = minZoom === null || minZoom === undefined ? defaultMinZoom : minZoom;
 
         if (minZoom >= defaultMinZoom && minZoom <= this.transform.maxZoom) {
+            if (minZoom === this.transform.minZoom) {
+                return this;
+            }
+
             this.transform.minZoom = minZoom;
             this._update();
 
@@ -716,6 +722,10 @@ class Map extends Camera {
         maxZoom = maxZoom === null || maxZoom === undefined ? defaultMaxZoom : maxZoom;
 
         if (maxZoom >= this.transform.minZoom) {
+            if (maxZoom === this.transform.maxZoom) {
+                return this;
+            }
+
             this.transform.maxZoom = maxZoom;
             this._update();
 
@@ -753,6 +763,10 @@ class Map extends Camera {
         }
 
         if (minPitch >= defaultMinPitch && minPitch <= this.transform.maxPitch) {
+            if (minPitch === this.transform.minPitch) {
+                return this;
+            }
+
             this.transform.minPitch = minPitch;
             this._update();
 
@@ -788,6 +802,10 @@ class Map extends Camera {
         }
 
         if (maxPitch >= this.transform.minPitch) {
+            if (maxPitch === this.transform.maxPitch) {
+                return this;
+            }
+
             this.transform.maxPitch = maxPitch;
             this._update();
 
@@ -834,6 +852,9 @@ class Map extends Camera {
      * @see [Render world copies](https://docs.mapbox.com/mapbox-gl-js/example/render-world-copies/)
      */
     setRenderWorldCopies(renderWorldCopies?: ?boolean) {
+        if (renderWorldCopies === this.transform.renderWorldCopies) {
+            return this;
+        }
         this.transform.renderWorldCopies = renderWorldCopies;
         return this._update();
     }
@@ -1480,7 +1501,9 @@ class Map extends Camera {
      */
     addSource(id: string, source: SourceSpecification) {
         this._lazyInitEmptyStyle();
-        this.style.addSource(id, source);
+        if (!this.style.addSource(id, source)) {
+            return this;
+        }
         return this._update(true);
     }
 
@@ -1546,7 +1569,9 @@ class Map extends Camera {
      * map.removeSource('bathymetry-data');
      */
     removeSource(id: string) {
-        this.style.removeSource(id);
+        if (!this.style.removeSource(id)) {
+            return this;
+        }
         return this._update(true);
     }
 
@@ -1885,7 +1910,9 @@ class Map extends Camera {
      */
     addLayer(layer: LayerSpecification | CustomLayerInterface, beforeId?: string) {
         this._lazyInitEmptyStyle();
-        this.style.addLayer(layer, beforeId);
+        if (!this.style.addLayer(layer, beforeId)) {
+            return this;
+        }
         return this._update(true);
     }
 
@@ -1901,7 +1928,9 @@ class Map extends Camera {
      * map.moveLayer('polygon', 'country-label');
      */
     moveLayer(id: string, beforeId?: string) {
-        this.style.moveLayer(id, beforeId);
+        if (!this.style.moveLayer(id, beforeId)) {
+            return this;
+        }
         return this._update(true);
     }
 
@@ -1919,7 +1948,9 @@ class Map extends Camera {
      * if (map.getLayer('state-data')) map.removeLayer('state-data');
      */
     removeLayer(id: string) {
-        this.style.removeLayer(id);
+        if (!this.style.removeLayer(id)) {
+            return this;
+        }
         return this._update(true);
     }
 
@@ -1961,7 +1992,9 @@ class Map extends Camera {
      *
      */
     setLayerZoomRange(layerId: string, minzoom: number, maxzoom: number) {
-        this.style.setLayerZoomRange(layerId, minzoom, maxzoom);
+        if (!this.style.setLayerZoomRange(layerId, minzoom, maxzoom)) {
+            return this;
+        }
         return this._update(true);
     }
 
@@ -1999,7 +2032,9 @@ class Map extends Camera {
      * @see Tutorial: [Show changes over time](https://docs.mapbox.com/help/tutorials/show-changes-over-time/)
      */
     setFilter(layerId: string, filter: ?FilterSpecification,  options: StyleSetterOptions = {}) {
-        this.style.setFilter(layerId, filter, options);
+        if (!this.style.setFilter(layerId, filter, options)) {
+            return this;
+        }
         return this._update(true);
     }
 
@@ -2030,7 +2065,9 @@ class Map extends Camera {
      * @see [Create a draggable point](https://www.mapbox.com/mapbox-gl-js/example/drag-a-point/)
      */
     setPaintProperty(layerId: string, name: string, value: any, options: StyleSetterOptions = {}) {
-        this.style.setPaintProperty(layerId, name, value, options);
+        if (!this.style.setPaintProperty(layerId, name, value, options)) {
+            return this;
+        }
         return this._update(true);
     }
 
@@ -2059,7 +2096,9 @@ class Map extends Camera {
      * @see [Show and hide layers](https://docs.mapbox.com/mapbox-gl-js/example/toggle-layers/)
      */
     setLayoutProperty(layerId: string, name: string, value: any, options: StyleSetterOptions = {}) {
-        this.style.setLayoutProperty(layerId, name, value, options);
+        if (!this.style.setLayoutProperty(layerId, name, value, options)) {
+            return this;
+        }
         return this._update(true);
     }
 
@@ -2087,7 +2126,9 @@ class Map extends Camera {
      */
     setLight(light: LightSpecification, options: StyleSetterOptions = {}) {
         this._lazyInitEmptyStyle();
-        this.style.setLight(light, options);
+        if (!this.style.setLight(light, options)) {
+            return this;
+        }
         return this._update(true);
     }
 
@@ -2140,7 +2181,9 @@ class Map extends Camera {
      * @see Tutorial: [Create interactive hover effects with Mapbox GL JS](https://docs.mapbox.com/help/tutorials/create-interactive-hover-effects-with-mapbox-gl-js/)
      */
     setFeatureState(feature: { source: string; sourceLayer?: string; id: string | number; }, state: Object) {
-        this.style.setFeatureState(feature, state);
+        if (!this.style.setFeatureState(feature, state)) {
+            return this;
+        }
         return this._update();
     }
 
@@ -2192,7 +2235,9 @@ class Map extends Camera {
      *
     */
     removeFeatureState(target: { source: string; sourceLayer?: string; id?: string | number; }, key?: string) {
-        this.style.removeFeatureState(target, key);
+        if (!this.style.removeFeatureState(target, key)) {
+            return this;
+        }
         return this._update();
     }
 

--- a/test/unit/ui/control/geolocate.test.js
+++ b/test/unit/ui/control/geolocate.test.js
@@ -424,7 +424,7 @@ test('GeolocateControl switches to BACKGROUND state on map manipulation', (t) =>
     geolocate.once('geolocate', () => {
         t.equal(geolocate._watchState, 'ACTIVE_LOCK');
         map.jumpTo({
-            center: [0, 0]
+            center: [10, 5]
         });
         t.equal(geolocate._watchState, 'BACKGROUND');
         t.end();


### PR DESCRIPTION
Our map has performance issues due to paint-, layout-properties or filters being touched within a "mousemove"- or `requestAnimationFrame` handler. Even though we set the same value every time, mapbox will still decide to repaint.
We have many sources and layers, so repainting is slow (see #96) and should be avoided if possible.

While we will likely fix this in our own app by how we use the API, I feel this should also be guarded against by the API itself.
[Even mapbox samples themselves do redundant changes in "mousemove" handlers](https://docs.mapbox.com/mapbox-gl-js/example/hover-styles/), so I believe that many users will be affected by this.

Internally, [mapbox also guards against this (which prevents some computations, but still triggers a repaint)](https://github.com/maplibre/maplibre-gl-js/blob/256d1b898f1bd21f829977d4dec602a7f649f5a0/src/style/style.js#L897-L908).
Mapbox also [already guards against redundant changes for setters in the API](https://github.com/maplibre/maplibre-gl-js/blob/256d1b898f1bd21f829977d4dec602a7f649f5a0/src/ui/map.js#L2719-L2724).

This PR extends the internal checks (more of them) and returns a boolean whether an early-out was taken.
This information is then used to skip `map._update` which will then avoid an expensive `map.triggerRepaint`.

I tried to fix as many affected functions that I'm aware of, but I might not have guarded everything. There are also plenty of situations where these guards will fail.

I'm aware of the following shortcomings and potential issues:

- `setFeatureState` will report slightly better errors for unknown keys, because error-checking might already occur in `getFeatureState`.
- The guard for `removeFeatureState` is very incomplete. Removing a missing-key will trigger repaints anyway. Some code is already present, I just didn't deep dive into the feature-state deletion logic.
- Camera transforms using `jumpTo` are handled, but `easeTo` isn't.
- Changing values back and forth will trigger a repaint, even if it didn't change effectively.
- `setFeatureState` might be considerably slower / unusable if large objects are passed into it. We basically trust that people don't throw `window` or similar into a feature-state (which would potentially take a long time to compare).
- Some users might depend on the old behaviour to trigger map repaints or events.
- A related issue is not addressed: Setting unused parameters will still trigger a repaint (= touching an unused source or an invisible layer will still trigger a repaint).
- I added a missing `return` that might affect behaviour for a niche case; I'll leave a review comment to point it out.

---

Following is code I've been using for testing this feature. I don't check all features though, so there might be bugs left.

Note that master will repeatedly draw with the following code, thereby causing high CPU and GPU usage.
With my proposed change, maplibbre will not draw because changes are redundant.

I have not used this code in production yet, so this has gotten very little testing.
The automated tests in mapbox aren't designed to test for this either (I don't think adding a test for this is necessary though).

```html
<!DOCTYPE html>
<html>
<head>
    <title>Mapbox GL JS debug page</title>
    <meta charset='utf-8'>
    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
    <link rel='stylesheet' href='http://localhost:9966/dist/maplibre-gl.css' />
    <style>
        body { margin: 0; padding: 0; }
        html, body, #map { height: 100%; }
    </style>
</head>

<body>
<div id='map'></div>

<script src='http://localhost:9966/dist/maplibre-gl-dev.js'></script>
<script src='http://localhost:9966/debug/access_token_generated.js'></script>
<script>

var map = window.map = new maplibregl.Map({
    container: 'map',
    zoom: 0.5,
    center: [0, 0],
    style: 'mapbox://styles/mapbox/streets-v10',
    hash: true
});

// Create a GeoJSON source with an simple lineString.
var geojson = {
    'type': 'FeatureCollection',
    'features': [
        {
            'type': 'Feature',
            'geometry': {
                'type': 'LineString',
                'coordinates': [[0, 0], [90, 0]]
            }
        }
    ]
};

map.on('load', function () {
    map.addSource('line', {
        'type': 'geojson',
        'data': geojson
    });

    // add the line which will be "modified" every frame
    map.addLayer({
        'id': 'line-animation',
        'type': 'line',
        'source': 'line',
        'layout': {
            'line-cap': 'round',
            'line-join': 'round'
        },
        'paint': {
            'line-color': '#ed6498',
            'line-width': 5,
            'line-opacity': 0.8
        }
    });

    // Hook so we can log the map repaint behaviour
    const _map_triggerRepaint = map.triggerRepaint;
    map.triggerRepaint = () => {
      var err = new Error();
      console.log(`Repaint at ${performance.now()}; stack was ${err.stack}`);
      _map_triggerRepaint.call(map);
    };

    setRedundantStates();

    // Keep setting the same flags (we expect that this won't trigger a repaint)
    function setRedundantStates(timestamp) {
       
        // Guarded
        map.setRenderWorldCopies(true);
        map.setMaxBounds(undefined);
        map.setMinPitch(0.0);
        map.setMaxPitch(60.0);
        map.setMinZoom(0);
        map.setMaxZoom(100);
        map.setLayerZoomRange('line-animation', 0, 22);
        map.setPaintProperty('line-animation', 'line-width', 5);
        map.setLayoutProperty('line-animation', 'line-cap', 'round');       
        map.setFilter('line-animation', undefined);      
        map.setLight({"color": "white"});
        map.setFeatureState({ source: 'line', id: 'id' }, { 'existing-key': undefined });

        // Guarded (jump transforms)
        if (true) {
            map.setZoom(5);
            map.setBearing(90);
            map.setCenter([-74, 38]);
        }

        // Not guarded yet (ease transforms)
        if (false) {
            map.zoomTo(5);
            map.rotateTo(90);
            map.panTo([-74, 38]);
        }

        // Not guarded yet (broken guards)
        if (false) {
            // Guard exists but it's very incomplete
            map.removeFeatureState({ source: 'line', id: 'id' }, 'missing-key');
        }

        // Not guarded yet (back and forth before map update)
        if (false) {
            map.setMaxPitch(50.0);
            map.setMaxPitch(60.0);
        }


        // Request the next frame of the animation.
        animation = requestAnimationFrame(setRedundantStates);
    }
});

</script>
</body>
</html>
```