### PR TITLE
Specify `lang="en"` on all `<html>` elements

### DIFF
--- a/bench/gl-stats.html
+++ b/bench/gl-stats.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html>
+<html lang="en">
 <head>
 <meta charset="utf-8">
 <script>

--- a/bench/styles/index.html
+++ b/bench/styles/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
     <title>MapLibre GL JS Benchmarks</title>
 

--- a/bench/versions/index.html
+++ b/bench/versions/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
     <title>MapLibre GL JS Benchmarks</title>
 

--- a/debug/2762.html
+++ b/debug/2762.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
     <title>MapLibre GL JS debug page</title>
     <meta charset='utf-8'>

--- a/debug/3895.html
+++ b/debug/3895.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
     <title>MapLibre GL JS debug page</title>
     <meta charset='utf-8'>

--- a/debug/7438.html
+++ b/debug/7438.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
     <title>MapLibre GL JS debug page</title>
     <meta charset='utf-8'>

--- a/debug/7517.html
+++ b/debug/7517.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 
 <head>
     <title>MapLibre GL JS debug page</title>

--- a/debug/animate.html
+++ b/debug/animate.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
     <title>MapLibre GL JS debug page</title>
     <meta charset='utf-8'>

--- a/debug/bounds.html
+++ b/debug/bounds.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
     <title>MapLibre GL JS debug page</title>
     <meta charset='utf-8'>

--- a/debug/cache_api.html
+++ b/debug/cache_api.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
     <title>MapLibre GL JS debug page</title>
     <meta charset='utf-8'>

--- a/debug/canvas.html
+++ b/debug/canvas.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
     <title>MapLibre GL JS debug page</title>
     <meta charset='utf-8'>

--- a/debug/chinese.html
+++ b/debug/chinese.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
     <title>MapLibre GL JS debug page</title>
     <meta charset='utf-8'>

--- a/debug/circles.html
+++ b/debug/circles.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
     <title>MapLibre GL JS debug page</title>
     <meta charset='utf-8'>

--- a/debug/cluster.html
+++ b/debug/cluster.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
     <title>MapLibre GL JS debug page</title>
     <meta charset='utf-8'>

--- a/debug/color_spaces.html
+++ b/debug/color_spaces.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
     <title>MapLibre GL JS debug page</title>
     <meta charset='utf-8'>

--- a/debug/csp-static.html
+++ b/debug/csp-static.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
     <title>MapLibre GL JS debug page</title>
     <meta charset='utf-8'>

--- a/debug/csp.html
+++ b/debug/csp.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
     <title>MapLibre GL JS debug page</title>
     <meta http-equiv="Content-Security-Policy" content="worker-src blob: ; img-src data: blob: ; script-src http: 'nonce-dummy'; connect-src https://*.tiles.mapbox.com https://api.mapbox.com">

--- a/debug/custom3d.html
+++ b/debug/custom3d.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
     <title>MapLibre GL JS debug page</title>
     <meta charset='utf-8'>

--- a/debug/debug.html
+++ b/debug/debug.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
     <title>MapLibre GL JS debug page</title>
     <meta charset='utf-8'>

--- a/debug/default-image.html
+++ b/debug/default-image.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
     <title>MapLibre GL JS debug page</title>
     <meta charset='utf-8'>

--- a/debug/events.html
+++ b/debug/events.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
 <title>MapLibre GL JS debug page</title>
 <meta charset='utf-8'>

--- a/debug/extrusion-query.html
+++ b/debug/extrusion-query.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
     <title>MapLibre GL JS debug page</title>
     <meta charset='utf-8'>

--- a/debug/featurestate.html
+++ b/debug/featurestate.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
     <title>MapLibre GL JS debug page</title>
     <meta charset='utf-8'>

--- a/debug/heatmap.html
+++ b/debug/heatmap.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
     <title>MapLibre GL JS debug page</title>
     <meta charset='utf-8'>

--- a/debug/highlightpoints.html
+++ b/debug/highlightpoints.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
     <title>MapLibre GL JS debug page</title>
     <meta charset='utf-8'>

--- a/debug/hillshade.html
+++ b/debug/hillshade.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
     <title>MapLibre GL JS debug page</title>
     <meta charset='utf-8'>

--- a/debug/iframe-blob.html
+++ b/debug/iframe-blob.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
     <title>MapLibre GL JS debug page</title>
     <meta charset='utf-8'>
