### PR TITLE
Update link from logo from Mapbox to MapLibre

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Features and improvements
 
 - *...Add new stuff here...*
+- Replace link to mapbox on LogoControl by link to maplibre (#151)
 - Migrate style spec files from mapbox to maplibre (#147)
 - Publish the MapLibre style spec in NPM (#140)
 - Replace mapboxgl with maplibregl in JSDocs inline examples (#134)

--- a/src/ui/control/logo_control.js
+++ b/src/ui/control/logo_control.js
@@ -28,7 +28,7 @@ class LogoControl {
         const anchor = DOM.create('a', 'mapboxgl-ctrl-logo');
         anchor.target = "_blank";
         anchor.rel = "noopener nofollow";
-        anchor.href = "https://www.maplibre.org/";
+        anchor.href = "https://maplibre.org/";
         anchor.setAttribute("aria-label", this._map._getUIString('LogoControl.Title'));
         anchor.setAttribute("rel", "noopener nofollow");
         this._container.appendChild(anchor);

--- a/src/ui/control/logo_control.js
+++ b/src/ui/control/logo_control.js
@@ -7,9 +7,7 @@ import {bindAll} from '../../util/util';
 import type Map from '../map';
 
 /**
- * A `LogoControl` is a control that adds the Mapbox watermark
- * to the map as required by the [terms of service](https://www.mapbox.com/tos/) for Mapbox
- * vector tiles and core styles.
+ * A `LogoControl` is a control that adds the watermark.
  *
  * @implements {IControl}
  * @private
@@ -30,7 +28,7 @@ class LogoControl {
         const anchor = DOM.create('a', 'mapboxgl-ctrl-logo');
         anchor.target = "_blank";
         anchor.rel = "noopener nofollow";
-        anchor.href = "https://www.mapbox.com/";
+        anchor.href = "https://www.maplibre.org/";
         anchor.setAttribute("aria-label", this._map._getUIString('LogoControl.Title'));
         anchor.setAttribute("rel", "noopener nofollow");
         this._container.appendChild(anchor);


### PR DESCRIPTION
As discussed in https://github.com/maplibre/maplibre-gl-js/issues/121#issuecomment-831017594 and brought up in https://github.com/EqualStreetNames/equalstreetnames/issues/191

I found out that the link in the bottom left (from the MapLibre logo) goes to Mapbox.com, but probably should not.
This PR aims to correct that, and also changes the help text of the function a bit.

## Launch Checklist

 - [x] confirm your changes do not include backports from Mapbox projects (unless with compliant license)
 - [x] briefly describe the changes in this PR
 - [x] add an entry inside this element for inclusion in the `maplibre-gl-js` changelog: `<changelog></changelog>`
 - [ ] include before/after visuals or gifs if this PR includes visual changes
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [ ] manually test the debug page
 - [ ] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
