### PR TITLE
Fix compile time issue with typescript strict mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,21 +6,21 @@
 
 ### 🐞 Bug fixes
 
-- *...Add fixed bugs here...*
+- Add void return for some method declaration to match TS strict mode (#194)
 
 ## 1.15.0
 
 ### Features and improvements
 
-- ** Breaking Change: ** Rename css classes ((#83)[https://github.com/maplibre/maplibre-gl-js/issues/83])
-- Added custom protocol support to allow overriding ajax calls ((#29)[https://github.com/maplibre/maplibre-gl-js/issues/29])
+- ** Breaking Change: ** Rename css classes (#83)
+- Added custom protocol support to allow overriding ajax calls (#29)
 - Added setTransformRequest to map (#159)
 - Publish @maplibre/maplibre-gl-style-spec v14.0.0 on NPM (#149)
 - Replace link to mapbox on LogoControl by link to maplibre (#151)
 - Migrate style spec files from mapbox to maplibre (#147)
 - Publish the MapLibre style spec in NPM (#140)
 - Replace mapboxgl with maplibregl in JSDocs inline examples (#134)
-- Bring in typescript definitions file (#24) 
+- Bring in typescript definitions file (#24)
 - Update example links to https://maplibre.org/maplibre-gl-js-docs/ (#131)
 - Improve performance of layers with constant `*-sort-key` (#78)
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -73,14 +73,14 @@ declare namespace maplibregl {
      *      return { cancel: () => { } };
      * });
      */
-    export function addProtocol(customProtocol: string, loadFn: (requestParameters: RequestParameters, callback: ResponseCallback<any>) => Cancelable);
+    export function addProtocol(customProtocol: string, loadFn: (requestParameters: RequestParameters, callback: ResponseCallback<any>) => Cancelable): void;
     /**
      * Removes a previusly added protocol
      * @param {string} customProtocol - the custom protocol to remove registration for
      * @example
      * maplibregl.removeProtocol('custom');
      */
-    export function removeProtocol(customProtocol: string);
+    export function removeProtocol(customProtocol: string): void;
 
     export function setRTLTextPlugin(pluginURL: string, callback: (error: Error) => void, deferred?: boolean): void;
     export function getRTLTextPluginStatus(): PluginStatus;


### PR DESCRIPTION
Since the release of the new version 1.15.0, I have an error in the declaration of 2 methods with the strict mode of Typescript. The strict mode of TS implies to fill the type of returns. 

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] confirm your changes do not include backports from Mapbox projects (unless with compliant license)
 - [x] briefly describe the changes in this PR
 - [ ] include before/after visuals or gifs if this PR includes visual changes
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [ ] manually test the debug page
 - [ ] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [ ] add an entry inside this element for inclusion in the `maplibre-gl-js` changelog: `<changelog></changelog>`