@@ -20,7 +20,7 @@ const css = document.createElement("a");
 css.href = "../dist/maplibre-gl.css";
 document.querySelector('iframe').src = URL.createObjectURL(new Blob([ `
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
     <title>MapLibre GL JS debug page</title>
     <meta charset='utf-8'>

--- a/debug/iframe.html
+++ b/debug/iframe.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
     <title>MapLibre GL JS debug page</title>
     <meta charset='utf-8'>

--- a/debug/image.html
+++ b/debug/image.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
     <title>MapLibre GL JS debug page</title>
     <meta charset='utf-8'>

--- a/debug/index.html
+++ b/debug/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
     <title>MapLibre GL JS debug page</title>
     <meta charset='utf-8'>

--- a/debug/is-safari.html
+++ b/debug/is-safari.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
     <title>MapLibre GL JS debug page</title>
     <meta charset='utf-8'>

--- a/debug/line-gradient.html
+++ b/debug/line-gradient.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
     <title>MapLibre GL JS debug page</title>
     <meta charset='utf-8'>

--- a/debug/markers.html
+++ b/debug/markers.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
     <title>MapLibre GL JS debug page</title>
     <meta charset='utf-8'>

--- a/debug/mobile_scroll.html
+++ b/debug/mobile_scroll.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
     <title>MapLibre GL JS debug page</title>
     <meta charset='utf-8'>

--- a/debug/multiple.html
+++ b/debug/multiple.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
     <title>MapLibre GL JS debug page</title>
     <meta charset='utf-8'>

--- a/debug/no_wrap.html
+++ b/debug/no_wrap.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
     <title>MapLibre GL JS debug page</title>
     <meta charset='utf-8'>

--- a/debug/popup.html
+++ b/debug/popup.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
     <title>MapLibre GL JS debug page</title>
     <meta charset='utf-8'>

--- a/debug/query_features.html
+++ b/debug/query_features.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
     <title>MapLibre GL JS debug page</title>
     <meta charset='utf-8'>

--- a/debug/raster-streets.html
+++ b/debug/raster-streets.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
     <title>MapLibre GL JS debug page</title>
     <meta charset='utf-8'>

--- a/debug/rtl.html
+++ b/debug/rtl.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
     <title>MapLibre GL JS debug page</title>
     <meta charset='utf-8'>

--- a/debug/satellite.html
+++ b/debug/satellite.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
     <title>MapLibre GL JS debug page</title>
     <meta charset='utf-8'>

--- a/debug/setstyle.html
+++ b/debug/setstyle.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
     <title>MapLibre GL JS debug page</title>
     <meta charset='utf-8'>

--- a/debug/stretchable.html
+++ b/debug/stretchable.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
     <title>MapLibre GL JS debug page</title>
     <meta charset='utf-8'>

--- a/debug/textsize.html
+++ b/debug/textsize.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
     <title>MapLibre GL JS debug page</title>
     <meta charset='utf-8'>

--- a/debug/threejs.html
+++ b/debug/threejs.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
     <title>MapLibre GL JS debug page</title>
     <meta charset='utf-8'>

--- a/debug/tinysdf.html
+++ b/debug/tinysdf.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
     <title>MapLibre GL JS debug page</title>
     <meta charset='utf-8'>

--- a/debug/token.html
+++ b/debug/token.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
     <title>MapLibre GL JS debug page</title>
     <meta charset='utf-8'>

--- a/debug/update_image.html
+++ b/debug/update_image.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
- <html>
+ <html lang="en">
 <head>
     <title>MapLibre GL JS debug page</title>
     <meta charset='utf-8'>

--- a/debug/variable-anchor-with-icon-text-fit.html
+++ b/debug/variable-anchor-with-icon-text-fit.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
     <meta charset='utf-8' />
     <title>MapLibre GL JS debug page</title>

--- a/debug/video.html
+++ b/debug/video.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
     <title>MapLibre GL JS debug page</title>
     <meta charset='utf-8'>

--- a/debug/wms.html
+++ b/debug/wms.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
     <title>MapLibre GL JS debug page</title>
     <meta charset='utf-8'>

--- a/test/browser/fixtures/land.html
+++ b/test/browser/fixtures/land.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
     <title>MapLibre GL JS debug page</title>
     <meta charset='utf-8'>

--- a/test/integration/testem_page.html
+++ b/test/integration/testem_page.html
@@ -1,4 +1,4 @@
-<html>
+<html lang="en">
 <head>
     <title>
         Mapbox GL JS Integration Tests

--- a/test/release/index.html
+++ b/test/release/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
     <title>MapLibre GL JS release testing page</title>
     <meta charset='utf-8'>

--- a/test/release/index.js
+++ b/test/release/index.js
@@ -206,7 +206,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
             iframeDoc.write([
                 '<!DOCTYPE html>',
-                '<html>',
+                '<html lang="en">',
                 '<head>',
                 '    <title>MapLibre GL JS debug page</title>',
                 '    <meta charset="utf-8">',


### PR DESCRIPTION
Specifying the [`lang`](https://html.spec.whatwg.org/multipage/dom.html#attr-lang) attribute to declare the default language of documents ensures correct pronunciation by screen readers.

Edit: To clarify, the default language if `lang` is omitted or set to the empty string indicates that the primary language is _unknown_.

For more information, see:
- https://www.w3.org/International/questions/qa-html-language-declarations
- https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/lang