### PR TITLE
Restrict geckodriver to version 1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,7 +128,7 @@ jobs:
       - run: yarn install --frozen-lockfile
       - run: yarn run build-dev
       - run: DETECT_CHROMEDRIVER_VERSION=true yarn global add chromedriver
-      - run: yarn global add geckodriver
+      - run: yarn global add geckodriver@^1.22.3
       - name: Test Chrome
         env:
           SELENIUM_BROWSER: chrome

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,11 +2,11 @@
 
 name: CI
 
-on: push
-  # push:
-  #   branches: [main]
-  # pull_request:
-  #   branches: [main]
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
 
 jobs:
   lint_build_test:


### PR DESCRIPTION
The workflow `ci.yml` is failing because we use node `v10` and we run in the action `yarn global add geckodriver`, i.e. we always use the latest version of the geckodriver. Now `v2.0.0` of geckodriver came out and it requires at least  node `v12`. 

To fix this test I suggest in this pull request to restrict the geckodriver version range to `v1`.

Another approach would be to use geckodriver `v2.0.0` and move on to node `v12`, which is something we might want to do anyway sometime in the future.


 - ✅ confirm your changes do not include backports from Mapbox projects (unless with compliant license)
 - 🐋  briefly describe the changes in this PR
 - [ ] include before/after visuals or gifs if this PR includes visual changes
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [ ] manually test the debug page
 - 👍 apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog' -> please skip
 - [ ] add an entry inside this element for inclusion in the `maplibre-gl-js` changelog: `<changelog></changelog>`
