### PR TITLE
Add version reminder when publishing a release

### DIFF
--- a/RELEASE-PROCESS.md
+++ b/RELEASE-PROCESS.md
@@ -1,6 +1,6 @@
 ## Publish to NPM
 
-To publish this library to NPM, create a tag and push it to GitHub. A workflow will do all the necessary steps:
+To publish this library to NPM, create a tag and push it to GitHub. Make sure that the version in ```package.json``` matches the version you define in the tag. A workflow will do all the necessary steps:
 
 ```bash
 git checkout main


### PR DESCRIPTION
## Launch Checklist

This pull requests adds a reminder to ```RELEASE-PROCESS.md``` to check that the version in ```package.json``` matches the version of the git tag.

 - ✅ confirm your changes do not include backports from Mapbox projects (unless with compliant license)
 - ✅ briefly describe the changes in this PR
 - [ ] include before/after visuals or gifs if this PR includes visual changes
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [ ] manually test the debug page
 - ✅ apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog' -> please skip changelog
 - [ ] add an entry inside this element for inclusion in the `maplibre-gl-js` changelog: `<changelog></changelog>`
