### PR TITLE
[Docs] Fixed code snippet typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ If you depend on mapbox-gl directly, simply replace `mapbox-gl` with `maplibre-g
 And replace ```mapboxgl``` with ```maplibregl``` in your JavaScript code:
 ```diff
 -    var map = new mapboxgl.Map({
-+    var map = new maplibre.Map({
++    var map = new maplibregl.Map({
 ```
 
 Want an example? [Try out MapLibre GL on CodePen](https://codepen.io/klokan/pen/WNoZRyx) and have a look at ones in the official [MapLibre GL JS Documentation](https://maplibre.org/maplibre-gl-js-docs/example/).


### PR DESCRIPTION
Fixed a code snippet for migrating from mapboxgl, which was advising to change it to maplibre instead of maplibregl.