### PR TITLE
Add type='button' to attrib button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 ### 🐞 Bug fixes
 
 - *...Add fixed bugs here...*
-- Prevented attribution button from submiting form
+- Prevented attribution button from submiting form (#178)
 
 ## 1.14.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 ### 🐞 Bug fixes
 
 - *...Add fixed bugs here...*
+- Prevented attribution button from submiting form
 
 ## 1.14.0
 

--- a/src/ui/control/attribution_control.js
+++ b/src/ui/control/attribution_control.js
@@ -57,6 +57,7 @@ class AttributionControl {
         this._container = DOM.create('div', 'mapboxgl-ctrl mapboxgl-ctrl-attrib');
         this._compactButton = DOM.create('button', 'mapboxgl-ctrl-attrib-button', this._container);
         this._compactButton.addEventListener('click', this._toggleAttribution);
+        this._compactButton.type = 'button';
         this._setElementTitle(this._compactButton, 'ToggleAttribution');
         this._innerContainer = DOM.create('div', 'mapboxgl-ctrl-attrib-inner', this._container);
         this._innerContainer.setAttribute('role', 'list');


### PR DESCRIPTION
Prevents form from submitting when clicked

 - [x] confirm your changes do not include backports from Mapbox projects (unless with compliant license)
 - [x] briefly describe the changes in this PR
 - [x] add an entry inside this element for inclusion in the `maplibre-gl-js` changelog: `<changelog></changelog>`
