### PR TITLE
Update google-chrome with apt in ci before browser-test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,7 +127,6 @@ jobs:
           architecture: x64
       - run: yarn install --frozen-lockfile
       - run: yarn run build-dev
-      - run: /usr/bin/google-chrome --version
       - run: DETECT_CHROMEDRIVER_VERSION=true yarn global add chromedriver
       - run: yarn global add geckodriver
       - name: Test Chrome

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,10 +128,7 @@ jobs:
       - run: yarn install --frozen-lockfile
       - run: yarn run build-dev
       - run: /usr/bin/google-chrome --version
-      - run: sudo apt update
-      - run: sudo apt upgrade google-chrome-stable -y
-      - run: /usr/bin/google-chrome --version
-      - run: yarn global add chromedriver
+      - run: DETECT_CHROMEDRIVER_VERSION=true yarn global add chromedriver
       - run: yarn global add geckodriver
       - name: Test Chrome
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,6 +127,10 @@ jobs:
           architecture: x64
       - run: yarn install --frozen-lockfile
       - run: yarn run build-dev
+      - run: /usr/bin/google-chrome --version
+      - run: sudo apt update
+      - run: sudo apt upgrade google-chrome-stable -y
+      - run: /usr/bin/google-chrome --version
       - run: yarn global add chromedriver
       - run: yarn global add geckodriver
       - name: Test Chrome


### PR DESCRIPTION
## Launch Checklist

This pull requests adds ```sudo apt update``` and ```sudo apt upgrade google-chrome-stable -y``` to the GitHub actions file ```ci.yml``` in order to get the latest version of google chrome. 

Right now we run into problems where ```/usr/bin/google-chrome``` has version 89 while ```chromedriver``` is at version 90.

See https://github.com/maplibre/maplibre-gl-js/issues/132#issuecomment-821325227 and https://github.com/maplibre/maplibre-gl-js/pull/119

 - ✅  confirm your changes do not include backports from Mapbox projects (unless with compliant license)
 - ✅  briefly describe the changes in this PR
 - [ ] include before/after visuals or gifs if this PR includes visual changes
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [ ] manually test the debug page
 - ✅ apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog' -> no change log
 - [ ] add an entry inside this element for inclusion in the `maplibre-gl-js` changelog: `<changelog></changelog>`
