### PR TITLE
Clone data for GeoJSON worker-message

### DIFF
--- a/src/source/geojson_source.js
+++ b/src/source/geojson_source.js
@@ -272,7 +272,7 @@ class GeoJSONSource extends Evented implements Source {
             options.request = this.map._requestManager.transformRequest(browser.resolveURL(data), ResourceType.Source);
             options.request.collectResourceTiming = this._collectResourceTiming;
         } else {
-            options.data = JSON.stringify(data);
+            options.data = data;
         }
 
         // target {this.type}.loadData rather than literally geojson.loadData,

--- a/src/source/geojson_source.js
+++ b/src/source/geojson_source.js
@@ -2,7 +2,7 @@
 
 import {Event, ErrorEvent, Evented} from '../util/evented';
 
-import {extend} from '../util/util';
+import {clone, extend} from '../util/util';
 import EXTENT from '../data/extent';
 import {ResourceType} from '../util/ajax';
 import browser from '../util/browser';
@@ -181,7 +181,7 @@ class GeoJSONSource extends Evented implements Source {
      * @returns {GeoJSONSource} this
      */
     setData(data: GeoJSON | string) {
-        this._data = data;
+        this._data = clone(data);
         this.fire(new Event('dataloading', {dataType: 'source'}));
         this._updateWorkerData((err) => {
             if (err) {

--- a/src/source/geojson_worker_source.js
+++ b/src/source/geojson_worker_source.js
@@ -283,6 +283,12 @@ class GeoJSONWorkerSource extends VectorTileWorkerSource {
             } catch (e) {
                 return callback(new Error(`Input data given to '${params.source}' is not a valid GeoJSON object.`));
             }
+        } else if (typeof params.data === 'object') {
+            try {
+                return callback(null, params.data);
+            } catch (e) {
+                return callback(new Error(`Input data given to '${params.source}' is not a valid GeoJSON object.`));
+            }
         } else {
             return callback(new Error(`Input data given to '${params.source}' is not a valid GeoJSON object.`));
         }


### PR DESCRIPTION
This avoids some of the issues I described in #106 by preparing the data for the worker using `clone`, instead of `JSON.stringify` / `JSON.parse`.
It's probably still not perfect, but it's much much better.

For our GeoJSON, we went from:

- main-thread:
  - Old: ~200ms (`JSON.stringify`)
  - New: ~50ms (`clone`)
- worker-thread:
  - Old: ~200ms (`JSON.parse`)
  - New: ~0ms *(nothing to do)*

So total preparation time for sending the data to the worker goes from 400ms to 50ms.

---

We did not deploy this in our fork yet, and I hope the community can help us to battle-test this.

A better solution (than `clone`) is probably to correctly clone the location arrays, assuming they contain no-references.

Originally I was going to [do something smarter like geobuf](https://github.com/maplibre/maplibre-gl-js/issues/106#issuecomment-802834969) but it gave a lot of problems and no benefits.