### PR TITLE
Add dev to style spec version

### DIFF
--- a/src/style-spec/README.md
+++ b/src/style-spec/README.md
@@ -56,4 +56,3 @@ $ gl-style-validate style.json
 Will validate the given style JSON and print errors to stdout. Provide a
 `--json` flag to get JSON output.
 
-To validate that a style can be uploaded to the Mapbox Styles API, use the `--mapbox-api-supported` flag.

--- a/src/style-spec/package.json
+++ b/src/style-spec/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@maplibre/maplibre-gl-style-spec",
   "description": "a specification for maplibre gl styles",
-  "version": "14.0.0",
+  "version": "14.1.0-dev",
   "author": "MapLibre",
   "keywords": [
     "mapbox",


### PR DESCRIPTION
This pull request adds `-dev` to the style spec version in `src/style-spec/package.json`. This prevents accidental workflow runs of `publish-style-spec.yml`. The pull request also removes a note about `--mapbox-api-supported` in the readme of the style spec.

 - 🐳  confirm your changes do not include backports from Mapbox projects (unless with compliant license)
 - ✅ briefly describe the changes in this PR
 - [ ] include before/after visuals or gifs if this PR includes visual changes
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [ ] manually test the debug page
 - 👍 apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog' -> `no changelog please`
 - [ ] add an entry inside this element for inclusion in the `maplibre-gl-js` changelog: `<changelog></changelog>`
