### PR TITLE
remove detectmissingcss method

### DIFF
--- a/bench/gl-stats.html
+++ b/bench/gl-stats.html
@@ -9,7 +9,6 @@ let now = performance.now();
 window.performance.now = () => now;
 </script>
 <script src="../dist/maplibre-gl.js"></script>
-<style>.mapboxgl-canary { background-color: salmon; }</style>
 </head>
 <body style="margin: 0; padding: 0"><div id="map" style="width: 500px; height: 500px"></div></body>
 <script>

--- a/src/css/maplibre-gl.css
+++ b/src/css/maplibre-gl.css
@@ -16,10 +16,6 @@
     height: 100%;
 }
 
-.mapboxgl-canary {
-    background-color: salmon;
-}
-
 .mapboxgl-canvas-container.mapboxgl-interactive,
 .mapboxgl-ctrl-group button.mapboxgl-ctrl-compass {
     cursor: -webkit-grab;

--- a/src/ui/map.js
+++ b/src/ui/map.js
@@ -270,7 +270,6 @@ class Map extends Camera {
     handlers: HandlerManager;
 
     _container: HTMLElement;
-    _missingCSSCanary: HTMLElement;
     _canvasContainer: HTMLElement;
     _controlContainer: HTMLElement;
     _controlPositions: {[_: string]: HTMLElement};
@@ -2283,23 +2282,9 @@ class Map extends Camera {
         return [width, height];
     }
 
-    _detectMissingCSS(): void {
-        const computedColor = window.getComputedStyle(this._missingCSSCanary).getPropertyValue('background-color');
-        if (computedColor !== 'rgb(250, 128, 114)') {
-            warnOnce('This page appears to be missing CSS declarations for ' +
-                'Mapbox GL JS, which may cause the map to display incorrectly. ' +
-                'Please ensure your page includes mapbox-gl.css, as described ' +
-                'in https://www.mapbox.com/mapbox-gl-js/api/.');
-        }
-    }
-
     _setupContainer() {
         const container = this._container;
         container.classList.add('mapboxgl-map');
-
-        const missingCSSCanary = this._missingCSSCanary = DOM.create('div', 'mapboxgl-canary', container);
-        missingCSSCanary.style.visibility = 'hidden';
-        this._detectMissingCSS();
 
         const canvasContainer = this._canvasContainer = DOM.create('div', 'mapboxgl-canvas-container', container);
         if (this._interactive) {
@@ -2607,7 +2592,6 @@ class Map extends Camera {
         if (extension) extension.loseContext();
         removeNode(this._canvasContainer);
         removeNode(this._controlContainer);
-        removeNode(this._missingCSSCanary);
         this._container.classList.remove('mapboxgl-map');
 
         PerformanceUtils.clearMetrics();

--- a/test/unit/ui/handler/box_zoom.test.js
+++ b/test/unit/ui/handler/box_zoom.test.js
@@ -9,7 +9,7 @@ function createMap(clickTolerance) {
 }
 
 test('BoxZoomHandler fires boxzoomstart and boxzoomend events at appropriate times', (t) => {
-    const map = createMap(t);
+    const map = createMap();
 
     const boxzoomstart = t.spy();
     const boxzoomend   = t.spy();
@@ -37,7 +37,7 @@ test('BoxZoomHandler fires boxzoomstart and boxzoomend events at appropriate tim
 });
 
 test('BoxZoomHandler avoids conflicts with DragPanHandler when disabled and reenabled (#2237)', (t) => {
-    const map = createMap(t);
+    const map = createMap();
 
     map.boxZoom.disable();
     map.boxZoom.enable();
@@ -80,7 +80,7 @@ test('BoxZoomHandler avoids conflicts with DragPanHandler when disabled and reen
 });
 
 test('BoxZoomHandler does not begin a box zoom if preventDefault is called on the mousedown event', (t) => {
-    const map = createMap(t);
+    const map = createMap();
 
     map.on('mousedown', e => e.preventDefault());
 
@@ -107,7 +107,7 @@ test('BoxZoomHandler does not begin a box zoom if preventDefault is called on th
 });
 
 test('BoxZoomHandler does not begin a box zoom on spurious mousemove events', (t) => {
-    const map = createMap(t);
+    const map = createMap();
 
     const boxzoomstart = t.spy();
     const boxzoomend   = t.spy();
@@ -135,7 +135,7 @@ test('BoxZoomHandler does not begin a box zoom on spurious mousemove events', (t
 });
 
 test('BoxZoomHandler does not begin a box zoom until mouse move is larger than click tolerance', (t) => {
-    const map = createMap(t, 4);
+    const map = createMap(4);
 
     const boxzoomstart = t.spy();
     const boxzoomend   = t.spy();

--- a/test/unit/ui/handler/box_zoom.test.js
+++ b/test/unit/ui/handler/box_zoom.test.js
@@ -4,7 +4,7 @@ import Map from '../../../../src/ui/map';
 import DOM from '../../../../src/util/dom';
 import simulate from '../../../util/simulate_interaction';
 
-function createMap(t, clickTolerance) {
+function createMap(clickTolerance) {
     return new Map({container: DOM.create('div', '', window.document.body), clickTolerance});
 }
 

--- a/test/unit/ui/handler/box_zoom.test.js
+++ b/test/unit/ui/handler/box_zoom.test.js
@@ -4,7 +4,7 @@ import Map from '../../../../src/ui/map';
 import DOM from '../../../../src/util/dom';
 import simulate from '../../../util/simulate_interaction';
 
-function createMap(clickTolerance) {
+function createMap(t, clickTolerance) {
     return new Map({container: DOM.create('div', '', window.document.body), clickTolerance});
 }
 

--- a/test/unit/ui/handler/box_zoom.test.js
+++ b/test/unit/ui/handler/box_zoom.test.js
@@ -5,7 +5,6 @@ import DOM from '../../../../src/util/dom';
 import simulate from '../../../util/simulate_interaction';
 
 function createMap(t, clickTolerance) {
-    t.stub(Map.prototype, '_detectMissingCSS');
     return new Map({container: DOM.create('div', '', window.document.body), clickTolerance});
 }
 

--- a/test/unit/ui/handler/dblclick_zoom.test.js
+++ b/test/unit/ui/handler/dblclick_zoom.test.js
@@ -5,7 +5,6 @@ import DOM from '../../../../src/util/dom';
 import simulate from '../../../util/simulate_interaction';
 
 function createMap(t) {
-    t.stub(Map.prototype, '_detectMissingCSS');
     return new Map({container: DOM.create('div', '', window.document.body)});
 }
 

--- a/test/unit/ui/handler/dblclick_zoom.test.js
+++ b/test/unit/ui/handler/dblclick_zoom.test.js
@@ -4,7 +4,7 @@ import Map from '../../../../src/ui/map';
 import DOM from '../../../../src/util/dom';
 import simulate from '../../../util/simulate_interaction';
 
-function createMap(t) {
+function createMap() {
     return new Map({container: DOM.create('div', '', window.document.body)});
 }
 

--- a/test/unit/ui/handler/drag_pan.test.js
+++ b/test/unit/ui/handler/drag_pan.test.js
@@ -16,7 +16,7 @@ function createMap(clickTolerance, dragPan) {
 const buttons = 1;
 
 test('DragPanHandler fires dragstart, drag, and dragend events at appropriate times in response to a mouse-triggered drag', (t) => {
-    const map = createMap(t);
+    const map = createMap();
 
     const dragstart = t.spy();
     const drag      = t.spy();
@@ -49,7 +49,7 @@ test('DragPanHandler fires dragstart, drag, and dragend events at appropriate ti
 });
 
 test('DragPanHandler captures mousemove events during a mouse-triggered drag (receives them even if they occur outside the map)', (t) => {
-    const map = createMap(t);
+    const map = createMap();
 
     const dragstart = t.spy();
     const drag      = t.spy();
@@ -82,7 +82,7 @@ test('DragPanHandler captures mousemove events during a mouse-triggered drag (re
 });
 
 test('DragPanHandler fires dragstart, drag, and dragend events at appropriate times in response to a touch-triggered drag', (t) => {
-    const map = createMap(t);
+    const map = createMap();
     const target = map.getCanvas();
 
     const dragstart = t.spy();
@@ -116,7 +116,7 @@ test('DragPanHandler fires dragstart, drag, and dragend events at appropriate ti
 });
 
 test('DragPanHandler prevents mousemove events from firing during a drag (#1555)', (t) => {
-    const map = createMap(t);
+    const map = createMap();
 
     const mousemove = t.spy();
     map.on('mousemove', mousemove);
@@ -137,7 +137,7 @@ test('DragPanHandler prevents mousemove events from firing during a drag (#1555)
 });
 
 test('DragPanHandler ends a mouse-triggered drag if the window blurs', (t) => {
-    const map = createMap(t);
+    const map = createMap();
 
     const dragend = t.spy();
     map.on('dragend', dragend);
@@ -156,7 +156,7 @@ test('DragPanHandler ends a mouse-triggered drag if the window blurs', (t) => {
 });
 
 test('DragPanHandler ends a touch-triggered drag if the window blurs', (t) => {
-    const map = createMap(t);
+    const map = createMap();
     const target = map.getCanvas();
 
     const dragend = t.spy();
@@ -176,7 +176,7 @@ test('DragPanHandler ends a touch-triggered drag if the window blurs', (t) => {
 });
 
 test('DragPanHandler requests a new render frame after each mousemove event', (t) => {
-    const map = createMap(t);
+    const map = createMap();
     const requestFrame = t.spy(map.handlers, '_requestFrame');
 
     simulate.mousedown(map.getCanvas());
@@ -196,7 +196,7 @@ test('DragPanHandler requests a new render frame after each mousemove event', (t
 
 test('DragPanHandler can interleave with another handler', (t) => {
     // https://github.com/mapbox/mapbox-gl-js/issues/6106
-    const map = createMap(t);
+    const map = createMap();
 
     const dragstart = t.spy();
     const drag      = t.spy();
@@ -243,7 +243,7 @@ test('DragPanHandler can interleave with another handler', (t) => {
 
 ['ctrl', 'shift'].forEach((modifier) => {
     test(`DragPanHandler does not begin a drag if the ${modifier} key is down on mousedown`, (t) => {
-        const map = createMap(t);
+        const map = createMap();
         t.ok(map.dragRotate.isEnabled());
 
         const dragstart = t.spy();
@@ -277,7 +277,7 @@ test('DragPanHandler can interleave with another handler', (t) => {
     });
 
     test(`DragPanHandler still ends a drag if the ${modifier} key is down on mouseup`, (t) => {
-        const map = createMap(t);
+        const map = createMap();
         t.ok(map.dragRotate.isEnabled());
 
         const dragstart = t.spy();
@@ -312,7 +312,7 @@ test('DragPanHandler can interleave with another handler', (t) => {
 });
 
 test('DragPanHandler does not begin a drag on right button mousedown', (t) => {
-    const map = createMap(t);
+    const map = createMap();
     map.dragRotate.disable();
 
     const dragstart = t.spy();
@@ -346,7 +346,7 @@ test('DragPanHandler does not begin a drag on right button mousedown', (t) => {
 });
 
 test('DragPanHandler does not end a drag on right button mouseup', (t) => {
-    const map = createMap(t);
+    const map = createMap();
     map.dragRotate.disable();
 
     const dragstart = t.spy();
@@ -398,7 +398,7 @@ test('DragPanHandler does not end a drag on right button mouseup', (t) => {
 });
 
 test('DragPanHandler does not begin a drag if preventDefault is called on the mousedown event', (t) => {
-    const map = createMap(t);
+    const map = createMap();
 
     map.on('mousedown', e => e.preventDefault());
 
@@ -428,7 +428,7 @@ test('DragPanHandler does not begin a drag if preventDefault is called on the mo
 });
 
 test('DragPanHandler does not begin a drag if preventDefault is called on the touchstart event', (t) => {
-    const map = createMap(t);
+    const map = createMap();
     const target = map.getCanvas();
 
     map.on('touchstart', e => e.preventDefault());
@@ -459,7 +459,7 @@ test('DragPanHandler does not begin a drag if preventDefault is called on the to
 });
 
 test('DragPanHandler does not begin a drag if preventDefault is called on the touchstart event (delegated)', (t) => {
-    const map = createMap(t);
+    const map = createMap();
     const target = map.getCanvas();
 
     t.stub(map, 'getLayer')

--- a/test/unit/ui/handler/drag_pan.test.js
+++ b/test/unit/ui/handler/drag_pan.test.js
@@ -5,7 +5,6 @@ import DOM from '../../../../src/util/dom';
 import simulate from '../../../util/simulate_interaction';
 
 function createMap(t, clickTolerance, dragPan) {
-    t.stub(Map.prototype, '_detectMissingCSS');
     return new Map({
         container: DOM.create('div', '', window.document.body),
         clickTolerance: clickTolerance || 0,

--- a/test/unit/ui/handler/drag_pan.test.js
+++ b/test/unit/ui/handler/drag_pan.test.js
@@ -4,7 +4,7 @@ import Map from '../../../../src/ui/map';
 import DOM from '../../../../src/util/dom';
 import simulate from '../../../util/simulate_interaction';
 
-function createMap(clickTolerance, dragPan) {
+function createMap(t, clickTolerance, dragPan) {
     return new Map({
         container: DOM.create('div', '', window.document.body),
         clickTolerance: clickTolerance || 0,

--- a/test/unit/ui/handler/drag_pan.test.js
+++ b/test/unit/ui/handler/drag_pan.test.js
@@ -4,7 +4,7 @@ import Map from '../../../../src/ui/map';
 import DOM from '../../../../src/util/dom';
 import simulate from '../../../util/simulate_interaction';
 
-function createMap(t, clickTolerance, dragPan) {
+function createMap(clickTolerance, dragPan) {
     return new Map({
         container: DOM.create('div', '', window.document.body),
         clickTolerance: clickTolerance || 0,

--- a/test/unit/ui/handler/drag_rotate.test.js
+++ b/test/unit/ui/handler/drag_rotate.test.js
@@ -7,7 +7,6 @@ import simulate from '../../../util/simulate_interaction';
 import browser from '../../../../src/util/browser';
 
 function createMap(t, options) {
-    t.stub(Map.prototype, '_detectMissingCSS');
     return new Map(extend({container: DOM.create('div', '', window.document.body)}, options));
 }
 

--- a/test/unit/ui/handler/drag_rotate.test.js
+++ b/test/unit/ui/handler/drag_rotate.test.js
@@ -11,7 +11,7 @@ function createMap(options) {
 }
 
 test('DragRotateHandler#isActive', (t) => {
-    const map = createMap(t);
+    const map = createMap();
 
     // Prevent inertial rotation.
     t.stub(browser, 'now').returns(0);
@@ -35,7 +35,7 @@ test('DragRotateHandler#isActive', (t) => {
 });
 
 test('DragRotateHandler fires rotatestart, rotate, and rotateend events at appropriate times in response to a right-click drag', (t) => {
-    const map = createMap(t);
+    const map = createMap();
 
     // Prevent inertial rotation.
     t.stub(browser, 'now').returns(0);
@@ -71,7 +71,7 @@ test('DragRotateHandler fires rotatestart, rotate, and rotateend events at appro
 });
 
 test('DragRotateHandler stops firing events after mouseup', (t) => {
-    const map = createMap(t);
+    const map = createMap();
 
     // Prevent inertial rotation.
     t.stub(browser, 'now').returns(0);
@@ -98,7 +98,7 @@ test('DragRotateHandler stops firing events after mouseup', (t) => {
 });
 
 test('DragRotateHandler fires rotatestart, rotate, and rotateend events at appropriate times in response to a control-left-click drag', (t) => {
-    const map = createMap(t);
+    const map = createMap();
 
     // Prevent inertial rotation.
     t.stub(browser, 'now').returns(0);
@@ -134,7 +134,7 @@ test('DragRotateHandler fires rotatestart, rotate, and rotateend events at appro
 });
 
 test('DragRotateHandler pitches in response to a right-click drag by default', (t) => {
-    const map = createMap(t);
+    const map = createMap();
 
     // Prevent inertial rotation.
     t.stub(browser, 'now').returns(0);
@@ -162,7 +162,7 @@ test('DragRotateHandler pitches in response to a right-click drag by default', (
 });
 
 test('DragRotateHandler doesn\'t fire pitch event when rotating only', (t) => {
-    const map = createMap(t);
+    const map = createMap();
 
     // Prevent inertial rotation.
     t.stub(browser, 'now').returns(0);
@@ -189,7 +189,7 @@ test('DragRotateHandler doesn\'t fire pitch event when rotating only', (t) => {
 });
 
 test('DragRotateHandler pitches in response to a control-left-click drag', (t) => {
-    const map = createMap(t);
+    const map = createMap();
 
     // Prevent inertial rotation.
     t.stub(browser, 'now').returns(0);
@@ -217,7 +217,7 @@ test('DragRotateHandler pitches in response to a control-left-click drag', (t) =
 });
 
 test('DragRotateHandler does not pitch if given pitchWithRotate: false', (t) => {
-    const map = createMap(t, {pitchWithRotate: false});
+    const map = createMap({pitchWithRotate: false});
 
     const spy = t.spy();
 
@@ -242,7 +242,7 @@ test('DragRotateHandler does not pitch if given pitchWithRotate: false', (t) => 
 });
 
 test('DragRotateHandler does not rotate or pitch when disabled', (t) => {
-    const map = createMap(t);
+    const map = createMap();
 
     map.dragRotate.disable();
 
@@ -268,7 +268,7 @@ test('DragRotateHandler does not rotate or pitch when disabled', (t) => {
 
 test('DragRotateHandler ensures that map.isMoving() returns true during drag', (t) => {
     // The bearingSnap option here ensures that the moveend event is sent synchronously.
-    const map = createMap(t, {bearingSnap: 0});
+    const map = createMap({bearingSnap: 0});
 
     simulate.mousedown(map.getCanvas(), {buttons: 2, button: 2});
     simulate.mousemove(map.getCanvas(), {buttons: 2, clientX: 10, clientY: 10});
@@ -285,7 +285,7 @@ test('DragRotateHandler ensures that map.isMoving() returns true during drag', (
 
 test('DragRotateHandler fires move events', (t) => {
     // The bearingSnap option here ensures that the moveend event is sent synchronously.
-    const map = createMap(t, {bearingSnap: 0});
+    const map = createMap({bearingSnap: 0});
 
     // Prevent inertial rotation.
     t.stub(browser, 'now').returns(0);
@@ -314,7 +314,7 @@ test('DragRotateHandler fires move events', (t) => {
 
 test('DragRotateHandler doesn\'t fire rotate event when pitching only', (t) => {
     // The bearingSnap option here ensures that the moveend event is sent synchronously.
-    const map = createMap(t, {bearingSnap: 0});
+    const map = createMap({bearingSnap: 0});
 
     // Prevent inertial rotation.
     t.stub(browser, 'now').returns(0);
@@ -345,7 +345,7 @@ test('DragRotateHandler doesn\'t fire rotate event when pitching only', (t) => {
 
 test('DragRotateHandler includes originalEvent property in triggered events', (t) => {
     // The bearingSnap option here ensures that the moveend event is sent synchronously.
-    const map = createMap(t, {bearingSnap: 0});
+    const map = createMap({bearingSnap: 0});
 
     // Prevent inertial rotation.
     t.stub(browser, 'now').returns(0);
@@ -394,7 +394,7 @@ test('DragRotateHandler includes originalEvent property in triggered events', (t
 });
 
 test('DragRotateHandler responds to events on the canvas container (#1301)', (t) => {
-    const map = createMap(t);
+    const map = createMap();
 
     // Prevent inertial rotation.
     t.stub(browser, 'now').returns(0);
@@ -422,7 +422,7 @@ test('DragRotateHandler responds to events on the canvas container (#1301)', (t)
 });
 
 test('DragRotateHandler prevents mousemove events from firing during a drag (#1555)', (t) => {
-    const map = createMap(t);
+    const map = createMap();
 
     // Prevent inertial rotation.
     t.stub(browser, 'now').returns(0);
@@ -442,7 +442,7 @@ test('DragRotateHandler prevents mousemove events from firing during a drag (#15
 });
 
 test('DragRotateHandler ends a control-left-click drag on mouseup even when the control key was previously released (#1888)', (t) => {
-    const map = createMap(t);
+    const map = createMap();
 
     // Prevent inertial rotation.
     t.stub(browser, 'now').returns(0);
@@ -470,7 +470,7 @@ test('DragRotateHandler ends a control-left-click drag on mouseup even when the 
 });
 
 test('DragRotateHandler ends rotation if the window blurs (#3389)', (t) => {
-    const map = createMap(t);
+    const map = createMap();
 
     // Prevent inertial rotation.
     t.stub(browser, 'now').returns(0);
@@ -497,7 +497,7 @@ test('DragRotateHandler ends rotation if the window blurs (#3389)', (t) => {
 });
 
 test('DragRotateHandler requests a new render frame after each mousemove event', (t) => {
-    const map = createMap(t);
+    const map = createMap();
     const requestRenderFrame = t.spy(map.handlers, '_requestFrame');
 
     // Prevent inertial rotation.
@@ -520,7 +520,7 @@ test('DragRotateHandler requests a new render frame after each mousemove event',
 
 test('DragRotateHandler can interleave with another handler', (t) => {
     // https://github.com/mapbox/mapbox-gl-js/issues/6106
-    const map = createMap(t);
+    const map = createMap();
 
     // Prevent inertial rotation.
     t.stub(browser, 'now').returns(0);
@@ -570,7 +570,7 @@ test('DragRotateHandler can interleave with another handler', (t) => {
 });
 
 test('DragRotateHandler does not begin a drag on left-button mousedown without the control key', (t) => {
-    const map = createMap(t);
+    const map = createMap();
     map.dragPan.disable();
 
     const rotatestart = t.spy();
@@ -604,7 +604,7 @@ test('DragRotateHandler does not begin a drag on left-button mousedown without t
 });
 
 test('DragRotateHandler does not end a right-button drag on left-button mouseup', (t) => {
-    const map = createMap(t);
+    const map = createMap();
     map.dragPan.disable();
 
     // Prevent inertial rotation.
@@ -659,7 +659,7 @@ test('DragRotateHandler does not end a right-button drag on left-button mouseup'
 });
 
 test('DragRotateHandler does not end a control-left-button drag on right-button mouseup', (t) => {
-    const map = createMap(t);
+    const map = createMap();
     map.dragPan.disable();
 
     // Prevent inertial rotation.
@@ -714,7 +714,7 @@ test('DragRotateHandler does not end a control-left-button drag on right-button 
 });
 
 test('DragRotateHandler does not begin a drag if preventDefault is called on the mousedown event', (t) => {
-    const map = createMap(t);
+    const map = createMap();
 
     map.on('mousedown', e => e.preventDefault());
 
@@ -744,7 +744,7 @@ test('DragRotateHandler does not begin a drag if preventDefault is called on the
 });
 
 test(`DragRotateHandler can be disabled after mousedown (#2419)`, (t) => {
-    const map = createMap(t);
+    const map = createMap();
 
     // Prevent inertial rotation.
     t.stub(browser, 'now').returns(0);
@@ -785,7 +785,7 @@ test(`DragRotateHandler can be disabled after mousedown (#2419)`, (t) => {
 });
 
 test('DragRotateHandler does not begin rotation on spurious mousemove events', (t) => {
-    const map = createMap(t);
+    const map = createMap();
 
     const rotatestart = t.spy();
     const rotate      = t.spy();
@@ -818,7 +818,7 @@ test('DragRotateHandler does not begin rotation on spurious mousemove events', (
 });
 
 test('DragRotateHandler does not begin a mouse drag if moved less than click tolerance', (t) => {
-    const map = createMap(t, {clickTolerance: 4});
+    const map = createMap({clickTolerance: 4});
 
     // Prevent inertial rotation.
     t.stub(browser, 'now').returns(0);

--- a/test/unit/ui/handler/drag_rotate.test.js
+++ b/test/unit/ui/handler/drag_rotate.test.js
@@ -6,7 +6,7 @@ import DOM from '../../../../src/util/dom';
 import simulate from '../../../util/simulate_interaction';
 import browser from '../../../../src/util/browser';
 
-function createMap(options) {
+function createMap(t, options) {
     return new Map(extend({container: DOM.create('div', '', window.document.body)}, options));
 }
 

--- a/test/unit/ui/handler/drag_rotate.test.js
+++ b/test/unit/ui/handler/drag_rotate.test.js
@@ -6,7 +6,7 @@ import DOM from '../../../../src/util/dom';
 import simulate from '../../../util/simulate_interaction';
 import browser from '../../../../src/util/browser';
 
-function createMap(t, options) {
+function createMap(options) {
     return new Map(extend({container: DOM.create('div', '', window.document.body)}, options));
 }
 

--- a/test/unit/ui/handler/keyboard.test.js
+++ b/test/unit/ui/handler/keyboard.test.js
@@ -5,7 +5,7 @@ import window from '../../../../src/util/window';
 import simulate from '../../../util/simulate_interaction';
 import {extend} from '../../../../src/util/util';
 
-function createMap(options) {
+function createMap(t, options) {
     return new Map(extend({
         container: DOM.create('div', '', window.document.body),
     }, options));

--- a/test/unit/ui/handler/keyboard.test.js
+++ b/test/unit/ui/handler/keyboard.test.js
@@ -5,7 +5,7 @@ import window from '../../../../src/util/window';
 import simulate from '../../../util/simulate_interaction';
 import {extend} from '../../../../src/util/util';
 
-function createMap(t, options) {
+function createMap(options) {
     return new Map(extend({
         container: DOM.create('div', '', window.document.body),
     }, options));

--- a/test/unit/ui/handler/keyboard.test.js
+++ b/test/unit/ui/handler/keyboard.test.js
@@ -12,7 +12,7 @@ function createMap(options) {
 }
 
 test('KeyboardHandler responds to keydown events', (t) => {
-    const map = createMap(t);
+    const map = createMap();
     const h = map.keyboard;
     t.spy(h, 'keydown');
 
@@ -23,7 +23,7 @@ test('KeyboardHandler responds to keydown events', (t) => {
 });
 
 test('KeyboardHandler pans map in response to arrow keys', (t) => {
-    const map = createMap(t, {zoom: 10, center: [0, 0]});
+    const map = createMap({zoom: 10, center: [0, 0]});
     t.spy(map, 'easeTo');
 
     simulate.keydown(map.getCanvas(), {keyCode: 32, key: " "});
@@ -57,7 +57,7 @@ test('KeyboardHandler pans map in response to arrow keys', (t) => {
 });
 
 test('KeyboardHandler pans map in response to arrow keys when disableRotation has been called', (t) => {
-    const map = createMap(t, {zoom: 10, center: [0, 0]});
+    const map = createMap({zoom: 10, center: [0, 0]});
     t.spy(map, 'easeTo');
     map.keyboard.disableRotation();
 
@@ -92,7 +92,7 @@ test('KeyboardHandler pans map in response to arrow keys when disableRotation ha
 });
 
 test('KeyboardHandler rotates map in response to Shift+left/right arrow keys', async (t) => {
-    const map = createMap(t, {zoom: 10, center: [0, 0], bearing: 0});
+    const map = createMap({zoom: 10, center: [0, 0], bearing: 0});
     t.spy(map, 'easeTo');
 
     simulate.keydown(map.getCanvas(), {keyCode: 32, key: " "});
@@ -115,7 +115,7 @@ test('KeyboardHandler rotates map in response to Shift+left/right arrow keys', a
 });
 
 test('KeyboardHandler does not rotate map in response to Shift+left/right arrow keys when disableRotation has been called', async (t) => {
-    const map = createMap(t, {zoom: 10, center: [0, 0], bearing: 0});
+    const map = createMap({zoom: 10, center: [0, 0], bearing: 0});
     t.spy(map, 'easeTo');
     map.keyboard.disableRotation();
 
@@ -139,7 +139,7 @@ test('KeyboardHandler does not rotate map in response to Shift+left/right arrow 
 });
 
 test('KeyboardHandler pitches map in response to Shift+up/down arrow keys', async (t) => {
-    const map = createMap(t, {zoom: 10, center: [0, 0], pitch: 30});
+    const map = createMap({zoom: 10, center: [0, 0], pitch: 30});
     t.spy(map, 'easeTo');
 
     simulate.keydown(map.getCanvas(), {keyCode: 32, key: " "});
@@ -162,7 +162,7 @@ test('KeyboardHandler pitches map in response to Shift+up/down arrow keys', asyn
 });
 
 test('KeyboardHandler does not pitch map in response to Shift+up/down arrow keys when disableRotation has been called', async (t) => {
-    const map = createMap(t, {zoom: 10, center: [0, 0], pitch: 30});
+    const map = createMap({zoom: 10, center: [0, 0], pitch: 30});
     t.spy(map, 'easeTo');
     map.keyboard.disableRotation();
 
@@ -186,7 +186,7 @@ test('KeyboardHandler does not pitch map in response to Shift+up/down arrow keys
 });
 
 test('KeyboardHandler zooms map in response to -/+ keys', (t) => {
-    const map = createMap(t, {zoom: 10, center: [0, 0]});
+    const map = createMap({zoom: 10, center: [0, 0]});
     t.spy(map, 'easeTo');
 
     simulate.keydown(map.getCanvas(), {keyCode: 187, key: "Equal"});
@@ -212,7 +212,7 @@ test('KeyboardHandler zooms map in response to -/+ keys', (t) => {
 });
 
 test('KeyboardHandler zooms map in response to -/+ keys when disableRotation has been called', (t) => {
-    const map = createMap(t, {zoom: 10, center: [0, 0]});
+    const map = createMap({zoom: 10, center: [0, 0]});
     t.spy(map, 'easeTo');
     map.keyboard.disableRotation();
 

--- a/test/unit/ui/handler/keyboard.test.js
+++ b/test/unit/ui/handler/keyboard.test.js
@@ -6,7 +6,6 @@ import simulate from '../../../util/simulate_interaction';
 import {extend} from '../../../../src/util/util';
 
 function createMap(t, options) {
-    t.stub(Map.prototype, '_detectMissingCSS');
     return new Map(extend({
         container: DOM.create('div', '', window.document.body),
     }, options));

--- a/test/unit/ui/handler/map_event.test.js
+++ b/test/unit/ui/handler/map_event.test.js
@@ -4,7 +4,7 @@ import Map from '../../../../src/ui/map';
 import DOM from '../../../../src/util/dom';
 import simulate from '../../../util/simulate_interaction';
 
-function createMap(t) {
+function createMap() {
     return new Map({interactive: false, container: DOM.create('div', '', window.document.body)});
 }
 

--- a/test/unit/ui/handler/map_event.test.js
+++ b/test/unit/ui/handler/map_event.test.js
@@ -5,7 +5,6 @@ import DOM from '../../../../src/util/dom';
 import simulate from '../../../util/simulate_interaction';
 
 function createMap(t) {
-    t.stub(Map.prototype, '_detectMissingCSS');
     return new Map({interactive: false, container: DOM.create('div', '', window.document.body)});
 }
 

--- a/test/unit/ui/handler/mouse_rotate.test.js
+++ b/test/unit/ui/handler/mouse_rotate.test.js
@@ -7,7 +7,6 @@ import simulate from '../../../util/simulate_interaction';
 import browser from '../../../../src/util/browser';
 
 function createMap(t, options) {
-    t.stub(Map.prototype, '_detectMissingCSS');
     return new Map(extend({container: DOM.create('div', '', window.document.body)}, options));
 }
 

--- a/test/unit/ui/handler/mouse_rotate.test.js
+++ b/test/unit/ui/handler/mouse_rotate.test.js
@@ -11,7 +11,7 @@ function createMap(options) {
 }
 
 test('MouseRotateHandler#isActive', (t) => {
-    const map = createMap(t);
+    const map = createMap();
     const mouseRotate = map.handlers._handlersById.mouseRotate;
 
     // Prevent inertial rotation.
@@ -35,7 +35,7 @@ test('MouseRotateHandler#isActive', (t) => {
 });
 
 test('MouseRotateHandler#isActive #4622 regression test', (t) => {
-    const map = createMap(t);
+    const map = createMap();
     const mouseRotate = map.handlers._handlersById.mouseRotate;
 
     // Prevent inertial rotation.

--- a/test/unit/ui/handler/mouse_rotate.test.js
+++ b/test/unit/ui/handler/mouse_rotate.test.js
@@ -6,7 +6,7 @@ import DOM from '../../../../src/util/dom';
 import simulate from '../../../util/simulate_interaction';
 import browser from '../../../../src/util/browser';
 
-function createMap(options) {
+function createMap(t, options) {
     return new Map(extend({container: DOM.create('div', '', window.document.body)}, options));
 }
 

--- a/test/unit/ui/handler/mouse_rotate.test.js
+++ b/test/unit/ui/handler/mouse_rotate.test.js
@@ -6,7 +6,7 @@ import DOM from '../../../../src/util/dom';
 import simulate from '../../../util/simulate_interaction';
 import browser from '../../../../src/util/browser';
 
-function createMap(t, options) {
+function createMap(options) {
     return new Map(extend({container: DOM.create('div', '', window.document.body)}, options));
 }
 

--- a/test/unit/ui/handler/scroll_zoom.test.js
+++ b/test/unit/ui/handler/scroll_zoom.test.js
@@ -8,7 +8,6 @@ import {equalWithPrecision} from '../../../util';
 import sinon from 'sinon';
 
 function createMap(t) {
-    t.stub(Map.prototype, '_detectMissingCSS');
     return new Map({
         container: DOM.create('div', '', window.document.body),
         style: {

--- a/test/unit/ui/handler/scroll_zoom.test.js
+++ b/test/unit/ui/handler/scroll_zoom.test.js
@@ -7,7 +7,7 @@ import simulate from '../../../util/simulate_interaction';
 import {equalWithPrecision} from '../../../util';
 import sinon from 'sinon';
 
-function createMap(t) {
+function createMap() {
     return new Map({
         container: DOM.create('div', '', window.document.body),
         style: {

--- a/test/unit/ui/handler/touch_zoom_rotate.test.js
+++ b/test/unit/ui/handler/touch_zoom_rotate.test.js
@@ -6,7 +6,6 @@ import DOM from '../../../../src/util/dom';
 import simulate from '../../../util/simulate_interaction';
 
 function createMap(t) {
-    t.stub(Map.prototype, '_detectMissingCSS');
     return new Map({container: DOM.create('div', '', window.document.body)});
 }
 

--- a/test/unit/ui/handler/touch_zoom_rotate.test.js
+++ b/test/unit/ui/handler/touch_zoom_rotate.test.js
@@ -5,7 +5,7 @@ import Marker from '../../../../src/ui/marker';
 import DOM from '../../../../src/util/dom';
 import simulate from '../../../util/simulate_interaction';
 
-function createMap(t) {
+function createMap() {
     return new Map({container: DOM.create('div', '', window.document.body)});
 }
 

--- a/test/unit/ui/map.test.js
+++ b/test/unit/ui/map.test.js
@@ -2050,28 +2050,6 @@ test('Map', (t) => {
         t.end();
     });
 
-    t.test('should not warn when CSS is present', (t) => {
-        const stub = t.stub(console, 'warn');
-
-        const styleSheet = new window.CSSStyleSheet();
-        window.document.styleSheets[0] = styleSheet;
-        window.document.styleSheets.length = 1;
-
-        new Map({container: window.document.createElement('div')});
-
-        t.notok(stub.calledOnce);
-        t.end();
-    });
-
-    t.test('should warn when CSS is missing', (t) => {
-        const stub = t.stub(console, 'warn');
-        new Map({container: window.document.createElement('div')});
-
-        t.ok(stub.calledOnce);
-
-        t.end();
-    });
-
     t.test('continues camera animation on resize', (t) => {
         const map = createMap(t),
             container = map.getContainer();

--- a/test/unit/ui/map.test.js
+++ b/test/unit/ui/map.test.js
@@ -76,11 +76,11 @@ test('Map', (t) => {
     t.test('initial bounds options in constructor options', (t) => {
         const bounds = [[-133, 16], [-68, 50]];
 
-        const map = (fitBoundsOptions, skipCSSStub) => {
+        const map = (fitBoundsOptions) => {
             const container = window.document.createElement('div');
             Object.defineProperty(container, 'offsetWidth', {value: 512});
             Object.defineProperty(container, 'offsetHeight', {value: 512});
-            return createMap(t, {skipCSSStub, container, bounds, fitBoundsOptions});
+            return createMap(t, {container, bounds, fitBoundsOptions});
         };
 
         const unpadded = map(undefined, false);
@@ -623,7 +623,7 @@ test('Map', (t) => {
             [ 70.31249999999977, 57.32652122521695 ] ]));
 
         t.test('rotated bounds', (t) => {
-            const map = createMap(t, {zoom: 1, bearing: 45, skipCSSStub: true});
+            const map = createMap(t, {zoom: 1, bearing: 45});
             t.deepEqual(
                 toFixed([[-49.718445552178764, -44.44541580601936], [49.7184455522, 44.445415806019355]]),
                 toFixed(map.getBounds().toArray())

--- a/test/unit/ui/map.test.js
+++ b/test/unit/ui/map.test.js
@@ -950,7 +950,7 @@ test('Map', (t) => {
 
     t.test('#remove', (t) => {
         const map = createMap(t);
-        t.equal(map.getContainer().childNodes.length, 3);
+        t.equal(map.getContainer().childNodes.length, 2);
         map.remove();
         t.equal(map.getContainer().childNodes.length, 0);
         t.end();

--- a/test/unit/ui/map.test.js
+++ b/test/unit/ui/map.test.js
@@ -131,7 +131,6 @@ test('Map', (t) => {
     });
 
     t.test('emits load event after a style is set', (t) => {
-        t.stub(Map.prototype, '_detectMissingCSS');
         const map = new Map({container: window.document.createElement('div')});
 
         map.on('load', fail);
@@ -148,7 +147,6 @@ test('Map', (t) => {
 
     t.test('#setStyle', (t) => {
         t.test('returns self', (t) => {
-            t.stub(Map.prototype, '_detectMissingCSS');
             const map = new Map({container: window.document.createElement('div')});
             t.equal(map.setStyle({
                 version: 8,
@@ -227,7 +225,6 @@ test('Map', (t) => {
         });
 
         t.test('style transform overrides unmodified map transform', (t) => {
-            t.stub(Map.prototype, '_detectMissingCSS');
             const map = new Map({container: window.document.createElement('div')});
             map.transform.lngRange = [-120, 140];
             map.transform.latRange = [-60, 80];
@@ -245,7 +242,6 @@ test('Map', (t) => {
         });
 
         t.test('style transform does not override map transform modified via options', (t) => {
-            t.stub(Map.prototype, '_detectMissingCSS');
             const map = new Map({container: window.document.createElement('div'), zoom: 10, center: [-77.0186, 38.8888]});
             t.notOk(map.transform.unmodified, 'map transform is modified by options');
             map.setStyle(createStyle());
@@ -259,7 +255,6 @@ test('Map', (t) => {
         });
 
         t.test('style transform does not override map transform modified via setters', (t) => {
-            t.stub(Map.prototype, '_detectMissingCSS');
             const map = new Map({container: window.document.createElement('div')});
             t.ok(map.transform.unmodified);
             map.setZoom(10);
@@ -290,7 +285,6 @@ test('Map', (t) => {
 
     t.test('#setTransformRequest', (t) => {
         t.test('returns self', (t) => {
-            t.stub(Map.prototype, '_detectMissingCSS');
             const transformRequest = () => { };
             const map = new Map({container: window.document.createElement('div')});
             t.equal(map.setTransformRequest(transformRequest), map);
@@ -2060,7 +2054,6 @@ test('Map', (t) => {
         const stub = t.stub(console, 'warn');
 
         const styleSheet = new window.CSSStyleSheet();
-        styleSheet.insertRule('.mapboxgl-canary { background-color: rgb(250, 128, 114); }', 0);
         window.document.styleSheets[0] = styleSheet;
         window.document.styleSheets.length = 1;
 

--- a/test/unit/ui/map/isMoving.test.js
+++ b/test/unit/ui/map/isMoving.test.js
@@ -5,7 +5,7 @@ import Map from '../../../../src/ui/map';
 import DOM from '../../../../src/util/dom';
 import simulate from '../../../util/simulate_interaction';
 
-function createMap(t) {
+function createMap() {
     return new Map({container: DOM.create('div', '', window.document.body)});
 }
 

--- a/test/unit/ui/map/isMoving.test.js
+++ b/test/unit/ui/map/isMoving.test.js
@@ -6,7 +6,6 @@ import DOM from '../../../../src/util/dom';
 import simulate from '../../../util/simulate_interaction';
 
 function createMap(t) {
-    t.stub(Map.prototype, '_detectMissingCSS');
     return new Map({container: DOM.create('div', '', window.document.body)});
 }
 

--- a/test/unit/ui/map/isRotating.test.js
+++ b/test/unit/ui/map/isRotating.test.js
@@ -6,7 +6,6 @@ import simulate from '../../../util/simulate_interaction';
 import browser from '../../../../src/util/browser';
 
 function createMap(t) {
-    t.stub(Map.prototype, '_detectMissingCSS');
     return new Map({container: DOM.create('div', '', window.document.body)});
 }
 

--- a/test/unit/ui/map/isRotating.test.js
+++ b/test/unit/ui/map/isRotating.test.js
@@ -5,7 +5,7 @@ import DOM from '../../../../src/util/dom';
 import simulate from '../../../util/simulate_interaction';
 import browser from '../../../../src/util/browser';
 
-function createMap(t) {
+function createMap() {
     return new Map({container: DOM.create('div', '', window.document.body)});
 }
 

--- a/test/unit/ui/map/isZooming.test.js
+++ b/test/unit/ui/map/isZooming.test.js
@@ -5,7 +5,7 @@ import Map from '../../../../src/ui/map';
 import DOM from '../../../../src/util/dom';
 import simulate from '../../../util/simulate_interaction';
 
-function createMap(t) {
+function createMap() {
     return new Map({container: DOM.create('div', '', window.document.body)});
 }
 

--- a/test/unit/ui/map/isZooming.test.js
+++ b/test/unit/ui/map/isZooming.test.js
@@ -6,7 +6,6 @@ import DOM from '../../../../src/util/dom';
 import simulate from '../../../util/simulate_interaction';
 
 function createMap(t) {
-    t.stub(Map.prototype, '_detectMissingCSS');
     return new Map({container: DOM.create('div', '', window.document.body)});
 }
 

--- a/test/util/index.js
+++ b/test/util/index.js
@@ -19,7 +19,6 @@ export function createMap(t, options, callback) {
     Object.defineProperty(container, 'clientWidth', {value: 200, configurable: true});
     Object.defineProperty(container, 'clientHeight', {value: 200, configurable: true});
 
-    if (!options || !options.skipCSSStub) t.stub(Map.prototype, '_detectMissingCSS');
     if (options && options.deleteStyle) delete defaultOptions.style;
 
     const map = new Map(extend(defaultOptions, options));


### PR DESCRIPTION
Remove missingcss method and mapboxgl-canary dom element. The only purpose is checking whether the css is added and warn if not. This is unnecessary bloat.

#74 (comment)

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [ ] confirm your changes do not include backports from Mapbox projects (unless with compliant license)
 - [ ] briefly describe the changes in this PR
 - [ ] include before/after visuals or gifs if this PR includes visual changes
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [ ] manually test the debug page
 - [ ] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [ ] add an entry inside this element for inclusion in the `maplibre-gl-js` changelog: `<changelog></changelog>`
