### PR TITLE
Refactor the GeoJSONSource typings from class to interface to hide the private constructor

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1229,10 +1229,8 @@ declare namespace maplibregl {
         type: 'geojson';
     }
 
-    export class GeoJSONSource implements GeoJSONSourceRaw {
+    export interface GeoJSONSource extends GeoJSONSourceRaw {
         type: 'geojson';
-
-        constructor(options?: maplibregl.GeoJSONSourceOptions);
 
         setData(data: GeoJSON.Feature<GeoJSON.Geometry> | GeoJSON.FeatureCollection<GeoJSON.Geometry> | String): this;
 


### PR DESCRIPTION
The GeoJsonSource constructor is declared as private and should not be directly instantiated from outside, because to every GeoJSONSource also a corresponding SourceCache instance has to be created. 
https://github.com/maplibre/maplibre-gl-js/blob/0c6ead362589465ffa14a8feb99b689640c698d3/src/source/geojson_source.js#L89
Instantiating the GeoJSONSource from outside also leads to error messages when used with a bundler like webpack see https://github.com/mapbox/mapbox-gl-js/issues/3050   
Exporting the constructor in the typing files is missleading and error prone. This PR replaces the GeoJSONSource class declaration with an interface to get rid of the exported constructor.   

The GeoJsonSource class should only be consumed via Map#getSource and Layer#source. For adding GeoJSON features to the map GeoJSONSourceRaw should be used e.g. via Map#addSource.  

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [x] confirm your changes do not include backports from Mapbox projects (unless with compliant license)
 - [x] briefly describe the changes in this PR
 - [ ] include before/after visuals or gifs if this PR includes visual changes
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [ ] manually test the debug page
 - [ ] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [ ] add an entry inside this element for inclusion in the `maplibre-gl-js` changelog: `<changelog></changelog>`
