### PR TITLE
Add --access=public to style spec npm publish command

### DIFF
--- a/.github/workflows/publish-style-spec.yml
+++ b/.github/workflows/publish-style-spec.yml
@@ -37,6 +37,6 @@ jobs:
         run: |
           cd src/style-spec
           node -e "if(require('./package').version.includes('dev')) { process.exit(1) }"
-          npm publish
+          npm publish --access=public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}


### PR DESCRIPTION
This pull requests adds the [`--access=public`](https://docs.npmjs.com/cli/v7/using-npm/config#access) flag to `npm publish` for the style spec, to avoid this error:

```
npm ERR! 402 Payment Required - PUT https://registry.npmjs.org/@maplibre%2fmaplibre-gl-style-spec - You must sign up for private packages
```

See https://github.com/maplibre/maplibre-gl-js/runs/2503036374 for the failing publishing run without this flag.

 - ✅ confirm your changes do not include backports from Mapbox projects (unless with compliant license)
 - ✅  briefly describe the changes in this PR
 - [ ] include before/after visuals or gifs if this PR includes visual changes
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [ ] manually test the debug page
 - ✅  apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog' `skip`
 - [ ] add an entry inside this element for inclusion in the `maplibre-gl-js` changelog: `<changelog></changelog>`
