### PR TITLE
Add migration diff for javascript code block

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,11 @@ If you depend on mapbox-gl directly, simply replace `mapbox-gl` with `maplibre-g
   }
 ```
 
-And replace ```mapboxgl``` with ```maplibregl``` in your JavaScript code.
+And replace ```mapboxgl``` with ```maplibregl``` in your JavaScript code:
+```diff
+-    var map = new mapboxgl.Map({
++    var map = new maplibre.Map({
+```
 
 Want an example? [Try out MapLibre GL on CodePen](https://codepen.io/klokan/pen/WNoZRyx) and have a look at ones in the official [MapLibre GL JS Documentation](https://maplibre.org/maplibre-gl-js-docs/example/).
 


### PR DESCRIPTION
This pull request updates the readme to better explain how to migrate from `v1.13.0` mapbox to `v1.14.0` maplibre.

 - ✅  confirm your changes do not include backports from Mapbox projects (unless with compliant license)
 - 😄 briefly describe the changes in this PR
 - [ ] include before/after visuals or gifs if this PR includes visual changes
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [ ] manually test the debug page
 - 👍  apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog' `skip`
 - add an entry inside this element for inclusion in the `maplibre-gl-js` changelog: `<changelog></changelog>`
