### PR TITLE
[WIP] Suppress error messages for missing raster tiles

### DIFF
--- a/src/source/source_cache.js
+++ b/src/source/source_cache.js
@@ -252,8 +252,9 @@ class SourceCache extends Evented {
     _tileLoaded(tile: Tile, id: string, previousState: TileState, err: ?Error) {
         if (err) {
             tile.state = 'errored';
-            if ((err: any).status !== 404) this._source.fire(new ErrorEvent(err, {tile}));
-            // continue to try loading parent/children tiles if a tile doesn't exist (404)
+            const status = (err: any).status;
+            if (status !== 404 && status !== 204) this._source.fire(new ErrorEvent(err, {tile}));
+            // continue to try loading parent/children tiles if a tile doesn't exist(404) or has no content (204)
             else this.update(this.transform);
             return;
         }

--- a/src/util/ajax.js
+++ b/src/util/ajax.js
@@ -146,7 +146,7 @@ function makeFetchRequest(requestParameters: RequestParameters, callback: Respon
         const requestTime = Date.now();
 
         window.fetch(request).then(response => {
-            if (response.ok) {
+            if (response.ok && response.status !== 204) {
                 const cacheableResponse = cacheIgnoringSearch ? response.clone() : null;
                 return finishRequest(response, cacheableResponse, requestTime);
 
@@ -215,7 +215,7 @@ function makeXMLHttpRequest(requestParameters: RequestParameters, callback: Resp
         callback(new Error(xhr.statusText));
     };
     xhr.onload = () => {
-        if (((xhr.status >= 200 && xhr.status < 300) || xhr.status === 0) && xhr.response !== null) {
+        if (((xhr.status >= 200 && xhr.status < 300 && xhr.status != 204) || xhr.status === 0) && xhr.response !== null) {
             let data: mixed = xhr.response;
             if (requestParameters.type === 'json') {
                 // We're manually parsing JSON here to get better error messages.

--- a/src/util/ajax.js
+++ b/src/util/ajax.js
@@ -215,7 +215,7 @@ function makeXMLHttpRequest(requestParameters: RequestParameters, callback: Resp
         callback(new Error(xhr.statusText));
     };
     xhr.onload = () => {
-        if (((xhr.status >= 200 && xhr.status < 300 && xhr.status != 204) || xhr.status === 0) && xhr.response !== null) {
+        if (((xhr.status >= 200 && xhr.status < 300 && xhr.status !== 204) || xhr.status === 0) && xhr.response !== null) {
             let data: mixed = xhr.response;
             if (requestParameters.type === 'json') {
                 // We're manually parsing JSON here to get better error messages.


### PR DESCRIPTION
This PR adds explicit support for the 204 status code returned from a tileserver to get rid of 
the large number of error messages in the dev console when requesting raster sources.
  
closes #160 

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [ ] confirm your changes do not include backports from Mapbox projects (unless with compliant license)
 - [ ] briefly describe the changes in this PR
 - [ ] include before/after visuals or gifs if this PR includes visual changes
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [ ] manually test the debug page
 - [ ] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [ ] add an entry inside this element for inclusion in the `maplibre-gl-js` changelog: `<changelog></changelog>`
