### PR TITLE
Add cache for coveringTiles

### DIFF
--- a/src/geo/transform.js
+++ b/src/geo/transform.js
@@ -55,6 +55,7 @@ class Transform {
     _constraining: boolean;
     _posMatrixCache: {[_: string]: Float32Array};
     _alignedPosMatrixCache: {[_: string]: Float32Array};
+    _coveringTilesCache: {[_: string]: Array<any>};
 
     constructor(minZoom: ?number, maxZoom: ?number, minPitch: ?number, maxPitch: ?number, renderWorldCopies: boolean | void) {
         this.tileSize = 512; // constant
@@ -80,6 +81,7 @@ class Transform {
         this._edgeInsets = new EdgeInsets();
         this._posMatrixCache = {};
         this._alignedPosMatrixCache = {};
+        this._coveringTilesCache = {};
     }
 
     clone(): Transform {
@@ -318,10 +320,19 @@ class Transform {
             minzoom?: number,
             maxzoom?: number,
             roundZoom?: boolean,
-            reparseOverscaled?: boolean,
-            renderWorldCopies?: boolean
+            reparseOverscaled?: boolean
         }
     ): Array<OverscaledTileID> {
+
+        const loadCacheEntry = (cacheEntry): Array<OverscaledTileID> => {
+            return cacheEntry.map(it => new OverscaledTileID(it.overscaledZ, it.wrap, it.zoom, it.x, it.y));
+        };
+
+        const optionsKey = JSON.stringify([options, this._renderWorldCopies]);
+        if (this._coveringTilesCache[optionsKey]) {
+            return loadCacheEntry(this._coveringTilesCache[optionsKey]);
+        }
+
         let z = this.coveringZoomLevel(options);
         const actualZ = z;
 
@@ -356,7 +367,7 @@ class Transform {
 
         // Do a depth-first traversal to find visible tiles and proper levels of detail
         const stack = [];
-        const result = [];
+        const cacheEntry = [];
         const maxZoom = z;
         const overscaledZ = options.reparseOverscaled ? actualZ : z;
 
@@ -399,8 +410,13 @@ class Transform {
 
             // Have we reached the target depth or is the tile too far away to be any split further?
             if (it.zoom === maxZoom || (longestDim > distToSplit && it.zoom >= minZoom)) {
-                result.push({
-                    tileID: new OverscaledTileID(it.zoom === maxZoom ? overscaledZ : it.zoom, it.wrap, it.zoom, x, y),
+                cacheEntry.push({
+                    tileParameters: {
+                        overscaledZ: it.zoom === maxZoom ? overscaledZ : it.zoom,
+                        wrap: it.wrap,
+                        zoom: it.zoom,
+                        x, y
+                    },
                     distanceSq: vec2.sqrLen([centerPoint[0] - 0.5 - x, centerPoint[1] - 0.5 - y])
                 });
                 continue;
@@ -414,7 +430,10 @@ class Transform {
             }
         }
 
-        return result.sort((a, b) => a.distanceSq - b.distanceSq).map(a => a.tileID);
+        const sortedCacheEntry = cacheEntry.sort((a, b) => a.distanceSq - b.distanceSq).map(a => a.tileParameters);
+        this._coveringTilesCache[optionsKey] = sortedCacheEntry;
+
+        return loadCacheEntry(sortedCacheEntry);
     }
 
     resize(width: number, height: number) {
@@ -765,6 +784,7 @@ class Transform {
 
         this._posMatrixCache = {};
         this._alignedPosMatrixCache = {};
+        this._coveringTilesCache = {};
     }
 
     maxPitchScaleFactor() {


### PR DESCRIPTION
Another tiny step towards reducing repaint time for #96.

Occasionally, we'd see a long `coveringTiles` in our profiler, which gets worse as you have more sources, because covering tiles are collected for each source seperately.

As a short-term solution for this (fighting symptoms, not the cause), we decided to add memoization to our fork. While this doesn't seem to have an impact in practice, it still appears to be a measurable difference, so I'm proposing it here.
We didn't deploy this yet, so this has gotten very little testing.

---

I wish I could provide better benchmarks, but #76 (and even then, the benchmark might not be suitable for animations).
Also I'm currently working on a macOS machine and have a really hard time to get stable measurements.
I opted to do a rather naive measurement across 1000 frames, with my CPU turbo boost disabled.

Following was measured on a production build using a modified animate-a-line sample on fullscreen map (1680x914 on 1680x1050 display) in Chrome; with a tweak to cause camera zoom on a city in Germany, and the source / layer for the line was duplicated 5 times (with only one of them being animated).

<details><summary><b>Click here to expand the source-code for my test-case.</b></summary>

```html
<!DOCTYPE html>
<html>
<head>
    <title>Mapbox GL JS debug page</title>
    <meta charset='utf-8'>
    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
    <link rel='stylesheet' href='http://localhost:9966/dist/maplibre-gl.css' />
    <style>
        body { margin: 0; padding: 0; }
        html, body, #map { height: 100%; }
    </style>
</head>

<body>
<div id='map'></div>

<script src='http://localhost:9966/dist/maplibre-gl.js'></script>
<script src='http://localhost:9966/debug/access_token_generated.js'></script>
<script>

var map = window.map = new maplibregl.Map({
    container: 'map',
    zoom: 0.5,
    center: [0, 0],
    style: 'mapbox://styles/mapbox/streets-v10',
    hash: false
});

// Create a GeoJSON source with an empty lineString.
var geojson = {
    'type': 'FeatureCollection',
    'features': [
        {
            'type': 'Feature',
            'geometry': {
                'type': 'LineString',
                'coordinates': [[0, 0]]
            }
        }
    ]
};

var speedFactor = 30; // number of frames per longitude degree
var animation; // to store and cancel the animation
var startTime = 0;
var progress = 0; // progress = timestamp - startTime
var resetTime = false; // indicator of whether time reset is needed for the animation
var pauseButton = document.getElementById('pause');

map.on('load', function () {

    // Hack to add multiple sources
    for(let i = 0; i < 5; i++) {
      map.addSource('line' + i, {
          'type': 'geojson',
          'data': geojson
      });

      // add the line which will be modified in the animation
      map.addLayer({
          'id': 'line-animation' + i,
          'type': 'line',
          'source': 'line' + i,
          'layout': {
              'line-cap': 'round',
              'line-join': 'round'
          },
          'paint': {
              'line-color': '#ed6498',
              'line-width': 5,
              'line-opacity': 0.8
          }
      });
    }

    startTime = performance.now();

    animateLine();

    // reset startTime and progress once the tab loses or gains focus
    // requestAnimationFrame also pauses on hidden tabs by default
    document.addEventListener('visibilitychange', function () {
        resetTime = true;
    });

    // animated in a circle as a sine wave along the map.
    function animateLine(timestamp) {
        if (resetTime) {
            // resume previous progress
            startTime = performance.now() - progress;
            resetTime = false;
        } else {
            progress = timestamp - startTime;
        }

        // restart if it finishes a loop
        if (progress > speedFactor * 360) {
            startTime = timestamp;
            geojson.features[0].geometry.coordinates = [];
        } else {
            var x = progress / speedFactor;
            // draw a sine wave with some math.
            var y = Math.sin((x * Math.PI) / 90) * 40;
            // append new coordinates to the lineString
            geojson.features[0].geometry.coordinates.push([x, y]);
            // then update the map
            map.getSource('line' + 0).setData(geojson);

          // Hack to zoom camera
          if (!isNaN(x)) {
            const z = 7 + (x / 50.0) % 10
            map.setZoom(z);
            map.setCenter([7, 51]);
          }

        }

        // Request the next frame of the animation.
        animation = requestAnimationFrame(animateLine);
    }
});

</script>
</body>
</html>
```
</details>

---

**Before this PR**

```
coveringTiles took about 684.4749951851554us per frame (1000 frames)
coveringTiles took about 86.68629624938646us per call (7896 calls)
coveringTiles took about 621.6999990283512us per frame (1000 frames)
coveringTiles took about 78.56691508003932us per call (7913 calls)
coveringTiles took about 708.9000004925765us per frame (1000 frames)
coveringTiles took about 89.98476777006556us per call (7878 calls)
```

**After this PR**

```
coveringTiles took about 470.2399995876476us per frame (1000 frames)
coveringTiles took about 59.74336165514517us per call (7871 calls)
coveringTiles took about 387.3749999329448us per frame (1000 frames)
coveringTiles took about 49.05965044743475us per call (7896 calls)
coveringTiles took about 375.5949986516498us per frame (1000 frames)
coveringTiles took about 47.38771115968329us per call (7926 calls)
```

The above was measured by hooking the `coveringTiles` function like this:

```js
  const _transform = map.transform;
  const _transform_coveringTiles = _transform.coveringTiles.bind(_transform);
  let totalDuration = 0;
  let frameCount = 0;
  let callCount = 0;
  map.transform.coveringTiles = (options) => {
    const start = performance.now();
    const result = _transform_coveringTiles(options);
    const finish = performance.now();
    const duration = finish - start;
    totalDuration += duration;
    callCount++;
    return result;
  };
  
  // Add an event to print durations
  map.on("render", () => {
    frameCount++;
    if (frameCount >= 1000) {
      console.log(`coveringTiles took about ${totalDuration / frameCount * 1000}us per frame (${frameCount} frames)`);
      console.log(`coveringTiles took about ${totalDuration / callCount * 1000}us per call (${callCount} calls)`);
      totalDuration = 0;
      frameCount = 0;
      callCount = 0;
    }
  });
```

*Note that this way of profiling does not consider GC or other side-effects!*