### PR TITLE
Fix link on LogoControl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Features and improvements
 
 - *...Add new stuff here...*
+- Replace link to mapbox on LogoControl by link to maplibre (#150)
 - Migrate style spec files from mapbox to maplibre (#147)
 - Publish the MapLibre style spec in NPM (#140)
 - Replace mapboxgl with maplibregl in JSDocs inline examples (#134)

--- a/src/ui/control/logo_control.js
+++ b/src/ui/control/logo_control.js
@@ -30,7 +30,7 @@ class LogoControl {
         const anchor = DOM.create('a', 'mapboxgl-ctrl-logo');
         anchor.target = "_blank";
         anchor.rel = "noopener nofollow";
-        anchor.href = "https://www.mapbox.com/";
+        anchor.href = "https://maplibre.org/";
         anchor.setAttribute("aria-label", this._map._getUIString('LogoControl.Title'));
         anchor.setAttribute("rel", "noopener nofollow");
         this._container.appendChild(anchor);


### PR DESCRIPTION
Replace link to https://mapbox.com/ by link to https://maplibre.org/ on logo.

See https://github.com/maplibre/maplibre-gl-js/issues/121#issuecomment-831017594 and https://github.com/maplibre/maplibre-gl-js/issues/121#issuecomment-831073949

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [x] confirm your changes do not include backports from Mapbox projects (unless with compliant license)
 - [x] briefly describe the changes in this PR
 - [ ] ~~include before/after visuals or gifs if this PR includes visual changes~~
 - [ ] ~~write tests for all new functionality~~
 - [ ] ~~document any changes to public APIs~~
 - [ ] post benchmark scores
 - [ ] manually test the debug page
 - [ ] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [x] add an entry inside this element for inclusion in the `maplibre-gl-js` changelog: `<changelog>Replace link to mapbox on LogoControl by link to maplibre</changelog>`
