### PR TITLE
added setTransformRequest to map to allow dynamically setting the transformRequestFn

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -296,6 +296,8 @@ declare namespace mapboxgl {
 
         setStyle(style: mapboxgl.Style | string, options?: { diff?: boolean; localIdeographFontFamily?: string }): this;
 
+        setTransformRequest(transformRequest: RequestTransformFunction): void;
+
         getStyle(): mapboxgl.Style;
 
         isStyleLoaded(): boolean;

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -1343,6 +1343,19 @@ class Map extends Camera {
         }
     }
 
+    /**
+     *  Updates the requestManager's transform request with a new function
+     * 
+     *  @param transformRequest A callback run before the Map makes a request for an external URL. The callback can be used to modify the url, set headers, or set the credentials property for cross-origin requests.
+     *    Expected to return an object with a `url` property and optionally `headers` and `credentials` properties
+     * 
+     *  @example
+     *  map.setTransformRequest((url: string, resourceType: string) => {});
+     */
+    setTransformRequest(transformRequest: RequestTransformFunction) {
+        this._requestManager.setTransformRequest(transformRequest);
+    }
+
     _getUIString(key: string) {
         const str = this._locale[key];
         if (str == null) {

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -1345,15 +1345,18 @@ class Map extends Camera {
 
     /**
      *  Updates the requestManager's transform request with a new function
-     * 
+     *
      *  @param transformRequest A callback run before the Map makes a request for an external URL. The callback can be used to modify the url, set headers, or set the credentials property for cross-origin requests.
      *    Expected to return an object with a `url` property and optionally `headers` and `credentials` properties
-     * 
+     *
+     *  @returns {Map} `this`
+     *
      *  @example
      *  map.setTransformRequest((url: string, resourceType: string) => {});
      */
     setTransformRequest(transformRequest: RequestTransformFunction) {
         this._requestManager.setTransformRequest(transformRequest);
+        return this;
     }
 
     _getUIString(key: string) {

--- a/src/util/mapbox.js
+++ b/src/util/mapbox.js
@@ -194,6 +194,10 @@ export class RequestManager {
         urlObject.params.push(`access_token=${accessToken}`);
         return formatUrl(urlObject);
     }
+
+    setTransformRequest(transformRequest: RequestTransformFunction) {
+        this._transformRequestFn = transformRequest;
+    }
 }
 
 function isMapboxURL(url: string) {

--- a/test/unit/ui/map.test.js
+++ b/test/unit/ui/map.test.js
@@ -288,6 +288,29 @@ test('Map', (t) => {
         t.end();
     });
 
+    t.test('#setTransformRequest', (t) => {
+        t.test('returns self', (t) => {
+            t.stub(Map.prototype, '_detectMissingCSS');
+            const transformRequest = () => { };
+            const map = new Map({container: window.document.createElement('div')});
+            t.equal(map.setTransformRequest(transformRequest), map);
+            t.equal(map._requestManager._transformRequestFn, transformRequest);
+            t.end();
+        });
+
+        t.test('can be called more than once', (t) => {
+            const map = createMap(t);
+
+            const transformRequest = () => { };
+            map.setTransformRequest(transformRequest);
+            map.setTransformRequest(transformRequest);
+
+            t.end();
+        });
+
+        t.end();
+    });
+
     t.test('#is_Loaded', (t) => {
 
         t.test('Map#isSourceLoaded', (t) => {


### PR DESCRIPTION
## Description
- Added api for setting a transformRequest instead of only being set in the constructor
  - This allows the map object to be created (without setting style so no rendering) and for the transformRequest to be dynamically set after the map object's instantiation
  - EX: 
```
var map = new Map({
     container: "map",
     center: [-123.1187, 49.2819],
     zoom: 10,
   });
map.setTransformRequest((url: string, resourceType: string) => {});
map.setStyle(style);
```

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [x] confirm your changes do not include backports from Mapbox projects (unless with compliant license)
 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] document any changes to public APIs
