### PR TITLE
Update map.js to remove missingcss method and mapboxgl-canary element.

### DIFF
--- a/bench/gl-stats.html
+++ b/bench/gl-stats.html
@@ -9,7 +9,6 @@ let now = performance.now();
 window.performance.now = () => now;
 </script>
 <script src="../dist/maplibre-gl.js"></script>
-<style>.mapboxgl-canary { background-color: salmon; }</style>
 </head>
 <body style="margin: 0; padding: 0"><div id="map" style="width: 500px; height: 500px"></div></body>
 <script>

--- a/src/css/maplibre-gl.css
+++ b/src/css/maplibre-gl.css
@@ -16,10 +16,6 @@
     height: 100%;
 }
 
-.mapboxgl-canary {
-    background-color: salmon;
-}
-
 .mapboxgl-canvas-container.mapboxgl-interactive,
 .mapboxgl-ctrl-group button.mapboxgl-ctrl-compass {
     cursor: -webkit-grab;

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -270,7 +270,6 @@ class Map extends Camera {
     handlers: HandlerManager;
 
     _container: HTMLElement;
-    _missingCSSCanary: HTMLElement;
     _canvasContainer: HTMLElement;
     _controlContainer: HTMLElement;
     _controlPositions: {[_: string]: HTMLElement};
@@ -2283,23 +2282,9 @@ class Map extends Camera {
         return [width, height];
     }
 
-    _detectMissingCSS(): void {
-        const computedColor = window.getComputedStyle(this._missingCSSCanary).getPropertyValue('background-color');
-        if (computedColor !== 'rgb(250, 128, 114)') {
-            warnOnce('This page appears to be missing CSS declarations for ' +
-                'Mapbox GL JS, which may cause the map to display incorrectly. ' +
-                'Please ensure your page includes mapbox-gl.css, as described ' +
-                'in https://www.mapbox.com/mapbox-gl-js/api/.');
-        }
-    }
-
     _setupContainer() {
         const container = this._container;
         container.classList.add('mapboxgl-map');
-
-        const missingCSSCanary = this._missingCSSCanary = DOM.create('div', 'mapboxgl-canary', container);
-        missingCSSCanary.style.visibility = 'hidden';
-        this._detectMissingCSS();
 
         const canvasContainer = this._canvasContainer = DOM.create('div', 'mapboxgl-canvas-container', container);
         if (this._interactive) {
@@ -2607,7 +2592,6 @@ class Map extends Camera {
         if (extension) extension.loseContext();
         removeNode(this._canvasContainer);
         removeNode(this._controlContainer);
-        removeNode(this._missingCSSCanary);
         this._container.classList.remove('mapboxgl-map');
 
         PerformanceUtils.clearMetrics();

--- a/test/unit/ui/handler/box_zoom.test.js
+++ b/test/unit/ui/handler/box_zoom.test.js
@@ -5,7 +5,6 @@ import DOM from '../../../../src/util/dom';
 import simulate from '../../../util/simulate_interaction';
 
 function createMap(t, clickTolerance) {
-    t.stub(Map.prototype, '_detectMissingCSS');
     return new Map({container: DOM.create('div', '', window.document.body), clickTolerance});
 }
 

--- a/test/unit/ui/handler/dblclick_zoom.test.js
+++ b/test/unit/ui/handler/dblclick_zoom.test.js
@@ -5,7 +5,6 @@ import DOM from '../../../../src/util/dom';
 import simulate from '../../../util/simulate_interaction';
 
 function createMap(t) {
-    t.stub(Map.prototype, '_detectMissingCSS');
     return new Map({container: DOM.create('div', '', window.document.body)});
 }
 

--- a/test/unit/ui/handler/drag_pan.test.js
+++ b/test/unit/ui/handler/drag_pan.test.js
@@ -5,7 +5,6 @@ import DOM from '../../../../src/util/dom';
 import simulate from '../../../util/simulate_interaction';
 
 function createMap(t, clickTolerance, dragPan) {
-    t.stub(Map.prototype, '_detectMissingCSS');
     return new Map({
         container: DOM.create('div', '', window.document.body),
         clickTolerance: clickTolerance || 0,

--- a/test/unit/ui/handler/drag_rotate.test.js
+++ b/test/unit/ui/handler/drag_rotate.test.js
@@ -7,7 +7,6 @@ import simulate from '../../../util/simulate_interaction';
 import browser from '../../../../src/util/browser';
 
 function createMap(t, options) {
-    t.stub(Map.prototype, '_detectMissingCSS');
     return new Map(extend({container: DOM.create('div', '', window.document.body)}, options));
 }
 

--- a/test/unit/ui/handler/keyboard.test.js
+++ b/test/unit/ui/handler/keyboard.test.js
@@ -6,7 +6,6 @@ import simulate from '../../../util/simulate_interaction';
 import {extend} from '../../../../src/util/util';
 
 function createMap(t, options) {
-    t.stub(Map.prototype, '_detectMissingCSS');
     return new Map(extend({
         container: DOM.create('div', '', window.document.body),
     }, options));

--- a/test/unit/ui/handler/map_event.test.js
+++ b/test/unit/ui/handler/map_event.test.js
@@ -5,7 +5,6 @@ import DOM from '../../../../src/util/dom';
 import simulate from '../../../util/simulate_interaction';
 
 function createMap(t) {
-    t.stub(Map.prototype, '_detectMissingCSS');
     return new Map({interactive: false, container: DOM.create('div', '', window.document.body)});
 }
 

--- a/test/unit/ui/handler/mouse_rotate.test.js
+++ b/test/unit/ui/handler/mouse_rotate.test.js
@@ -7,7 +7,6 @@ import simulate from '../../../util/simulate_interaction';
 import browser from '../../../../src/util/browser';
 
 function createMap(t, options) {
-    t.stub(Map.prototype, '_detectMissingCSS');
     return new Map(extend({container: DOM.create('div', '', window.document.body)}, options));
 }
 

--- a/test/unit/ui/handler/scroll_zoom.test.js
+++ b/test/unit/ui/handler/scroll_zoom.test.js
@@ -8,7 +8,6 @@ import {equalWithPrecision} from '../../../util';
 import sinon from 'sinon';
 
 function createMap(t) {
-    t.stub(Map.prototype, '_detectMissingCSS');
     return new Map({
         container: DOM.create('div', '', window.document.body),
         style: {

--- a/test/unit/ui/handler/touch_zoom_rotate.test.js
+++ b/test/unit/ui/handler/touch_zoom_rotate.test.js
@@ -6,7 +6,6 @@ import DOM from '../../../../src/util/dom';
 import simulate from '../../../util/simulate_interaction';
 
 function createMap(t) {
-    t.stub(Map.prototype, '_detectMissingCSS');
     return new Map({container: DOM.create('div', '', window.document.body)});
 }
 

--- a/test/unit/ui/map.test.js
+++ b/test/unit/ui/map.test.js
@@ -131,7 +131,6 @@ test('Map', (t) => {
     });
 
     t.test('emits load event after a style is set', (t) => {
-        t.stub(Map.prototype, '_detectMissingCSS');
         const map = new Map({container: window.document.createElement('div')});
 
         map.on('load', fail);
@@ -148,7 +147,6 @@ test('Map', (t) => {
 
     t.test('#setStyle', (t) => {
         t.test('returns self', (t) => {
-            t.stub(Map.prototype, '_detectMissingCSS');
             const map = new Map({container: window.document.createElement('div')});
             t.equal(map.setStyle({
                 version: 8,
@@ -227,7 +225,6 @@ test('Map', (t) => {
         });
 
         t.test('style transform overrides unmodified map transform', (t) => {
-            t.stub(Map.prototype, '_detectMissingCSS');
             const map = new Map({container: window.document.createElement('div')});
             map.transform.lngRange = [-120, 140];
             map.transform.latRange = [-60, 80];
@@ -245,7 +242,6 @@ test('Map', (t) => {
         });
 
         t.test('style transform does not override map transform modified via options', (t) => {
-            t.stub(Map.prototype, '_detectMissingCSS');
             const map = new Map({container: window.document.createElement('div'), zoom: 10, center: [-77.0186, 38.8888]});
             t.notOk(map.transform.unmodified, 'map transform is modified by options');
             map.setStyle(createStyle());
@@ -259,7 +255,6 @@ test('Map', (t) => {
         });
 
         t.test('style transform does not override map transform modified via setters', (t) => {
-            t.stub(Map.prototype, '_detectMissingCSS');
             const map = new Map({container: window.document.createElement('div')});
             t.ok(map.transform.unmodified);
             map.setZoom(10);
@@ -290,7 +285,6 @@ test('Map', (t) => {
 
     t.test('#setTransformRequest', (t) => {
         t.test('returns self', (t) => {
-            t.stub(Map.prototype, '_detectMissingCSS');
             const transformRequest = () => { };
             const map = new Map({container: window.document.createElement('div')});
             t.equal(map.setTransformRequest(transformRequest), map);
@@ -2060,7 +2054,6 @@ test('Map', (t) => {
         const stub = t.stub(console, 'warn');
 
         const styleSheet = new window.CSSStyleSheet();
-        styleSheet.insertRule('.mapboxgl-canary { background-color: rgb(250, 128, 114); }', 0);
         window.document.styleSheets[0] = styleSheet;
         window.document.styleSheets.length = 1;
 

--- a/test/unit/ui/map/isMoving.test.js
+++ b/test/unit/ui/map/isMoving.test.js
@@ -6,7 +6,6 @@ import DOM from '../../../../src/util/dom';
 import simulate from '../../../util/simulate_interaction';
 
 function createMap(t) {
-    t.stub(Map.prototype, '_detectMissingCSS');
     return new Map({container: DOM.create('div', '', window.document.body)});
 }
 

--- a/test/unit/ui/map/isRotating.test.js
+++ b/test/unit/ui/map/isRotating.test.js
@@ -6,7 +6,6 @@ import simulate from '../../../util/simulate_interaction';
 import browser from '../../../../src/util/browser';
 
 function createMap(t) {
-    t.stub(Map.prototype, '_detectMissingCSS');
     return new Map({container: DOM.create('div', '', window.document.body)});
 }
 

--- a/test/unit/ui/map/isZooming.test.js
+++ b/test/unit/ui/map/isZooming.test.js
@@ -6,7 +6,6 @@ import DOM from '../../../../src/util/dom';
 import simulate from '../../../util/simulate_interaction';
 
 function createMap(t) {
-    t.stub(Map.prototype, '_detectMissingCSS');
     return new Map({container: DOM.create('div', '', window.document.body)});
 }
 

--- a/test/util/index.js
+++ b/test/util/index.js
@@ -19,7 +19,6 @@ export function createMap(t, options, callback) {
     Object.defineProperty(container, 'clientWidth', {value: 200, configurable: true});
     Object.defineProperty(container, 'clientHeight', {value: 200, configurable: true});
 
-    if (!options || !options.skipCSSStub) t.stub(Map.prototype, '_detectMissingCSS');
     if (options && options.deleteStyle) delete defaultOptions.style;
 
     const map = new Map(extend(defaultOptions, options));


### PR DESCRIPTION
Remove missingcss method and mapboxgl-canary dom element. The only purpose is checking whether the css is added and warn if not. This is unnecessary bloat.

https://github.com/maplibre/maplibre-gl-js/issues/74#issuecomment-871644077

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [x] confirm your changes do not include backports from Mapbox projects (unless with compliant license)
 - [x] briefly describe the changes in this PR
 - [ ] include before/after visuals or gifs if this PR includes visual changes
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [ ] manually test the debug page
 - [ ] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [ ] add an entry inside this element for inclusion in the `maplibre-gl-js` changelog: `<changelog></changelog>`
