### PR TITLE
Publish style spec v14.0.0 to NPM

### DIFF
--- a/.github/workflows/publish-style-spec.yml
+++ b/.github/workflows/publish-style-spec.yml
@@ -37,6 +37,6 @@ jobs:
         run: |
           cd src/style-spec
           node -e "if(require('./package').version.includes('dev')) { process.exit(1) }"
-          npm publish --dry-run
+          npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Features and improvements
 
 - *...Add new stuff here...*
+- Publish @maplibre/maplibre-gl-style-spec v13.17.0 on NPM (#149)
 - Migrate style spec files from mapbox to maplibre (#147)
 - Publish the MapLibre style spec in NPM (#140)
 - Replace mapboxgl with maplibregl in JSDocs inline examples (#134)

--- a/src/style-spec/CHANGELOG.md
+++ b/src/style-spec/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 14.0.0
+
+### Breaking changes
+
+* Remove the `--mapbox-api-supported` option of the `gl-style-validate` utility.
+
 ## 13.17.0
 
 ### ✨ Features and improvements

--- a/src/style-spec/package.json
+++ b/src/style-spec/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@maplibre/maplibre-gl-style-spec",
   "description": "a specification for maplibre gl styles",
-  "version": "13.17.0",
+  "version": "14.0.0",
   "author": "MapLibre",
   "keywords": [
     "mapbox",


### PR DESCRIPTION
This pull request removes the `--dry-run` flag from the [`publish-style-spec.yml`](https://github.com/maplibre/maplibre-gl-js/actions/workflows/publish-style-spec.yml) action.

You find the output of the last dry run here: https://github.com/maplibre/maplibre-gl-js/pull/147#issuecomment-830681902

If merged, we will be able to publish `v13.17.0` of the style spec to NPM at `@maplibre/maplibre-gl-style-spec`.

 - ✅  confirm your changes do not include backports from Mapbox projects (unless with compliant license)
 - ✅  briefly describe the changes in this PR
 - [ ] include before/after visuals or gifs if this PR includes visual changes
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [ ] manually test the debug page
 - 👍  apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - 👍 add an entry inside this element for inclusion in the `maplibre-gl-js` changelog: `<changelog></changelog>`
