### PR TITLE
Improve viewport `<meta>` tag values

### DIFF
--- a/bench/styles/index.html
+++ b/bench/styles/index.html
@@ -4,7 +4,7 @@
     <title>MapLibre GL JS Benchmarks</title>
 
     <meta charset='utf-8'>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
 
     <link href='https://www.mapbox.com/base/latest/base.css' rel='stylesheet' />
     <link rel='stylesheet' href='/dist/maplibre-gl.css'/>

--- a/bench/versions/index.html
+++ b/bench/versions/index.html
@@ -4,7 +4,7 @@
     <title>MapLibre GL JS Benchmarks</title>
 
     <meta charset='utf-8'>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
 
     <link href='https://www.mapbox.com/base/latest/base.css' rel='stylesheet' />
     <link rel='stylesheet' href='/dist/maplibre-gl.css'/>

--- a/debug/2762.html
+++ b/debug/2762.html
@@ -3,7 +3,7 @@
 <head>
     <title>MapLibre GL JS debug page</title>
     <meta charset='utf-8'>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel='stylesheet' href='../dist/maplibre-gl.css' />
     <style>
         body { margin: 0; padding: 0; }

--- a/debug/3895.html
+++ b/debug/3895.html
@@ -3,7 +3,7 @@
 <head>
     <title>MapLibre GL JS debug page</title>
     <meta charset='utf-8'>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel='stylesheet' href='../dist/maplibre-gl.css' />
     <style>
         body { margin: 0; padding: 0; }

--- a/debug/7438.html
+++ b/debug/7438.html
@@ -3,7 +3,7 @@
 <head>
     <title>MapLibre GL JS debug page</title>
     <meta charset='utf-8'>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel='stylesheet' href='../dist/maplibre-gl.css' />
     <style>
         body { margin: 0; padding: 0; }

