### PR TITLE
Replace mapboxgl with maplibregl in JSDocs inline examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### Features and improvements
 
 - *...Add new stuff here...*
-- Replace mapboxgl with maplibregl in JSDocs inline examples (#132)
+- Replace mapboxgl with maplibregl in JSDocs inline examples (#134)
 - Update example links to https://maplibre.org/maplibre-gl-js-docs/ (#131)
 - Improve performance of layers with constant `*-sort-key` (#78)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Features and improvements
 
 - *...Add new stuff here...*
+- Replace mapboxgl with maplibregl in JSDocs inline examples (#132)
 - Update example links to https://maplibre.org/maplibre-gl-js-docs/ (#131)
 - Improve performance of layers with constant `*-sort-key` (#78)
 

--- a/src/geo/lng_lat.js
+++ b/src/geo/lng_lat.js
@@ -24,7 +24,7 @@ export const earthRadius = 6371008.8;
  * @param {number} lng Longitude, measured in degrees.
  * @param {number} lat Latitude, measured in degrees.
  * @example
- * var ll = new mapboxgl.LngLat(-123.9749, 40.7736);
+ * var ll = new maplibregl.LngLat(-123.9749, 40.7736);
  * ll.lng; // = -123.9749
  * @see [Get coordinates of the mouse pointer](https://maplibre.org/maplibre-gl-js-docs/example/mouse-position/)
  * @see [Display a popup](https://maplibre.org/maplibre-gl-js-docs/example/popup/)
@@ -50,7 +50,7 @@ class LngLat {
      *
      * @returns {LngLat} The wrapped `LngLat` object.
      * @example
-     * var ll = new mapboxgl.LngLat(286.0251, 40.7736);
+     * var ll = new maplibregl.LngLat(286.0251, 40.7736);
      * var wrapped = ll.wrap();
      * wrapped.lng; // = -73.9749
      */
@@ -63,7 +63,7 @@ class LngLat {
      *
      * @returns {Array<number>} The coordinates represeted as an array of longitude and latitude.
      * @example
-     * var ll = new mapboxgl.LngLat(-73.9749, 40.7736);
+     * var ll = new maplibregl.LngLat(-73.9749, 40.7736);
      * ll.toArray(); // = [-73.9749, 40.7736]
      */
     toArray() {
@@ -75,7 +75,7 @@ class LngLat {
      *
      * @returns {string} The coordinates represented as a string of the format `'LngLat(lng, lat)'`.
      * @example
-     * var ll = new mapboxgl.LngLat(-73.9749, 40.7736);
+     * var ll = new maplibregl.LngLat(-73.9749, 40.7736);
      * ll.toString(); // = "LngLat(-73.9749, 40.7736)"
      */
     toString() {
@@ -89,8 +89,8 @@ class LngLat {
      * @param {LngLat} lngLat coordinates to compute the distance to
      * @returns {number} Distance in meters between the two coordinates.
      * @example
-     * var new_york = new mapboxgl.LngLat(-74.0060, 40.7128);
-     * var los_angeles = new mapboxgl.LngLat(-118.2437, 34.0522);
+     * var new_york = new maplibregl.LngLat(-74.0060, 40.7128);
+     * var los_angeles = new maplibregl.LngLat(-118.2437, 34.0522);
      * new_york.distanceTo(los_angeles); // = 3935751.690893987, "true distance" using a non-spherical approximation is ~3966km
      */
     distanceTo(lngLat: LngLat) {
@@ -109,7 +109,7 @@ class LngLat {
      * @param {number} [radius=0] Distance in meters from the coordinates to extend the bounds.
      * @returns {LngLatBounds} A new `LngLatBounds` object representing the coordinates extended by the `radius`.
      * @example
-     * var ll = new mapboxgl.LngLat(-73.9749, 40.7736);
+     * var ll = new maplibregl.LngLat(-73.9749, 40.7736);
      * ll.toBounds(100).toArray(); // = [[-73.97501862141328, 40.77351016847229], [-73.97478137858673, 40.77368983152771]]
      */
     toBounds(radius?: number = 0) {
@@ -131,7 +131,7 @@ class LngLat {
      * @returns {LngLat} A new `LngLat` object, if a conversion occurred, or the original `LngLat` object.
      * @example
      * var arr = [-73.9749, 40.7736];
-     * var ll = mapboxgl.LngLat.convert(arr);
+     * var ll = maplibregl.LngLat.convert(arr);
      * ll;   // = LngLat {lng: -73.9749, lat: 40.7736}
      */
     static convert(input: LngLatLike): LngLat {
@@ -158,7 +158,7 @@ class LngLat {
  *
  * @typedef {LngLat | {lng: number, lat: number} | {lon: number, lat: number} | [number, number]} LngLatLike
  * @example
- * var v1 = new mapboxgl.LngLat(-122.420679, 37.772537);
+ * var v1 = new maplibregl.LngLat(-122.420679, 37.772537);
  * var v2 = [-122.420679, 37.772537];
  * var v3 = {lon: -122.420679, lat: 37.772537};
  */

--- a/src/geo/lng_lat_bounds.js
+++ b/src/geo/lng_lat_bounds.js
@@ -17,9 +17,9 @@ import type {LngLatLike} from './lng_lat';
  * @param {LngLatLike} [sw] The southwest corner of the bounding box.
  * @param {LngLatLike} [ne] The northeast corner of the bounding box.
  * @example
- * var sw = new mapboxgl.LngLat(-73.9876, 40.7661);
- * var ne = new mapboxgl.LngLat(-73.9397, 40.8002);
- * var llb = new mapboxgl.LngLatBounds(sw, ne);
+ * var sw = new maplibregl.LngLat(-73.9876, 40.7661);
+ * var ne = new maplibregl.LngLat(-73.9397, 40.8002);
+ * var llb = new maplibregl.LngLatBounds(sw, ne);
  */
 class LngLatBounds {
     _ne: LngLat;
@@ -113,7 +113,7 @@ class LngLatBounds {
      *
      * @returns {LngLat} The bounding box's center.
      * @example
-     * var llb = new mapboxgl.LngLatBounds([-73.9876, 40.7661], [-73.9397, 40.8002]);
+     * var llb = new maplibregl.LngLatBounds([-73.9876, 40.7661], [-73.9397, 40.8002]);
      * llb.getCenter(); // = LngLat {lng: -73.96365, lat: 40.78315}
      */
     getCenter(): LngLat {
@@ -182,7 +182,7 @@ class LngLatBounds {
      * @returns {Array<Array<number>>} The bounding box represented as an array, consisting of the
      *   southwest and northeast coordinates of the bounding represented as arrays of numbers.
      * @example
-     * var llb = new mapboxgl.LngLatBounds([-73.9876, 40.7661], [-73.9397, 40.8002]);
+     * var llb = new maplibregl.LngLatBounds([-73.9876, 40.7661], [-73.9397, 40.8002]);
      * llb.toArray(); // = [[-73.9876, 40.7661], [-73.9397, 40.8002]]
      */
     toArray() {
@@ -195,7 +195,7 @@ class LngLatBounds {
      * @returns {string} The bounding box represents as a string of the format
      *   `'LngLatBounds(LngLat(lng, lat), LngLat(lng, lat))'`.
      * @example
-     * var llb = new mapboxgl.LngLatBounds([-73.9876, 40.7661], [-73.9397, 40.8002]);
+     * var llb = new maplibregl.LngLatBounds([-73.9876, 40.7661], [-73.9397, 40.8002]);
      * llb.toString(); // = "LngLatBounds(LngLat(-73.9876, 40.7661), LngLat(-73.9397, 40.8002))"
      */
     toString() {
@@ -217,12 +217,12 @@ class LngLatBounds {
     * @param {LngLatLike} lnglat geographic point to check against.
     * @returns {boolean} True if the point is within the bounding box.
     * @example
-    * var llb = new mapboxgl.LngLatBounds(
-    *   new mapboxgl.LngLat(-73.9876, 40.7661),
-    *   new mapboxgl.LngLat(-73.9397, 40.8002)
+    * var llb = new maplibregl.LngLatBounds(
+    *   new maplibregl.LngLat(-73.9876, 40.7661),
+    *   new maplibregl.LngLat(-73.9397, 40.8002)
     * );
     *
-    * var ll = new mapboxgl.LngLat(-73.9567, 40.7789);
+    * var ll = new maplibregl.LngLat(-73.9567, 40.7789);
     *
     * console.log(llb.contains(ll)); // = true
     */
@@ -249,7 +249,7 @@ class LngLatBounds {
      * @returns {LngLatBounds} A new `LngLatBounds` object, if a conversion occurred, or the original `LngLatBounds` object.
      * @example
      * var arr = [[-73.9876, 40.7661], [-73.9397, 40.8002]];
-     * var llb = mapboxgl.LngLatBounds.convert(arr);
+     * var llb = maplibregl.LngLatBounds.convert(arr);
      * llb;   // = LngLatBounds {_sw: LngLat {lng: -73.9876, lat: 40.7661}, _ne: LngLat {lng: -73.9397, lat: 40.8002}}
      */
     static convert(input: LngLatBoundsLike): LngLatBounds {
@@ -264,11 +264,11 @@ class LngLatBounds {
  *
  * @typedef {LngLatBounds | [LngLatLike, LngLatLike] | [number, number, number, number]} LngLatBoundsLike
  * @example
- * var v1 = new mapboxgl.LngLatBounds(
- *   new mapboxgl.LngLat(-73.9876, 40.7661),
- *   new mapboxgl.LngLat(-73.9397, 40.8002)
+ * var v1 = new maplibregl.LngLatBounds(
+ *   new maplibregl.LngLat(-73.9876, 40.7661),
+ *   new maplibregl.LngLat(-73.9397, 40.8002)
  * );
- * var v2 = new mapboxgl.LngLatBounds([-73.9876, 40.7661], [-73.9397, 40.8002])
+ * var v2 = new maplibregl.LngLatBounds([-73.9876, 40.7661], [-73.9397, 40.8002])
  * var v3 = [[-73.9876, 40.7661], [-73.9397, 40.8002]];
  */
 export type LngLatBoundsLike = LngLatBounds | [LngLatLike, LngLatLike] | [number, number, number, number];

--- a/src/geo/mercator_coordinate.js
+++ b/src/geo/mercator_coordinate.js
@@ -72,7 +72,7 @@ export function mercatorScale(lat: number) {
  * @param {number} y The y component of the position.
  * @param {number} z The z component of the position.
  * @example
- * var nullIsland = new mapboxgl.MercatorCoordinate(0.5, 0.5, 0);
+ * var nullIsland = new maplibregl.MercatorCoordinate(0.5, 0.5, 0);
  *
  * @see [Add a custom style layer](https://maplibre.org/maplibre-gl-js-docs/example/custom-style-layer/)
  */
@@ -94,7 +94,7 @@ class MercatorCoordinate {
      * @param {number} altitude The altitude in meters of the position.
      * @returns {MercatorCoordinate} The projected mercator coordinate.
      * @example
-     * var coord = mapboxgl.MercatorCoordinate.fromLngLat({ lng: 0, lat: 0}, 0);
+     * var coord = maplibregl.MercatorCoordinate.fromLngLat({ lng: 0, lat: 0}, 0);
      * coord; // MercatorCoordinate(0.5, 0.5, 0)
      */
     static fromLngLat(lngLatLike: LngLatLike, altitude: number = 0) {
@@ -111,7 +111,7 @@ class MercatorCoordinate {
      *
      * @returns {LngLat} The `LngLat` object.
      * @example
-     * var coord = new mapboxgl.MercatorCoordinate(0.5, 0.5, 0);
+     * var coord = new maplibregl.MercatorCoordinate(0.5, 0.5, 0);
      * var lngLat = coord.toLngLat(); // LngLat(0, 0)
      */
     toLngLat() {
@@ -125,7 +125,7 @@ class MercatorCoordinate {
      *
      * @returns {number} The altitude in meters.
      * @example
-     * var coord = new mapboxgl.MercatorCoordinate(0, 0, 0.02);
+     * var coord = new maplibregl.MercatorCoordinate(0, 0, 0.02);
      * coord.toAltitude(); // 6914.281956295339
      */
     toAltitude() {

--- a/src/index.js
+++ b/src/index.js
@@ -49,7 +49,7 @@ const exported = {
     config,
     /**
      * Initializes resources like WebWorkers that can be shared across maps to lower load
-     * times in some situations. `mapboxgl.workerUrl` and `mapboxgl.workerCount`, if being
+     * times in some situations. `maplibregl.workerUrl` and `maplibregl.workerCount`, if being
      * used, must be set before `prewarm()` is called to have an effect.
      *
      * By default, the lifecycle of these resources is managed automatically, and they are
@@ -57,7 +57,7 @@ const exported = {
      * resources will be created ahead of time, and will not be cleared when the last Map
      * is removed from the page. This allows them to be re-used by new Map instances that
      * are created later. They can be manually cleared by calling
-     * `mapboxgl.clearPrewarmedResources()`. This is only necessary if your web page remains
+     * `maplibregl.clearPrewarmedResources()`. This is only necessary if your web page remains
      * active but stops using maps altogether.
      *
      * This is primarily useful when using GL-JS maps in a single page app, wherein a user
@@ -66,18 +66,18 @@ const exported = {
      *
      * @function prewarm
      * @example
-     * mapboxgl.prewarm()
+     * maplibregl.prewarm()
      */
     prewarm,
     /**
-     * Clears up resources that have previously been created by `mapboxgl.prewarm()`.
+     * Clears up resources that have previously been created by `maplibregl.prewarm()`.
      * Note that this is typically not necessary. You should only call this function
      * if you expect the user of your app to not return to a Map view at any point
      * in your application.
      *
      * @function clearPrewarmedResources
      * @example
-     * mapboxgl.clearPrewarmedResources()
+     * maplibregl.clearPrewarmedResources()
      */
     clearPrewarmedResources,
 
@@ -87,7 +87,7 @@ const exported = {
      * @var {string} accessToken
      * @returns {string} The currently set access token.
      * @example
-     * mapboxgl.accessToken = myAccessToken;
+     * maplibregl.accessToken = myAccessToken;
      * @see [Display a map](https://maplibre.org/maplibre-gl-js-docs/examples/)
      */
     get accessToken(): ?string {
@@ -104,7 +104,7 @@ const exported = {
      * @var {string} baseApiUrl
      * @returns {string} The current base API URL.
      * @example
-     * mapboxgl.baseApiUrl = 'https://api.mapbox.com';
+     * maplibregl.baseApiUrl = 'https://api.mapbox.com';
      */
     get baseApiUrl(): ?string {
         return config.API_URL;
@@ -122,7 +122,7 @@ const exported = {
      * @var {string} workerCount
      * @returns {number} Number of workers currently configured.
      * @example
-     * mapboxgl.workerCount = 2;
+     * maplibregl.workerCount = 2;
      */
     get workerCount(): number {
         return WorkerPool.workerCount;
@@ -139,7 +139,7 @@ const exported = {
      * @var {string} maxParallelImageRequests
      * @returns {number} Number of parallel requests currently configured.
      * @example
-     * mapboxgl.maxParallelImageRequests = 10;
+     * maplibregl.maxParallelImageRequests = 10;
      */
     get maxParallelImageRequests(): number {
         return config.MAX_PARALLEL_IMAGE_REQUESTS;
@@ -164,7 +164,7 @@ const exported = {
      * @function clearStorage
      * @param {Function} callback Called with an error argument if there is an error.
      * @example
-     * mapboxgl.clearStorage();
+     * maplibregl.clearStorage();
      */
     clearStorage(callback?: (err: ?Error) => void) {
         clearTileCache(callback);
@@ -194,7 +194,7 @@ Debug.extend(exported, {isSafari, getPerformanceMetrics: PerformanceUtils.getPer
  * @return {boolean}
  * @example
  * // Show an alert if the browser does not support Mapbox GL
- * if (!mapboxgl.supported()) {
+ * if (!maplibregl.supported()) {
  *   alert('Your browser does not support Mapbox GL');
  * }
  * @see [Check for browser support](https://maplibre.org/maplibre-gl-js-docs/example/check-for-support/)
@@ -210,7 +210,7 @@ Debug.extend(exported, {isSafari, getPerformanceMetrics: PerformanceUtils.getPer
  * @param {boolean} lazy If set to `true`, mapboxgl will defer loading the plugin until rtl text is encountered,
  *    rtl text will then be rendered only after the plugin finishes loading.
  * @example
- * mapboxgl.setRTLTextPlugin('https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-rtl-text/v0.2.0/mapbox-gl-rtl-text.js');
+ * maplibregl.setRTLTextPlugin('https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-rtl-text/v0.2.0/mapbox-gl-rtl-text.js');
  * @see [Add support for right-to-left scripts](https://maplibre.org/maplibre-gl-js-docs/example/mapbox-gl-rtl-text/)
  */
 
@@ -221,7 +221,7 @@ Debug.extend(exported, {isSafari, getPerformanceMetrics: PerformanceUtils.getPer
   *
   * @function getRTLTextPluginStatus
   * @example
-  * const pluginStatus = mapboxgl.getRTLTextPluginStatus();
+  * const pluginStatus = maplibregl.getRTLTextPluginStatus();
   */
 
 export default exported;

--- a/src/ui/camera.js
+++ b/src/ui/camera.js
@@ -43,7 +43,7 @@ import type {PaddingOptions} from '../geo/edge_insets';
  * @property {PaddingOptions} padding Dimensions in pixels applied on each side of the viewport for shifting the vanishing point.
  * @example
  * // set the map's initial perspective with CameraOptions
- * var map = new mapboxgl.Map({
+ * var map = new maplibregl.Map({
  *   container: 'map',
  *   style: 'mapbox://styles/mapbox/streets-v11',
  *   center: [-73.5804, 45.53483],

--- a/src/ui/control/attribution_control.js
+++ b/src/ui/control/attribution_control.js
@@ -19,8 +19,8 @@ type Options = {
  * @param {boolean} [options.compact] If `true`, force a compact attribution that shows the full attribution on mouse hover. If `false`, force the full attribution control. The default is a responsive attribution that collapses when the map is less than 640 pixels wide. **Attribution should not be collapsed if it can comfortably fit on the map. `compact` should only be used to modify default attribution when map size makes it impossible to fit [default attribution](https://docs.mapbox.com/help/how-mapbox-works/attribution/) and when the automatic compact resizing for default settings are not sufficient.**
  * @param {string | Array<string>} [options.customAttribution] String or strings to show in addition to any other attributions.
  * @example
- * var map = new mapboxgl.Map({attributionControl: false})
- *     .addControl(new mapboxgl.AttributionControl({
+ * var map = new maplibregl.Map({attributionControl: false})
+ *     .addControl(new maplibregl.AttributionControl({
  *         compact: true
  *     }));
  */

--- a/src/ui/control/fullscreen_control.js
+++ b/src/ui/control/fullscreen_control.js
@@ -19,7 +19,7 @@ type Options = {
  * @param {HTMLElement} [options.container] `container` is the [compatible DOM element](https://developer.mozilla.org/en-US/docs/Web/API/Element/requestFullScreen#Compatible_elements) which should be made full screen. By default, the map container element will be made full screen.
  *
  * @example
- * map.addControl(new mapboxgl.FullscreenControl({container: document.querySelector('body')}));
+ * map.addControl(new maplibregl.FullscreenControl({container: document.querySelector('body')}));
  * @see [View a fullscreen map](https://maplibre.org/maplibre-gl-js-docs/example/fullscreen/)
  */
 

--- a/src/ui/control/geolocate_control.js
+++ b/src/ui/control/geolocate_control.js
@@ -86,7 +86,7 @@ let noTimeout = false;
  * @param {Object} [options.showUserLocation=true] By default a dot will be shown on the map at the user's location. Set to `false` to disable.
  *
  * @example
- * map.addControl(new mapboxgl.GeolocateControl({
+ * map.addControl(new maplibregl.GeolocateControl({
  *     positionOptions: {
  *         enableHighAccuracy: true
  *     },
@@ -436,7 +436,7 @@ class GeolocateControl extends Evented {
     * @returns {boolean} Returns `false` if called before control was added to a map, otherwise returns `true`.
     * @example
     * // Initialize the geolocate control.
-    * var geolocate = new mapboxgl.GeolocateControl({
+    * var geolocate = new maplibregl.GeolocateControl({
     *  positionOptions: {
     *    enableHighAccuracy: true
     *  },
@@ -592,7 +592,7 @@ export default GeolocateControl;
  * @property {Position} data The returned [Position](https://developer.mozilla.org/en-US/docs/Web/API/Position) object from the callback in [Geolocation.getCurrentPosition()](https://developer.mozilla.org/en-US/docs/Web/API/Geolocation/getCurrentPosition) or [Geolocation.watchPosition()](https://developer.mozilla.org/en-US/docs/Web/API/Geolocation/watchPosition).
  * @example
  * // Initialize the geolocate control.
- * var geolocate = new mapboxgl.GeolocateControl({
+ * var geolocate = new maplibregl.GeolocateControl({
  *   positionOptions: {
  *       enableHighAccuracy: true
  *   },
@@ -617,7 +617,7 @@ export default GeolocateControl;
  * @property {PositionError} data The returned [PositionError](https://developer.mozilla.org/en-US/docs/Web/API/PositionError) object from the callback in [Geolocation.getCurrentPosition()](https://developer.mozilla.org/en-US/docs/Web/API/Geolocation/getCurrentPosition) or [Geolocation.watchPosition()](https://developer.mozilla.org/en-US/docs/Web/API/Geolocation/watchPosition).
  * @example
  * // Initialize the geolocate control.
- * var geolocate = new mapboxgl.GeolocateControl({
+ * var geolocate = new maplibregl.GeolocateControl({
  *   positionOptions: {
  *       enableHighAccuracy: true
  *   },
@@ -642,7 +642,7 @@ export default GeolocateControl;
  * @property {Position} data The returned [Position](https://developer.mozilla.org/en-US/docs/Web/API/Position) object from the callback in [Geolocation.getCurrentPosition()](https://developer.mozilla.org/en-US/docs/Web/API/Geolocation/getCurrentPosition) or [Geolocation.watchPosition()](https://developer.mozilla.org/en-US/docs/Web/API/Geolocation/watchPosition).
  * @example
  * // Initialize the geolocate control.
- * var geolocate = new mapboxgl.GeolocateControl({
+ * var geolocate = new maplibregl.GeolocateControl({
  *   positionOptions: {
  *       enableHighAccuracy: true
  *   },
@@ -666,7 +666,7 @@ export default GeolocateControl;
  * @instance
  * @example
  * // Initialize the geolocate control.
- * var geolocate = new mapboxgl.GeolocateControl({
+ * var geolocate = new maplibregl.GeolocateControl({
  *   positionOptions: {
  *       enableHighAccuracy: true
  *   },
@@ -690,7 +690,7 @@ export default GeolocateControl;
  * @instance
  * @example
  * // Initialize the geolocate control.
- * var geolocate = new mapboxgl.GeolocateControl({
+ * var geolocate = new maplibregl.GeolocateControl({
  *   positionOptions: {
  *       enableHighAccuracy: true
  *   },

--- a/src/ui/control/navigation_control.js
+++ b/src/ui/control/navigation_control.js
@@ -28,7 +28,7 @@ const defaultOptions: Options = {
  * @param {Boolean} [options.showZoom=true] If `true` the zoom-in and zoom-out buttons are included.
  * @param {Boolean} [options.visualizePitch=false] If `true` the pitch is visualized by rotating X-axis of compass.
  * @example
- * var nav = new mapboxgl.NavigationControl();
+ * var nav = new maplibregl.NavigationControl();
  * map.addControl(nav, 'top-left');
  * @see [Display map navigation controls](https://maplibre.org/maplibre-gl-js-docs/example/navigation/)
  * @see [Add a third party vector tile source](https://maplibre.org/maplibre-gl-js-docs/example/third-party/)

--- a/src/ui/control/scale_control.js
+++ b/src/ui/control/scale_control.js
@@ -25,7 +25,7 @@ const defaultOptions: Options = {
  * @param {number} [options.maxWidth='100'] The maximum length of the scale control in pixels.
  * @param {string} [options.unit='metric'] Unit of the distance (`'imperial'`, `'metric'` or `'nautical'`).
  * @example
- * var scale = new mapboxgl.ScaleControl({
+ * var scale = new maplibregl.ScaleControl({
  *     maxWidth: 80,
  *     unit: 'imperial'
  * });

--- a/src/ui/events.js
+++ b/src/ui/events.js
@@ -302,14 +302,14 @@ export type MapEvent =
      * @property {MapMouseEvent} data
      * @example
      * // Initialize the map
-     * var map = new mapboxgl.Map({ // map options });
+     * var map = new maplibregl.Map({ // map options });
      * // Set an event listener
      * map.on('mousedown', function() {
      *   console.log('A mousedown event has occurred.');
      * });
      * @example
      * // Initialize the map
-     * var map = new mapboxgl.Map({ // map options });
+     * var map = new maplibregl.Map({ // map options });
      * // Set an event listener for a specific layer
      * map.on('mousedown', 'poi-label', function() {
      *   console.log('A mousedown event has occurred on a visible portion of the poi-label layer.');
@@ -331,14 +331,14 @@ export type MapEvent =
      * @property {MapMouseEvent} data
      * @example
      * // Initialize the map
-     * var map = new mapboxgl.Map({ // map options });
+     * var map = new maplibregl.Map({ // map options });
      * // Set an event listener
      * map.on('mouseup', function() {
      *   console.log('A mouseup event has occurred.');
      * });
      * @example
      * // Initialize the map
-     * var map = new mapboxgl.Map({ // map options });
+     * var map = new maplibregl.Map({ // map options });
      * // Set an event listener for a specific layer
      * map.on('mouseup', 'poi-label', function() {
      *   console.log('A mouseup event has occurred on a visible portion of the poi-label layer.');
@@ -362,14 +362,14 @@ export type MapEvent =
      * @property {MapMouseEvent} data
      * @example
      * // Initialize the map
-     * var map = new mapboxgl.Map({ // map options });
+     * var map = new maplibregl.Map({ // map options });
      * // Set an event listener
      * map.on('mouseover', function() {
      *   console.log('A mouseover event has occurred.');
      * });
      * @example
      * // Initialize the map
-     * var map = new mapboxgl.Map({ // map options });
+     * var map = new maplibregl.Map({ // map options });
      * // Set an event listener for a specific layer
      * map.on('mouseover', 'poi-label', function() {
      *   console.log('A mouseover event has occurred on a visible portion of the poi-label layer.');
@@ -394,14 +394,14 @@ export type MapEvent =
      * @property {MapMouseEvent} data
      * @example
      * // Initialize the map
-     * var map = new mapboxgl.Map({ // map options });
+     * var map = new maplibregl.Map({ // map options });
      * // Set an event listener
      * map.on('mousemove', function() {
      *   console.log('A mousemove event has occurred.');
      * });
      * @example
      * // Initialize the map
-     * var map = new mapboxgl.Map({ // map options });
+     * var map = new maplibregl.Map({ // map options });
      * // Set an event listener for a specific layer
      * map.on('mousemove', 'poi-label', function() {
      *   console.log('A mousemove event has occurred on a visible portion of the poi-label layer.');
@@ -425,14 +425,14 @@ export type MapEvent =
      * @property {MapMouseEvent} data
      * @example
      * // Initialize the map
-     * var map = new mapboxgl.Map({ // map options });
+     * var map = new maplibregl.Map({ // map options });
      * // Set an event listener
      * map.on('click', function(e) {
      *   console.log('A click event has occurred at ' + e.lngLat);
      * });
      * @example
      * // Initialize the map
-     * var map = new mapboxgl.Map({ // map options });
+     * var map = new maplibregl.Map({ // map options });
      * // Set an event listener for a specific layer
      * map.on('click', 'poi-label', function(e) {
      *   console.log('A click event has occurred on a visible portion of the poi-label layer at ' + e.lngLat);
@@ -456,14 +456,14 @@ export type MapEvent =
      * @property {MapMouseEvent} data
      * @example
      * // Initialize the map
-     * var map = new mapboxgl.Map({ // map options });
+     * var map = new maplibregl.Map({ // map options });
      * // Set an event listener
      * map.on('dblclick', function(e) {
      *   console.log('A dblclick event has occurred at ' + e.lngLat);
      * });
      * @example
      * // Initialize the map
-     * var map = new mapboxgl.Map({ // map options });
+     * var map = new maplibregl.Map({ // map options });
      * // Set an event listener for a specific layer
      * map.on('dblclick', 'poi-label', function(e) {
      *   console.log('A dblclick event has occurred on a visible portion of the poi-label layer at ' + e.lngLat);
@@ -484,7 +484,7 @@ export type MapEvent =
      * @property {MapMouseEvent} data
      * @example
      * // Initialize the map
-     * var map = new mapboxgl.Map({ // map options });
+     * var map = new maplibregl.Map({ // map options });
      * // Set an event listener
      * map.on('mouseenter', 'water', function() {
      *   console.log('A mouseenter event occurred on a visible portion of the water layer.');
@@ -507,7 +507,7 @@ export type MapEvent =
      * @property {MapMouseEvent} data
      * @example
      * // Initialize the map
-     * var map = new mapboxgl.Map({ // map options });
+     * var map = new maplibregl.Map({ // map options });
      * // Set an event listener that fires
      * // when the pointing device leaves
      * // a visible portion of the specified layer.
@@ -528,7 +528,7 @@ export type MapEvent =
      * @property {MapMouseEvent} data
      * @example
      * // Initialize the map
-     * var map = new mapboxgl.Map({ // map options });
+     * var map = new maplibregl.Map({ // map options });
      * // Set an event listener that fires
      * // when the pointing device leave's
      * // the map's canvas.
@@ -547,7 +547,7 @@ export type MapEvent =
      * @property {MapMouseEvent} data
      * @example
      * // Initialize the map
-     * var map = new mapboxgl.Map({ // map options });
+     * var map = new maplibregl.Map({ // map options });
      * // Set an event listener that fires
      * // when the right mouse button is
      * // pressed within the map.
@@ -566,7 +566,7 @@ export type MapEvent =
      * @property {MapWheelEvent} data
      * @example
      * // Initialize the map
-     * var map = new mapboxgl.Map({ // map options });
+     * var map = new maplibregl.Map({ // map options });
      * // Set an event listener that fires
      * // when a wheel event occurs within the map.
      * map.on('wheel', function() {
@@ -583,7 +583,7 @@ export type MapEvent =
      * @instance
      * @property {MapTouchEvent} data
      * // Initialize the map
-     * var map = new mapboxgl.Map({ // map options });
+     * var map = new maplibregl.Map({ // map options });
      * // Set an event listener that fires
      * // when a touchstart event occurs within the map.
      * map.on('touchstart', function() {
@@ -602,7 +602,7 @@ export type MapEvent =
      * @property {MapTouchEvent} data
      * @example
      * // Initialize the map
-     * var map = new mapboxgl.Map({ // map options });
+     * var map = new maplibregl.Map({ // map options });
      * // Set an event listener that fires
      * // when a touchstart event occurs within the map.
      * map.on('touchstart', function() {
@@ -621,7 +621,7 @@ export type MapEvent =
      * @property {MapTouchEvent} data
      * @example
      * // Initialize the map
-     * var map = new mapboxgl.Map({ // map options });
+     * var map = new maplibregl.Map({ // map options });
      * // Set an event listener that fires
      * // when a touchmove event occurs within the map.
      * map.on('touchmove', function() {
@@ -640,7 +640,7 @@ export type MapEvent =
      * @property {MapTouchEvent} data
      * @example
      * // Initialize the map
-     * var map = new mapboxgl.Map({ // map options });
+     * var map = new maplibregl.Map({ // map options });
      * // Set an event listener that fires
      * // when a touchcancel event occurs within the map.
      * map.on('touchcancel', function() {
@@ -659,7 +659,7 @@ export type MapEvent =
      * @property {{originalEvent: DragEvent}} data
      * @example
      * // Initialize the map
-     * var map = new mapboxgl.Map({ // map options });
+     * var map = new maplibregl.Map({ // map options });
      * // Set an event listener that fires
      * // just before the map begins a transition
      * // from one view to another.
@@ -679,7 +679,7 @@ export type MapEvent =
      * @property {MapMouseEvent | MapTouchEvent} data
      * @example
      * // Initialize the map
-     * var map = new mapboxgl.Map({ // map options });
+     * var map = new maplibregl.Map({ // map options });
      * // Set an event listener that fires
      * // repeatedly during an animated transition.
      * map.on('move', function() {
@@ -699,7 +699,7 @@ export type MapEvent =
      * @property {{originalEvent: DragEvent}} data
      * @example
      * // Initialize the map
-     * var map = new mapboxgl.Map({ // map options });
+     * var map = new maplibregl.Map({ // map options });
      * // Set an event listener that fires
      * // just after the map completes a transition.
      * map.on('moveend', function() {
@@ -718,7 +718,7 @@ export type MapEvent =
      * @property {{originalEvent: DragEvent}} data
      * @example
      * // Initialize the map
-     * var map = new mapboxgl.Map({ // map options });
+     * var map = new maplibregl.Map({ // map options });
      * // Set an event listener that fires
      * // when a "drag to pan" interaction starts.
      * map.on('dragstart', function() {
@@ -736,7 +736,7 @@ export type MapEvent =
      * @property {MapMouseEvent | MapTouchEvent} data
      * @example
      * // Initialize the map
-     * var map = new mapboxgl.Map({ // map options });
+     * var map = new maplibregl.Map({ // map options });
      * // Set an event listener that fires
      * // repeatedly  during a "drag to pan" interaction.
      * map.on('drag', function() {
@@ -754,7 +754,7 @@ export type MapEvent =
      * @property {{originalEvent: DragEvent}} data
      * @example
      * // Initialize the map
-     * var map = new mapboxgl.Map({ // map options });
+     * var map = new maplibregl.Map({ // map options });
      * // Set an event listener that fires
      * // when a "drag to pan" interaction ends.
      * map.on('dragend', function() {
@@ -774,7 +774,7 @@ export type MapEvent =
      * @property {MapMouseEvent | MapTouchEvent} data
      * @example
      * // Initialize the map
-     * var map = new mapboxgl.Map({ // map options });
+     * var map = new maplibregl.Map({ // map options });
      * // Set an event listener that fires
      * // just before a zoom transition starts.
      * map.on('zoomstart', function() {
@@ -793,7 +793,7 @@ export type MapEvent =
      * @property {MapMouseEvent | MapTouchEvent} data
      * @example
      * // Initialize the map
-     * var map = new mapboxgl.Map({ // map options });
+     * var map = new maplibregl.Map({ // map options });
      * // Set an event listener that fires
      * // repeatedly during a zoom transition.
      * map.on('zoom', function() {
@@ -812,7 +812,7 @@ export type MapEvent =
      * @property {MapMouseEvent | MapTouchEvent} data
      * @example
      * // Initialize the map
-     * var map = new mapboxgl.Map({ // map options });
+     * var map = new maplibregl.Map({ // map options });
      * // Set an event listener that fires
      * // just after a zoom transition finishes.
      * map.on('zoomend', function() {
@@ -830,7 +830,7 @@ export type MapEvent =
      * @property {MapMouseEvent | MapTouchEvent} data
      * @example
      * // Initialize the map
-     * var map = new mapboxgl.Map({ // map options });
+     * var map = new maplibregl.Map({ // map options });
      * // Set an event listener that fires
      * // just before a "drag to rotate" interaction starts.
      * map.on('rotatestart', function() {
@@ -848,7 +848,7 @@ export type MapEvent =
      * @property {MapMouseEvent | MapTouchEvent} data
      * @example
      * // Initialize the map
-     * var map = new mapboxgl.Map({ // map options });
+     * var map = new maplibregl.Map({ // map options });
      * // Set an event listener that fires
      * // repeatedly during "drag to rotate" interaction.
      * map.on('rotate', function() {
@@ -866,7 +866,7 @@ export type MapEvent =
      * @property {MapMouseEvent | MapTouchEvent} data
      * @example
      * // Initialize the map
-     * var map = new mapboxgl.Map({ // map options });
+     * var map = new maplibregl.Map({ // map options });
      * // Set an event listener that fires
      * // just after a "drag to rotate" interaction ends.
      * map.on('rotateend', function() {
@@ -885,7 +885,7 @@ export type MapEvent =
      * @property {MapEventData} data
      * @example
      * // Initialize the map
-     * var map = new mapboxgl.Map({ // map options });
+     * var map = new maplibregl.Map({ // map options });
      * // Set an event listener that fires
      * // just before a pitch (tilt) transition starts.
      * map.on('pitchstart', function() {
@@ -905,7 +905,7 @@ export type MapEvent =
      * @property {MapEventData} data
      * @example
      * // Initialize the map
-     * var map = new mapboxgl.Map({ // map options });
+     * var map = new maplibregl.Map({ // map options });
      * // Set an event listener that fires
      * // repeatedly during a pitch (tilt) transition.
      * map.on('pitch', function() {
@@ -924,7 +924,7 @@ export type MapEvent =
      * @property {MapEventData} data
      * @example
      * // Initialize the map
-     * var map = new mapboxgl.Map({ // map options });
+     * var map = new maplibregl.Map({ // map options });
      * // Set an event listener that fires
      * // just after a pitch (tilt) transition ends.
      * map.on('pitchend', function() {
@@ -942,7 +942,7 @@ export type MapEvent =
      * @property {MapBoxZoomEvent} data
      * @example
      * // Initialize the map
-     * var map = new mapboxgl.Map({ // map options });
+     * var map = new maplibregl.Map({ // map options });
      * // Set an event listener that fires
      * // just before a "box zoom" interaction starts.
      * map.on('boxzoomstart', function() {
@@ -961,7 +961,7 @@ export type MapEvent =
      * @property {MapBoxZoomEvent} data
      * @example
      * // Initialize the map
-     * var map = new mapboxgl.Map({ // map options });
+     * var map = new maplibregl.Map({ // map options });
      * // Set an event listener that fires
      * // just after a "box zoom" interaction ends.
      * map.on('boxzoomend', function() {
@@ -980,7 +980,7 @@ export type MapEvent =
      * @property {MapBoxZoomEvent} data
      * @example
      * // Initialize the map
-     * var map = new mapboxgl.Map({ // map options });
+     * var map = new maplibregl.Map({ // map options });
      * // Set an event listener that fires
      * // the user cancels a "box zoom" interaction.
      * map.on('boxzoomcancel', function() {
@@ -997,7 +997,7 @@ export type MapEvent =
      * @instance
      * @example
      * // Initialize the map
-     * var map = new mapboxgl.Map({ // map options });
+     * var map = new maplibregl.Map({ // map options });
      * // Set an event listener that fires
      * // immediately after the map has been resized.
      * map.on('resize', function() {
@@ -1014,7 +1014,7 @@ export type MapEvent =
      * @instance
      * @example
      * // Initialize the map
-     * var map = new mapboxgl.Map({ // map options });
+     * var map = new maplibregl.Map({ // map options });
      * // Set an event listener that fires
      * // when the WebGL context is lost.
      * map.on('webglcontextlost', function() {
@@ -1031,7 +1031,7 @@ export type MapEvent =
      * @instance
      * @example
      * // Initialize the map
-     * var map = new mapboxgl.Map({ // map options });
+     * var map = new maplibregl.Map({ // map options });
      * // Set an event listener that fires
      * // when the WebGL context is restored.
      * map.on('webglcontextrestored', function() {
@@ -1050,7 +1050,7 @@ export type MapEvent =
      * @type {Object}
      * @example
      * // Initialize the map
-     * var map = new mapboxgl.Map({ // map options });
+     * var map = new maplibregl.Map({ // map options });
      * // Set an event listener that fires
      * // when the map has finished loading.
      * map.on('load', function() {
@@ -1075,7 +1075,7 @@ export type MapEvent =
      * @instance
      * @example
      * // Initialize the map
-     * var map = new mapboxgl.Map({ // map options });
+     * var map = new maplibregl.Map({ // map options });
      * // Set an event listener that fires
      * // whenever the map is drawn to the screen.
      * map.on('render', function() {
@@ -1097,7 +1097,7 @@ export type MapEvent =
      * @instance
      * @example
      * // Initialize the map
-     * var map = new mapboxgl.Map({ // map options });
+     * var map = new maplibregl.Map({ // map options });
      * // Set an event listener that fires
      * // just before the map enters an "idle" state.
      * map.on('idle', function() {
@@ -1114,7 +1114,7 @@ export type MapEvent =
      * @instance
      * @example
      * // Initialize the map
-     * var map = new mapboxgl.Map({ // map options });
+     * var map = new maplibregl.Map({ // map options });
      * // Set an event listener that fires
      * // just after the map is removed.
      * map.on('remove', function() {
@@ -1135,7 +1135,7 @@ export type MapEvent =
      * @property {{error: {message: string}}} data
      * @example
      * // Initialize the map
-     * var map = new mapboxgl.Map({ // map options });
+     * var map = new maplibregl.Map({ // map options });
      * // Set an event listener that fires
      * // when an error occurs.
      * map.on('error', function() {
@@ -1154,7 +1154,7 @@ export type MapEvent =
      * @property {MapDataEvent} data
      * @example
      * // Initialize the map
-     * var map = new mapboxgl.Map({ // map options });
+     * var map = new maplibregl.Map({ // map options });
      * // Set an event listener that fires
      * // when map data loads or changes.
      * map.on('data', function() {
@@ -1174,7 +1174,7 @@ export type MapEvent =
      * @property {MapDataEvent} data
      * @example
      * // Initialize the map
-     * var map = new mapboxgl.Map({ // map options });
+     * var map = new maplibregl.Map({ // map options });
      * // Set an event listener that fires
      * // when the map's style loads or changes.
      * map.on('styledata', function() {
@@ -1193,7 +1193,7 @@ export type MapEvent =
      * @property {MapDataEvent} data
      * @example
      * // Initialize the map
-     * var map = new mapboxgl.Map({ // map options });
+     * var map = new maplibregl.Map({ // map options });
      * // Set an event listener that fires
      * // when one of the map's sources loads or changes.
      * map.on('sourcedata', function() {
@@ -1213,7 +1213,7 @@ export type MapEvent =
      * @property {MapDataEvent} data
      * @example
      * // Initialize the map
-     * var map = new mapboxgl.Map({ // map options });
+     * var map = new maplibregl.Map({ // map options });
      * // Set an event listener that fires
      * // when any map data begins loading
      * // or changing asynchronously.
@@ -1234,7 +1234,7 @@ export type MapEvent =
      * @property {MapDataEvent} data
      * @example
      * // Initialize the map
-     * var map = new mapboxgl.Map({ // map options });
+     * var map = new maplibregl.Map({ // map options });
      * // Set an event listener that fires
      * // map's style begins loading or
      * // changing asyncronously.
@@ -1255,7 +1255,7 @@ export type MapEvent =
      * @property {MapDataEvent} data
      * @example
      * // Initialize the map
-     * var map = new mapboxgl.Map({ // map options });
+     * var map = new maplibregl.Map({ // map options });
      * // Set an event listener that fires
      * // map's sources begin loading or
      * // changing asyncronously.
@@ -1276,7 +1276,7 @@ export type MapEvent =
      * @property {string} id The id of the missing image.
      * @example
      * // Initialize the map
-     * var map = new mapboxgl.Map({ // map options });
+     * var map = new maplibregl.Map({ // map options });
      * // Set an event listener that fires
      * // an icon or pattern is missing.
      * map.on('styleimagemissing', function() {

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -246,7 +246,7 @@ const defaultOptions = {
  * @param {string} [options.accessToken=null] If specified, map will use this token instead of the one defined in mapboxgl.accessToken.
  * @param {Object} [options.locale=null] A patch to apply to the default localization table for UI strings, e.g. control tooltips. The `locale` object maps namespaced UI string IDs to translated strings in the target language; see `src/ui/default_locale.js` for an example with all supported string IDs. The object may specify all UI strings (thereby adding support for a new translation) or only a subset of strings (thereby patching the default translation table).
  * @example
- * var map = new mapboxgl.Map({
+ * var map = new maplibregl.Map({
  *   container: 'map',
  *   center: [-122.420679, 37.772537],
  *   zoom: 13,
@@ -504,7 +504,7 @@ class Map extends Camera {
      * @returns {Map} `this`
      * @example
      * // Add zoom and rotation controls to the map.
-     * map.addControl(new mapboxgl.NavigationControl());
+     * map.addControl(new maplibregl.NavigationControl());
      * @see [Display map navigation controls](https://maplibre.org/maplibre-gl-js-docs/example/navigation/)
      */
     addControl(control: IControl, position?: ControlPosition) {
@@ -538,7 +538,7 @@ class Map extends Camera {
      * @returns {Map} `this`
      * @example
      * // Define a new navigation control.
-     * var navigation = new mapboxgl.NavigationControl();
+     * var navigation = new maplibregl.NavigationControl();
      * // Add zoom and rotation controls to the map.
      * map.addControl(navigation);
      * // Remove zoom and rotation controls from the map.
@@ -562,7 +562,7 @@ class Map extends Camera {
      * @returns {boolean} True if map contains control.
      * @example
      * // Define a new navigation control.
-     * var navigation = new mapboxgl.NavigationControl();
+     * var navigation = new maplibregl.NavigationControl();
      * // Add zoom and rotation controls to the map.
      * map.addControl(navigation);
      * // Check that the navigation control exists on the map.
@@ -1035,7 +1035,7 @@ class Map extends Camera {
      * // Set an event listener that will fire
      * // when a feature on the countries layer of the map is clicked
      * map.on('click', 'countries', function(e) {
-     *   new mapboxgl.Popup()
+     *   new maplibregl.Popup()
      *     .setLngLat(e.lngLat)
      *     .setHTML(`Country name: ${e.features[0].properties.name}`)
      *     .addTo(map);
@@ -2849,7 +2849,7 @@ function removeNode(node) {
  *
  * @typedef {Object} Point
  * @example
- * var point = new mapboxgl.Point(-77, 38);
+ * var point = new maplibregl.Point(-77, 38);
  */
 
 /**
@@ -2857,6 +2857,6 @@ function removeNode(node) {
  *
  * @typedef {(Point | Array<number>)} PointLike
  * @example
- * var p1 = new mapboxgl.Point(-77, 38); // a PointLike which is a Point
+ * var p1 = new maplibregl.Point(-77, 38); // a PointLike which is a Point
  * var p2 = [-77, 38]; // a PointLike which is an array of two numbers
  */

--- a/src/ui/marker.js
+++ b/src/ui/marker.js
@@ -42,12 +42,12 @@ type Options = {
  * @param {string} [options.pitchAlignment='auto'] `map` aligns the `Marker` to the plane of the map. `viewport` aligns the `Marker` to the plane of the viewport. `auto` automatically matches the value of `rotationAlignment`.
  * @param {string} [options.rotationAlignment='auto'] `map` aligns the `Marker`'s rotation relative to the map, maintaining a bearing as the map rotates. `viewport` aligns the `Marker`'s rotation relative to the viewport, agnostic to map rotations. `auto` is equivalent to `viewport`.
  * @example
- * var marker = new mapboxgl.Marker()
+ * var marker = new maplibregl.Marker()
  *   .setLngLat([30.5, 50.5])
  *   .addTo(map);
  * @example
  * // Set options
- * var marker = new mapboxgl.Marker({
+ * var marker = new maplibregl.Marker({
  *     color: "#FFFFFF",
  *     draggable: true
  *   }).setLngLat([30.5, 50.5])
@@ -237,7 +237,7 @@ export default class Marker extends Evented {
      * @param {Map} map The Mapbox GL JS map to add the marker to.
      * @returns {Marker} `this`
      * @example
-     * var marker = new mapboxgl.Marker()
+     * var marker = new maplibregl.Marker()
      *   .setLngLat([30.5, 50.5])
      *   .addTo(map); // add the marker to the map
      */
@@ -261,7 +261,7 @@ export default class Marker extends Evented {
     /**
      * Removes the marker from a map
      * @example
-     * var marker = new mapboxgl.Marker().addTo(map);
+     * var marker = new maplibregl.Marker().addTo(map);
      * marker.remove();
      * @returns {Marker} `this`
      */
@@ -308,7 +308,7 @@ export default class Marker extends Evented {
     * @returns {Marker} `this`
     * @example
     * // Create a new marker, set the longitude and latitude, and add it to the map
-    * new mapboxgl.Marker()
+    * new maplibregl.Marker()
     *   .setLngLat([-65.017, -16.457])
     *   .addTo(map);
     * @see [Add custom icons with Markers](https://maplibre.org/maplibre-gl-js-docs/example/custom-marker-icons/)
@@ -336,9 +336,9 @@ export default class Marker extends Evented {
      * set on this {@link Marker} instance is unset.
      * @returns {Marker} `this`
      * @example
-     * var marker = new mapboxgl.Marker()
+     * var marker = new maplibregl.Marker()
      *  .setLngLat([0, 0])
-     *  .setPopup(new mapboxgl.Popup().setHTML("<h1>Hello World!</h1>")) // add popup
+     *  .setPopup(new maplibregl.Popup().setHTML("<h1>Hello World!</h1>")) // add popup
      *  .addTo(map);
      * @see [Attach a popup to a marker instance](https://maplibre.org/maplibre-gl-js-docs/example/set-popup/)
      */
@@ -407,9 +407,9 @@ export default class Marker extends Evented {
      * Returns the {@link Popup} instance that is bound to the {@link Marker}.
      * @returns {Popup} popup
      * @example
-     * var marker = new mapboxgl.Marker()
+     * var marker = new maplibregl.Marker()
      *  .setLngLat([0, 0])
-     *  .setPopup(new mapboxgl.Popup().setHTML("<h1>Hello World!</h1>"))
+     *  .setPopup(new maplibregl.Popup().setHTML("<h1>Hello World!</h1>"))
      *  .addTo(map);
      *
      * console.log(marker.getPopup()); // return the popup instance
@@ -422,9 +422,9 @@ export default class Marker extends Evented {
      * Opens or closes the {@link Popup} instance that is bound to the {@link Marker}, depending on the current state of the {@link Popup}.
      * @returns {Marker} `this`
      * @example
-     * var marker = new mapboxgl.Marker()
+     * var marker = new maplibregl.Marker()
      *  .setLngLat([0, 0])
-     *  .setPopup(new mapboxgl.Popup().setHTML("<h1>Hello World!</h1>"))
+     *  .setPopup(new maplibregl.Popup().setHTML("<h1>Hello World!</h1>"))
      *  .addTo(map);
      *
      * marker.togglePopup(); // toggle popup open or closed

--- a/src/ui/popup.js
+++ b/src/ui/popup.js
@@ -86,7 +86,7 @@ const focusQuerySelector = [
  *  'left': [markerRadius, (markerHeight - markerRadius) * -1],
  *  'right': [-markerRadius, (markerHeight - markerRadius) * -1]
  *  };
- * var popup = new mapboxgl.Popup({offset: popupOffsets, className: 'my-class'})
+ * var popup = new maplibregl.Popup({offset: popupOffsets, className: 'my-class'})
  *   .setLngLat(e.lngLat)
  *   .setHTML("<h1>Hello World!</h1>")
  *   .setMaxWidth("300px")
@@ -119,7 +119,7 @@ export default class Popup extends Evented {
      * @param {Map} map The Mapbox GL JS map to add the popup to.
      * @returns {Popup} `this`
      * @example
-     * new mapboxgl.Popup()
+     * new maplibregl.Popup()
      *   .setLngLat([0, 0])
      *   .setHTML("<h1>Null Island</h1>")
      *   .addTo(map);
@@ -166,7 +166,7 @@ export default class Popup extends Evented {
          *
          * @example
          * // Create a popup
-         * var popup = new mapboxgl.Popup();
+         * var popup = new maplibregl.Popup();
          * // Set an event listener that will fire
          * // any time the popup is opened
          * popup.on('open', function(){
@@ -190,7 +190,7 @@ export default class Popup extends Evented {
      * Removes the popup from the map it has been added to.
      *
      * @example
-     * var popup = new mapboxgl.Popup().addTo(map);
+     * var popup = new maplibregl.Popup().addTo(map);
      * popup.remove();
      * @returns {Popup} `this`
      */
@@ -226,7 +226,7 @@ export default class Popup extends Evented {
          *
          * @example
          * // Create a popup
-         * var popup = new mapboxgl.Popup();
+         * var popup = new maplibregl.Popup();
          * // Set an event listener that will fire
          * // any time the popup is closed
          * popup.on('close', function(){
@@ -282,7 +282,7 @@ export default class Popup extends Evented {
      * Tracks the popup anchor to the cursor position on screens with a pointer device (it will be hidden on touchscreens). Replaces the `setLngLat` behavior.
      * For most use cases, set `closeOnClick` and `closeButton` to `false`.
      * @example
-     * var popup = new mapboxgl.Popup({ closeOnClick: false, closeButton: false })
+     * var popup = new maplibregl.Popup({ closeOnClick: false, closeButton: false })
      *   .setHTML("<h1>Hello World!</h1>")
      *   .trackPointer()
      *   .addTo(map);
@@ -310,7 +310,7 @@ export default class Popup extends Evented {
      * Returns the `Popup`'s HTML element.
      * @example
      * // Change the `Popup` element's font size
-     * var popup = new mapboxgl.Popup()
+     * var popup = new maplibregl.Popup()
      *   .setLngLat([-96, 37.8])
      *   .setHTML("<p>Hello World!</p>")
      *   .addTo(map);
@@ -332,7 +332,7 @@ export default class Popup extends Evented {
      * @param text Textual content for the popup.
      * @returns {Popup} `this`
      * @example
-     * var popup = new mapboxgl.Popup()
+     * var popup = new maplibregl.Popup()
      *   .setLngLat(e.lngLat)
      *   .setText('Hello, world!')
      *   .addTo(map);
@@ -351,7 +351,7 @@ export default class Popup extends Evented {
      * @param html A string representing HTML content for the popup.
      * @returns {Popup} `this`
      * @example
-     * var popup = new mapboxgl.Popup()
+     * var popup = new maplibregl.Popup()
      *   .setLngLat(e.lngLat)
      *   .setHTML("<h1>Hello World!</h1>")
      *   .addTo(map);
@@ -405,7 +405,7 @@ export default class Popup extends Evented {
      * // create an element with the popup content
      * var div = window.document.createElement('div');
      * div.innerHTML = 'Hello, world!';
-     * var popup = new mapboxgl.Popup()
+     * var popup = new maplibregl.Popup()
      *   .setLngLat(e.lngLat)
      *   .setDOMContent(div)
      *   .addTo(map);
@@ -436,7 +436,7 @@ export default class Popup extends Evented {
      * @param {string} className Non-empty string with CSS class name to add to popup container
      *
      * @example
-     * let popup = new mapboxgl.Popup()
+     * let popup = new maplibregl.Popup()
      * popup.addClassName('some-class')
      */
     addClassName(className: string) {
@@ -451,7 +451,7 @@ export default class Popup extends Evented {
      * @param {string} className Non-empty string with CSS class name to remove from popup container
      *
      * @example
-     * let popup = new mapboxgl.Popup()
+     * let popup = new maplibregl.Popup()
      * popup.removeClassName('some-class')
      */
     removeClassName(className: string) {
@@ -480,7 +480,7 @@ export default class Popup extends Evented {
      * @returns {boolean} if the class was removed return false, if class was added, then return true
      *
      * @example
-     * let popup = new mapboxgl.Popup()
+     * let popup = new maplibregl.Popup()
      * popup.toggleClassName('toggleClass')
      */
     toggleClassName(className: string) {


### PR DESCRIPTION
This pull request replaces ```mapboxgl``` with ```maplibregl``` in the inline examples in the comments of the public API.

 - ✅ confirm your changes do not include backports from Mapbox projects (unless with compliant license)
 - ✅ briefly describe the changes in this PR
 - [ ] include before/after visuals or gifs if this PR includes visual changes
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [ ] manually test the debug page
 - [ ] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - ✅ add an entry inside this element for inclusion in the `maplibre-gl-js` changelog: `<changelog>Replace mapboxgl with maplibregl in JSDocs inline examples</changelog>`
