### PR TITLE
Match style spec version to last style spec changelog entry

### DIFF
--- a/src/style-spec/package.json
+++ b/src/style-spec/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@maplibre/maplibre-gl-style-spec",
   "description": "a specification for maplibre gl styles",
-  "version": "13.18.0-dev",
+  "version": "13.17.0",
   "author": "MapLibre",
   "keywords": [
     "mapbox",


### PR DESCRIPTION
This pull request changes the version in ```src/style-spec/package.json``` to match the version of the last entry in ```src/style-spec/CHANGELOG.md```.

With this, a dry run of the ```publish-style-spec.yml``` workflow should succeed.

 - 👍  confirm your changes do not include backports from Mapbox projects (unless with compliant license)
 - 👍  briefly describe the changes in this PR
 - [ ] include before/after visuals or gifs if this PR includes visual changes
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [ ] manually test the debug page
 - 👍 apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog' -> _please skip_
 - [ ] add an entry inside this element for inclusion in the `maplibre-gl-js` changelog: `<changelog></changelog>`