--- a/debug/7517.html
+++ b/debug/7517.html
@@ -4,7 +4,7 @@
 <head>
     <title>MapLibre GL JS debug page</title>
     <meta charset='utf-8'>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel='stylesheet' href='../dist/maplibre-gl.css' />
     <style>
         body {

--- a/debug/animate.html
+++ b/debug/animate.html
@@ -3,7 +3,7 @@
 <head>
     <title>MapLibre GL JS debug page</title>
     <meta charset='utf-8'>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel='stylesheet' href='../dist/maplibre-gl.css' />
     <style>
         #map { width: 1200px; height: 800px;  }

--- a/debug/bounds.html
+++ b/debug/bounds.html
@@ -3,7 +3,7 @@
 <head>
     <title>MapLibre GL JS debug page</title>
     <meta charset='utf-8'>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel='stylesheet' href='../dist/maplibre-gl.css' />
     <style>
         body { margin: 0; padding: 0; }

--- a/debug/cache_api.html
+++ b/debug/cache_api.html
@@ -3,7 +3,7 @@
 <head>
     <title>MapLibre GL JS debug page</title>
     <meta charset='utf-8'>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel='stylesheet' href='../dist/maplibre-gl.css' />
     <style>
         body { margin: 0; padding: 0; }

--- a/debug/canvas.html
+++ b/debug/canvas.html
@@ -3,7 +3,7 @@
 <head>
     <title>MapLibre GL JS debug page</title>
     <meta charset='utf-8'>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel='stylesheet' href='../dist/maplibre-gl.css' />
     <style>
         body { margin: 0; padding: 0; }

--- a/debug/chinese.html
+++ b/debug/chinese.html
@@ -3,7 +3,7 @@
 <head>
     <title>MapLibre GL JS debug page</title>
     <meta charset='utf-8'>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel='stylesheet' href='../dist/maplibre-gl.css' />
     <style>
         body { margin: 0; padding: 0; }

--- a/debug/circles.html
+++ b/debug/circles.html
@@ -3,7 +3,7 @@
 <head>
     <title>MapLibre GL JS debug page</title>
     <meta charset='utf-8'>
-	<meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel='stylesheet' href='../dist/maplibre-gl.css' />
     <style>
         body { margin: 0; padding: 0; }

--- a/debug/cluster.html
+++ b/debug/cluster.html
@@ -3,7 +3,7 @@
 <head>
     <title>MapLibre GL JS debug page</title>
     <meta charset='utf-8'>
-	<meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel='stylesheet' href='../dist/maplibre-gl.css' />
     <style>
         body { margin: 0; padding: 0; }

--- a/debug/color_spaces.html
+++ b/debug/color_spaces.html
@@ -3,7 +3,7 @@
 <head>
     <title>MapLibre GL JS debug page</title>
     <meta charset='utf-8'>
-	<meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel='stylesheet' href='../dist/maplibre-gl.css' />
     <style>
         body { margin: 0; padding: 0; }

--- a/debug/csp-static.html
+++ b/debug/csp-static.html
@@ -6,7 +6,7 @@
 
     <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'nonce-app-js'; style-src 'self' 'nonce-app-css'; img-src data: blob: ; connect-src https://*.mapbox.com">
 
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel='stylesheet' href='../dist/maplibre-gl.css' />
     <style nonce="app-css">
         body { margin: 0; padding: 0; }

--- a/debug/csp.html
+++ b/debug/csp.html
@@ -4,7 +4,7 @@
     <title>MapLibre GL JS debug page</title>
     <meta http-equiv="Content-Security-Policy" content="worker-src blob: ; img-src data: blob: ; script-src http: 'nonce-dummy'; connect-src https://*.tiles.mapbox.com https://api.mapbox.com">
     <meta charset='utf-8'>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel='stylesheet' href='../dist/maplibre-gl.css' />
     <style>
         body { margin: 0; padding: 0; }

--- a/debug/custom3d.html
+++ b/debug/custom3d.html
@@ -3,7 +3,7 @@
 <head>
     <title>MapLibre GL JS debug page</title>
     <meta charset='utf-8'>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel='stylesheet' href='../dist/maplibre-gl.css' />
     <style>
         body { margin: 0; padding: 0; }

--- a/debug/debug.html
+++ b/debug/debug.html
@@ -3,7 +3,7 @@
 <head>
     <title>MapLibre GL JS debug page</title>
     <meta charset='utf-8'>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel='stylesheet' href='../dist/maplibre-gl.css' />
     <style>
         body { margin: 0; padding: 0; }

--- a/debug/default-image.html
+++ b/debug/default-image.html
@@ -3,7 +3,7 @@
 <head>
     <title>MapLibre GL JS debug page</title>
     <meta charset='utf-8'>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel='stylesheet' href='../dist/maplibre-gl.css' />
     <style>
         body { margin: 0; padding: 0; }

--- a/debug/events.html
+++ b/debug/events.html
@@ -3,7 +3,7 @@
 <head>
 <title>MapLibre GL JS debug page</title>
 <meta charset='utf-8'>
-<meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+<meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel='stylesheet' href='../dist/maplibre-gl.css' />
 <style>
 

--- a/debug/extrusion-query.html
+++ b/debug/extrusion-query.html
@@ -3,7 +3,7 @@
 <head>
     <title>MapLibre GL JS debug page</title>
     <meta charset='utf-8'>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel='stylesheet' href='../dist/maplibre-gl.css' />
 
     <style>

--- a/debug/featurestate.html
+++ b/debug/featurestate.html
@@ -3,7 +3,7 @@
 <head>
     <title>MapLibre GL JS debug page</title>
     <meta charset='utf-8'>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel='stylesheet' href='../dist/maplibre-gl.css' />
     <style>
         body { margin: 0; padding: 0; }

--- a/debug/heatmap.html
+++ b/debug/heatmap.html
@@ -3,7 +3,7 @@
 <head>
     <title>MapLibre GL JS debug page</title>
     <meta charset='utf-8'>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel='stylesheet' href='../dist/maplibre-gl.css' />
     <style>
         body { margin: 0; padding: 0; }

--- a/debug/highlightpoints.html
+++ b/debug/highlightpoints.html
@@ -3,7 +3,7 @@
 <head>
     <title>MapLibre GL JS debug page</title>
     <meta charset='utf-8'>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel='stylesheet' href='../dist/maplibre-gl.css' />
     <style>
         body { margin: 0; padding: 0; }

--- a/debug/hillshade.html
+++ b/debug/hillshade.html
@@ -3,7 +3,7 @@
 <head>
     <title>MapLibre GL JS debug page</title>
     <meta charset='utf-8'>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel='stylesheet' href='../dist/maplibre-gl.css' />
     <style>
         body { margin: 0; padding: 0; }

--- a/debug/iframe-blob.html
+++ b/debug/iframe-blob.html
@@ -3,7 +3,7 @@
 <head>
     <title>MapLibre GL JS debug page</title>
     <meta charset='utf-8'>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
 </head>
 
 <body>
@@ -24,7 +24,7 @@ document.querySelector('iframe').src = URL.createObjectURL(new Blob([ `
 <head>
     <title>MapLibre GL JS debug page</title>
     <meta charset='utf-8'>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel='stylesheet' href='${css.href}' />
     <style>
         body { margin: 0; padding: 0; }

--- a/debug/iframe.html
+++ b/debug/iframe.html
@@ -3,7 +3,7 @@
 <head>
     <title>MapLibre GL JS debug page</title>
     <meta charset='utf-8'>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
 </head>
 
 <body>

--- a/debug/image.html
+++ b/debug/image.html
@@ -3,7 +3,7 @@
 <head>
     <title>MapLibre GL JS debug page</title>
     <meta charset='utf-8'>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel='stylesheet' href='../dist/maplibre-gl.css' />
     <style>
         body { margin: 0; padding: 0; }

--- a/debug/index.html
+++ b/debug/index.html
@@ -3,7 +3,7 @@
 <head>
     <title>MapLibre GL JS debug page</title>
     <meta charset='utf-8'>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel='stylesheet' href='../dist/maplibre-gl.css' />
     <style>
         body { margin: 0; padding: 0; }

--- a/debug/is-safari.html
+++ b/debug/is-safari.html
@@ -3,7 +3,7 @@
 <head>
     <title>MapLibre GL JS debug page</title>
     <meta charset='utf-8'>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel='stylesheet' href='../dist/maplibre-gl.css' />
     <style>
         body { margin: 0; padding: 0; }

--- a/debug/line-gradient.html
+++ b/debug/line-gradient.html
@@ -3,7 +3,7 @@
 <head>
     <title>MapLibre GL JS debug page</title>
     <meta charset='utf-8'>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel='stylesheet' href='../dist/maplibre-gl.css' />
     <style>
     body { margin: 0; padding: 0; }

--- a/debug/markers.html
+++ b/debug/markers.html
@@ -3,7 +3,7 @@
 <head>
     <title>MapLibre GL JS debug page</title>
     <meta charset='utf-8'>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel='stylesheet' href='../dist/maplibre-gl.css' />
     <style>
         body { margin: 0; padding: 0; }

--- a/debug/mobile_scroll.html
+++ b/debug/mobile_scroll.html
@@ -3,7 +3,7 @@
 <head>
     <title>MapLibre GL JS debug page</title>
     <meta charset='utf-8'>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel='stylesheet' href='../dist/maplibre-gl.css' />
     <style>
         body { margin: 0; padding: 0; }

--- a/debug/multiple.html
+++ b/debug/multiple.html
@@ -3,7 +3,7 @@
 <head>
     <title>MapLibre GL JS debug page</title>
     <meta charset='utf-8'>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel='stylesheet' href='../dist/maplibre-gl.css' />
     <style>
         body { margin: 0; padding: 0; }

--- a/debug/no_wrap.html
+++ b/debug/no_wrap.html
@@ -3,7 +3,7 @@
 <head>
     <title>MapLibre GL JS debug page</title>
     <meta charset='utf-8'>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel='stylesheet' href='../dist/maplibre-gl.css' />
     <style>
         body { margin: 0; padding: 0; }

--- a/debug/popup.html
+++ b/debug/popup.html
@@ -3,7 +3,7 @@
 <head>
     <title>MapLibre GL JS debug page</title>
     <meta charset='utf-8'>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel='stylesheet' href='../dist/maplibre-gl.css' />
     <style>
         body { margin: 0; padding: 0; }

--- a/debug/query_features.html
+++ b/debug/query_features.html
@@ -3,7 +3,7 @@
 <head>
     <title>MapLibre GL JS debug page</title>
     <meta charset='utf-8'>
-	<meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel='stylesheet' href='../dist/maplibre-gl.css' />
     <style>
         body { margin: 0; padding: 0; }

--- a/debug/raster-streets.html
+++ b/debug/raster-streets.html
@@ -3,7 +3,7 @@
 <head>
     <title>MapLibre GL JS debug page</title>
     <meta charset='utf-8'>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel='stylesheet' href='../dist/maplibre-gl.css' />
     <style>
         body { margin: 0; padding: 0; }

--- a/debug/rtl.html
+++ b/debug/rtl.html
@@ -3,7 +3,7 @@
 <head>
     <title>MapLibre GL JS debug page</title>
     <meta charset='utf-8'>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel='stylesheet' href='/dist/maplibre-gl.css' />
     <style>
         body { margin: 0; padding: 0; }

--- a/debug/satellite.html
+++ b/debug/satellite.html
@@ -3,7 +3,7 @@
 <head>
     <title>MapLibre GL JS debug page</title>
     <meta charset='utf-8'>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel='stylesheet' href='../dist/maplibre-gl.css' />
     <style>
         body { margin: 0; padding: 0; }

--- a/debug/setstyle.html
+++ b/debug/setstyle.html
@@ -3,7 +3,7 @@
 <head>
     <title>MapLibre GL JS debug page</title>
     <meta charset='utf-8'>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel='stylesheet' href='../dist/maplibre-gl.css' />
     <style>
         body { margin: 0; padding: 0; }

--- a/debug/stretchable.html
+++ b/debug/stretchable.html
@@ -3,7 +3,7 @@
 <head>
     <title>MapLibre GL JS debug page</title>
     <meta charset='utf-8'>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel='stylesheet' href='../dist/maplibre-gl.css' />
     <style>
         body { margin: 0; padding: 0; }

--- a/debug/textsize.html
+++ b/debug/textsize.html
@@ -3,7 +3,7 @@
 <head>
     <title>MapLibre GL JS debug page</title>
     <meta charset='utf-8'>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel='stylesheet' href='../dist/maplibre-gl.css' />
     <style>
         body { margin: 0; padding: 0; }

--- a/debug/threejs.html
+++ b/debug/threejs.html
@@ -3,7 +3,7 @@
 <head>
     <title>MapLibre GL JS debug page</title>
     <meta charset='utf-8'>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel='stylesheet' href='../dist/maplibre-gl.css' />
     <style>
         body { margin: 0; padding: 0; }

--- a/debug/tinysdf.html
+++ b/debug/tinysdf.html
@@ -3,7 +3,7 @@
 <head>
     <title>MapLibre GL JS debug page</title>
     <meta charset='utf-8'>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel='stylesheet' href='../dist/maplibre-gl.css' />
     <style>
         body { margin: 0; padding: 0; }

--- a/debug/token.html
+++ b/debug/token.html
@@ -3,7 +3,7 @@
 <head>
     <title>MapLibre GL JS debug page</title>
     <meta charset='utf-8'>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel='stylesheet' href='../dist/maplibre-gl.css' />
     <style>
         body { margin: 0; padding: 0; }

--- a/debug/update_image.html
+++ b/debug/update_image.html
@@ -3,7 +3,7 @@
 <head>
     <title>MapLibre GL JS debug page</title>
     <meta charset='utf-8'>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel='stylesheet' href='../dist/maplibre-gl.css' />
     <style>
         body { margin: 0; padding: 0; }

--- a/debug/variable-anchor-with-icon-text-fit.html
+++ b/debug/variable-anchor-with-icon-text-fit.html
@@ -4,7 +4,7 @@
     <meta charset='utf-8' />
     <title>MapLibre GL JS debug page</title>
     <meta charset='utf-8'>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel='stylesheet' href='../dist/maplibre-gl.css' />
     <style>
         body { margin: 0; padding: 0; }

--- a/debug/video.html
+++ b/debug/video.html
@@ -3,7 +3,7 @@
 <head>
     <title>MapLibre GL JS debug page</title>
     <meta charset='utf-8'>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel='stylesheet' href='../dist/maplibre-gl.css' />
     <link href='https://www.mapbox.com/base/latest/base.css' rel='stylesheet' />
     <style>

--- a/debug/wms.html
+++ b/debug/wms.html
@@ -3,7 +3,7 @@
 <head>
     <title>MapLibre GL JS debug page</title>
     <meta charset='utf-8'>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel='stylesheet' href='../dist/maplibre-gl.css' />
     <style>
         body { margin: 0; padding: 0; }

--- a/test/browser/fixtures/land.html
+++ b/test/browser/fixtures/land.html
@@ -3,7 +3,7 @@
 <head>
     <title>MapLibre GL JS debug page</title>
     <meta charset='utf-8'>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel='stylesheet' href='../../../dist/maplibre-gl.css' />
     <style>
         body { margin: 0; padding: 0; }

--- a/test/release/index.html
+++ b/test/release/index.html
@@ -3,7 +3,7 @@
 <head>
     <title>MapLibre GL JS release testing page</title>
     <meta charset='utf-8'>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" type="text/css" href="index.css">
     <script src="https://api.mapbox.com/mapbox-gl-js/versions.jsonp"></script>
     <script>const mapboxgl = {};</script>

--- a/test/release/index.js
+++ b/test/release/index.js
@@ -210,7 +210,7 @@ document.addEventListener('DOMContentLoaded', function() {
                 '<head>',
                 '    <title>MapLibre GL JS debug page</title>',
                 '    <meta charset="utf-8">',
-                '    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">',
+                '    <meta name="viewport" content="width=device-width, initial-scale=1">',
                 '    <script src="' + js + '"><\/script>',
                 '    <script>maplibre.accessToken = "' + params.access_token + '";<\/script>',
                 '    <link rel="stylesheet" href="' + css + '" />',


### PR DESCRIPTION
- [x] Removes `user-scalable=no` from all viewport `<meta>` tags as it may be an accessibility issue for some users.

See motivation in https://dequeuniversity.com/rules/axe/4.1/meta-viewport (holds documentation for [axe-core](https://github.com/dequelabs/axe-core) which powers the accessibility audits in [Lighthouse](https://github.com/GoogleChrome/lighthouse)).

For further information see:
- The `<meta name="viewport">` definition in https://www.w3.org/TR/css-device-adapt-1/#viewport-meta
- MDN docs: https://developer.mozilla.org/en-US/docs/Web/HTML/Viewport_meta_tag.