### PR TITLE
Change MapLibre to MapLibre contributors

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2020, MapLibre
+Copyright (c) 2020, MapLibre contributors
 
 All rights reserved.
 


### PR DESCRIPTION
After consulting with laywer: "MapLibre" is not a legal entity, so it should be changed to "MapLibre contributors". Please wait for discussion in steering committe before merging.

