### PR TITLE
fix: update setTransformRequest to use TransformRequestFunction type

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -335,7 +335,7 @@ declare namespace maplibregl {
 
         setStyle(style: maplibregl.Style | string, options?: { diff?: boolean; localIdeographFontFamily?: string }): this;
 
-        setTransformRequest(transformRequest: RequestTransformFunction): void;
+        setTransformRequest(transformRequest: TransformRequestFunction): void;
 
         getStyle(): maplibregl.Style;
 


### PR DESCRIPTION
## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->
- https://github.com/maplibre/maplibre-gl-js/issues/186
- Added a typescript type fix for `setTransfomrRequest`, it was errantly using an undefined type `RequestTransformFunction`. Switched it to `TransformRequestFunction`
- Tried to test this by yarn linking `maplibre-gl` to a package using typescript and running build/tsc. Didn't see errors before or after making this change so not 100% sure how to confirm this change

 - [x] confirm your changes do not include backports from Mapbox projects (unless with compliant license)
 - [x] briefly describe the changes in this PR
