### PR TITLE
More

### DIFF
--- a/src/data/bucket/fill_bucket.ts
+++ b/src/data/bucket/fill_bucket.ts
@@ -29,7 +29,7 @@ import type VertexBuffer from '../../gl/vertex_buffer';
 import type Point from '@mapbox/point-geometry';
 import type {FeatureStates} from '../../source/source_state';
 import type {ImagePosition} from '../../render/image_atlas';
-import { PossiblyEvaluatedPropertyValue } from '../../style/properties';
+import {PossiblyEvaluatedPropertyValue} from '../../style/properties';
 
 class FillBucket implements Bucket {
     index: number;

--- a/src/style-spec/expression/compound_expression.ts
+++ b/src/style-spec/expression/compound_expression.ts
@@ -56,7 +56,7 @@ class CompoundExpression implements Expression {
         const op: string = (args[0] as any);
         const definition = CompoundExpression.definitions[op];
         if (!definition) {
-            return context.error(`Unknown expression "${op}". If you wanted a literal array, use ["literal", [...]].`, 0);
+            return context.error(`Unknown expression "${op}". If you wanted a literal array, use ["literal", [...]].`, 0) as null;
         }
 
         // Now check argument types against each signature

--- a/src/style-spec/expression/compound_expression.ts
+++ b/src/style-spec/expression/compound_expression.ts
@@ -87,7 +87,7 @@ class CompoundExpression implements Expression {
                 const arg = args[i];
                 const expectedType = Array.isArray(params) ?
                     params[i - 1] :
-                    params.type;
+                    (params as Varargs).type;
 
                 const parsed = signatureContext.parse(arg, 1 + parsedArgs.length, expectedType);
                 if (!parsed) {
@@ -110,13 +110,13 @@ class CompoundExpression implements Expression {
             }
 
             for (let i = 0; i < parsedArgs.length; i++) {
-                const expected = Array.isArray(params) ? params[i] : params.type;
+                const expected = Array.isArray(params) ? params[i] : (params as Varargs).type;
                 const arg = parsedArgs[i];
                 signatureContext.concat(i + 1).checkSubtype(expected, arg.type);
             }
 
             if (signatureContext.errors.length === 0) {
-                return new CompoundExpression(op, type, evaluate, parsedArgs);
+                return new CompoundExpression(op, type, evaluate as Evaluate, parsedArgs);
             }
         }
 
@@ -127,7 +127,7 @@ class CompoundExpression implements Expression {
         } else {
             const expected = overloads.length ? overloads : availableOverloads;
             const signatures = expected
-                .map(([params]) => stringifySignature(params))
+                .map(([params]) => stringifySignature(params as Signature))
                 .join(' | ');
 
             const actualTypes = [];

--- a/src/style-spec/expression/definitions/assertion.ts
+++ b/src/style-spec/expression/definitions/assertion.ts
@@ -36,7 +36,7 @@ class Assertion implements Expression {
 
     static parse(args: ReadonlyArray<unknown>, context: ParsingContext): Expression | undefined | null {
         if (args.length < 2)
-            return context.error(`Expected at least one argument.`);
+            return context.error(`Expected at least one argument.`) as null;
 
         let i = 1;
         let type;
@@ -47,7 +47,7 @@ class Assertion implements Expression {
             if (args.length > 2) {
                 const type = args[1];
                 if (typeof type !== 'string' || !(type in types) || type === 'object')
-                    return context.error('The item type argument of "array" must be one of string, number, boolean', 1);
+                    return context.error('The item type argument of "array" must be one of string, number, boolean', 1) as null;
                 itemType = types[type];
                 i++;
             } else {
@@ -61,7 +61,7 @@ class Assertion implements Expression {
                         args[2] < 0 ||
                         args[2] !== Math.floor(args[2]))
                 ) {
-                    return context.error('The length argument to "array" must be a positive integer literal', 2);
+                    return context.error('The length argument to "array" must be a positive integer literal', 2) as null;
                 }
                 N = args[2];
                 i++;

--- a/src/style-spec/expression/definitions/assertion.ts
+++ b/src/style-spec/expression/definitions/assertion.ts
@@ -75,7 +75,7 @@ class Assertion implements Expression {
 
         const parsed = [];
         for (; i < args.length; i++) {
-            const input = context.parse(args[i], i, ValueType);
+            const input = context.parse(args[i], i, ValueType as Type);
             if (!input) return null;
             parsed.push(input);
         }

--- a/src/style-spec/expression/definitions/at.ts
+++ b/src/style-spec/expression/definitions/at.ts
@@ -19,7 +19,7 @@ class At implements Expression {
         this.input = input;
     }
 
-    static parse(args: ReadonlyArray<unknown>, context: ParsingContext) {
+    static parse(args: ReadonlyArray<unknown>, context: ParsingContext): Expression | undefined | null {
         if (args.length !== 3)
             return context.error(`Expected 2 arguments, but found ${args.length - 1} instead.`);
 

--- a/src/style-spec/expression/definitions/at.ts
+++ b/src/style-spec/expression/definitions/at.ts
@@ -23,8 +23,8 @@ class At implements Expression {
         if (args.length !== 3)
             return context.error(`Expected 2 arguments, but found ${args.length - 1} instead.`) as null;
 
-        const index = context.parse(args[1], 1, NumberType);
-        const input = context.parse(args[2], 2, array(context.expectedType || ValueType));
+        const index = context.parse(args[1], 1, NumberType as Type);
+        const input = context.parse(args[2], 2, array((context.expectedType || ValueType) as Type));
 
         if (!index || !input) return null;
 

--- a/src/style-spec/expression/definitions/at.ts
+++ b/src/style-spec/expression/definitions/at.ts
@@ -21,7 +21,7 @@ class At implements Expression {
 
     static parse(args: ReadonlyArray<unknown>, context: ParsingContext): Expression | undefined | null {
         if (args.length !== 3)
-            return context.error(`Expected 2 arguments, but found ${args.length - 1} instead.`);
+            return context.error(`Expected 2 arguments, but found ${args.length - 1} instead.`) as null;
 
         const index = context.parse(args[1], 1, NumberType);
         const input = context.parse(args[2], 2, array(context.expectedType || ValueType));

--- a/src/style-spec/expression/definitions/case.ts
+++ b/src/style-spec/expression/definitions/case.ts
@@ -21,7 +21,7 @@ class Case implements Expression {
         this.otherwise = otherwise;
     }
 
-    static parse(args: ReadonlyArray<unknown>, context: ParsingContext) {
+    static parse(args: ReadonlyArray<unknown>, context: ParsingContext): Expression | undefined | null {
         if (args.length < 4)
             return context.error(`Expected at least 3 arguments, but found only ${args.length - 1}.`);
         if (args.length % 2 !== 0)

--- a/src/style-spec/expression/definitions/case.ts
+++ b/src/style-spec/expression/definitions/case.ts
@@ -34,7 +34,7 @@ class Case implements Expression {
 
         const branches = [];
         for (let i = 1; i < args.length - 1; i += 2) {
-            const test = context.parse(args[i], i, BooleanType);
+            const test = context.parse(args[i], i, BooleanType as Type);
             if (!test) return null;
 
             const result = context.parse(args[i + 1], i + 1, outputType);

--- a/src/style-spec/expression/definitions/case.ts
+++ b/src/style-spec/expression/definitions/case.ts
@@ -23,9 +23,9 @@ class Case implements Expression {
 
     static parse(args: ReadonlyArray<unknown>, context: ParsingContext): Expression | undefined | null {
         if (args.length < 4)
-            return context.error(`Expected at least 3 arguments, but found only ${args.length - 1}.`);
+            return context.error(`Expected at least 3 arguments, but found only ${args.length - 1}.`) as null;
         if (args.length % 2 !== 0)
-            return context.error(`Expected an odd number of arguments.`);
+            return context.error(`Expected an odd number of arguments.`) as null;
 
         let outputType: Type | undefined | null;
         if (context.expectedType && context.expectedType.kind !== 'value') {

--- a/src/style-spec/expression/definitions/coalesce.ts
+++ b/src/style-spec/expression/definitions/coalesce.ts
@@ -19,7 +19,7 @@ class Coalesce implements Expression {
 
     static parse(args: ReadonlyArray<unknown>, context: ParsingContext): Expression | undefined | null {
         if (args.length < 2) {
-            return context.error("Expectected at least one argument.");
+            return context.error("Expectected at least one argument.") as null;
         }
         let outputType: Type = (null as any);
         const expectedType = context.expectedType;

--- a/src/style-spec/expression/definitions/coalesce.ts
+++ b/src/style-spec/expression/definitions/coalesce.ts
@@ -17,7 +17,7 @@ class Coalesce implements Expression {
         this.args = args;
     }
 
-    static parse(args: ReadonlyArray<unknown>, context: ParsingContext) {
+    static parse(args: ReadonlyArray<unknown>, context: ParsingContext): Expression | undefined | null {
         if (args.length < 2) {
             return context.error("Expectected at least one argument.");
         }

--- a/src/style-spec/expression/definitions/coalesce.ts
+++ b/src/style-spec/expression/definitions/coalesce.ts
@@ -45,7 +45,7 @@ class Coalesce implements Expression {
             parsedArgs.some(arg => checkSubtype(expectedType, arg.type));
 
         return needsAnnotation ?
-            new Coalesce(ValueType, parsedArgs) :
+            new Coalesce(ValueType as Type, parsedArgs) :
             new Coalesce((outputType as any), parsedArgs);
     }
 

--- a/src/style-spec/expression/definitions/coercion.ts
+++ b/src/style-spec/expression/definitions/coercion.ts
@@ -38,13 +38,13 @@ class Coercion implements Expression {
 
     static parse(args: ReadonlyArray<unknown>, context: ParsingContext): Expression | undefined | null {
         if (args.length < 2)
-            return context.error(`Expected at least one argument.`);
+            return context.error(`Expected at least one argument.`) as null;
 
         const name: string = (args[0] as any);
         assert(types[name], name);
 
         if ((name === 'to-boolean' || name === 'to-string') && args.length !== 2)
-            return context.error(`Expected one argument.`);
+            return context.error(`Expected one argument.`) as null;
 
         const type = types[name];
 

--- a/src/style-spec/expression/definitions/coercion.ts
+++ b/src/style-spec/expression/definitions/coercion.ts
@@ -50,7 +50,7 @@ class Coercion implements Expression {
 
         const parsed = [];
         for (let i = 1; i < args.length; i++) {
-            const input = context.parse(args[i], i, ValueType);
+            const input = context.parse(args[i], i, ValueType as Type);
             if (!input) return null;
             parsed.push(input);
         }

--- a/src/style-spec/expression/definitions/collator.ts
+++ b/src/style-spec/expression/definitions/collator.ts
@@ -21,11 +21,11 @@ export default class CollatorExpression implements Expression {
 
     static parse(args: ReadonlyArray<unknown>, context: ParsingContext): Expression | undefined | null {
         if (args.length !== 2)
-            return context.error(`Expected one argument.`);
+            return context.error(`Expected one argument.`) as null;
 
         const options = (args[1] as any);
         if (typeof options !== "object" || Array.isArray(options))
-            return context.error(`Collator options argument must be an object.`);
+            return context.error(`Collator options argument must be an object.`) as null;
 
         const caseSensitive = context.parse(
             options['case-sensitive'] === undefined ? false : options['case-sensitive'], 1, BooleanType);

--- a/src/style-spec/expression/definitions/collator.ts
+++ b/src/style-spec/expression/definitions/collator.ts
@@ -13,7 +13,7 @@ export default class CollatorExpression implements Expression {
     locale: Expression | null;
 
     constructor(caseSensitive: Expression, diacriticSensitive: Expression, locale: Expression | null) {
-        this.type = CollatorType;
+        this.type = CollatorType as Type;
         this.locale = locale;
         this.caseSensitive = caseSensitive;
         this.diacriticSensitive = diacriticSensitive;
@@ -28,16 +28,16 @@ export default class CollatorExpression implements Expression {
             return context.error(`Collator options argument must be an object.`) as null;
 
         const caseSensitive = context.parse(
-            options['case-sensitive'] === undefined ? false : options['case-sensitive'], 1, BooleanType);
+            options['case-sensitive'] === undefined ? false : options['case-sensitive'], 1, BooleanType as Type);
         if (!caseSensitive) return null;
 
         const diacriticSensitive = context.parse(
-            options['diacritic-sensitive'] === undefined ? false : options['diacritic-sensitive'], 1, BooleanType);
+            options['diacritic-sensitive'] === undefined ? false : options['diacritic-sensitive'], 1, BooleanType as Type);
         if (!diacriticSensitive) return null;
 
         let locale = null;
         if (options['locale']) {
-            locale = context.parse(options['locale'], 1, StringType);
+            locale = context.parse(options['locale'], 1, StringType as Type);
             if (!locale) return null;
         }
 

--- a/src/style-spec/expression/definitions/comparison.ts
+++ b/src/style-spec/expression/definitions/comparison.ts
@@ -68,7 +68,7 @@ function makeComparison(op: ComparisonOperator, compareBasic, compareWithCollato
         hasUntypedArgument: boolean;
 
         constructor(lhs: Expression, rhs: Expression, collator?: Expression | null) {
-            this.type = BooleanType;
+            this.type = BooleanType as Type;
             this.lhs = lhs;
             this.rhs = rhs;
             this.collator = collator;
@@ -81,12 +81,12 @@ function makeComparison(op: ComparisonOperator, compareBasic, compareWithCollato
 
             const op: ComparisonOperator = (args[0] as any);
 
-            let lhs = context.parse(args[1], 1, ValueType);
+            let lhs = context.parse(args[1], 1, ValueType as Type);
             if (!lhs) return null;
             if (!isComparableType(op, lhs.type)) {
                 return context.concat(1).error(`"${op}" comparisons are not supported for type '${toString(lhs.type)}'.`) as null;
             }
-            let rhs = context.parse(args[2], 2, ValueType);
+            let rhs = context.parse(args[2], 2, ValueType as Type);
             if (!rhs) return null;
             if (!isComparableType(op, rhs.type)) {
                 return context.concat(2).error(`"${op}" comparisons are not supported for type '${toString(rhs.type)}'.`) as null;
@@ -121,7 +121,7 @@ function makeComparison(op: ComparisonOperator, compareBasic, compareWithCollato
                 ) {
                     return context.error(`Cannot use collator to compare non-string types.`) as null;
                 }
-                collator = context.parse(args[3], 3, CollatorType);
+                collator = context.parse(args[3], 3, CollatorType as Type);
                 if (!collator) return null;
             }
 

--- a/src/style-spec/expression/definitions/comparison.ts
+++ b/src/style-spec/expression/definitions/comparison.ts
@@ -77,19 +77,19 @@ function makeComparison(op: ComparisonOperator, compareBasic, compareWithCollato
 
         static parse(args: ReadonlyArray<unknown>, context: ParsingContext): Expression | undefined | null {
             if (args.length !== 3 && args.length !== 4)
-                return context.error(`Expected two or three arguments.`);
+                return context.error(`Expected two or three arguments.`) as null;
 
             const op: ComparisonOperator = (args[0] as any);
 
             let lhs = context.parse(args[1], 1, ValueType);
             if (!lhs) return null;
             if (!isComparableType(op, lhs.type)) {
-                return context.concat(1).error(`"${op}" comparisons are not supported for type '${toString(lhs.type)}'.`);
+                return context.concat(1).error(`"${op}" comparisons are not supported for type '${toString(lhs.type)}'.`) as null;
             }
             let rhs = context.parse(args[2], 2, ValueType);
             if (!rhs) return null;
             if (!isComparableType(op, rhs.type)) {
-                return context.concat(2).error(`"${op}" comparisons are not supported for type '${toString(rhs.type)}'.`);
+                return context.concat(2).error(`"${op}" comparisons are not supported for type '${toString(rhs.type)}'.`) as null;
             }
 
             if (
@@ -97,7 +97,7 @@ function makeComparison(op: ComparisonOperator, compareBasic, compareWithCollato
                 lhs.type.kind !== 'value' &&
                 rhs.type.kind !== 'value'
             ) {
-                return context.error(`Cannot compare types '${toString(lhs.type)}' and '${toString(rhs.type)}'.`);
+                return context.error(`Cannot compare types '${toString(lhs.type)}' and '${toString(rhs.type)}'.`) as null;
             }
 
             if (isOrderComparison) {
@@ -119,7 +119,7 @@ function makeComparison(op: ComparisonOperator, compareBasic, compareWithCollato
                     lhs.type.kind !== 'value' &&
                     rhs.type.kind !== 'value'
                 ) {
-                    return context.error(`Cannot use collator to compare non-string types.`);
+                    return context.error(`Cannot use collator to compare non-string types.`) as null;
                 }
                 collator = context.parse(args[3], 3, CollatorType);
                 if (!collator) return null;

--- a/src/style-spec/expression/definitions/format.ts
+++ b/src/style-spec/expression/definitions/format.ts
@@ -35,12 +35,12 @@ export default class FormatExpression implements Expression {
 
     static parse(args: ReadonlyArray<unknown>, context: ParsingContext): Expression | undefined | null {
         if (args.length < 2) {
-            return context.error(`Expected at least one argument.`);
+            return context.error(`Expected at least one argument.`) as null;
         }
 
         const firstArg = args[1];
         if (!Array.isArray(firstArg) && typeof firstArg === 'object')  {
-            return context.error(`First argument must be an image or text section.`);
+            return context.error(`First argument must be an image or text section.`) as null;
         }
 
         const sections: Array<FormattedSectionExpression> = [];
@@ -79,7 +79,7 @@ export default class FormatExpression implements Expression {
 
                 const kind = content.type.kind;
                 if (kind !== 'string' && kind !== 'value' && kind !== 'null' && kind !== 'resolvedImage')
-                    return context.error(`Formatted text type must be 'string', 'value', 'image' or 'null'.`);
+                    return context.error(`Formatted text type must be 'string', 'value', 'image' or 'null'.`) as null;
 
                 nextTokenMayBeObject = true;
                 sections.push({content, scale: null, font: null, textColor: null});

--- a/src/style-spec/expression/definitions/format.ts
+++ b/src/style-spec/expression/definitions/format.ts
@@ -29,7 +29,7 @@ export default class FormatExpression implements Expression {
     sections: Array<FormattedSectionExpression>;
 
     constructor(sections: Array<FormattedSectionExpression>) {
-        this.type = FormattedType;
+        this.type = FormattedType as Type;
         this.sections = sections;
     }
 
@@ -53,19 +53,19 @@ export default class FormatExpression implements Expression {
 
                 let scale = null;
                 if (arg['font-scale']) {
-                    scale = context.parse(arg['font-scale'], 1, NumberType);
+                    scale = context.parse(arg['font-scale'], 1, NumberType as Type);
                     if (!scale) return null;
                 }
 
                 let font = null;
                 if (arg['text-font']) {
-                    font = context.parse(arg['text-font'], 1, array(StringType));
+                    font = context.parse(arg['text-font'], 1, array(StringType as Type));
                     if (!font) return null;
                 }
 
                 let textColor = null;
                 if (arg['text-color']) {
-                    textColor = context.parse(arg['text-color'], 1, ColorType);
+                    textColor = context.parse(arg['text-color'], 1, ColorType as Type);
                     if (!textColor) return null;
                 }
 
@@ -74,7 +74,7 @@ export default class FormatExpression implements Expression {
                 lastExpression.font = font;
                 lastExpression.textColor = textColor;
             } else {
-                const content = context.parse(args[i], 1, ValueType);
+                const content = context.parse(args[i], 1, ValueType as Type);
                 if (!content) return null;
 
                 const kind = content.type.kind;

--- a/src/style-spec/expression/definitions/image.ts
+++ b/src/style-spec/expression/definitions/image.ts
@@ -11,7 +11,7 @@ export default class ImageExpression implements Expression {
     input: Expression;
 
     constructor(input: Expression) {
-        this.type = ResolvedImageType;
+        this.type = ResolvedImageType as Type;
         this.input = input;
     }
 
@@ -20,7 +20,7 @@ export default class ImageExpression implements Expression {
             return context.error(`Expected two arguments.`) as null;
         }
 
-        const name = context.parse(args[1], 1, StringType);
+        const name = context.parse(args[1], 1, StringType as Type);
         if (!name) return context.error(`No image name provided.`) as null;
 
         return new ImageExpression(name);

--- a/src/style-spec/expression/definitions/image.ts
+++ b/src/style-spec/expression/definitions/image.ts
@@ -17,11 +17,11 @@ export default class ImageExpression implements Expression {
 
     static parse(args: ReadonlyArray<unknown>, context: ParsingContext): Expression | undefined | null {
         if (args.length !== 2) {
-            return context.error(`Expected two arguments.`);
+            return context.error(`Expected two arguments.`) as null;
         }
 
         const name = context.parse(args[1], 1, StringType);
-        if (!name) return context.error(`No image name provided.`);
+        if (!name) return context.error(`No image name provided.`) as null;
 
         return new ImageExpression(name);
     }

--- a/src/style-spec/expression/definitions/in.ts
+++ b/src/style-spec/expression/definitions/in.ts
@@ -29,7 +29,7 @@ class In implements Expression {
 
     static parse(args: ReadonlyArray<unknown>, context: ParsingContext): Expression | undefined | null {
         if (args.length !== 3) {
-            return context.error(`Expected 2 arguments, but found ${args.length - 1} instead.`);
+            return context.error(`Expected 2 arguments, but found ${args.length - 1} instead.`) as null;
         }
 
         const needle = context.parse(args[1], 1, ValueType);
@@ -39,7 +39,7 @@ class In implements Expression {
         if (!needle || !haystack) return null;
 
         if (!isValidType(needle.type, [BooleanType, StringType, NumberType, NullType, ValueType])) {
-            return context.error(`Expected first argument to be of type boolean, string, number or null, but found ${toString(needle.type)} instead`);
+            return context.error(`Expected first argument to be of type boolean, string, number or null, but found ${toString(needle.type)} instead`) as null;
         }
 
         return new In(needle, haystack);

--- a/src/style-spec/expression/definitions/in.ts
+++ b/src/style-spec/expression/definitions/in.ts
@@ -22,7 +22,7 @@ class In implements Expression {
     haystack: Expression;
 
     constructor(needle: Expression, haystack: Expression) {
-        this.type = BooleanType;
+        this.type = BooleanType as Type;
         this.needle = needle;
         this.haystack = haystack;
     }
@@ -32,13 +32,13 @@ class In implements Expression {
             return context.error(`Expected 2 arguments, but found ${args.length - 1} instead.`) as null;
         }
 
-        const needle = context.parse(args[1], 1, ValueType);
+        const needle = context.parse(args[1], 1, ValueType as Type);
 
-        const haystack = context.parse(args[2], 2, ValueType);
+        const haystack = context.parse(args[2], 2, ValueType as Type);
 
         if (!needle || !haystack) return null;
 
-        if (!isValidType(needle.type, [BooleanType, StringType, NumberType, NullType, ValueType])) {
+        if (!isValidType(needle.type, [BooleanType as Type, StringType as Type, NumberType as Type, NullType as Type, ValueType as Type])) {
             return context.error(`Expected first argument to be of type boolean, string, number or null, but found ${toString(needle.type)} instead`) as null;
         }
 

--- a/src/style-spec/expression/definitions/in.ts
+++ b/src/style-spec/expression/definitions/in.ts
@@ -27,7 +27,7 @@ class In implements Expression {
         this.haystack = haystack;
     }
 
-    static parse(args: ReadonlyArray<unknown>, context: ParsingContext) {
+    static parse(args: ReadonlyArray<unknown>, context: ParsingContext): Expression | undefined | null {
         if (args.length !== 3) {
             return context.error(`Expected 2 arguments, but found ${args.length - 1} instead.`);
         }

--- a/src/style-spec/expression/definitions/index.ts
+++ b/src/style-spec/expression/definitions/index.ts
@@ -125,99 +125,99 @@ function varargs(type: Type): Varargs {
 
 CompoundExpression.register(expressions, {
     'error': [
-        ErrorType,
-        [StringType],
+        ErrorType as Type,
+        [StringType as Type],
         (ctx, [v]) => { throw new RuntimeError(v.evaluate(ctx)); }
     ],
     'typeof': [
-        StringType,
-        [ValueType],
+        StringType as Type,
+        [ValueType as Type],
         (ctx, [v]) => typeToString(typeOf(v.evaluate(ctx)))
     ],
     'to-rgba': [
-        array(NumberType, 4),
-        [ColorType],
+        array(NumberType as Type, 4),
+        [ColorType as Type],
         (ctx, [v]) => {
             return v.evaluate(ctx).toArray();
         }
     ],
     'rgb': [
-        ColorType,
-        [NumberType, NumberType, NumberType],
+        ColorType as Type,
+        [NumberType as Type, NumberType as Type, NumberType as Type],
         rgba
     ],
     'rgba': [
-        ColorType,
-        [NumberType, NumberType, NumberType, NumberType],
+        ColorType as Type,
+        [NumberType as Type, NumberType as Type, NumberType as Type, NumberType as Type],
         rgba
     ],
     'has': {
-        type: BooleanType,
+        type: (BooleanType as Type),
         overloads: [
             [
-                [StringType],
+                [StringType as Type],
                 (ctx, [key]) => has(key.evaluate(ctx), ctx.properties())
             ], [
-                [StringType, ObjectType],
+                [StringType as Type, ObjectType as Type],
                 (ctx, [key, obj]) => has(key.evaluate(ctx), obj.evaluate(ctx))
             ]
         ]
     },
     'get': {
-        type: ValueType,
+        type: (ValueType as Type),
         overloads: [
             [
-                [StringType],
+                [StringType as Type],
                 (ctx, [key]) => get(key.evaluate(ctx), ctx.properties())
             ], [
-                [StringType, ObjectType],
+                [StringType as Type, ObjectType as Type],
                 (ctx, [key, obj]) => get(key.evaluate(ctx), obj.evaluate(ctx))
             ]
         ]
     },
     'feature-state': [
-        ValueType,
-        [StringType],
+        ValueType as Type,
+        [StringType as Type],
         (ctx, [key]) => get(key.evaluate(ctx), ctx.featureState || {})
     ],
     'properties': [
-        ObjectType,
+        ObjectType as Type,
         [],
         (ctx) => ctx.properties()
     ],
     'geometry-type': [
-        StringType,
+        StringType as Type,
         [],
         (ctx) => ctx.geometryType()
     ],
     'id': [
-        ValueType,
+        ValueType as Type,
         [],
         (ctx) => ctx.id()
     ],
     'zoom': [
-        NumberType,
+        NumberType as Type,
         [],
         (ctx) => ctx.globals.zoom
     ],
     'heatmap-density': [
-        NumberType,
+        NumberType as Type,
         [],
         (ctx) => ctx.globals.heatmapDensity || 0
     ],
     'line-progress': [
-        NumberType,
+        NumberType as Type,
         [],
         (ctx) => ctx.globals.lineProgress || 0
     ],
     'accumulated': [
-        ValueType,
+        ValueType as Type,
         [],
         (ctx) => ctx.globals.accumulated === undefined ? null : ctx.globals.accumulated
     ],
     '+': [
-        NumberType,
-        varargs(NumberType),
+        NumberType as Type,
+        varargs(NumberType as Type),
         (ctx, args) => {
             let result = 0;
             for (const arg of args) {
@@ -227,8 +227,8 @@ CompoundExpression.register(expressions, {
         }
     ],
     '*': [
-        NumberType,
-        varargs(NumberType),
+        NumberType as Type,
+        varargs(NumberType as Type),
         (ctx, args) => {
             let result = 1;
             for (const arg of args) {
@@ -238,115 +238,115 @@ CompoundExpression.register(expressions, {
         }
     ],
     '-': {
-        type: NumberType,
+        type: (NumberType as Type),
         overloads: [
             [
-                [NumberType, NumberType],
+                [NumberType as Type, NumberType as Type],
                 (ctx, [a, b]) => a.evaluate(ctx) - b.evaluate(ctx)
             ], [
-                [NumberType],
+                [NumberType as Type],
                 (ctx, [a]) => -a.evaluate(ctx)
             ]
         ]
     },
     '/': [
-        NumberType,
-        [NumberType, NumberType],
+        NumberType as Type,
+        [NumberType as Type, NumberType as Type],
         (ctx, [a, b]) => a.evaluate(ctx) / b.evaluate(ctx)
     ],
     '%': [
-        NumberType,
-        [NumberType, NumberType],
+        NumberType as Type,
+        [NumberType as Type, NumberType as Type],
         (ctx, [a, b]) => a.evaluate(ctx) % b.evaluate(ctx)
     ],
     'ln2': [
-        NumberType,
+        NumberType as Type,
         [],
         () => Math.LN2
     ],
     'pi': [
-        NumberType,
+        NumberType as Type,
         [],
         () => Math.PI
     ],
     'e': [
-        NumberType,
+        NumberType as Type,
         [],
         () => Math.E
     ],
     '^': [
-        NumberType,
-        [NumberType, NumberType],
+        NumberType as Type,
+        [NumberType as Type, NumberType as Type],
         (ctx, [b, e]) => Math.pow(b.evaluate(ctx), e.evaluate(ctx))
     ],
     'sqrt': [
-        NumberType,
-        [NumberType],
+        NumberType as Type,
+        [NumberType as Type],
         (ctx, [x]) => Math.sqrt(x.evaluate(ctx))
     ],
     'log10': [
-        NumberType,
-        [NumberType],
+        NumberType as Type,
+        [NumberType as Type],
         (ctx, [n]) => Math.log(n.evaluate(ctx)) / Math.LN10
     ],
     'ln': [
-        NumberType,
-        [NumberType],
+        NumberType as Type,
+        [NumberType as Type],
         (ctx, [n]) => Math.log(n.evaluate(ctx))
     ],
     'log2': [
-        NumberType,
-        [NumberType],
+        NumberType as Type,
+        [NumberType as Type],
         (ctx, [n]) => Math.log(n.evaluate(ctx)) / Math.LN2
     ],
     'sin': [
-        NumberType,
-        [NumberType],
+        NumberType as Type,
+        [NumberType as Type],
         (ctx, [n]) => Math.sin(n.evaluate(ctx))
     ],
     'cos': [
-        NumberType,
-        [NumberType],
+        NumberType as Type,
+        [NumberType as Type],
         (ctx, [n]) => Math.cos(n.evaluate(ctx))
     ],
     'tan': [
-        NumberType,
-        [NumberType],
+        NumberType as Type,
+        [NumberType as Type],
         (ctx, [n]) => Math.tan(n.evaluate(ctx))
     ],
     'asin': [
-        NumberType,
-        [NumberType],
+        NumberType as Type,
+        [NumberType as Type],
         (ctx, [n]) => Math.asin(n.evaluate(ctx))
     ],
     'acos': [
-        NumberType,
-        [NumberType],
+        NumberType as Type,
+        [NumberType as Type],
         (ctx, [n]) => Math.acos(n.evaluate(ctx))
     ],
     'atan': [
-        NumberType,
-        [NumberType],
+        NumberType as Type,
+        [NumberType as Type],
         (ctx, [n]) => Math.atan(n.evaluate(ctx))
     ],
     'min': [
-        NumberType,
-        varargs(NumberType),
+        NumberType as Type,
+        varargs(NumberType as Type),
         (ctx, args) => Math.min(...args.map(arg => arg.evaluate(ctx)))
     ],
     'max': [
-        NumberType,
-        varargs(NumberType),
+        NumberType as Type,
+        varargs(NumberType as Type),
         (ctx, args) => Math.max(...args.map(arg => arg.evaluate(ctx)))
     ],
     'abs': [
-        NumberType,
-        [NumberType],
+        NumberType as Type,
+        [NumberType as Type],
         (ctx, [n]) => Math.abs(n.evaluate(ctx))
     ],
     'round': [
-        NumberType,
-        [NumberType],
+        NumberType as Type,
+        [NumberType as Type],
         (ctx, [n]) => {
             const v = n.evaluate(ctx);
             // Javascript's Math.round() rounds towards +Infinity for halfway
@@ -356,33 +356,33 @@ CompoundExpression.register(expressions, {
         }
     ],
     'floor': [
-        NumberType,
-        [NumberType],
+        NumberType as Type,
+        [NumberType as Type],
         (ctx, [n]) => Math.floor(n.evaluate(ctx))
     ],
     'ceil': [
-        NumberType,
-        [NumberType],
+        NumberType as Type,
+        [NumberType as Type],
         (ctx, [n]) => Math.ceil(n.evaluate(ctx))
     ],
     'filter-==': [
-        BooleanType,
-        [StringType, ValueType],
+        BooleanType as Type,
+        [StringType as Type, ValueType as Type],
         (ctx, [k, v]) => ctx.properties()[(k as any).value] === (v as any).value
     ],
     'filter-id-==': [
-        BooleanType,
-        [ValueType],
+        BooleanType as Type,
+        [ValueType as Type],
         (ctx, [v]) => ctx.id() === (v as any).value
     ],
     'filter-type-==': [
-        BooleanType,
-        [StringType],
+        BooleanType as Type,
+        [StringType as Type],
         (ctx, [v]) => ctx.geometryType() === (v as any).value
     ],
     'filter-<': [
-        BooleanType,
-        [StringType, ValueType],
+        BooleanType as Type,
+        [StringType as Type, ValueType as Type],
         (ctx, [k, v]) => {
             const a = ctx.properties()[(k as any).value];
             const b = (v as any).value;
@@ -390,8 +390,8 @@ CompoundExpression.register(expressions, {
         }
     ],
     'filter-id-<': [
-        BooleanType,
-        [ValueType],
+        BooleanType as Type,
+        [ValueType as Type],
         (ctx, [v]) => {
             const a = ctx.id();
             const b = (v as any).value;
@@ -399,8 +399,8 @@ CompoundExpression.register(expressions, {
         }
     ],
     'filter->': [
-        BooleanType,
-        [StringType, ValueType],
+        BooleanType as Type,
+        [StringType as Type, ValueType as Type],
         (ctx, [k, v]) => {
             const a = ctx.properties()[(k as any).value];
             const b = (v as any).value;
@@ -408,8 +408,8 @@ CompoundExpression.register(expressions, {
         }
     ],
     'filter-id->': [
-        BooleanType,
-        [ValueType],
+        BooleanType as Type,
+        [ValueType as Type],
         (ctx, [v]) => {
             const a = ctx.id();
             const b = (v as any).value;
@@ -417,8 +417,8 @@ CompoundExpression.register(expressions, {
         }
     ],
     'filter-<=': [
-        BooleanType,
-        [StringType, ValueType],
+        BooleanType as Type,
+        [StringType as Type, ValueType as Type],
         (ctx, [k, v]) => {
             const a = ctx.properties()[(k as any).value];
             const b = (v as any).value;
@@ -426,8 +426,8 @@ CompoundExpression.register(expressions, {
         }
     ],
     'filter-id-<=': [
-        BooleanType,
-        [ValueType],
+        BooleanType as Type,
+        [ValueType as Type],
         (ctx, [v]) => {
             const a = ctx.id();
             const b = (v as any).value;
@@ -435,8 +435,8 @@ CompoundExpression.register(expressions, {
         }
     ],
     'filter->=': [
-        BooleanType,
-        [StringType, ValueType],
+        BooleanType as Type,
+        [StringType as Type, ValueType as Type],
         (ctx, [k, v]) => {
             const a = ctx.properties()[(k as any).value];
             const b = (v as any).value;
@@ -444,8 +444,8 @@ CompoundExpression.register(expressions, {
         }
     ],
     'filter-id->=': [
-        BooleanType,
-        [ValueType],
+        BooleanType as Type,
+        [ValueType as Type],
         (ctx, [v]) => {
             const a = ctx.id();
             const b = (v as any).value;
@@ -453,46 +453,46 @@ CompoundExpression.register(expressions, {
         }
     ],
     'filter-has': [
-        BooleanType,
-        [ValueType],
+        BooleanType as Type,
+        [ValueType as Type],
         (ctx, [k]) => (k as any).value in ctx.properties()
     ],
     'filter-has-id': [
-        BooleanType,
+        BooleanType as Type,
         [],
         (ctx) => (ctx.id() !== null && ctx.id() !== undefined)
     ],
     'filter-type-in': [
-        BooleanType,
-        [array(StringType)],
+        BooleanType as Type,
+        [array(StringType as Type)],
         (ctx, [v]) => (v as any).value.indexOf(ctx.geometryType()) >= 0
     ],
     'filter-id-in': [
-        BooleanType,
-        [array(ValueType)],
+        BooleanType as Type,
+        [array(ValueType as Type)],
         (ctx, [v]) => (v as any).value.indexOf(ctx.id()) >= 0
     ],
     'filter-in-small': [
-        BooleanType,
-        [StringType, array(ValueType)],
+        BooleanType as Type,
+        [StringType as Type, array(ValueType as Type)],
         // assumes v is an array literal
         (ctx, [k, v]) => (v as any).value.indexOf(ctx.properties()[(k as any).value]) >= 0
     ],
     'filter-in-large': [
-        BooleanType,
-        [StringType, array(ValueType)],
+        BooleanType as Type,
+        [StringType as Type, array(ValueType as Type)],
         // assumes v is a array literal with values sorted in ascending order and of a single type
         (ctx, [k, v]) => binarySearch(ctx.properties()[(k as any).value], (v as any).value, 0, (v as any).value.length - 1)
     ],
     'all': {
-        type: BooleanType,
+        type: (BooleanType as Type),
         overloads: [
             [
-                [BooleanType, BooleanType],
+                [BooleanType as Type, BooleanType as Type],
                 (ctx, [a, b]) => a.evaluate(ctx) && b.evaluate(ctx)
             ],
             [
-                varargs(BooleanType),
+                varargs(BooleanType as Type),
                 (ctx, args) => {
                     for (const arg of args) {
                         if (!arg.evaluate(ctx))
@@ -504,14 +504,14 @@ CompoundExpression.register(expressions, {
         ]
     },
     'any': {
-        type: BooleanType,
+        type: (BooleanType as Type),
         overloads: [
             [
-                [BooleanType, BooleanType],
+                [BooleanType as Type, BooleanType as Type],
                 (ctx, [a, b]) => a.evaluate(ctx) || b.evaluate(ctx)
             ],
             [
-                varargs(BooleanType),
+                varargs(BooleanType as Type),
                 (ctx, args) => {
                     for (const arg of args) {
                         if (arg.evaluate(ctx))
@@ -523,13 +523,13 @@ CompoundExpression.register(expressions, {
         ]
     },
     '!': [
-        BooleanType,
-        [BooleanType],
+        BooleanType as Type,
+        [BooleanType as Type],
         (ctx, [b]) => !b.evaluate(ctx)
     ],
     'is-supported-script': [
-        BooleanType,
-        [StringType],
+        BooleanType as Type,
+        [StringType as Type],
         // At parse time this will always return true, so we need to exclude this expression with isGlobalPropertyConstant
         (ctx, [s]) => {
             const isSupportedScript = ctx.globals && ctx.globals.isSupportedScript;
@@ -540,23 +540,23 @@ CompoundExpression.register(expressions, {
         }
     ],
     'upcase': [
-        StringType,
-        [StringType],
+        StringType as Type,
+        [StringType as Type],
         (ctx, [s]) => s.evaluate(ctx).toUpperCase()
     ],
     'downcase': [
-        StringType,
-        [StringType],
+        StringType as Type,
+        [StringType as Type],
         (ctx, [s]) => s.evaluate(ctx).toLowerCase()
     ],
     'concat': [
-        StringType,
-        varargs(ValueType),
+        StringType as Type,
+        varargs(ValueType as Type),
         (ctx, args) => args.map(arg => valueToString(arg.evaluate(ctx))).join('')
     ],
     'resolved-locale': [
-        StringType,
-        [CollatorType],
+        StringType as Type,
+        [CollatorType as Type],
         (ctx, [collator]) => collator.evaluate(ctx).resolvedLocale()
     ]
 });

--- a/src/style-spec/expression/definitions/index_of.ts
+++ b/src/style-spec/expression/definitions/index_of.ts
@@ -23,7 +23,7 @@ class IndexOf implements Expression {
     fromIndex: Expression | undefined | null;
 
     constructor(needle: Expression, haystack: Expression, fromIndex?: Expression) {
-        this.type = NumberType;
+        this.type = NumberType as Type;
         this.needle = needle;
         this.haystack = haystack;
         this.fromIndex = fromIndex;
@@ -34,17 +34,17 @@ class IndexOf implements Expression {
             return context.error(`Expected 3 or 4 arguments, but found ${args.length - 1} instead.`) as null;
         }
 
-        const needle = context.parse(args[1], 1, ValueType);
+        const needle = context.parse(args[1], 1, ValueType as Type);
 
-        const haystack = context.parse(args[2], 2, ValueType);
+        const haystack = context.parse(args[2], 2, ValueType as Type);
 
         if (!needle || !haystack) return null;
-        if (!isValidType(needle.type, [BooleanType, StringType, NumberType, NullType, ValueType])) {
+        if (!isValidType(needle.type, [BooleanType as Type, StringType as Type, NumberType as Type, NullType as Type, ValueType as Type])) {
             return context.error(`Expected first argument to be of type boolean, string, number or null, but found ${toString(needle.type)} instead`) as null;
         }
 
         if (args.length === 4) {
-            const fromIndex = context.parse(args[3], 3, NumberType);
+            const fromIndex = context.parse(args[3], 3, NumberType as Type);
             if (!fromIndex) return null;
             return new IndexOf(needle, haystack, fromIndex);
         } else {

--- a/src/style-spec/expression/definitions/index_of.ts
+++ b/src/style-spec/expression/definitions/index_of.ts
@@ -31,7 +31,7 @@ class IndexOf implements Expression {
 
     static parse(args: ReadonlyArray<unknown>, context: ParsingContext): Expression | undefined | null {
         if (args.length <= 2 ||  args.length >= 5) {
-            return context.error(`Expected 3 or 4 arguments, but found ${args.length - 1} instead.`);
+            return context.error(`Expected 3 or 4 arguments, but found ${args.length - 1} instead.`) as null;
         }
 
         const needle = context.parse(args[1], 1, ValueType);
@@ -40,7 +40,7 @@ class IndexOf implements Expression {
 
         if (!needle || !haystack) return null;
         if (!isValidType(needle.type, [BooleanType, StringType, NumberType, NullType, ValueType])) {
-            return context.error(`Expected first argument to be of type boolean, string, number or null, but found ${toString(needle.type)} instead`);
+            return context.error(`Expected first argument to be of type boolean, string, number or null, but found ${toString(needle.type)} instead`) as null;
         }
 
         if (args.length === 4) {

--- a/src/style-spec/expression/definitions/index_of.ts
+++ b/src/style-spec/expression/definitions/index_of.ts
@@ -29,7 +29,7 @@ class IndexOf implements Expression {
         this.fromIndex = fromIndex;
     }
 
-    static parse(args: ReadonlyArray<unknown>, context: ParsingContext) {
+    static parse(args: ReadonlyArray<unknown>, context: ParsingContext): Expression | undefined | null {
         if (args.length <= 2 ||  args.length >= 5) {
             return context.error(`Expected 3 or 4 arguments, but found ${args.length - 1} instead.`);
         }

--- a/src/style-spec/expression/definitions/interpolate.ts
+++ b/src/style-spec/expression/definitions/interpolate.ts
@@ -58,7 +58,7 @@ class Interpolate implements Expression {
         return t;
     }
 
-    static parse(args: ReadonlyArray<unknown>, context: ParsingContext) {
+    static parse(args: ReadonlyArray<unknown>, context: ParsingContext): Expression | undefined | null {
         let [operator, interpolation, input, ...rest] = args;
 
         if (!Array.isArray(interpolation) || interpolation.length === 0) {

--- a/src/style-spec/expression/definitions/interpolate.ts
+++ b/src/style-spec/expression/definitions/interpolate.ts
@@ -62,7 +62,7 @@ class Interpolate implements Expression {
         let [operator, interpolation, input, ...rest] = args;
 
         if (!Array.isArray(interpolation) || interpolation.length === 0) {
-            return context.error(`Expected an interpolation type expression.`, 1);
+            return context.error(`Expected an interpolation type expression.`, 1) as null;
         }
 
         if (interpolation[0] === 'linear') {
@@ -70,7 +70,7 @@ class Interpolate implements Expression {
         } else if (interpolation[0] === 'exponential') {
             const base = interpolation[1];
             if (typeof base !== 'number')
-                return context.error(`Exponential interpolation requires a numeric base.`, 1, 1);
+                return context.error(`Exponential interpolation requires a numeric base.`, 1, 1) as null;
             interpolation = {
                 name: 'exponential',
                 base
@@ -81,7 +81,7 @@ class Interpolate implements Expression {
                 controlPoints.length !== 4 ||
                 controlPoints.some(t => typeof t !== 'number' || t < 0 || t > 1)
             ) {
-                return context.error('Cubic bezier interpolation requires four numeric arguments with values between 0 and 1.', 1);
+                return context.error('Cubic bezier interpolation requires four numeric arguments with values between 0 and 1.', 1) as null;
             }
 
             interpolation = {
@@ -89,15 +89,15 @@ class Interpolate implements Expression {
                 controlPoints: (controlPoints as any)
             };
         } else {
-            return context.error(`Unknown interpolation type ${String(interpolation[0])}`, 1, 0);
+            return context.error(`Unknown interpolation type ${String(interpolation[0])}`, 1, 0) as null;
         }
 
         if (args.length - 1 < 4) {
-            return context.error(`Expected at least 4 arguments, but found only ${args.length - 1}.`);
+            return context.error(`Expected at least 4 arguments, but found only ${args.length - 1}.`) as null;
         }
 
         if ((args.length - 1) % 2 !== 0) {
-            return context.error(`Expected an even number of arguments.`);
+            return context.error(`Expected an even number of arguments.`) as null;
         }
 
         input = context.parse(input, 2, NumberType);
@@ -120,11 +120,11 @@ class Interpolate implements Expression {
             const valueKey = i + 4;
 
             if (typeof label !== 'number') {
-                return context.error('Input/output pairs for "interpolate" expressions must be defined using literal numeric values (not computed expressions) for the input values.', labelKey);
+                return context.error('Input/output pairs for "interpolate" expressions must be defined using literal numeric values (not computed expressions) for the input values.', labelKey) as null;
             }
 
             if (stops.length && stops[stops.length - 1][0] >= label) {
-                return context.error('Input/output pairs for "interpolate" expressions must be arranged with input values in strictly ascending order.', labelKey);
+                return context.error('Input/output pairs for "interpolate" expressions must be arranged with input values in strictly ascending order.', labelKey) as null;
             }
 
             const parsed = context.parse(value, valueKey, outputType);
@@ -141,7 +141,7 @@ class Interpolate implements Expression {
                 typeof outputType.N === 'number'
             )
         ) {
-            return context.error(`Type ${toString(outputType)} is not interpolatable.`);
+            return context.error(`Type ${toString(outputType)} is not interpolatable.`) as null;
         }
 
         return new Interpolate(outputType, (operator as any), interpolation, input, stops);

--- a/src/style-spec/expression/definitions/interpolate.ts
+++ b/src/style-spec/expression/definitions/interpolate.ts
@@ -100,14 +100,14 @@ class Interpolate implements Expression {
             return context.error(`Expected an even number of arguments.`) as null;
         }
 
-        input = context.parse(input, 2, NumberType);
+        input = context.parse(input, 2, NumberType as Type);
         if (!input) return null;
 
         const stops: Stops = [];
 
         let outputType: Type = (null as any);
         if (operator === 'interpolate-hcl' || operator === 'interpolate-lab') {
-            outputType = ColorType;
+            outputType = ColorType as Type;
         } else if (context.expectedType && context.expectedType.kind !== 'value') {
             outputType = context.expectedType;
         }

--- a/src/style-spec/expression/definitions/length.ts
+++ b/src/style-spec/expression/definitions/length.ts
@@ -19,13 +19,13 @@ class Length implements Expression {
 
     static parse(args: ReadonlyArray<unknown>, context: ParsingContext): Expression | undefined | null {
         if (args.length !== 2)
-            return context.error(`Expected 1 argument, but found ${args.length - 1} instead.`);
+            return context.error(`Expected 1 argument, but found ${args.length - 1} instead.`) as null;
 
         const input = context.parse(args[1], 1);
         if (!input) return null;
 
         if (input.type.kind !== 'array' && input.type.kind !== 'string' && input.type.kind !== 'value')
-            return context.error(`Expected argument of type string or array, but found ${toString(input.type)} instead.`);
+            return context.error(`Expected argument of type string or array, but found ${toString(input.type)} instead.`) as null;
 
         return new Length(input);
     }

--- a/src/style-spec/expression/definitions/length.ts
+++ b/src/style-spec/expression/definitions/length.ts
@@ -13,7 +13,7 @@ class Length implements Expression {
     input: Expression;
 
     constructor(input: Expression) {
-        this.type = NumberType;
+        this.type = NumberType as Type;
         this.input = input;
     }
 

--- a/src/style-spec/expression/definitions/length.ts
+++ b/src/style-spec/expression/definitions/length.ts
@@ -17,7 +17,7 @@ class Length implements Expression {
         this.input = input;
     }
 
-    static parse(args: ReadonlyArray<unknown>, context: ParsingContext) {
+    static parse(args: ReadonlyArray<unknown>, context: ParsingContext): Expression | undefined | null {
         if (args.length !== 2)
             return context.error(`Expected 1 argument, but found ${args.length - 1} instead.`);
 

--- a/src/style-spec/expression/definitions/let.ts
+++ b/src/style-spec/expression/definitions/let.ts
@@ -27,18 +27,18 @@ class Let implements Expression {
 
     static parse(args: ReadonlyArray<unknown>, context: ParsingContext): Expression | undefined | null {
         if (args.length < 4)
-            return context.error(`Expected at least 3 arguments, but found ${args.length - 1} instead.`);
+            return context.error(`Expected at least 3 arguments, but found ${args.length - 1} instead.`) as null;
 
         const bindings: Array<[string, Expression]> = [];
         for (let i = 1; i < args.length - 1; i += 2) {
             const name = args[i];
 
             if (typeof name !== 'string') {
-                return context.error(`Expected string, but found ${typeof name} instead.`, i);
+                return context.error(`Expected string, but found ${typeof name} instead.`, i) as null;
             }
 
             if (/[^a-zA-Z0-9_]/.test(name)) {
-                return context.error(`Variable names must contain only alphanumeric characters or '_'.`, i);
+                return context.error(`Variable names must contain only alphanumeric characters or '_'.`, i) as null;
             }
 
             const value = context.parse(args[i + 1], i + 1);

--- a/src/style-spec/expression/definitions/let.ts
+++ b/src/style-spec/expression/definitions/let.ts
@@ -25,7 +25,7 @@ class Let implements Expression {
         fn(this.result);
     }
 
-    static parse(args: ReadonlyArray<unknown>, context: ParsingContext) {
+    static parse(args: ReadonlyArray<unknown>, context: ParsingContext): Expression | undefined | null {
         if (args.length < 4)
             return context.error(`Expected at least 3 arguments, but found ${args.length - 1} instead.`);
 

--- a/src/style-spec/expression/definitions/literal.ts
+++ b/src/style-spec/expression/definitions/literal.ts
@@ -18,10 +18,10 @@ class Literal implements Expression {
 
     static parse(args: ReadonlyArray<unknown>, context: ParsingContext): Expression | undefined | null {
         if (args.length !== 2)
-            return context.error(`'literal' expression requires exactly one argument, but found ${args.length - 1} instead.`);
+            return context.error(`'literal' expression requires exactly one argument, but found ${args.length - 1} instead.`) as null;
 
         if (!isValue(args[1]))
-            return context.error(`invalid value`);
+            return context.error(`invalid value`) as null;
 
         const value = (args[1] as any);
         let type = typeOf(value);

--- a/src/style-spec/expression/definitions/literal.ts
+++ b/src/style-spec/expression/definitions/literal.ts
@@ -16,7 +16,7 @@ class Literal implements Expression {
         this.value = value;
     }
 
-    static parse(args: ReadonlyArray<unknown>, context: ParsingContext) {
+    static parse(args: ReadonlyArray<unknown>, context: ParsingContext): Expression | undefined | null {
         if (args.length !== 2)
             return context.error(`'literal' expression requires exactly one argument, but found ${args.length - 1} instead.`);
 

--- a/src/style-spec/expression/definitions/match.ts
+++ b/src/style-spec/expression/definitions/match.ts
@@ -32,7 +32,7 @@ class Match implements Expression {
         this.otherwise = otherwise;
     }
 
-    static parse(args: ReadonlyArray<unknown>, context: ParsingContext) {
+    static parse(args: ReadonlyArray<unknown>, context: ParsingContext): Expression | undefined | null {
         if (args.length < 5)
             return context.error(`Expected at least 4 arguments, but found only ${args.length - 1}.`);
         if (args.length % 2 !== 1)

--- a/src/style-spec/expression/definitions/match.ts
+++ b/src/style-spec/expression/definitions/match.ts
@@ -34,9 +34,9 @@ class Match implements Expression {
 
     static parse(args: ReadonlyArray<unknown>, context: ParsingContext): Expression | undefined | null {
         if (args.length < 5)
-            return context.error(`Expected at least 4 arguments, but found only ${args.length - 1}.`);
+            return context.error(`Expected at least 4 arguments, but found only ${args.length - 1}.`) as null;
         if (args.length % 2 !== 1)
-            return context.error(`Expected an even number of arguments.`);
+            return context.error(`Expected an even number of arguments.`) as null;
 
         let inputType;
         let outputType;
@@ -55,17 +55,17 @@ class Match implements Expression {
 
             const labelContext = context.concat(i);
             if (labels.length === 0) {
-                return labelContext.error('Expected at least one branch label.');
+                return labelContext.error('Expected at least one branch label.') as null;
             }
 
             for (const label of labels) {
                 if (typeof label !== 'number' && typeof label !== 'string') {
-                    return labelContext.error(`Branch labels must be numbers or strings.`);
+                    return labelContext.error(`Branch labels must be numbers or strings.`) as null;
                 } else if (typeof label === 'number' && Math.abs(label) > Number.MAX_SAFE_INTEGER) {
-                    return labelContext.error(`Branch labels must be integers no larger than ${Number.MAX_SAFE_INTEGER}.`);
+                    return labelContext.error(`Branch labels must be integers no larger than ${Number.MAX_SAFE_INTEGER}.`) as null;
 
                 } else if (typeof label === 'number' && Math.floor(label) !== label) {
-                    return labelContext.error(`Numeric branch labels must be integer values.`);
+                    return labelContext.error(`Numeric branch labels must be integer values.`) as null;
 
                 } else if (!inputType) {
                     inputType = typeOf(label);
@@ -74,7 +74,7 @@ class Match implements Expression {
                 }
 
                 if (typeof cases[String(label)] !== 'undefined') {
-                    return labelContext.error('Branch labels must be unique.');
+                    return labelContext.error('Branch labels must be unique.') as null;
                 }
 
                 cases[String(label)] = outputs.length;

--- a/src/style-spec/expression/definitions/match.ts
+++ b/src/style-spec/expression/definitions/match.ts
@@ -86,7 +86,7 @@ class Match implements Expression {
             outputs.push(result);
         }
 
-        const input = context.parse(args[1], 1, ValueType);
+        const input = context.parse(args[1], 1, ValueType as Type);
         if (!input) return null;
 
         const otherwise = context.parse(args[args.length - 1], args.length - 1, outputType);

--- a/src/style-spec/expression/definitions/number_format.ts
+++ b/src/style-spec/expression/definitions/number_format.ts
@@ -37,7 +37,7 @@ export default class NumberFormat implements Expression {
                 currency: Expression | null,
                 minFractionDigits: Expression | null,
                 maxFractionDigits: Expression | null) {
-        this.type = StringType;
+        this.type = StringType as Type;
         this.number = number;
         this.locale = locale;
         this.currency = currency;
@@ -49,7 +49,7 @@ export default class NumberFormat implements Expression {
         if (args.length !== 3)
             return context.error(`Expected two arguments.`) as null;
 
-        const number = context.parse(args[1], 1, NumberType);
+        const number = context.parse(args[1], 1, NumberType as Type);
         if (!number) return null;
 
         const options = (args[2] as any);
@@ -58,25 +58,25 @@ export default class NumberFormat implements Expression {
 
         let locale = null;
         if (options['locale']) {
-            locale = context.parse(options['locale'], 1, StringType);
+            locale = context.parse(options['locale'], 1, StringType as Type);
             if (!locale) return null;
         }
 
         let currency = null;
         if (options['currency']) {
-            currency = context.parse(options['currency'], 1, StringType);
+            currency = context.parse(options['currency'], 1, StringType as Type);
             if (!currency) return null;
         }
 
         let minFractionDigits = null;
         if (options['min-fraction-digits']) {
-            minFractionDigits = context.parse(options['min-fraction-digits'], 1, NumberType);
+            minFractionDigits = context.parse(options['min-fraction-digits'], 1, NumberType as Type);
             if (!minFractionDigits) return null;
         }
 
         let maxFractionDigits = null;
         if (options['max-fraction-digits']) {
-            maxFractionDigits = context.parse(options['max-fraction-digits'], 1, NumberType);
+            maxFractionDigits = context.parse(options['max-fraction-digits'], 1, NumberType as Type);
             if (!maxFractionDigits) return null;
         }
 

--- a/src/style-spec/expression/definitions/number_format.ts
+++ b/src/style-spec/expression/definitions/number_format.ts
@@ -47,14 +47,14 @@ export default class NumberFormat implements Expression {
 
     static parse(args: ReadonlyArray<unknown>, context: ParsingContext): Expression | undefined | null {
         if (args.length !== 3)
-            return context.error(`Expected two arguments.`);
+            return context.error(`Expected two arguments.`) as null;
 
         const number = context.parse(args[1], 1, NumberType);
         if (!number) return null;
 
         const options = (args[2] as any);
         if (typeof options !== "object" || Array.isArray(options))
-            return context.error(`NumberFormat options argument must be an object.`);
+            return context.error(`NumberFormat options argument must be an object.`) as null;
 
         let locale = null;
         if (options['locale']) {

--- a/src/style-spec/expression/definitions/slice.ts
+++ b/src/style-spec/expression/definitions/slice.ts
@@ -34,17 +34,17 @@ class Slice implements Expression {
             return context.error(`Expected 3 or 4 arguments, but found ${args.length - 1} instead.`) as null;
         }
 
-        const input = context.parse(args[1], 1, ValueType);
-        const beginIndex = context.parse(args[2], 2, NumberType);
+        const input = context.parse(args[1], 1, ValueType as Type);
+        const beginIndex = context.parse(args[2], 2, NumberType as Type);
 
         if (!input || !beginIndex) return null;
 
-        if (!isValidType(input.type, [array(ValueType), StringType, ValueType])) {
+        if (!isValidType(input.type, [array(ValueType as Type), StringType as Type, ValueType as Type])) {
             return context.error(`Expected first argument to be of type array or string, but found ${toString(input.type)} instead`) as null;
         }
 
         if (args.length === 4) {
-            const endIndex = context.parse(args[3], 3, NumberType);
+            const endIndex = context.parse(args[3], 3, NumberType as Type);
             if (!endIndex) return null;
             return new Slice(input.type, input, beginIndex, endIndex);
         } else {

--- a/src/style-spec/expression/definitions/slice.ts
+++ b/src/style-spec/expression/definitions/slice.ts
@@ -31,7 +31,7 @@ class Slice implements Expression {
 
     static parse(args: ReadonlyArray<unknown>, context: ParsingContext): Expression | undefined | null {
         if (args.length <= 2 ||  args.length >= 5) {
-            return context.error(`Expected 3 or 4 arguments, but found ${args.length - 1} instead.`);
+            return context.error(`Expected 3 or 4 arguments, but found ${args.length - 1} instead.`) as null;
         }
 
         const input = context.parse(args[1], 1, ValueType);
@@ -40,7 +40,7 @@ class Slice implements Expression {
         if (!input || !beginIndex) return null;
 
         if (!isValidType(input.type, [array(ValueType), StringType, ValueType])) {
-            return context.error(`Expected first argument to be of type array or string, but found ${toString(input.type)} instead`);
+            return context.error(`Expected first argument to be of type array or string, but found ${toString(input.type)} instead`) as null;
         }
 
         if (args.length === 4) {

--- a/src/style-spec/expression/definitions/slice.ts
+++ b/src/style-spec/expression/definitions/slice.ts
@@ -29,7 +29,7 @@ class Slice implements Expression {
 
     }
 
-    static parse(args: ReadonlyArray<unknown>, context: ParsingContext) {
+    static parse(args: ReadonlyArray<unknown>, context: ParsingContext): Expression | undefined | null {
         if (args.length <= 2 ||  args.length >= 5) {
             return context.error(`Expected 3 or 4 arguments, but found ${args.length - 1} instead.`);
         }

--- a/src/style-spec/expression/definitions/step.ts
+++ b/src/style-spec/expression/definitions/step.ts
@@ -36,7 +36,7 @@ class Step implements Expression {
             return context.error(`Expected an even number of arguments.`) as null;
         }
 
-        const input = context.parse(args[1], 1, NumberType);
+        const input = context.parse(args[1], 1, NumberType as Type);
         if (!input) return null;
 
         const stops: Stops = [];

--- a/src/style-spec/expression/definitions/step.ts
+++ b/src/style-spec/expression/definitions/step.ts
@@ -29,11 +29,11 @@ class Step implements Expression {
 
     static parse(args: ReadonlyArray<unknown>, context: ParsingContext): Expression | undefined | null {
         if (args.length - 1 < 4) {
-            return context.error(`Expected at least 4 arguments, but found only ${args.length - 1}.`);
+            return context.error(`Expected at least 4 arguments, but found only ${args.length - 1}.`) as null;
         }
 
         if ((args.length - 1) % 2 !== 0) {
-            return context.error(`Expected an even number of arguments.`);
+            return context.error(`Expected an even number of arguments.`) as null;
         }
 
         const input = context.parse(args[1], 1, NumberType);
@@ -54,11 +54,11 @@ class Step implements Expression {
             const valueKey = i + 1;
 
             if (typeof label !== 'number') {
-                return context.error('Input/output pairs for "step" expressions must be defined using literal numeric values (not computed expressions) for the input values.', labelKey);
+                return context.error('Input/output pairs for "step" expressions must be defined using literal numeric values (not computed expressions) for the input values.', labelKey) as null;
             }
 
             if (stops.length && stops[stops.length - 1][0] >= label) {
-                return context.error('Input/output pairs for "step" expressions must be arranged with input values in strictly ascending order.', labelKey);
+                return context.error('Input/output pairs for "step" expressions must be arranged with input values in strictly ascending order.', labelKey) as null;
             }
 
             const parsed = context.parse(value, valueKey, outputType);

--- a/src/style-spec/expression/definitions/step.ts
+++ b/src/style-spec/expression/definitions/step.ts
@@ -27,7 +27,7 @@ class Step implements Expression {
         }
     }
 
-    static parse(args: ReadonlyArray<unknown>, context: ParsingContext) {
+    static parse(args: ReadonlyArray<unknown>, context: ParsingContext): Expression | undefined | null {
         if (args.length - 1 < 4) {
             return context.error(`Expected at least 4 arguments, but found only ${args.length - 1}.`);
         }

--- a/src/style-spec/expression/definitions/var.ts
+++ b/src/style-spec/expression/definitions/var.ts
@@ -14,7 +14,7 @@ class Var implements Expression {
         this.boundExpression = boundExpression;
     }
 
-    static parse(args: ReadonlyArray<unknown>, context: ParsingContext) {
+    static parse(args: ReadonlyArray<unknown>, context: ParsingContext): Expression | undefined | null {
         if (args.length !== 2 || typeof args[1] !== 'string')
             return context.error(`'var' expression requires exactly one string literal argument.`);
 

--- a/src/style-spec/expression/definitions/var.ts
+++ b/src/style-spec/expression/definitions/var.ts
@@ -16,11 +16,11 @@ class Var implements Expression {
 
     static parse(args: ReadonlyArray<unknown>, context: ParsingContext): Expression | undefined | null {
         if (args.length !== 2 || typeof args[1] !== 'string')
-            return context.error(`'var' expression requires exactly one string literal argument.`);
+            return context.error(`'var' expression requires exactly one string literal argument.`) as null;
 
         const name = args[1];
         if (!context.scope.has(name)) {
-            return context.error(`Unknown variable "${name}". Make sure "${name}" has been bound in an enclosing "let" expression before using it.`, 1);
+            return context.error(`Unknown variable "${name}". Make sure "${name}" has been bound in an enclosing "let" expression before using it.`, 1) as null;
         }
 
         return new Var(name, context.scope.get(name));

--- a/src/style-spec/expression/definitions/within.ts
+++ b/src/style-spec/expression/definitions/within.ts
@@ -293,7 +293,7 @@ class Within implements Expression {
 
     static parse(args: ReadonlyArray<unknown>, context: ParsingContext): Expression | undefined | null {
         if (args.length !== 2)
-            return context.error(`'within' expression requires exactly one argument, but found ${args.length - 1} instead.`);
+            return context.error(`'within' expression requires exactly one argument, but found ${args.length - 1} instead.`) as null;
         if (isValue(args[1])) {
             const geojson = (args[1] as any);
             if (geojson.type === 'FeatureCollection') {
@@ -312,7 +312,7 @@ class Within implements Expression {
                 return new Within(geojson, geojson);
             }
         }
-        return context.error(`'within' expression requires valid geojson object that contains polygon geometry type.`);
+        return context.error(`'within' expression requires valid geojson object that contains polygon geometry type.`) as null;
     }
 
     evaluate(ctx: EvaluationContext) {

--- a/src/style-spec/expression/definitions/within.ts
+++ b/src/style-spec/expression/definitions/within.ts
@@ -291,7 +291,7 @@ class Within implements Expression {
         this.geometries = geometries;
     }
 
-    static parse(args: ReadonlyArray<unknown>, context: ParsingContext) {
+    static parse(args: ReadonlyArray<unknown>, context: ParsingContext): Expression | undefined | null {
         if (args.length !== 2)
             return context.error(`'within' expression requires exactly one argument, but found ${args.length - 1} instead.`);
         if (isValue(args[1])) {

--- a/src/style-spec/expression/definitions/within.ts
+++ b/src/style-spec/expression/definitions/within.ts
@@ -286,7 +286,7 @@ class Within implements Expression {
     geometries: GeoJSONPolygons;
 
     constructor(geojson: GeoJSON, geometries: GeoJSONPolygons) {
-        this.type = BooleanType;
+        this.type = BooleanType as Type;
         this.geojson = geojson;
         this.geometries = geometries;
     }

--- a/src/style-spec/expression/parsing_context.ts
+++ b/src/style-spec/expression/parsing_context.ts
@@ -90,7 +90,7 @@ class ParsingContext {
 
         if (Array.isArray(expr)) {
             if (expr.length === 0) {
-                return this.error(`Expected an array with at least one element. If you wanted a literal array, use ["literal", []].`);
+                return this.error(`Expected an array with at least one element. If you wanted a literal array, use ["literal", []].`) as null;
             }
 
             const op = expr[0];
@@ -142,13 +142,13 @@ class ParsingContext {
                 return parsed;
             }
 
-            return this.error(`Unknown expression "${op}". If you wanted a literal array, use ["literal", [...]].`, 0);
+            return this.error(`Unknown expression "${op}". If you wanted a literal array, use ["literal", [...]].`, 0) as null;
         } else if (typeof expr === 'undefined') {
-            return this.error(`'undefined' value invalid. Use null instead.`);
+            return this.error(`'undefined' value invalid. Use null instead.`) as null;
         } else if (typeof expr === 'object') {
-            return this.error(`Bare objects invalid. Use ["literal", {...}] instead.`);
+            return this.error(`Bare objects invalid. Use ["literal", {...}] instead.`) as null;
         } else {
-            return this.error(`Expected an array, but found ${typeof expr} instead.`);
+            return this.error(`Expected an array, but found ${typeof expr} instead.`) as null;
         }
     }
 

--- a/src/style-spec/expression/types.ts
+++ b/src/style-spec/expression/types.ts
@@ -84,7 +84,7 @@ const valueMemberTypes = [
     ColorType,
     FormattedType,
     ObjectType,
-    array(ValueType),
+    array(ValueType as ValueTypeT),
     ResolvedImageType
 ];
 
@@ -107,7 +107,7 @@ export function checkSubtype(expected: Type, t: Type): string | undefined | null
         return null;
     } else if (expected.kind === 'value') {
         for (const memberType of valueMemberTypes) {
-            if (!checkSubtype(memberType, t)) {
+            if (!checkSubtype(memberType as Type, t)) {
                 return null;
             }
         }

--- a/src/style-spec/expression/values.ts
+++ b/src/style-spec/expression/values.ts
@@ -69,21 +69,21 @@ export function isValue(mixed: unknown): boolean {
 
 export function typeOf(value: Value): Type {
     if (value === null) {
-        return NullType;
+        return NullType as Type;
     } else if (typeof value === 'string') {
-        return StringType;
+        return StringType as Type;
     } else if (typeof value === 'boolean') {
-        return BooleanType;
+        return BooleanType as Type;
     } else if (typeof value === 'number') {
-        return NumberType;
+        return NumberType as Type;
     } else if (value instanceof Color) {
-        return ColorType;
+        return ColorType as Type;
     } else if (value instanceof Collator) {
-        return CollatorType;
+        return CollatorType as Type;
     } else if (value instanceof Formatted) {
-        return FormattedType;
+        return FormattedType as Type;
     } else if (value instanceof ResolvedImage) {
-        return ResolvedImageType;
+        return ResolvedImageType as Type;
     } else if (Array.isArray(value)) {
         const length = value.length;
         let itemType: Type | typeof undefined;
@@ -103,7 +103,7 @@ export function typeOf(value: Value): Type {
         return array(itemType || ValueType, length);
     } else {
         assert(typeof value === 'object');
-        return ObjectType;
+        return ObjectType as Type;
     }
 }
 

--- a/src/style-spec/feature_filter/index.ts
+++ b/src/style-spec/feature_filter/index.ts
@@ -1,6 +1,7 @@
 import {createExpression} from '../expression';
 import type {GlobalProperties, Feature} from '../expression';
 import type {CanonicalTileID} from '../../source/tile_id';
+import {StylePropertySpecification} from '../style-spec';
 
 type FilterExpression = (
   globalProperties: GlobalProperties,
@@ -87,7 +88,7 @@ function createFilter(filter: any): FeatureFilter {
         filter = convertFilter(filter);
     }
 
-    const compiled = createExpression(filter, filterSpec);
+    const compiled = createExpression(filter, filterSpec as StylePropertySpecification);
     if (compiled.result === 'error') {
         throw new Error(compiled.value.map(err => `${err.key}: ${err.message}`).join(', '));
     } else {

--- a/src/style-spec/function/convert.ts
+++ b/src/style-spec/function/convert.ts
@@ -139,7 +139,7 @@ function convertPropertyFunction(parameters, propertySpec, stops) {
     const get = ['get', parameters.property];
     if (type === 'categorical' && typeof stops[0][0] === 'boolean') {
         assert(parameters.stops.length > 0 && parameters.stops.length <= 2);
-        const expression = ['case'];
+        const expression: any = ['case'];
         for (const stop of stops) {
             expression.push(['==', get, stop[0]], stop[1]);
         }
@@ -243,7 +243,7 @@ function getFunctionType(parameters, propertySpec) {
 
 // "String with {name} token" => ["concat", "String with ", ["get", "name"], " token"]
 export function convertTokenString(s: string) {
-    const result = ['concat'];
+    const result: any = ['concat'];
     const re = /{([^{}]+)}/g;
     let pos = 0;
     for (let match = re.exec(s); match !== null; match = re.exec(s)) {

--- a/src/style-spec/function/index.ts
+++ b/src/style-spec/function/index.ts
@@ -131,7 +131,7 @@ export function createFunction(parameters, propertySpec) {
     }
 }
 
-function coalesce(a, b, c) {
+function coalesce(a, b, c?) {
     if (a !== undefined) return a;
     if (b !== undefined) return b;
     if (c !== undefined) return c;

--- a/src/symbol/check_max_angle.ts
+++ b/src/symbol/check_max_angle.ts
@@ -22,7 +22,7 @@ function checkMaxAngle(line: Array<Point>, anchor: Anchor, labelLength: number, 
     if (anchor.segment === undefined) return true;
 
     let p = anchor;
-    let index = anchor.segment + 1;
+    let index = Number(anchor.segment) + 1;
     let anchorDistance = 0;
 
     // move backwards along the line to the first segment the label appears on

--- a/src/symbol/mergelines.ts
+++ b/src/symbol/mergelines.ts
@@ -35,7 +35,7 @@ export default function(features: Array<SymbolFeature>): Array<SymbolFeature> {
         return i;
     }
 
-    function getKey(text, geom, onRight) {
+    function getKey(text, geom, onRight?) {
         const point = onRight ? geom[0][geom[0].length - 1] : geom[0][0];
         return `${text}:${point.x}:${point.y}`;
     }

--- a/src/symbol/quads.ts
+++ b/src/symbol/quads.ts
@@ -10,6 +10,7 @@ import type SymbolStyleLayer from '../style/style_layer/symbol_style_layer';
 import type {Feature} from '../style-spec/expression';
 import type {StyleImage} from '../style/style_image';
 import ONE_EM from './one_em';
+import {Rect} from '../render/glyph_atlas';
 
 /**
  * A textured quad for rendering a single icon or glyph.
@@ -237,7 +238,7 @@ export function getGlyphQuads(
     for (const line of shaping.positionedLines) {
         for (const positionedGlyph of line.positionedGlyphs) {
             if (!positionedGlyph.rect) continue;
-            const textureRect = positionedGlyph.rect || {};
+            const textureRect: Rect = positionedGlyph.rect || {} as Rect;
 
             // The rects have an additional buffer that is not included in their size.
             const glyphPadding = 1.0;

--- a/src/symbol/symbol_layout.ts
+++ b/src/symbol/symbol_layout.ts
@@ -560,7 +560,7 @@ function getDefaultHorizontalShaping(
 ): Shaping | null {
     // We don't care which shaping we get because this is used for collision purposes
     // and all the justifications have the same collision box
-    for (const justification: any in horizontalShaping) {
+    for (const justification in horizontalShaping) {
         return horizontalShaping[justification];
     }
     return null;
@@ -701,7 +701,7 @@ function addSymbol(bucket: SymbolBucket,
         }
     }
 
-    for (const justification: any in shapedTextOrientations.horizontal) {
+    for (const justification in shapedTextOrientations.horizontal) {
         const shaping = shapedTextOrientations.horizontal[justification];
 
         if (!textCollisionFeature) {

--- a/src/symbol/symbol_layout.ts
+++ b/src/symbol/symbol_layout.ts
@@ -768,7 +768,7 @@ function addSymbol(bucket: SymbolBucket,
     );
 
     if (feature.sortKey !== undefined) {
-        bucket.addToSortKeyRanges(bucket.symbolInstances.length, feature.sortKey);
+        bucket.addToSortKeyRanges(bucket.symbolInstances.length, feature.sortKey as number);
     }
 
     bucket.symbolInstances.emplaceBack(

--- a/src/symbol/symbol_layout.ts
+++ b/src/symbol/symbol_layout.ts
@@ -174,7 +174,7 @@ export function performSymbolLayout(bucket: SymbolBucket,
     const layout = bucket.layers[0].layout;
     const unevaluatedLayoutValues = bucket.layers[0]._unevaluatedLayout._values;
 
-    const sizes = {};
+    const sizes: {[k: string]: any} = {};
 
     if (bucket.textSizeData.kind === 'composite') {
         const {minZoom, maxZoom} = bucket.textSizeData;
@@ -327,7 +327,7 @@ export function performSymbolLayout(bucket: SymbolBucket,
         const shapedText = getDefaultHorizontalShaping(shapedTextOrientations.horizontal) || shapedTextOrientations.vertical;
         bucket.iconsInText = shapedText ? shapedText.iconsInText : false;
         if (shapedText || shapedIcon) {
-            addFeature(bucket, feature, shapedTextOrientations, shapedIcon, imageMap, sizes, layoutTextSize, layoutIconSize, textOffset, isSDFIcon, canonical);
+            addFeature(bucket, feature, shapedTextOrientations, shapedIcon, imageMap, sizes as Sizes, layoutTextSize, layoutIconSize, textOffset, isSDFIcon, canonical);
         }
     }
 
@@ -608,7 +608,7 @@ function addSymbol(bucket: SymbolBucket,
     let numVerticalGlyphVertices = 0;
     let placedIconSymbolIndex = -1;
     let verticalPlacedIconSymbolIndex = -1;
-    const placedTextSymbolIndices = {};
+    const placedTextSymbolIndices: {[k: string]: any} = {};
     let key = murmur3('');
 
     let textOffset0 = 0;

--- a/src/symbol/symbol_layout.ts
+++ b/src/symbol/symbol_layout.ts
@@ -196,7 +196,7 @@ export function performSymbolLayout(bucket: SymbolBucket,
     sizes.layoutIconSize = unevaluatedLayoutValues['icon-size'].possiblyEvaluate(new EvaluationParameters(bucket.zoom + 1), canonical);
     sizes.textMaxSize = unevaluatedLayoutValues['text-size'].possiblyEvaluate(new EvaluationParameters(18));
 
-    const lineHeight = layout.get('text-line-height') * ONE_EM;
+    const lineHeight = Number(layout.get('text-line-height')) * ONE_EM;
     const textAlongLine = layout.get('text-rotation-alignment') === 'map' && layout.get('symbol-placement') !== 'point';
     const keepUpright = layout.get('text-keep-upright');
     const textSize = layout.get('text-size');
@@ -386,10 +386,10 @@ function addFeature(bucket: SymbolBucket,
         textBoxScale = bucket.tilePixelRatio * fontScale,
         textMaxBoxScale = bucket.tilePixelRatio * textMaxSize / glyphSize,
         iconBoxScale = bucket.tilePixelRatio * layoutIconSize,
-        symbolMinDistance = bucket.tilePixelRatio * layout.get('symbol-spacing'),
-        textPadding = layout.get('text-padding') * bucket.tilePixelRatio,
-        iconPadding = layout.get('icon-padding') * bucket.tilePixelRatio,
-        textMaxAngle = layout.get('text-max-angle') / 180 * Math.PI,
+        symbolMinDistance = bucket.tilePixelRatio * Number(layout.get('symbol-spacing')),
+        textPadding = Number(layout.get('text-padding')) * bucket.tilePixelRatio,
+        iconPadding = Number(layout.get('icon-padding')) * bucket.tilePixelRatio,
+        textMaxAngle = Number(layout.get('text-max-angle')) / 180 * Math.PI,
         textAlongLine = layout.get('text-rotation-alignment') === 'map' && layout.get('symbol-placement') !== 'point',
         iconAlongLine = layout.get('icon-rotation-alignment') === 'map' && layout.get('symbol-placement') !== 'point',
         symbolPlacement = layout.get('symbol-placement'),

--- a/src/symbol/symbol_layout.ts
+++ b/src/symbol/symbol_layout.ts
@@ -207,7 +207,7 @@ export function performSymbolLayout(bucket: SymbolBucket,
         const layoutTextSize = sizes.layoutTextSize.evaluate(feature, {}, canonical);
         const layoutIconSize = sizes.layoutIconSize.evaluate(feature, {}, canonical);
 
-        const shapedTextOrientations = {
+        const shapedTextOrientations: {[k: string]: any} = {
             horizontal: {},
             vertical: undefined
         };

--- a/src/symbol/symbol_layout.ts
+++ b/src/symbol/symbol_layout.ts
@@ -228,7 +228,7 @@ export function performSymbolLayout(bucket: SymbolBucket,
                 if (radialOffset) {
                     // The style spec says don't use `text-offset` and `text-radial-offset` together
                     // but doesn't actually specify what happens if you use both. We go with the radial offset.
-                    textOffset = evaluateVariableOffset(textAnchor, [radialOffset * ONE_EM, INVALID_TEXT_OFFSET]);
+                    textOffset = evaluateVariableOffset(textAnchor, [radialOffset * ONE_EM, INVALID_TEXT_OFFSET]) as [number, number];
                 } else {
                     textOffset = (layout.get('text-offset').evaluate(feature, {}, canonical).map(t => t * ONE_EM) as any);
                 }

--- a/src/ui/camera.ts
+++ b/src/ui/camera.ts
@@ -104,7 +104,7 @@ export type AnimationOptions = {
  * @see [Fit a map to a bounding box](https://maplibre.org/maplibre-gl-js-docs/example/fitbounds/)
  */
 
-class Camera extends Evented {
+abstract class Camera extends Evented {
     transform: Transform;
     _moving: boolean;
     _zooming: boolean;
@@ -124,8 +124,8 @@ class Camera extends Evented {
     _onEaseEnd: (easeId?: string) => void;
     _easeFrameId: TaskID | undefined | null;
 
-    readonly _requestRenderFrame: (a: () => void) => TaskID;
-    readonly _cancelRenderFrame: (_: TaskID) => void;
+    abstract _requestRenderFrame(a: () => void): TaskID;
+    abstract _cancelRenderFrame(_: TaskID): void;
 
     constructor(transform: Transform, options: {
       bearingSnap: number

--- a/src/ui/handler_manager.ts
+++ b/src/ui/handler_manager.ts
@@ -403,7 +403,7 @@ class HandlerManager {
     }
 
     _applyChanges() {
-        const combined = {};
+        const combined: {[k: string]: any} = {};
         const combinedEventsInProgress = {};
         const combinedDeactivatedHandlers = {};
 

--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -112,7 +112,8 @@ type MapOptions = {
   bounds?: LngLatBoundsLike,
   fitBoundsOptions?: Object,
   localIdeographFontFamily?: string,
-  style: Object | string
+  style: Object | string,
+  pitchWithRotate?: boolean
 };
 
 const defaultMinZoom = -2;
@@ -392,7 +393,7 @@ class Map extends Camera {
         }
 
         const transform = new Transform(options.minZoom, options.maxZoom, options.minPitch, options.maxPitch, options.renderWorldCopies);
-        super(transform, options);
+        super(transform, {bearingSnap: options.bearingSnap});
 
         this._interactive = options.interactive;
         this._maxTileCacheSize = options.maxTileCacheSize;
@@ -453,7 +454,12 @@ class Map extends Camera {
             window.addEventListener('orientationchange', this._onWindowResize, false);
         }
 
-        this.handlers = new HandlerManager(this, options);
+        this.handlers = new HandlerManager(this, {
+            interactive: options.interactive,
+            pitchWithRotate: options.pitchWithRotate,
+            clickTolerance: options.clickTolerance,
+            bearingSnap: options.bearingSnap
+        });
 
         const hashName = (typeof options.hash === 'string' && options.hash) || undefined;
         this._hash = options.hash && (new Hash(hashName)).addTo(this);

--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -104,7 +104,15 @@ type MapOptions = {
   maxTileCacheSize?: number,
   transformRequest?: RequestTransformFunction,
   accessToken: string,
-  locale?: any
+  locale?: any,
+  fadeDuration?: number,
+  crossSourceCollisions?: boolean,
+  collectResourceTiming?: boolean,
+  clickTolerance?: number,
+  bounds?: LngLatBoundsLike,
+  fitBoundsOptions?: Object,
+  localIdeographFontFamily?: string,
+  style: Object | string
 };
 
 const defaultMinZoom = -2;

--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -112,7 +112,7 @@ type MapOptions = {
   bounds?: LngLatBoundsLike,
   fitBoundsOptions?: Object,
   localIdeographFontFamily?: string,
-  style: Object | string,
+  style: StyleSpecification | string,
   pitchWithRotate?: boolean
 };
 

--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -56,8 +56,8 @@ import type {
     LightSpecification,
     SourceSpecification
 } from '../style-spec/types';
-import { Listener } from 'selenium-webdriver';
-import { Callback } from '../types/callback';
+import {Listener} from 'selenium-webdriver';
+import {Callback} from '../types/callback';
 
 type ControlPosition = "top-left" | "top-right" | "bottom-left" | "bottom-right";
 
@@ -1721,9 +1721,9 @@ class Map extends Camera {
             return this.fire(new ErrorEvent(new Error(
                 'The map has no image with that id. If you are adding a new image use `map.addImage(...)` instead.')));
         }
-        const imageData = (image instanceof HTMLImageElement || (ImageBitmap && image instanceof ImageBitmap)) 
-            ? browser.getImageData(image as HTMLImageElement | ImageBitmap) 
-            : image as ImageData;
+        const imageData = (image instanceof HTMLImageElement || (ImageBitmap && image instanceof ImageBitmap)) ?
+            browser.getImageData(image as HTMLImageElement | ImageBitmap) :
+            image as ImageData;
         const {width, height, data} = imageData;
 
         if (width === undefined || height === undefined) {

--- a/src/util/dispatcher.ts
+++ b/src/util/dispatcher.ts
@@ -40,7 +40,7 @@ class Dispatcher {
      * Broadcast a message to all Workers.
      * @private
      */
-    broadcast(type: string, data: unknown, cb?: Function) {
+    broadcast(type: string, data: unknown, cb?: (...args: any[]) => any) {
         assert(this.actors.length);
         cb = cb || function () {};
         asyncAll(this.actors, (actor, done) => {

--- a/src/util/dom.ts
+++ b/src/util/dom.ts
@@ -24,7 +24,6 @@ interface DOMInterface {
     remove(node: HTMLElement);
 }
 
-
 const DOM = {} as DOMInterface;
 export default DOM;
 

--- a/src/util/primitives.ts
+++ b/src/util/primitives.ts
@@ -10,7 +10,7 @@ class Frustum {
         this.planes = planes_;
     }
 
-    static fromInvProjectionMatrix(invProj: Float64Array, worldSize: number, zoom: number): Frustum {
+    static fromInvProjectionMatrix(invProj: Float32Array, worldSize: number, zoom: number): Frustum {
         const clipSpaceCorners = [
             [-1, 1, -1, 1],
             [ 1, 1, -1, 1],
@@ -26,8 +26,8 @@ class Frustum {
 
         // Transform frustum corner points from clip space to tile space
         const frustumCoords = clipSpaceCorners
-            .map(v => vec4.transformMat4([], v, invProj))
-            .map(v => vec4.scale([], v, 1.0 / v[3] / worldSize * scale));
+            .map(v => vec4.transformMat4(new Float32Array, v as vec4, invProj))
+            .map(v => vec4.scale(new Float32Array, v, 1.0 / v[3] / worldSize * scale));
 
         const frustumPlanePointIndices = [
             [0, 1, 2],  // near
@@ -39,14 +39,14 @@ class Frustum {
         ];
 
         const frustumPlanes = frustumPlanePointIndices.map((p: Array<number>) => {
-            const a = vec3.sub([], frustumCoords[p[0]], frustumCoords[p[1]]);
-            const b = vec3.sub([], frustumCoords[p[2]], frustumCoords[p[1]]);
-            const n = vec3.normalize([], vec3.cross([], a, b));
-            const d = -vec3.dot(n, frustumCoords[p[1]]);
-            return n.concat(d);
+            const a = vec3.sub(new Float32Array, frustumCoords[p[0]] as vec3, frustumCoords[p[1]] as vec3);
+            const b = vec3.sub(new Float32Array, frustumCoords[p[2]] as vec3, frustumCoords[p[1]] as vec3);
+            const n = vec3.normalize(new Float32Array, vec3.cross(new Float32Array, a, b));
+            const d = -vec3.dot(n, frustumCoords[p[1]] as vec3);
+            return (n as number[]).concat(d);
         });
 
-        return new Frustum(frustumCoords, frustumPlanes);
+        return new Frustum(frustumCoords as number[][], frustumPlanes);
     }
 }
 
@@ -58,7 +58,7 @@ class Aabb {
     constructor(min_: vec3, max_: vec3) {
         this.min = min_;
         this.max = max_;
-        this.center = vec3.scale([], vec3.add([], this.min, this.max), 0.5);
+        this.center = vec3.scale(new Float32Array, vec3.add(new Float32Array, this.min, this.max), 0.5);
     }
 
     quadrant(index: number): Aabb {
@@ -106,7 +106,7 @@ class Aabb {
             let pointsInside = 0;
 
             for (let i = 0; i < aabbPoints.length; i++) {
-                pointsInside += vec4.dot(plane, aabbPoints[i]) >= 0;
+                pointsInside += Number(vec4.dot(plane as vec4, aabbPoints[i] as vec4) >= 0);
             }
 
             if (pointsInside === 0)

--- a/src/util/primitives.ts
+++ b/src/util/primitives.ts
@@ -26,8 +26,8 @@ class Frustum {
 
         // Transform frustum corner points from clip space to tile space
         const frustumCoords = clipSpaceCorners
-            .map(v => vec4.transformMat4(new Float32Array, v as vec4, invProj))
-            .map(v => vec4.scale(new Float32Array, v, 1.0 / v[3] / worldSize * scale));
+            .map(v => vec4.transformMat4(new Float32Array(), v as vec4, invProj))
+            .map(v => vec4.scale(new Float32Array(), v, 1.0 / v[3] / worldSize * scale));
 
         const frustumPlanePointIndices = [
             [0, 1, 2],  // near
@@ -39,9 +39,9 @@ class Frustum {
         ];
 
         const frustumPlanes = frustumPlanePointIndices.map((p: Array<number>) => {
-            const a = vec3.sub(new Float32Array, frustumCoords[p[0]] as vec3, frustumCoords[p[1]] as vec3);
-            const b = vec3.sub(new Float32Array, frustumCoords[p[2]] as vec3, frustumCoords[p[1]] as vec3);
-            const n = vec3.normalize(new Float32Array, vec3.cross(new Float32Array, a, b));
+            const a = vec3.sub(new Float32Array(), frustumCoords[p[0]] as vec3, frustumCoords[p[1]] as vec3);
+            const b = vec3.sub(new Float32Array(), frustumCoords[p[2]] as vec3, frustumCoords[p[1]] as vec3);
+            const n = vec3.normalize(new Float32Array(), vec3.cross(new Float32Array(), a, b));
             const d = -vec3.dot(n, frustumCoords[p[1]] as vec3);
             return (n as number[]).concat(d);
         });
@@ -58,7 +58,7 @@ class Aabb {
     constructor(min_: vec3, max_: vec3) {
         this.min = min_;
         this.max = max_;
-        this.center = vec3.scale(new Float32Array, vec3.add(new Float32Array, this.min, this.max), 0.5);
+        this.center = vec3.scale(new Float32Array(), vec3.add(new Float32Array(), this.min, this.max), 0.5);
     }
 
     quadrant(index: number): Aabb {

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -214,9 +214,9 @@ export function uniqueId(): number {
  */
 export function uuid(): string {
     function b(a?): string {
-        return a 
-            ? (a ^ Math.random() * 16 >> a / 4).toString(16)
-            : "10000000-1000-4000-80000000-100000000000".replace(/[018]/g, b);
+        return a ?
+            (a ^ Math.random() * 16 >> a / 4).toString(16) :
+            "10000000-1000-4000-80000000-100000000000".replace(/[018]/g, b);
     }
     return b();
 }


### PR DESCRIPTION
This pull request is my work in progress on the typescript migration. 

* [gl-matrix](https://glmatrix.net/) types need to be converted explicitly. They use 32-bit floating point numbers, I don't know why originally mapbox was passing in `Float64Array`
* some automatic lint fixes

 - [ 😸 ] confirm your changes do not include backports from Mapbox projects (unless with compliant license)
 - [ ] briefly describe the changes in this PR
 - [ ] include before/after visuals or gifs if this PR includes visual changes
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [ ] manually test the debug page
 - [ ] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [ ] add an entry inside this element for inclusion in the `maplibre-gl-js` changelog: `<changelog></changelog>`
