### PR TITLE
Update readme migration instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ If you depend on mapbox-gl directly, simply replace `mapbox-gl` with `maplibre-g
   }
 ```
 
-Want an example? [Try out MapLibre GL on CodePen](https://codepen.io/klokan/pen/WNoZRyx)
+And replace ```mapboxgl``` with ```maplibregl``` in your JavaScript code.
+
+Want an example? [Try out MapLibre GL on CodePen](https://codepen.io/klokan/pen/WNoZRyx) and have a look at ones in the official [MapLibre GL JS Documentation](https://maplibre.org/maplibre-gl-js-docs/example/).
 
 If you use mapbox-gl via bindings (react, vue, etc), you may need to wait a little longer as we develop an easy migration path for each binding. Contributions welcome!
 


### PR DESCRIPTION
This pull requests adds a note to the README to replace ```mapboxgl``` with ```maplibregl``` when migrating. This was not needed in maplibre-gl-js ```1.13.0``` but with ```1.14.0``` it is.

I also added in a link to the documentation website at https://maplibre.org/maplibre-gl-js-docs/api/.

 - ✅ confirm your changes do not include backports from Mapbox projects (unless with compliant license)
 - ✅ briefly describe the changes in this PR
 - [ ] include before/after visuals or gifs if this PR includes visual changes
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [ ] manually test the debug page
 - ✅ apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog' 
 - please skip changelog
 - [ ] add an entry inside this element for inclusion in the `maplibre-gl-js` changelog: `<changelog></changelog>`
