### PR TITLE
Dispatch event to docs to trigger workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -173,3 +173,16 @@ jobs:
           yarn publish --non-interactive
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
+
+  dispatch_event_to_docs:
+    name: Dispatch release event to docs
+    runs-on: ubuntu-latest
+    needs: release
+    steps:
+      - name: Repository Dispatch
+        uses: peter-evans/repository-dispatch@v1
+        with:
+          token: ${{ secrets.DOCS_ACCESS_TOKEN }}
+          repository: maplibre/maplibre-gl-js-docs
+          event-type: release-maplibre-gl-js
+


### PR DESCRIPTION
Added a job that dispatches a `release-maplibre-gl-js` event to the docs repository. My changes in https://github.com/maplibre/maplibre-gl-js-docs/pull/63 should receive this event and trigger the deploy workflow there.

To make this work, a user with write access to the docs repository must create a PAT (personal access token). More information here:
https://github.com/peter-evans/repository-dispatch#token