### PR TITLE
Update example links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Features and improvements
 
 - *...Add new stuff here...*
+- Update example links to https://maplibre.org/maplibre-gl-js-docs/
 - Improve performance of layers with constant `*-sort-key` (#78)
 
 ### 🐞 Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### Features and improvements
 
 - *...Add new stuff here...*
-- Update example links to https://maplibre.org/maplibre-gl-js-docs/
+- Update example links to https://maplibre.org/maplibre-gl-js-docs/ (#131)
 - Improve performance of layers with constant `*-sort-key` (#78)
 
 ### 🐞 Bug fixes

--- a/src/geo/lng_lat.js
+++ b/src/geo/lng_lat.js
@@ -26,10 +26,10 @@ export const earthRadius = 6371008.8;
  * @example
  * var ll = new mapboxgl.LngLat(-123.9749, 40.7736);
  * ll.lng; // = -123.9749
- * @see [Get coordinates of the mouse pointer](https://www.mapbox.com/mapbox-gl-js/example/mouse-position/)
- * @see [Display a popup](https://www.mapbox.com/mapbox-gl-js/example/popup/)
- * @see [Highlight features within a bounding box](https://www.mapbox.com/mapbox-gl-js/example/using-box-queryrenderedfeatures/)
- * @see [Create a timeline animation](https://www.mapbox.com/mapbox-gl-js/example/timeline-animation/)
+ * @see [Get coordinates of the mouse pointer](https://maplibre.org/maplibre-gl-js-docs/example/mouse-position/)
+ * @see [Display a popup](https://maplibre.org/maplibre-gl-js-docs/example/popup/)
+ * @see [Highlight features within a bounding box](https://maplibre.org/maplibre-gl-js-docs/example/using-box-queryrenderedfeatures/)
+ * @see [Create a timeline animation](https://maplibre.org/maplibre-gl-js-docs/example/timeline-animation/)
  */
 class LngLat {
     lng: number;

--- a/src/geo/lng_lat.js
+++ b/src/geo/lng_lat.js
@@ -28,7 +28,6 @@ export const earthRadius = 6371008.8;
  * ll.lng; // = -123.9749
  * @see [Get coordinates of the mouse pointer](https://maplibre.org/maplibre-gl-js-docs/example/mouse-position/)
  * @see [Display a popup](https://maplibre.org/maplibre-gl-js-docs/example/popup/)
- * @see [Highlight features within a bounding box](https://maplibre.org/maplibre-gl-js-docs/example/using-box-queryrenderedfeatures/)
  * @see [Create a timeline animation](https://maplibre.org/maplibre-gl-js-docs/example/timeline-animation/)
  */
 class LngLat {

--- a/src/geo/mercator_coordinate.js
+++ b/src/geo/mercator_coordinate.js
@@ -74,7 +74,7 @@ export function mercatorScale(lat: number) {
  * @example
  * var nullIsland = new mapboxgl.MercatorCoordinate(0.5, 0.5, 0);
  *
- * @see [Add a custom style layer](https://www.mapbox.com/mapbox-gl-js/example/custom-style-layer/)
+ * @see [Add a custom style layer](https://maplibre.org/maplibre-gl-js-docs/example/custom-style-layer/)
  */
 class MercatorCoordinate {
     x: number;

--- a/src/index.js
+++ b/src/index.js
@@ -88,7 +88,7 @@ const exported = {
      * @returns {string} The currently set access token.
      * @example
      * mapboxgl.accessToken = myAccessToken;
-     * @see [Display a map](https://www.mapbox.com/mapbox-gl-js/examples/)
+     * @see [Display a map](https://maplibre.org/maplibre-gl-js-docs/examples/)
      */
     get accessToken(): ?string {
         return config.ACCESS_TOKEN;
@@ -197,7 +197,7 @@ Debug.extend(exported, {isSafari, getPerformanceMetrics: PerformanceUtils.getPer
  * if (!mapboxgl.supported()) {
  *   alert('Your browser does not support Mapbox GL');
  * }
- * @see [Check for browser support](https://www.mapbox.com/mapbox-gl-js/example/check-for-support/)
+ * @see [Check for browser support](https://maplibre.org/maplibre-gl-js-docs/example/check-for-support/)
  */
 
 /**
@@ -211,7 +211,7 @@ Debug.extend(exported, {isSafari, getPerformanceMetrics: PerformanceUtils.getPer
  *    rtl text will then be rendered only after the plugin finishes loading.
  * @example
  * mapboxgl.setRTLTextPlugin('https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-rtl-text/v0.2.0/mapbox-gl-rtl-text.js');
- * @see [Add support for right-to-left scripts](https://www.mapbox.com/mapbox-gl-js/example/mapbox-gl-rtl-text/)
+ * @see [Add support for right-to-left scripts](https://maplibre.org/maplibre-gl-js-docs/example/mapbox-gl-rtl-text/)
  */
 
 /**

--- a/src/source/geojson_source.js
+++ b/src/source/geojson_source.js
@@ -57,10 +57,10 @@ import type {GeoJSONSourceSpecification, PromoteIdSpecification} from '../style-
  *       }
  *   }]
  * });
- * @see [Draw GeoJSON points](https://www.mapbox.com/mapbox-gl-js/example/geojson-markers/)
- * @see [Add a GeoJSON line](https://www.mapbox.com/mapbox-gl-js/example/geojson-line/)
- * @see [Create a heatmap from points](https://www.mapbox.com/mapbox-gl-js/example/heatmap/)
- * @see [Create and style clusters](https://www.mapbox.com/mapbox-gl-js/example/cluster/)
+ * @see [Draw GeoJSON points](https://maplibre.org/maplibre-gl-js-docs/example/geojson-markers/)
+ * @see [Add a GeoJSON line](https://maplibre.org/maplibre-gl-js-docs/example/geojson-line/)
+ * @see [Create a heatmap from points](https://maplibre.org/maplibre-gl-js-docs/example/heatmap/)
+ * @see [Create and style clusters](https://maplibre.org/maplibre-gl-js-docs/example/cluster/)
  */
 class GeoJSONSource extends Evented implements Source {
     type: 'geojson';

--- a/src/source/image_source.js
+++ b/src/source/image_source.js
@@ -62,7 +62,7 @@ type Coordinates = [[number, number], [number, number], [number, number], [numbe
  * })
  *
  * map.removeSource('some id');  // remove
- * @see [Add an image](https://www.mapbox.com/mapbox-gl-js/example/image-on-a-map/)
+ * @see [Add an image](https://maplibre.org/maplibre-gl-js-docs/example/image-on-a-map/)
  */
 class ImageSource extends Evented implements Source {
     type: string;

--- a/src/source/image_source.js
+++ b/src/source/image_source.js
@@ -62,7 +62,6 @@ type Coordinates = [[number, number], [number, number], [number, number], [numbe
  * })
  *
  * map.removeSource('some id');  // remove
- * @see [Add an image](https://maplibre.org/maplibre-gl-js-docs/example/image-on-a-map/)
  */
 class ImageSource extends Evented implements Source {
     type: string;

--- a/src/source/vector_tile_source.js
+++ b/src/source/vector_tile_source.js
@@ -42,8 +42,8 @@ import type {VectorSourceSpecification, PromoteIdSpecification} from '../style-s
  *
  * @example
  * map.getSource('some id').setTiles(['https://d25uarhxywzl1j.cloudfront.net/v0.1/{z}/{x}/{y}.mvt']);
- * @see [Add a vector tile source](https://docs.mapbox.com/mapbox-gl-js/example/vector-source/)
- * @see [Add a third party vector tile source](https://docs.mapbox.com/mapbox-gl-js/example/third-party/)
+ * @see [Add a vector tile source](https://maplibre.org/maplibre-gl-js-docs/example/vector-source/)
+ * @see [Add a third party vector tile source](https://maplibre.org/maplibre-gl-js-docs/example/third-party/)
  */
 class VectorTileSource extends Evented implements Source {
     type: 'vector';

--- a/src/source/video_source.js
+++ b/src/source/video_source.js
@@ -44,7 +44,7 @@ import type {VideoSourceSpecification} from '../style-spec/types';
  * ]);
  *
  * map.removeSource('some id');  // remove
- * @see [Add a video](https://www.mapbox.com/mapbox-gl-js/example/video-on-a-map/)
+ * @see [Add a video](https://maplibre.org/maplibre-gl-js-docs/example/video-on-a-map/)
  */
 class VideoSource extends ImageSource {
     options: VideoSourceSpecification;

--- a/src/style/style_image.js
+++ b/src/style/style_image.js
@@ -56,7 +56,7 @@ export function renderStyleImage(image: StyleImage) {
  * @property {number} height
  * @property {Uint8Array | Uint8ClampedArray} data
  *
- * @see [Add an animated icon to the map.](https://docs.mapbox.com/mapbox-gl-js/example/add-image-animated/)
+ * @see [Add an animated icon to the map.](https://maplibre.org/maplibre-gl-js-docs/example/add-image-animated/)
  *
  * @example
  * var flashingSquare = {

--- a/src/ui/camera.js
+++ b/src/ui/camera.js
@@ -51,10 +51,10 @@ import type {PaddingOptions} from '../geo/edge_insets';
  *   bearing: -60,
  *   zoom: 10
  * });
- * @see [Set pitch and bearing](https://docs.mapbox.com/mapbox-gl-js/example/set-perspective/)
- * @see [Jump to a series of locations](https://docs.mapbox.com/mapbox-gl-js/example/jump-to/)
- * @see [Fly to a location](https://docs.mapbox.com/mapbox-gl-js/example/flyto/)
- * @see [Display buildings in 3D](https://docs.mapbox.com/mapbox-gl-js/example/3d-buildings/)
+ * @see [Set pitch and bearing](https://maplibre.org/maplibre-gl-js-docs/example/set-perspective/)
+ * @see [Jump to a series of locations](https://maplibre.org/maplibre-gl-js-docs/example/jump-to/)
+ * @see [Fly to a location](https://maplibre.org/maplibre-gl-js-docs/example/flyto/)
+ * @see [Display buildings in 3D](https://maplibre.org/maplibre-gl-js-docs/example/3d-buildings/)
  */
 export type CameraOptions = {
     center?: LngLatLike,
@@ -108,8 +108,8 @@ export type AnimationOptions = {
  * map.fitBounds(bbox, {
  *   padding: 20
  * });
- * @see [Fit to the bounds of a LineString](https://docs.mapbox.com/mapbox-gl-js/example/zoomto-linestring/)
- * @see [Fit a map to a bounding box](https://docs.mapbox.com/mapbox-gl-js/example/fitbounds/)
+ * @see [Fit to the bounds of a LineString](https://maplibre.org/maplibre-gl-js-docs/example/zoomto-linestring/)
+ * @see [Fit a map to a bounding box](https://maplibre.org/maplibre-gl-js-docs/example/fitbounds/)
  */
 
 class Camera extends Evented {
@@ -184,7 +184,7 @@ class Camera extends Evented {
      * @fires movestart
      * @fires moveend
      * @returns {Map} `this`
-     * @see [Navigate the map with game-like controls](https://www.mapbox.com/mapbox-gl-js/example/game-controls/)
+     * @see [Navigate the map with game-like controls](https://maplibre.org/maplibre-gl-js-docs/example/game-controls/)
      */
     panBy(offset: PointLike, options?: AnimationOptions, eventData?: Object) {
         offset = Point.convert(offset).mult(-1);
@@ -206,7 +206,7 @@ class Camera extends Evented {
      * @example
      * // Specify that the panTo animation should last 5000 milliseconds.
      * map.panTo([-74, 38], {duration: 5000});
-     * @see [Update a feature in realtime](https://docs.mapbox.com/mapbox-gl-js/example/live-update-feature/)
+     * @see [Update a feature in realtime](https://maplibre.org/maplibre-gl-js-docs/example/live-update-feature/)
      */
     panTo(lnglat: LngLatLike, options?: AnimationOptions, eventData?: Object) {
         return this.easeTo(extend({
@@ -325,7 +325,7 @@ class Camera extends Evented {
      *
      * @memberof Map#
      * @returns The map's current bearing.
-     * @see [Navigate the map with game-like controls](https://www.mapbox.com/mapbox-gl-js/example/game-controls/)
+     * @see [Navigate the map with game-like controls](https://maplibre.org/maplibre-gl-js-docs/example/game-controls/)
      */
     getBearing(): number { return this.transform.bearing; }
 
@@ -612,7 +612,7 @@ class Camera extends Evented {
      * map.fitBounds(bbox, {
      *   padding: {top: 10, bottom:25, left: 15, right: 5}
      * });
-     * @see [Fit a map to a bounding box](https://www.mapbox.com/mapbox-gl-js/example/fitbounds/)
+     * @see [Fit a map to a bounding box](https://maplibre.org/maplibre-gl-js-docs/example/fitbounds/)
      */
     fitBounds(bounds: LngLatBoundsLike, options?: AnimationOptions & CameraOptions, eventData?: Object) {
         return this._fitInternal(
@@ -703,8 +703,8 @@ class Camera extends Evented {
      *   pitch: 45,
      *   bearing: 90
      * });
-     * @see [Jump to a series of locations](https://docs.mapbox.com/mapbox-gl-js/example/jump-to/)
-     * @see [Update a feature in realtime](https://docs.mapbox.com/mapbox-gl-js/example/live-update-feature/)
+     * @see [Jump to a series of locations](https://maplibre.org/maplibre-gl-js-docs/example/jump-to/)
+     * @see [Update a feature in realtime](https://maplibre.org/maplibre-gl-js-docs/example/live-update-feature/)
      */
     jumpTo(options: CameraOptions, eventData?: Object) {
         this.stop();
@@ -785,7 +785,7 @@ class Camera extends Evented {
      * @fires zoomend
      * @fires pitchend
      * @returns {Map} `this`
-     * @see [Navigate the map with game-like controls](https://www.mapbox.com/mapbox-gl-js/example/game-controls/)
+     * @see [Navigate the map with game-like controls](https://maplibre.org/maplibre-gl-js-docs/example/game-controls/)
      */
     easeTo(options: CameraOptions & AnimationOptions & {easeId?: string}, eventData?: Object) {
         this._stop(false, options.easeId);
@@ -993,9 +993,9 @@ class Camera extends Evented {
      *     return t;
      *   }
      * });
-     * @see [Fly to a location](https://www.mapbox.com/mapbox-gl-js/example/flyto/)
-     * @see [Slowly fly to a location](https://www.mapbox.com/mapbox-gl-js/example/flyto-options/)
-     * @see [Fly to a location based on scroll position](https://www.mapbox.com/mapbox-gl-js/example/scroll-fly-to/)
+     * @see [Fly to a location](https://maplibre.org/maplibre-gl-js-docs/example/flyto/)
+     * @see [Slowly fly to a location](https://maplibre.org/maplibre-gl-js-docs/example/flyto-options/)
+     * @see [Fly to a location based on scroll position](https://maplibre.org/maplibre-gl-js-docs/example/scroll-fly-to/)
      */
     flyTo(options: Object, eventData?: Object) {
         // Fall through to jumpTo if user has set prefers-reduced-motion

--- a/src/ui/control/fullscreen_control.js
+++ b/src/ui/control/fullscreen_control.js
@@ -20,7 +20,7 @@ type Options = {
  *
  * @example
  * map.addControl(new mapboxgl.FullscreenControl({container: document.querySelector('body')}));
- * @see [View a fullscreen map](https://www.mapbox.com/mapbox-gl-js/example/fullscreen/)
+ * @see [View a fullscreen map](https://maplibre.org/maplibre-gl-js-docs/example/fullscreen/)
  */
 
 class FullscreenControl {

--- a/src/ui/control/geolocate_control.js
+++ b/src/ui/control/geolocate_control.js
@@ -92,7 +92,7 @@ let noTimeout = false;
  *     },
  *     trackUserLocation: true
  * }));
- * @see [Locate the user](https://www.mapbox.com/mapbox-gl-js/example/locate-user/)
+ * @see [Locate the user](https://maplibre.org/maplibre-gl-js-docs/example/locate-user/)
  */
 class GeolocateControl extends Evented {
     _map: Map;

--- a/src/ui/control/navigation_control.js
+++ b/src/ui/control/navigation_control.js
@@ -30,8 +30,8 @@ const defaultOptions: Options = {
  * @example
  * var nav = new mapboxgl.NavigationControl();
  * map.addControl(nav, 'top-left');
- * @see [Display map navigation controls](https://www.mapbox.com/mapbox-gl-js/example/navigation/)
- * @see [Add a third party vector tile source](https://www.mapbox.com/mapbox-gl-js/example/third-party/)
+ * @see [Display map navigation controls](https://maplibre.org/maplibre-gl-js-docs/example/navigation/)
+ * @see [Add a third party vector tile source](https://maplibre.org/maplibre-gl-js-docs/example/third-party/)
  */
 class NavigationControl {
     _map: Map;

--- a/src/ui/events.js
+++ b/src/ui/events.js
@@ -314,8 +314,8 @@ export type MapEvent =
      * map.on('mousedown', 'poi-label', function() {
      *   console.log('A mousedown event has occurred on a visible portion of the poi-label layer.');
      * });
-     * @see [Highlight features within a bounding box](https://docs.mapbox.com/mapbox-gl-js/example/using-box-queryrenderedfeatures/)
-     * @see [Create a draggable point](https://docs.mapbox.com/mapbox-gl-js/example/drag-a-point/)
+     * @see [Highlight features within a bounding box](https://maplibre.org/maplibre-gl-js-docs/example/using-box-queryrenderedfeatures/)
+     * @see [Create a draggable point](https://maplibre.org/maplibre-gl-js-docs/example/drag-a-point/)
      */
     | 'mousedown'
 
@@ -344,8 +344,8 @@ export type MapEvent =
      * map.on('mouseup', 'poi-label', function() {
      *   console.log('A mouseup event has occurred on a visible portion of the poi-label layer.');
      * });
-     * @see [Highlight features within a bounding box](https://docs.mapbox.com/mapbox-gl-js/example/using-box-queryrenderedfeatures/)
-     * @see [Create a draggable point](https://docs.mapbox.com/mapbox-gl-js/example/drag-a-point/)
+     * @see [Highlight features within a bounding box](https://maplibre.org/maplibre-gl-js-docs/example/using-box-queryrenderedfeatures/)
+     * @see [Create a draggable point](https://maplibre.org/maplibre-gl-js-docs/example/drag-a-point/)
      */
     | 'mouseup'
 
@@ -376,9 +376,9 @@ export type MapEvent =
      * map.on('mouseover', 'poi-label', function() {
      *   console.log('A mouseover event has occurred on a visible portion of the poi-label layer.');
      * });
-     * @see [Get coordinates of the mouse pointer](https://www.mapbox.com/mapbox-gl-js/example/mouse-position/)
-     * @see [Highlight features under the mouse pointer](https://www.mapbox.com/mapbox-gl-js/example/hover-styles/)
-     * @see [Display a popup on hover](https://www.mapbox.com/mapbox-gl-js/example/popup-on-hover/)
+     * @see [Get coordinates of the mouse pointer](https://maplibre.org/maplibre-gl-js-docs/example/mouse-position/)
+     * @see [Highlight features under the mouse pointer](https://maplibre.org/maplibre-gl-js-docs/example/hover-styles/)
+     * @see [Display a popup on hover](https://maplibre.org/maplibre-gl-js-docs/example/popup-on-hover/)
      */
     | 'mouseover'
 
@@ -408,9 +408,9 @@ export type MapEvent =
      * map.on('mousemove', 'poi-label', function() {
      *   console.log('A mousemove event has occurred on a visible portion of the poi-label layer.');
      * });
-     * @see [Get coordinates of the mouse pointer](https://www.mapbox.com/mapbox-gl-js/example/mouse-position/)
-     * @see [Highlight features under the mouse pointer](https://www.mapbox.com/mapbox-gl-js/example/hover-styles/)
-     * @see [Display a popup on over](https://www.mapbox.com/mapbox-gl-js/example/popup-on-hover/)
+     * @see [Get coordinates of the mouse pointer](https://maplibre.org/maplibre-gl-js-docs/example/mouse-position/)
+     * @see [Highlight features under the mouse pointer](https://maplibre.org/maplibre-gl-js-docs/example/hover-styles/)
+     * @see [Display a popup on over](https://maplibre.org/maplibre-gl-js-docs/example/popup-on-hover/)
      */
     | 'mousemove'
 
@@ -439,8 +439,8 @@ export type MapEvent =
      * map.on('click', 'poi-label', function(e) {
      *   console.log('A click event has occurred on a visible portion of the poi-label layer at ' + e.lngLat);
      * });
-     * @see [Measure distances](https://www.mapbox.com/mapbox-gl-js/example/measure/)
-     * @see [Center the map on a clicked symbol](https://www.mapbox.com/mapbox-gl-js/example/center-on-symbol/)
+     * @see [Measure distances](https://maplibre.org/maplibre-gl-js-docs/example/measure/)
+     * @see [Center the map on a clicked symbol](https://maplibre.org/maplibre-gl-js-docs/example/center-on-symbol/)
      */
     | 'click'
 
@@ -491,8 +491,8 @@ export type MapEvent =
      * map.on('mouseenter', 'water', function() {
      *   console.log('A mouseenter event occurred on a visible portion of the water layer.');
      * });
-     * @see [Center the map on a clicked symbol](https://docs.mapbox.com/mapbox-gl-js/example/center-on-symbol/)
-     * @see [Display a popup on click](https://docs.mapbox.com/mapbox-gl-js/example/popup-on-click/)
+     * @see [Center the map on a clicked symbol](https://maplibre.org/maplibre-gl-js-docs/example/center-on-symbol/)
+     * @see [Display a popup on click](https://maplibre.org/maplibre-gl-js-docs/example/popup-on-click/)
      */
     | 'mouseenter'
 
@@ -516,8 +516,8 @@ export type MapEvent =
      * map.on('mouseleave', 'water', function() {
      *   console.log('A mouseleave event occurred.');
      * });
-     * @see [Highlight features under the mouse pointer](https://www.mapbox.com/mapbox-gl-js/example/hover-styles/)
-     * @see [Display a popup on click](https://docs.mapbox.com/mapbox-gl-js/example/popup-on-click/)
+     * @see [Highlight features under the mouse pointer](https://maplibre.org/maplibre-gl-js-docs/example/hover-styles/)
+     * @see [Display a popup on click](https://maplibre.org/maplibre-gl-js-docs/example/popup-on-click/)
      */
     | 'mouseleave'
 
@@ -591,7 +591,7 @@ export type MapEvent =
      * map.on('touchstart', function() {
      *   console.log('A touchstart event occurred.');
      * });
-     * @see [Create a draggable point](https://docs.mapbox.com/mapbox-gl-js/example/drag-a-point/)
+     * @see [Create a draggable point](https://maplibre.org/maplibre-gl-js-docs/example/drag-a-point/)
      */
     | 'touchstart'
 
@@ -610,7 +610,7 @@ export type MapEvent =
      * map.on('touchstart', function() {
      *   console.log('A touchstart event occurred.');
      * });
-     * @see [Create a draggable point](https://docs.mapbox.com/mapbox-gl-js/example/drag-a-point/)
+     * @see [Create a draggable point](https://maplibre.org/maplibre-gl-js-docs/example/drag-a-point/)
      */
     | 'touchend'
 
@@ -629,7 +629,7 @@ export type MapEvent =
      * map.on('touchmove', function() {
      *   console.log('A touchmove event occurred.');
      * });
-     * @see [Create a draggable point](https://docs.mapbox.com/mapbox-gl-js/example/drag-a-point/)
+     * @see [Create a draggable point](https://maplibre.org/maplibre-gl-js-docs/example/drag-a-point/)
      */
     | 'touchmove'
 
@@ -687,8 +687,8 @@ export type MapEvent =
      * map.on('move', function() {
      *   console.log('A move event occurred.');
      * });
-     * @see [Display HTML clusters with custom properties](https://docs.mapbox.com/mapbox-gl-js/example/cluster-html/)
-     * @see [Filter features within map view](https://docs.mapbox.com/mapbox-gl-js/example/filter-features-within-map-view/)
+     * @see [Display HTML clusters with custom properties](https://maplibre.org/maplibre-gl-js-docs/example/cluster-html/)
+     * @see [Filter features within map view](https://maplibre.org/maplibre-gl-js-docs/example/filter-features-within-map-view/)
      */
     | 'move'
 
@@ -708,9 +708,9 @@ export type MapEvent =
      * map.on('moveend', function() {
      *   console.log('A moveend event occurred.');
      * });
-     * @see [Play map locations as a slideshow](https://www.mapbox.com/mapbox-gl-js/example/playback-locations/)
-     * @see [Filter features within map view](https://www.mapbox.com/mapbox-gl-js/example/filter-features-within-map-view/)
-     * @see [Display HTML clusters with custom properties](https://docs.mapbox.com/mapbox-gl-js/example/cluster-html/)
+     * @see [Play map locations as a slideshow](https://maplibre.org/maplibre-gl-js-docs/example/playback-locations/)
+     * @see [Filter features within map view](https://maplibre.org/maplibre-gl-js-docs/example/filter-features-within-map-view/)
+     * @see [Display HTML clusters with custom properties](https://maplibre.org/maplibre-gl-js-docs/example/cluster-html/)
      */
     | 'moveend'
 
@@ -765,7 +765,7 @@ export type MapEvent =
      * map.on('dragend', function() {
      *   console.log('A dragend event occurred.');
      * });
-     * @see [Create a draggable marker](https://docs.mapbox.com/mapbox-gl-js/example/drag-a-marker/)
+     * @see [Create a draggable marker](https://maplibre.org/maplibre-gl-js-docs/example/drag-a-marker/)
      */
     | 'dragend'
 
@@ -804,7 +804,7 @@ export type MapEvent =
      * map.on('zoom', function() {
      *   console.log('A zoom event occurred.');
      * });
-     * @see [Update a choropleth layer by zoom level](https://www.mapbox.com/mapbox-gl-js/example/updating-choropleth/)
+     * @see [Update a choropleth layer by zoom level](https://maplibre.org/maplibre-gl-js-docs/example/updating-choropleth/)
      */
     | 'zoom'
 
@@ -1062,9 +1062,9 @@ export type MapEvent =
      * map.on('load', function() {
      *   console.log('A load event occurred.');
      * });
-     * @see [Draw GeoJSON points](https://www.mapbox.com/mapbox-gl-js/example/geojson-markers/)
-     * @see [Add live realtime data](https://www.mapbox.com/mapbox-gl-js/example/live-geojson/)
-     * @see [Animate a point](https://www.mapbox.com/mapbox-gl-js/example/animate-point-along-line/)
+     * @see [Draw GeoJSON points](https://maplibre.org/maplibre-gl-js-docs/example/geojson-markers/)
+     * @see [Add live realtime data](https://maplibre.org/maplibre-gl-js-docs/example/live-geojson/)
+     * @see [Animate a point](https://maplibre.org/maplibre-gl-js-docs/example/animate-point-along-line/)
      */
     | 'load'
 
@@ -1166,7 +1166,7 @@ export type MapEvent =
      * map.on('data', function() {
      *   console.log('A data event occurred.');
      * });
-     * @see [Display HTML clusters with custom properties](https://docs.mapbox.com/mapbox-gl-js/example/cluster-html/)
+     * @see [Display HTML clusters with custom properties](https://maplibre.org/maplibre-gl-js-docs/example/cluster-html/)
      */
     | 'data'
 

--- a/src/ui/events.js
+++ b/src/ui/events.js
@@ -314,7 +314,6 @@ export type MapEvent =
      * map.on('mousedown', 'poi-label', function() {
      *   console.log('A mousedown event has occurred on a visible portion of the poi-label layer.');
      * });
-     * @see [Highlight features within a bounding box](https://maplibre.org/maplibre-gl-js-docs/example/using-box-queryrenderedfeatures/)
      * @see [Create a draggable point](https://maplibre.org/maplibre-gl-js-docs/example/drag-a-point/)
      */
     | 'mousedown'
@@ -344,7 +343,6 @@ export type MapEvent =
      * map.on('mouseup', 'poi-label', function() {
      *   console.log('A mouseup event has occurred on a visible portion of the poi-label layer.');
      * });
-     * @see [Highlight features within a bounding box](https://maplibre.org/maplibre-gl-js-docs/example/using-box-queryrenderedfeatures/)
      * @see [Create a draggable point](https://maplibre.org/maplibre-gl-js-docs/example/drag-a-point/)
      */
     | 'mouseup'
@@ -688,7 +686,6 @@ export type MapEvent =
      *   console.log('A move event occurred.');
      * });
      * @see [Display HTML clusters with custom properties](https://maplibre.org/maplibre-gl-js-docs/example/cluster-html/)
-     * @see [Filter features within map view](https://maplibre.org/maplibre-gl-js-docs/example/filter-features-within-map-view/)
      */
     | 'move'
 
@@ -708,8 +705,6 @@ export type MapEvent =
      * map.on('moveend', function() {
      *   console.log('A moveend event occurred.');
      * });
-     * @see [Play map locations as a slideshow](https://maplibre.org/maplibre-gl-js-docs/example/playback-locations/)
-     * @see [Filter features within map view](https://maplibre.org/maplibre-gl-js-docs/example/filter-features-within-map-view/)
      * @see [Display HTML clusters with custom properties](https://maplibre.org/maplibre-gl-js-docs/example/cluster-html/)
      */
     | 'moveend'
@@ -804,7 +799,6 @@ export type MapEvent =
      * map.on('zoom', function() {
      *   console.log('A zoom event occurred.');
      * });
-     * @see [Update a choropleth layer by zoom level](https://maplibre.org/maplibre-gl-js-docs/example/updating-choropleth/)
      */
     | 'zoom'
 

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -1230,8 +1230,6 @@ class Map extends Camera {
      * // Query all rendered features from a single layer
      * var features = map.queryRenderedFeatures({ layers: ['my-layer-name'] });
      * @see [Get features under the mouse pointer](https://maplibre.org/maplibre-gl-js-docs/example/queryrenderedfeatures/)
-     * @see [Highlight features within a bounding box](https://maplibre.org/maplibre-gl-js-docs/example/using-box-queryrenderedfeatures/)
-     * @see [Filter features within map view](https://maplibre.org/maplibre-gl-js-docs/example/filter-features-within-map-view/)
      */
     queryRenderedFeatures(geometry?: PointLike | [PointLike, PointLike], options?: Object) {
         // The first parameter can be omitted entirely, making this effectively an overloaded method
@@ -1302,7 +1300,6 @@ class Map extends Camera {
      *   sourceLayer: 'your-source-layer'
      * });
      *
-     * @see [Highlight features containing similar data](https://maplibre.org/maplibre-gl-js-docs/example/query-similar-features/)
      */
     querySourceFeatures(sourceId: string, parameters: ?{sourceLayer: ?string, filter: ?Array<any>, validate?: boolean}) {
         return this.style.querySourceFeatures(sourceId, parameters);
@@ -1333,7 +1330,6 @@ class Map extends Camera {
      * @example
      * map.setStyle("mapbox://styles/mapbox/streets-v11");
      *
-     * @see [Change a map's style](https://maplibre.org/maplibre-gl-js-docs/example/setstyle/)
      */
     setStyle(style: StyleSpecification | string | null, options?: {diff?: boolean} & StyleOptions) {
         options = extend({}, {localIdeographFontFamily: this._localIdeographFontFamily}, options);
@@ -1474,9 +1470,7 @@ class Map extends Camera {
      *     }
      *   }
      * });
-     * @see Vector source: [Show and hide layers](https://maplibre.org/maplibre-gl-js-docs/example/toggle-layers/)
      * @see GeoJSON source: [Add live realtime data](https://maplibre.org/maplibre-gl-js-docs/example/live-geojson/)
-     * @see Raster DEM source: [Add hillshading](https://maplibre.org/maplibre-gl-js-docs/example/hillshade/)
      */
     addSource(id: string, source: SourceSpecification) {
         this._lazyInitEmptyStyle();
@@ -1993,8 +1987,6 @@ class Map extends Camera {
      * // remove the filter for the 'bike-docks' style layer
      * map.setFilter('bike-docks', null);
      *
-     * @see [Filter features within map view](https://maplibre.org/maplibre-gl-js-docs/example/filter-features-within-map-view/)
-     * @see [Highlight features containing similar data](https://maplibre.org/maplibre-gl-js-docs/example/query-similar-features/)
      * @see [Create a timeline animation](https://maplibre.org/maplibre-gl-js-docs/example/timeline-animation/)
      * @see Tutorial: [Show changes over time](https://docs.mapbox.com/help/tutorials/show-changes-over-time/)
      */
@@ -2026,7 +2018,6 @@ class Map extends Camera {
      * @example
      * map.setPaintProperty('my-layer', 'fill-color', '#faafee');
      * @see [Change a layer's color with buttons](https://maplibre.org/maplibre-gl-js-docs/example/color-switcher/)
-     * @see [Adjust a layer's opacity](https://maplibre.org/maplibre-gl-js-docs/example/adjust-layer-opacity/)
      * @see [Create a draggable point](https://maplibre.org/maplibre-gl-js-docs/example/drag-a-point/)
      */
     setPaintProperty(layerId: string, name: string, value: any, options: StyleSetterOptions = {}) {
@@ -2056,7 +2047,6 @@ class Map extends Camera {
      * @returns {Map} `this`
      * @example
      * map.setLayoutProperty('my-layer', 'visibility', 'none');
-     * @see [Show and hide layers](https://maplibre.org/maplibre-gl-js-docs/example/toggle-layers/)
      */
     setLayoutProperty(layerId: string, name: string, value: any, options: StyleSetterOptions = {}) {
         this.style.setLayoutProperty(layerId, name, value, options);
@@ -2083,7 +2073,6 @@ class Map extends Camera {
      * @returns {Map} `this`
      * @example
      * var layerVisibility = map.getLayoutProperty('my-layer', 'visibility');
-     * @see [Show and hide layers](https://maplibre.org/maplibre-gl-js-docs/example/toggle-layers/)
      */
     setLight(light: LightSpecification, options: StyleSetterOptions = {}) {
         this._lazyInitEmptyStyle();
@@ -2249,7 +2238,6 @@ class Map extends Camera {
      *
      * @returns {HTMLElement} The container of the map's `<canvas>`.
      * @see [Create a draggable point](https://maplibre.org/maplibre-gl-js-docs/example/drag-a-point/)
-     * @see [Highlight features within a bounding box](https://maplibre.org/maplibre-gl-js-docs/example/using-box-queryrenderedfeatures/)
      */
     getCanvasContainer() {
         return this._canvasContainer;

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -237,7 +237,7 @@ const defaultOptions = {
  *   font-family for locally overriding generation of glyphs in the 'CJK Unified Ideographs', 'Hiragana', 'Katakana' and 'Hangul Syllables' ranges.
  *   In these ranges, font settings from the map's style will be ignored, except for font-weight keywords (light/regular/medium/bold).
  *   Set to `false`, to enable font settings from the map's style for these glyph ranges.  Note that [Mapbox Studio](https://studio.mapbox.com/) sets this value to `false` by default.
- *   The purpose of this option is to avoid bandwidth-intensive glyph server requests. (See [Use locally generated ideographs](https://www.mapbox.com/mapbox-gl-js/example/local-ideographs).)
+ *   The purpose of this option is to avoid bandwidth-intensive glyph server requests. (See [Use locally generated ideographs](https://maplibre.org/maplibre-gl-js-docs/example/local-ideographs).)
  * @param {RequestTransformFunction} [options.transformRequest=null] A callback run before the Map makes a request for an external URL. The callback can be used to modify the url, set headers, or set the credentials property for cross-origin requests.
  *   Expected to return an object with a `url` property and optionally `headers` and `credentials` properties.
  * @param {boolean} [options.collectResourceTiming=false] If `true`, Resource Timing API information will be collected for requests made by GeoJSON and Vector Tile web workers (this information is normally inaccessible from the main Javascript thread). Information will be returned in a `resourceTiming` property of relevant `data` events.
@@ -505,7 +505,7 @@ class Map extends Camera {
      * @example
      * // Add zoom and rotation controls to the map.
      * map.addControl(new mapboxgl.NavigationControl());
-     * @see [Display map navigation controls](https://www.mapbox.com/mapbox-gl-js/example/navigation/)
+     * @see [Display map navigation controls](https://maplibre.org/maplibre-gl-js-docs/example/navigation/)
      */
     addControl(control: IControl, position?: ControlPosition) {
         if (position === undefined) {
@@ -814,7 +814,7 @@ class Map extends Camera {
      * @returns {boolean} renderWorldCopies
      * @example
      * var worldCopiesRendered = map.getRenderWorldCopies();
-     * @see [Render world copies](https://docs.mapbox.com/mapbox-gl-js/example/render-world-copies/)
+     * @see [Render world copies](https://maplibre.org/maplibre-gl-js-docs/example/render-world-copies/)
      */
     getRenderWorldCopies() { return this.transform.renderWorldCopies; }
 
@@ -831,7 +831,7 @@ class Map extends Camera {
      * @returns {Map} `this`
      * @example
      * map.setRenderWorldCopies(true);
-     * @see [Render world copies](https://docs.mapbox.com/mapbox-gl-js/example/render-world-copies/)
+     * @see [Render world copies](https://maplibre.org/maplibre-gl-js-docs/example/render-world-copies/)
      */
     setRenderWorldCopies(renderWorldCopies?: ?boolean) {
         this.transform.renderWorldCopies = renderWorldCopies;
@@ -1040,10 +1040,10 @@ class Map extends Camera {
      *     .setHTML(`Country name: ${e.features[0].properties.name}`)
      *     .addTo(map);
      * });
-     * @see [Display popup on click](https://docs.mapbox.com/mapbox-gl-js/example/popup-on-click/)
-     * @see [Center the map on a clicked symbol](https://docs.mapbox.com/mapbox-gl-js/example/center-on-symbol/)
-     * @see [Create a hover effect](https://docs.mapbox.com/mapbox-gl-js/example/hover-styles/)
-     * @see [Create a draggable marker](https://docs.mapbox.com/mapbox-gl-js/example/drag-a-point/)
+     * @see [Display popup on click](https://maplibre.org/maplibre-gl-js-docs/example/popup-on-click/)
+     * @see [Center the map on a clicked symbol](https://maplibre.org/maplibre-gl-js-docs/example/center-on-symbol/)
+     * @see [Create a hover effect](https://maplibre.org/maplibre-gl-js-docs/example/hover-styles/)
+     * @see [Create a draggable marker](https://maplibre.org/maplibre-gl-js-docs/example/drag-a-point/)
      */
     on(type: MapEvent, layerId: any, listener: any) {
         if (listener === undefined) {
@@ -1229,9 +1229,9 @@ class Map extends Camera {
      * @example
      * // Query all rendered features from a single layer
      * var features = map.queryRenderedFeatures({ layers: ['my-layer-name'] });
-     * @see [Get features under the mouse pointer](https://www.mapbox.com/mapbox-gl-js/example/queryrenderedfeatures/)
-     * @see [Highlight features within a bounding box](https://www.mapbox.com/mapbox-gl-js/example/using-box-queryrenderedfeatures/)
-     * @see [Filter features within map view](https://www.mapbox.com/mapbox-gl-js/example/filter-features-within-map-view/)
+     * @see [Get features under the mouse pointer](https://maplibre.org/maplibre-gl-js-docs/example/queryrenderedfeatures/)
+     * @see [Highlight features within a bounding box](https://maplibre.org/maplibre-gl-js-docs/example/using-box-queryrenderedfeatures/)
+     * @see [Filter features within map view](https://maplibre.org/maplibre-gl-js-docs/example/filter-features-within-map-view/)
      */
     queryRenderedFeatures(geometry?: PointLike | [PointLike, PointLike], options?: Object) {
         // The first parameter can be omitted entirely, making this effectively an overloaded method
@@ -1302,7 +1302,7 @@ class Map extends Camera {
      *   sourceLayer: 'your-source-layer'
      * });
      *
-     * @see [Highlight features containing similar data](https://www.mapbox.com/mapbox-gl-js/example/query-similar-features/)
+     * @see [Highlight features containing similar data](https://maplibre.org/maplibre-gl-js-docs/example/query-similar-features/)
      */
     querySourceFeatures(sourceId: string, parameters: ?{sourceLayer: ?string, filter: ?Array<any>, validate?: boolean}) {
         return this.style.querySourceFeatures(sourceId, parameters);
@@ -1333,7 +1333,7 @@ class Map extends Camera {
      * @example
      * map.setStyle("mapbox://styles/mapbox/streets-v11");
      *
-     * @see [Change a map's style](https://www.mapbox.com/mapbox-gl-js/example/setstyle/)
+     * @see [Change a map's style](https://maplibre.org/maplibre-gl-js-docs/example/setstyle/)
      */
     setStyle(style: StyleSpecification | string | null, options?: {diff?: boolean} & StyleOptions) {
         options = extend({}, {localIdeographFontFamily: this._localIdeographFontFamily}, options);
@@ -1474,9 +1474,9 @@ class Map extends Camera {
      *     }
      *   }
      * });
-     * @see Vector source: [Show and hide layers](https://docs.mapbox.com/mapbox-gl-js/example/toggle-layers/)
-     * @see GeoJSON source: [Add live realtime data](https://docs.mapbox.com/mapbox-gl-js/example/live-geojson/)
-     * @see Raster DEM source: [Add hillshading](https://docs.mapbox.com/mapbox-gl-js/example/hillshade/)
+     * @see Vector source: [Show and hide layers](https://maplibre.org/maplibre-gl-js-docs/example/toggle-layers/)
+     * @see GeoJSON source: [Add live realtime data](https://maplibre.org/maplibre-gl-js-docs/example/live-geojson/)
+     * @see Raster DEM source: [Add hillshading](https://maplibre.org/maplibre-gl-js-docs/example/hillshade/)
      */
     addSource(id: string, source: SourceSpecification) {
         this._lazyInitEmptyStyle();
@@ -1566,9 +1566,9 @@ class Map extends Camera {
      * [Sources](https://docs.mapbox.com/mapbox-gl-js/style-spec/sources/) page.
      * @example
      * var sourceObject = map.getSource('points');
-     * @see [Create a draggable point](https://docs.mapbox.com/mapbox-gl-js/example/drag-a-point/)
-     * @see [Animate a point](https://docs.mapbox.com/mapbox-gl-js/example/animate-point-along-line/)
-     * @see [Add live realtime data](https://docs.mapbox.com/mapbox-gl-js/example/live-geojson/)
+     * @see [Create a draggable point](https://maplibre.org/maplibre-gl-js-docs/example/drag-a-point/)
+     * @see [Animate a point](https://maplibre.org/maplibre-gl-js-docs/example/animate-point-along-line/)
+     * @see [Add live realtime data](https://maplibre.org/maplibre-gl-js-docs/example/live-geojson/)
      */
     getSource(id: string) {
         return this.style.getSource(id);
@@ -1617,8 +1617,8 @@ class Map extends Camera {
      * });
      *
      *
-     * @see Use `HTMLImageElement`: [Add an icon to the map](https://www.mapbox.com/mapbox-gl-js/example/add-image/)
-     * @see Use `ImageData`: [Add a generated icon to the map](https://www.mapbox.com/mapbox-gl-js/example/add-image-generated/)
+     * @see Use `HTMLImageElement`: [Add an icon to the map](https://maplibre.org/maplibre-gl-js-docs/example/add-image/)
+     * @see Use `ImageData`: [Add a generated icon to the map](https://maplibre.org/maplibre-gl-js-docs/example/add-image-generated/)
      */
     addImage(id: string,
              image: HTMLImageElement | ImageBitmap | ImageData | {width: number, height: number, data: Uint8Array | Uint8ClampedArray} | StyleImageInterface,
@@ -1753,7 +1753,7 @@ class Map extends Camera {
      *   map.addImage('kitten', image);
      * });
      *
-     * @see [Add an icon to the map](https://www.mapbox.com/mapbox-gl-js/example/add-image/)
+     * @see [Add an icon to the map](https://maplibre.org/maplibre-gl-js-docs/example/add-image/)
      */
     loadImage(url: string, callback: Function) {
         getImage(this._requestManager.transformRequest(url, ResourceType.Image), callback);
@@ -1879,9 +1879,9 @@ class Map extends Camera {
      * // Add the layer before the existing `cities` layer
      * }, 'cities');
      *
-     * @see [Create and style clusters](https://docs.mapbox.com/mapbox-gl-js/example/cluster/)
-     * @see [Add a vector tile source](https://docs.mapbox.com/mapbox-gl-js/example/vector-source/)
-     * @see [Add a WMS source](https://docs.mapbox.com/mapbox-gl-js/example/wms/)
+     * @see [Create and style clusters](https://maplibre.org/maplibre-gl-js-docs/example/cluster/)
+     * @see [Add a vector tile source](https://maplibre.org/maplibre-gl-js-docs/example/vector-source/)
+     * @see [Add a WMS source](https://maplibre.org/maplibre-gl-js-docs/example/wms/)
      */
     addLayer(layer: LayerSpecification | CustomLayerInterface, beforeId?: string) {
         this._lazyInitEmptyStyle();
@@ -1933,8 +1933,8 @@ class Map extends Camera {
      * @example
      * var stateDataLayer = map.getLayer('state-data');
      *
-     * @see [Filter symbols by toggling a list](https://www.mapbox.com/mapbox-gl-js/example/filter-markers/)
-     * @see [Filter symbols by text input](https://www.mapbox.com/mapbox-gl-js/example/filter-markers-by-input/)
+     * @see [Filter symbols by toggling a list](https://maplibre.org/maplibre-gl-js-docs/example/filter-markers/)
+     * @see [Filter symbols by text input](https://maplibre.org/maplibre-gl-js-docs/example/filter-markers-by-input/)
      */
     getLayer(id: string) {
         return this.style.getLayer(id);
@@ -1993,9 +1993,9 @@ class Map extends Camera {
      * // remove the filter for the 'bike-docks' style layer
      * map.setFilter('bike-docks', null);
      *
-     * @see [Filter features within map view](https://www.mapbox.com/mapbox-gl-js/example/filter-features-within-map-view/)
-     * @see [Highlight features containing similar data](https://www.mapbox.com/mapbox-gl-js/example/query-similar-features/)
-     * @see [Create a timeline animation](https://www.mapbox.com/mapbox-gl-js/example/timeline-animation/)
+     * @see [Filter features within map view](https://maplibre.org/maplibre-gl-js-docs/example/filter-features-within-map-view/)
+     * @see [Highlight features containing similar data](https://maplibre.org/maplibre-gl-js-docs/example/query-similar-features/)
+     * @see [Create a timeline animation](https://maplibre.org/maplibre-gl-js-docs/example/timeline-animation/)
      * @see Tutorial: [Show changes over time](https://docs.mapbox.com/help/tutorials/show-changes-over-time/)
      */
     setFilter(layerId: string, filter: ?FilterSpecification,  options: StyleSetterOptions = {}) {
@@ -2025,9 +2025,9 @@ class Map extends Camera {
      * @returns {Map} `this`
      * @example
      * map.setPaintProperty('my-layer', 'fill-color', '#faafee');
-     * @see [Change a layer's color with buttons](https://www.mapbox.com/mapbox-gl-js/example/color-switcher/)
-     * @see [Adjust a layer's opacity](https://www.mapbox.com/mapbox-gl-js/example/adjust-layer-opacity/)
-     * @see [Create a draggable point](https://www.mapbox.com/mapbox-gl-js/example/drag-a-point/)
+     * @see [Change a layer's color with buttons](https://maplibre.org/maplibre-gl-js-docs/example/color-switcher/)
+     * @see [Adjust a layer's opacity](https://maplibre.org/maplibre-gl-js-docs/example/adjust-layer-opacity/)
+     * @see [Create a draggable point](https://maplibre.org/maplibre-gl-js-docs/example/drag-a-point/)
      */
     setPaintProperty(layerId: string, name: string, value: any, options: StyleSetterOptions = {}) {
         this.style.setPaintProperty(layerId, name, value, options);
@@ -2056,7 +2056,7 @@ class Map extends Camera {
      * @returns {Map} `this`
      * @example
      * map.setLayoutProperty('my-layer', 'visibility', 'none');
-     * @see [Show and hide layers](https://docs.mapbox.com/mapbox-gl-js/example/toggle-layers/)
+     * @see [Show and hide layers](https://maplibre.org/maplibre-gl-js-docs/example/toggle-layers/)
      */
     setLayoutProperty(layerId: string, name: string, value: any, options: StyleSetterOptions = {}) {
         this.style.setLayoutProperty(layerId, name, value, options);
@@ -2083,7 +2083,7 @@ class Map extends Camera {
      * @returns {Map} `this`
      * @example
      * var layerVisibility = map.getLayoutProperty('my-layer', 'visibility');
-     * @see [Show and hide layers](https://docs.mapbox.com/mapbox-gl-js/example/toggle-layers/)
+     * @see [Show and hide layers](https://maplibre.org/maplibre-gl-js-docs/example/toggle-layers/)
      */
     setLight(light: LightSpecification, options: StyleSetterOptions = {}) {
         this._lazyInitEmptyStyle();
@@ -2136,7 +2136,7 @@ class Map extends Camera {
      *   }
      * });
      *
-     * @see [Create a hover effect](https://docs.mapbox.com/mapbox-gl-js/example/hover-styles/)
+     * @see [Create a hover effect](https://maplibre.org/maplibre-gl-js-docs/example/hover-styles/)
      * @see Tutorial: [Create interactive hover effects with Mapbox GL JS](https://docs.mapbox.com/help/tutorials/create-interactive-hover-effects-with-mapbox-gl-js/)
      */
     setFeatureState(feature: { source: string; sourceLayer?: string; id: string | number; }, state: Object) {
@@ -2248,8 +2248,8 @@ class Map extends Camera {
      * map controls.
      *
      * @returns {HTMLElement} The container of the map's `<canvas>`.
-     * @see [Create a draggable point](https://www.mapbox.com/mapbox-gl-js/example/drag-a-point/)
-     * @see [Highlight features within a bounding box](https://www.mapbox.com/mapbox-gl-js/example/using-box-queryrenderedfeatures/)
+     * @see [Create a draggable point](https://maplibre.org/maplibre-gl-js-docs/example/drag-a-point/)
+     * @see [Highlight features within a bounding box](https://maplibre.org/maplibre-gl-js-docs/example/using-box-queryrenderedfeatures/)
      */
     getCanvasContainer() {
         return this._canvasContainer;
@@ -2259,9 +2259,9 @@ class Map extends Camera {
      * Returns the map's `<canvas>` element.
      *
      * @returns {HTMLCanvasElement} The map's `<canvas>` element.
-     * @see [Measure distances](https://www.mapbox.com/mapbox-gl-js/example/measure/)
-     * @see [Display a popup on hover](https://www.mapbox.com/mapbox-gl-js/example/popup-on-hover/)
-     * @see [Center the map on a clicked symbol](https://www.mapbox.com/mapbox-gl-js/example/center-on-symbol/)
+     * @see [Measure distances](https://maplibre.org/maplibre-gl-js-docs/example/measure/)
+     * @see [Display a popup on hover](https://maplibre.org/maplibre-gl-js-docs/example/popup-on-hover/)
+     * @see [Center the map on a clicked symbol](https://maplibre.org/maplibre-gl-js-docs/example/center-on-symbol/)
      */
     getCanvas() {
         return this._canvas;
@@ -2618,8 +2618,8 @@ class Map extends Camera {
      * next frame is rendered will still result in only a single frame being rendered.
      * @example
      * map.triggerRepaint();
-     * @see [Add a 3D model](https://docs.mapbox.com/mapbox-gl-js/example/add-3d-model/)
-     * @see [Add an animated icon to the map](https://docs.mapbox.com/mapbox-gl-js/example/add-image-animated/)
+     * @see [Add a 3D model](https://maplibre.org/maplibre-gl-js-docs/example/add-3d-model/)
+     * @see [Add an animated icon to the map](https://maplibre.org/maplibre-gl-js-docs/example/add-image-animated/)
      */
     triggerRepaint() {
         if (this.style && !this._frame) {

--- a/src/ui/marker.js
+++ b/src/ui/marker.js
@@ -313,7 +313,6 @@ export default class Marker extends Evented {
     *   .addTo(map);
     * @see [Add custom icons with Markers](https://maplibre.org/maplibre-gl-js-docs/example/custom-marker-icons/)
     * @see [Create a draggable Marker](https://maplibre.org/maplibre-gl-js-docs/example/drag-a-marker/)
-    * @see [Add a marker using a place name](https://maplibre.org/maplibre-gl-js-docs/example/marker-from-geocode/)
     */
     setLngLat(lnglat: LngLatLike) {
         this._lngLat = LngLat.convert(lnglat);

--- a/src/ui/marker.js
+++ b/src/ui/marker.js
@@ -52,8 +52,8 @@ type Options = {
  *     draggable: true
  *   }).setLngLat([30.5, 50.5])
  *   .addTo(map);
- * @see [Add custom icons with Markers](https://www.mapbox.com/mapbox-gl-js/example/custom-marker-icons/)
- * @see [Create a draggable Marker](https://www.mapbox.com/mapbox-gl-js/example/drag-a-marker/)
+ * @see [Add custom icons with Markers](https://maplibre.org/maplibre-gl-js-docs/example/custom-marker-icons/)
+ * @see [Create a draggable Marker](https://maplibre.org/maplibre-gl-js-docs/example/drag-a-marker/)
  */
 export default class Marker extends Evented {
     _map: Map;
@@ -296,7 +296,7 @@ export default class Marker extends Evented {
     * var lngLat = marker.getLngLat();
     * // Print the marker's longitude and latitude values in the console
     * console.log('Longitude: ' + lngLat.lng + ', Latitude: ' + lngLat.lat )
-    * @see [Create a draggable Marker](https://docs.mapbox.com/mapbox-gl-js/example/drag-a-marker/)
+    * @see [Create a draggable Marker](https://maplibre.org/maplibre-gl-js-docs/example/drag-a-marker/)
     */
     getLngLat() {
         return this._lngLat;
@@ -311,9 +311,9 @@ export default class Marker extends Evented {
     * new mapboxgl.Marker()
     *   .setLngLat([-65.017, -16.457])
     *   .addTo(map);
-    * @see [Add custom icons with Markers](https://docs.mapbox.com/mapbox-gl-js/example/custom-marker-icons/)
-    * @see [Create a draggable Marker](https://docs.mapbox.com/mapbox-gl-js/example/drag-a-marker/)
-    * @see [Add a marker using a place name](https://docs.mapbox.com/mapbox-gl-js/example/marker-from-geocode/)
+    * @see [Add custom icons with Markers](https://maplibre.org/maplibre-gl-js-docs/example/custom-marker-icons/)
+    * @see [Create a draggable Marker](https://maplibre.org/maplibre-gl-js-docs/example/drag-a-marker/)
+    * @see [Add a marker using a place name](https://maplibre.org/maplibre-gl-js-docs/example/marker-from-geocode/)
     */
     setLngLat(lnglat: LngLatLike) {
         this._lngLat = LngLat.convert(lnglat);
@@ -341,7 +341,7 @@ export default class Marker extends Evented {
      *  .setLngLat([0, 0])
      *  .setPopup(new mapboxgl.Popup().setHTML("<h1>Hello World!</h1>")) // add popup
      *  .addTo(map);
-     * @see [Attach a popup to a marker instance](https://docs.mapbox.com/mapbox-gl-js/example/set-popup/)
+     * @see [Attach a popup to a marker instance](https://maplibre.org/maplibre-gl-js-docs/example/set-popup/)
      */
     setPopup(popup: ?Popup) {
         if (this._popup) {

--- a/src/ui/popup.js
+++ b/src/ui/popup.js
@@ -91,10 +91,10 @@ const focusQuerySelector = [
  *   .setHTML("<h1>Hello World!</h1>")
  *   .setMaxWidth("300px")
  *   .addTo(map);
- * @see [Display a popup](https://www.mapbox.com/mapbox-gl-js/example/popup/)
- * @see [Display a popup on hover](https://www.mapbox.com/mapbox-gl-js/example/popup-on-hover/)
- * @see [Display a popup on click](https://www.mapbox.com/mapbox-gl-js/example/popup-on-click/)
- * @see [Attach a popup to a marker instance](https://www.mapbox.com/mapbox-gl-js/example/set-popup/)
+ * @see [Display a popup](https://maplibre.org/maplibre-gl-js-docs/example/popup/)
+ * @see [Display a popup on hover](https://maplibre.org/maplibre-gl-js-docs/example/popup-on-hover/)
+ * @see [Display a popup on click](https://maplibre.org/maplibre-gl-js-docs/example/popup-on-click/)
+ * @see [Attach a popup to a marker instance](https://maplibre.org/maplibre-gl-js-docs/example/set-popup/)
  */
 export default class Popup extends Evented {
     _map: Map;
@@ -123,10 +123,10 @@ export default class Popup extends Evented {
      *   .setLngLat([0, 0])
      *   .setHTML("<h1>Null Island</h1>")
      *   .addTo(map);
-     * @see [Display a popup](https://docs.mapbox.com/mapbox-gl-js/example/popup/)
-     * @see [Display a popup on hover](https://docs.mapbox.com/mapbox-gl-js/example/popup-on-hover/)
-     * @see [Display a popup on click](https://docs.mapbox.com/mapbox-gl-js/example/popup-on-click/)
-     * @see [Show polygon information on click](https://docs.mapbox.com/mapbox-gl-js/example/polygon-popup-on-click/)
+     * @see [Display a popup](https://maplibre.org/maplibre-gl-js-docs/example/popup/)
+     * @see [Display a popup on hover](https://maplibre.org/maplibre-gl-js-docs/example/popup-on-hover/)
+     * @see [Display a popup on click](https://maplibre.org/maplibre-gl-js-docs/example/popup-on-click/)
+     * @see [Show polygon information on click](https://maplibre.org/maplibre-gl-js-docs/example/polygon-popup-on-click/)
      */
     addTo(map: Map) {
         if (this._map) this.remove();
@@ -355,10 +355,10 @@ export default class Popup extends Evented {
      *   .setLngLat(e.lngLat)
      *   .setHTML("<h1>Hello World!</h1>")
      *   .addTo(map);
-     * @see [Display a popup](https://docs.mapbox.com/mapbox-gl-js/example/popup/)
-     * @see [Display a popup on hover](https://docs.mapbox.com/mapbox-gl-js/example/popup-on-hover/)
-     * @see [Display a popup on click](https://docs.mapbox.com/mapbox-gl-js/example/popup-on-click/)
-     * @see [Attach a popup to a marker instance](https://docs.mapbox.com/mapbox-gl-js/example/set-popup/)
+     * @see [Display a popup](https://maplibre.org/maplibre-gl-js-docs/example/popup/)
+     * @see [Display a popup on hover](https://maplibre.org/maplibre-gl-js-docs/example/popup-on-hover/)
+     * @see [Display a popup on click](https://maplibre.org/maplibre-gl-js-docs/example/popup-on-click/)
+     * @see [Attach a popup to a marker instance](https://maplibre.org/maplibre-gl-js-docs/example/set-popup/)
      */
     setHTML(html: string) {
         const frag = window.document.createDocumentFragment();


### PR DESCRIPTION
## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

This pull requests updates the links to examples in JSDoc comments from Mapbox to MapLibre. The links are defined in the ```@see``` tags and they show up in the [documentation website](https://maplibre.org/maplibre-gl-js-docs/api/).

I did not migrate all existing examples to the new documentation website because some of them were incompatible with ```maplibregl``` or they required a mapbox access token, see https://github.com/maplibre/maplibre-gl-js-docs/pull/36. Links to examples that were not migrated are removed.

 - ✅ confirm your changes do not include backports from Mapbox projects (unless with compliant license)
 - ✅ briefly describe the changes in this PR
 - 🔲 include before/after visuals or gifs if this PR includes visual changes 
 - 🔲 write tests for all new functionality
 - 🔲 document any changes to public APIs
 - 🔲 post benchmark scores
 - 🔲 manually test the debug page
 - 🔲 apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - ✅ add an entry inside this element for inclusion in the `maplibre-gl-js` changelog: `<changelog>Update example links to https://maplibre.org/maplibre-gl-js-docs/</changelog>`
