### PR TITLE
Fix style spec casts

### DIFF
--- a/src/style-spec/expression/definitions/assertion.ts
+++ b/src/style-spec/expression/definitions/assertion.ts
@@ -75,7 +75,7 @@ class Assertion implements Expression {
 
         const parsed = [];
         for (; i < args.length; i++) {
-            const input = context.parse(args[i], i, ValueType as Type);
+            const input = context.parse(args[i], i, ValueType);
             if (!input) return null;
             parsed.push(input);
         }

--- a/src/style-spec/expression/definitions/at.ts
+++ b/src/style-spec/expression/definitions/at.ts
@@ -23,8 +23,8 @@ class At implements Expression {
         if (args.length !== 3)
             return context.error(`Expected 2 arguments, but found ${args.length - 1} instead.`) as null;
 
-        const index = context.parse(args[1], 1, NumberType as Type);
-        const input = context.parse(args[2], 2, array((context.expectedType || ValueType) as Type));
+        const index = context.parse(args[1], 1, NumberType);
+        const input = context.parse(args[2], 2, array(context.expectedType || ValueType));
 
         if (!index || !input) return null;
 

--- a/src/style-spec/expression/definitions/case.ts
+++ b/src/style-spec/expression/definitions/case.ts
@@ -34,7 +34,7 @@ class Case implements Expression {
 
         const branches = [];
         for (let i = 1; i < args.length - 1; i += 2) {
-            const test = context.parse(args[i], i, BooleanType as Type);
+            const test = context.parse(args[i], i, BooleanType);
             if (!test) return null;
 
             const result = context.parse(args[i + 1], i + 1, outputType);

--- a/src/style-spec/expression/definitions/coalesce.ts
+++ b/src/style-spec/expression/definitions/coalesce.ts
@@ -45,7 +45,7 @@ class Coalesce implements Expression {
             parsedArgs.some(arg => checkSubtype(expectedType, arg.type));
 
         return needsAnnotation ?
-            new Coalesce(ValueType as Type, parsedArgs) :
+            new Coalesce(ValueType, parsedArgs) :
             new Coalesce((outputType as any), parsedArgs);
     }
 

--- a/src/style-spec/expression/definitions/coercion.ts
+++ b/src/style-spec/expression/definitions/coercion.ts
@@ -50,7 +50,7 @@ class Coercion implements Expression {
 
         const parsed = [];
         for (let i = 1; i < args.length; i++) {
-            const input = context.parse(args[i], i, ValueType as Type);
+            const input = context.parse(args[i], i, ValueType);
             if (!input) return null;
             parsed.push(input);
         }

--- a/src/style-spec/expression/definitions/collator.ts
+++ b/src/style-spec/expression/definitions/collator.ts
@@ -13,7 +13,7 @@ export default class CollatorExpression implements Expression {
     locale: Expression | null;
 
     constructor(caseSensitive: Expression, diacriticSensitive: Expression, locale: Expression | null) {
-        this.type = CollatorType as Type;
+        this.type = CollatorType;
         this.locale = locale;
         this.caseSensitive = caseSensitive;
         this.diacriticSensitive = diacriticSensitive;
@@ -28,16 +28,16 @@ export default class CollatorExpression implements Expression {
             return context.error(`Collator options argument must be an object.`) as null;
 
         const caseSensitive = context.parse(
-            options['case-sensitive'] === undefined ? false : options['case-sensitive'], 1, BooleanType as Type);
+            options['case-sensitive'] === undefined ? false : options['case-sensitive'], 1, BooleanType);
         if (!caseSensitive) return null;
 
         const diacriticSensitive = context.parse(
-            options['diacritic-sensitive'] === undefined ? false : options['diacritic-sensitive'], 1, BooleanType as Type);
+            options['diacritic-sensitive'] === undefined ? false : options['diacritic-sensitive'], 1, BooleanType);
         if (!diacriticSensitive) return null;
 
         let locale = null;
         if (options['locale']) {
-            locale = context.parse(options['locale'], 1, StringType as Type);
+            locale = context.parse(options['locale'], 1, StringType);
             if (!locale) return null;
         }
 

--- a/src/style-spec/expression/definitions/comparison.ts
+++ b/src/style-spec/expression/definitions/comparison.ts
@@ -68,7 +68,7 @@ function makeComparison(op: ComparisonOperator, compareBasic, compareWithCollato
         hasUntypedArgument: boolean;
 
         constructor(lhs: Expression, rhs: Expression, collator?: Expression | null) {
-            this.type = BooleanType as Type;
+            this.type = BooleanType;
             this.lhs = lhs;
             this.rhs = rhs;
             this.collator = collator;
@@ -81,12 +81,12 @@ function makeComparison(op: ComparisonOperator, compareBasic, compareWithCollato
 
             const op: ComparisonOperator = (args[0] as any);
 
-            let lhs = context.parse(args[1], 1, ValueType as Type);
+            let lhs = context.parse(args[1], 1, ValueType);
             if (!lhs) return null;
             if (!isComparableType(op, lhs.type)) {
                 return context.concat(1).error(`"${op}" comparisons are not supported for type '${toString(lhs.type)}'.`) as null;
             }
-            let rhs = context.parse(args[2], 2, ValueType as Type);
+            let rhs = context.parse(args[2], 2, ValueType);
             if (!rhs) return null;
             if (!isComparableType(op, rhs.type)) {
                 return context.concat(2).error(`"${op}" comparisons are not supported for type '${toString(rhs.type)}'.`) as null;
@@ -121,7 +121,7 @@ function makeComparison(op: ComparisonOperator, compareBasic, compareWithCollato
                 ) {
                     return context.error(`Cannot use collator to compare non-string types.`) as null;
                 }
-                collator = context.parse(args[3], 3, CollatorType as Type);
+                collator = context.parse(args[3], 3, CollatorType);
                 if (!collator) return null;
             }
 

--- a/src/style-spec/expression/definitions/format.ts
+++ b/src/style-spec/expression/definitions/format.ts
@@ -29,7 +29,7 @@ export default class FormatExpression implements Expression {
     sections: Array<FormattedSectionExpression>;
 
     constructor(sections: Array<FormattedSectionExpression>) {
-        this.type = FormattedType as Type;
+        this.type = FormattedType;
         this.sections = sections;
     }
 
@@ -53,19 +53,19 @@ export default class FormatExpression implements Expression {
 
                 let scale = null;
                 if (arg['font-scale']) {
-                    scale = context.parse(arg['font-scale'], 1, NumberType as Type);
+                    scale = context.parse(arg['font-scale'], 1, NumberType);
                     if (!scale) return null;
                 }
 
                 let font = null;
                 if (arg['text-font']) {
-                    font = context.parse(arg['text-font'], 1, array(StringType as Type));
+                    font = context.parse(arg['text-font'], 1, array(StringType));
                     if (!font) return null;
                 }
 
                 let textColor = null;
                 if (arg['text-color']) {
-                    textColor = context.parse(arg['text-color'], 1, ColorType as Type);
+                    textColor = context.parse(arg['text-color'], 1, ColorType);
                     if (!textColor) return null;
                 }
 
@@ -74,7 +74,7 @@ export default class FormatExpression implements Expression {
                 lastExpression.font = font;
                 lastExpression.textColor = textColor;
             } else {
-                const content = context.parse(args[i], 1, ValueType as Type);
+                const content = context.parse(args[i], 1, ValueType);
                 if (!content) return null;
 
                 const kind = content.type.kind;

--- a/src/style-spec/expression/definitions/image.ts
+++ b/src/style-spec/expression/definitions/image.ts
@@ -11,7 +11,7 @@ export default class ImageExpression implements Expression {
     input: Expression;
 
     constructor(input: Expression) {
-        this.type = ResolvedImageType as Type;
+        this.type = ResolvedImageType;
         this.input = input;
     }
 
@@ -20,7 +20,7 @@ export default class ImageExpression implements Expression {
             return context.error(`Expected two arguments.`) as null;
         }
 
-        const name = context.parse(args[1], 1, StringType as Type);
+        const name = context.parse(args[1], 1, StringType);
         if (!name) return context.error(`No image name provided.`) as null;
 
         return new ImageExpression(name);

--- a/src/style-spec/expression/definitions/in.ts
+++ b/src/style-spec/expression/definitions/in.ts
@@ -22,7 +22,7 @@ class In implements Expression {
     haystack: Expression;
 
     constructor(needle: Expression, haystack: Expression) {
-        this.type = BooleanType as Type;
+        this.type = BooleanType;
         this.needle = needle;
         this.haystack = haystack;
     }
@@ -32,13 +32,13 @@ class In implements Expression {
             return context.error(`Expected 2 arguments, but found ${args.length - 1} instead.`) as null;
         }
 
-        const needle = context.parse(args[1], 1, ValueType as Type);
+        const needle = context.parse(args[1], 1, ValueType);
 
-        const haystack = context.parse(args[2], 2, ValueType as Type);
+        const haystack = context.parse(args[2], 2, ValueType);
 
         if (!needle || !haystack) return null;
 
-        if (!isValidType(needle.type, [BooleanType as Type, StringType as Type, NumberType as Type, NullType as Type, ValueType as Type])) {
+        if (!isValidType(needle.type, [BooleanType, StringType, NumberType, NullType, ValueType])) {
             return context.error(`Expected first argument to be of type boolean, string, number or null, but found ${toString(needle.type)} instead`) as null;
         }
 

--- a/src/style-spec/expression/definitions/index.ts
+++ b/src/style-spec/expression/definitions/index.ts
@@ -125,99 +125,99 @@ function varargs(type: Type): Varargs {
 
 CompoundExpression.register(expressions, {
     'error': [
-        ErrorType as Type,
-        [StringType as Type],
+        ErrorType,
+        [StringType],
         (ctx, [v]) => { throw new RuntimeError(v.evaluate(ctx)); }
     ],
     'typeof': [
-        StringType as Type,
-        [ValueType as Type],
+        StringType,
+        [ValueType],
         (ctx, [v]) => typeToString(typeOf(v.evaluate(ctx)))
     ],
     'to-rgba': [
-        array(NumberType as Type, 4),
-        [ColorType as Type],
+        array(NumberType, 4),
+        [ColorType],
         (ctx, [v]) => {
             return v.evaluate(ctx).toArray();
         }
     ],
     'rgb': [
-        ColorType as Type,
-        [NumberType as Type, NumberType as Type, NumberType as Type],
+        ColorType,
+        [NumberType, NumberType, NumberType],
         rgba
     ],
     'rgba': [
-        ColorType as Type,
-        [NumberType as Type, NumberType as Type, NumberType as Type, NumberType as Type],
+        ColorType,
+        [NumberType, NumberType, NumberType, NumberType],
         rgba
     ],
     'has': {
-        type: (BooleanType as Type),
+        type: BooleanType,
         overloads: [
             [
-                [StringType as Type],
+                [StringType],
                 (ctx, [key]) => has(key.evaluate(ctx), ctx.properties())
             ], [
-                [StringType as Type, ObjectType as Type],
+                [StringType, ObjectType],
                 (ctx, [key, obj]) => has(key.evaluate(ctx), obj.evaluate(ctx))
             ]
         ]
     },
     'get': {
-        type: (ValueType as Type),
+        type: ValueType,
         overloads: [
             [
-                [StringType as Type],
+                [StringType],
                 (ctx, [key]) => get(key.evaluate(ctx), ctx.properties())
             ], [
-                [StringType as Type, ObjectType as Type],
+                [StringType, ObjectType],
                 (ctx, [key, obj]) => get(key.evaluate(ctx), obj.evaluate(ctx))
             ]
         ]
     },
     'feature-state': [
-        ValueType as Type,
-        [StringType as Type],
+        ValueType,
+        [StringType],
         (ctx, [key]) => get(key.evaluate(ctx), ctx.featureState || {})
     ],
     'properties': [
-        ObjectType as Type,
+        ObjectType,
         [],
         (ctx) => ctx.properties()
     ],
     'geometry-type': [
-        StringType as Type,
+        StringType,
         [],
         (ctx) => ctx.geometryType()
     ],
     'id': [
-        ValueType as Type,
+        ValueType,
         [],
         (ctx) => ctx.id()
     ],
     'zoom': [
-        NumberType as Type,
+        NumberType,
         [],
         (ctx) => ctx.globals.zoom
     ],
     'heatmap-density': [
-        NumberType as Type,
+        NumberType,
         [],
         (ctx) => ctx.globals.heatmapDensity || 0
     ],
     'line-progress': [
-        NumberType as Type,
+        NumberType,
         [],
         (ctx) => ctx.globals.lineProgress || 0
     ],
     'accumulated': [
-        ValueType as Type,
+        ValueType,
         [],
         (ctx) => ctx.globals.accumulated === undefined ? null : ctx.globals.accumulated
     ],
     '+': [
-        NumberType as Type,
-        varargs(NumberType as Type),
+        NumberType,
+        varargs(NumberType),
         (ctx, args) => {
             let result = 0;
             for (const arg of args) {
@@ -227,8 +227,8 @@ CompoundExpression.register(expressions, {
         }
     ],
     '*': [
-        NumberType as Type,
-        varargs(NumberType as Type),
+        NumberType,
+        varargs(NumberType),
         (ctx, args) => {
             let result = 1;
             for (const arg of args) {
@@ -238,115 +238,115 @@ CompoundExpression.register(expressions, {
         }
     ],
     '-': {
-        type: (NumberType as Type),
+        type: NumberType,
         overloads: [
             [
-                [NumberType as Type, NumberType as Type],
+                [NumberType, NumberType],
                 (ctx, [a, b]) => a.evaluate(ctx) - b.evaluate(ctx)
             ], [
-                [NumberType as Type],
+                [NumberType],
                 (ctx, [a]) => -a.evaluate(ctx)
             ]
         ]
     },
     '/': [
-        NumberType as Type,
-        [NumberType as Type, NumberType as Type],
+        NumberType,
+        [NumberType, NumberType],
         (ctx, [a, b]) => a.evaluate(ctx) / b.evaluate(ctx)
     ],
     '%': [
-        NumberType as Type,
-        [NumberType as Type, NumberType as Type],
+        NumberType,
+        [NumberType, NumberType],
         (ctx, [a, b]) => a.evaluate(ctx) % b.evaluate(ctx)
     ],
     'ln2': [
-        NumberType as Type,
+        NumberType,
         [],
         () => Math.LN2
     ],
     'pi': [
-        NumberType as Type,
+        NumberType,
         [],
         () => Math.PI
     ],
     'e': [
-        NumberType as Type,
+        NumberType,
         [],
         () => Math.E
     ],
     '^': [
-        NumberType as Type,
-        [NumberType as Type, NumberType as Type],
+        NumberType,
+        [NumberType, NumberType],
         (ctx, [b, e]) => Math.pow(b.evaluate(ctx), e.evaluate(ctx))
     ],
     'sqrt': [
-        NumberType as Type,
-        [NumberType as Type],
+        NumberType,
+        [NumberType],
         (ctx, [x]) => Math.sqrt(x.evaluate(ctx))
     ],
     'log10': [
-        NumberType as Type,
-        [NumberType as Type],
+        NumberType,
+        [NumberType],
         (ctx, [n]) => Math.log(n.evaluate(ctx)) / Math.LN10
     ],
     'ln': [
-        NumberType as Type,
-        [NumberType as Type],
+        NumberType,
+        [NumberType],
         (ctx, [n]) => Math.log(n.evaluate(ctx))
     ],
     'log2': [
-        NumberType as Type,
-        [NumberType as Type],
+        NumberType,
+        [NumberType],
         (ctx, [n]) => Math.log(n.evaluate(ctx)) / Math.LN2
     ],
     'sin': [
-        NumberType as Type,
-        [NumberType as Type],
+        NumberType,
+        [NumberType],
         (ctx, [n]) => Math.sin(n.evaluate(ctx))
     ],
     'cos': [
-        NumberType as Type,
-        [NumberType as Type],
+        NumberType,
+        [NumberType],
         (ctx, [n]) => Math.cos(n.evaluate(ctx))
     ],
     'tan': [
-        NumberType as Type,
-        [NumberType as Type],
+        NumberType,
+        [NumberType],
         (ctx, [n]) => Math.tan(n.evaluate(ctx))
     ],
     'asin': [
-        NumberType as Type,
-        [NumberType as Type],
+        NumberType,
+        [NumberType],
         (ctx, [n]) => Math.asin(n.evaluate(ctx))
     ],
     'acos': [
-        NumberType as Type,
-        [NumberType as Type],
+        NumberType,
+        [NumberType],
         (ctx, [n]) => Math.acos(n.evaluate(ctx))
     ],
     'atan': [
-        NumberType as Type,
-        [NumberType as Type],
+        NumberType,
+        [NumberType],
         (ctx, [n]) => Math.atan(n.evaluate(ctx))
     ],
     'min': [
-        NumberType as Type,
-        varargs(NumberType as Type),
+        NumberType,
+        varargs(NumberType),
         (ctx, args) => Math.min(...args.map(arg => arg.evaluate(ctx)))
     ],
     'max': [
-        NumberType as Type,
-        varargs(NumberType as Type),
+        NumberType,
+        varargs(NumberType),
         (ctx, args) => Math.max(...args.map(arg => arg.evaluate(ctx)))
     ],
     'abs': [
-        NumberType as Type,
-        [NumberType as Type],
+        NumberType,
+        [NumberType],
         (ctx, [n]) => Math.abs(n.evaluate(ctx))
     ],
     'round': [
-        NumberType as Type,
-        [NumberType as Type],
+        NumberType,
+        [NumberType],
         (ctx, [n]) => {
             const v = n.evaluate(ctx);
             // Javascript's Math.round() rounds towards +Infinity for halfway
@@ -356,33 +356,33 @@ CompoundExpression.register(expressions, {
         }
     ],
     'floor': [
-        NumberType as Type,
-        [NumberType as Type],
+        NumberType,
+        [NumberType],
         (ctx, [n]) => Math.floor(n.evaluate(ctx))
     ],
     'ceil': [
-        NumberType as Type,
-        [NumberType as Type],
+        NumberType,
+        [NumberType],
         (ctx, [n]) => Math.ceil(n.evaluate(ctx))
     ],
     'filter-==': [
-        BooleanType as Type,
-        [StringType as Type, ValueType as Type],
+        BooleanType,
+        [StringType, ValueType],
         (ctx, [k, v]) => ctx.properties()[(k as any).value] === (v as any).value
     ],
     'filter-id-==': [
-        BooleanType as Type,
-        [ValueType as Type],
+        BooleanType,
+        [ValueType],
         (ctx, [v]) => ctx.id() === (v as any).value
     ],
     'filter-type-==': [
-        BooleanType as Type,
-        [StringType as Type],
+        BooleanType,
+        [StringType],
         (ctx, [v]) => ctx.geometryType() === (v as any).value
     ],
     'filter-<': [
-        BooleanType as Type,
-        [StringType as Type, ValueType as Type],
+        BooleanType,
+        [StringType, ValueType],
         (ctx, [k, v]) => {
             const a = ctx.properties()[(k as any).value];
             const b = (v as any).value;
@@ -390,8 +390,8 @@ CompoundExpression.register(expressions, {
         }
     ],
     'filter-id-<': [
-        BooleanType as Type,
-        [ValueType as Type],
+        BooleanType,
+        [ValueType],
         (ctx, [v]) => {
             const a = ctx.id();
             const b = (v as any).value;
@@ -399,8 +399,8 @@ CompoundExpression.register(expressions, {
         }
     ],
     'filter->': [
-        BooleanType as Type,
-        [StringType as Type, ValueType as Type],
+        BooleanType,
+        [StringType, ValueType],
         (ctx, [k, v]) => {
             const a = ctx.properties()[(k as any).value];
             const b = (v as any).value;
@@ -408,8 +408,8 @@ CompoundExpression.register(expressions, {
         }
     ],
     'filter-id->': [
-        BooleanType as Type,
-        [ValueType as Type],
+        BooleanType,
+        [ValueType],
         (ctx, [v]) => {
             const a = ctx.id();
             const b = (v as any).value;
@@ -417,8 +417,8 @@ CompoundExpression.register(expressions, {
         }
     ],
     'filter-<=': [
-        BooleanType as Type,
-        [StringType as Type, ValueType as Type],
+        BooleanType,
+        [StringType, ValueType],
         (ctx, [k, v]) => {
             const a = ctx.properties()[(k as any).value];
             const b = (v as any).value;
@@ -426,8 +426,8 @@ CompoundExpression.register(expressions, {
         }
     ],
     'filter-id-<=': [
-        BooleanType as Type,
-        [ValueType as Type],
+        BooleanType,
+        [ValueType],
         (ctx, [v]) => {
             const a = ctx.id();
             const b = (v as any).value;
@@ -435,8 +435,8 @@ CompoundExpression.register(expressions, {
         }
     ],
     'filter->=': [
-        BooleanType as Type,
-        [StringType as Type, ValueType as Type],
+        BooleanType,
+        [StringType, ValueType],
         (ctx, [k, v]) => {
             const a = ctx.properties()[(k as any).value];
             const b = (v as any).value;
@@ -444,8 +444,8 @@ CompoundExpression.register(expressions, {
         }
     ],
     'filter-id->=': [
-        BooleanType as Type,
-        [ValueType as Type],
+        BooleanType,
+        [ValueType],
         (ctx, [v]) => {
             const a = ctx.id();
             const b = (v as any).value;
@@ -453,46 +453,46 @@ CompoundExpression.register(expressions, {
         }
     ],
     'filter-has': [
-        BooleanType as Type,
-        [ValueType as Type],
+        BooleanType,
+        [ValueType],
         (ctx, [k]) => (k as any).value in ctx.properties()
     ],
     'filter-has-id': [
-        BooleanType as Type,
+        BooleanType,
         [],
         (ctx) => (ctx.id() !== null && ctx.id() !== undefined)
     ],
     'filter-type-in': [
-        BooleanType as Type,
-        [array(StringType as Type)],
+        BooleanType,
+        [array(StringType)],
         (ctx, [v]) => (v as any).value.indexOf(ctx.geometryType()) >= 0
     ],
     'filter-id-in': [
-        BooleanType as Type,
-        [array(ValueType as Type)],
+        BooleanType,
+        [array(ValueType)],
         (ctx, [v]) => (v as any).value.indexOf(ctx.id()) >= 0
     ],
     'filter-in-small': [
-        BooleanType as Type,
-        [StringType as Type, array(ValueType as Type)],
+        BooleanType,
+        [StringType, array(ValueType)],
         // assumes v is an array literal
         (ctx, [k, v]) => (v as any).value.indexOf(ctx.properties()[(k as any).value]) >= 0
     ],
     'filter-in-large': [
-        BooleanType as Type,
-        [StringType as Type, array(ValueType as Type)],
+        BooleanType,
+        [StringType, array(ValueType)],
         // assumes v is a array literal with values sorted in ascending order and of a single type
         (ctx, [k, v]) => binarySearch(ctx.properties()[(k as any).value], (v as any).value, 0, (v as any).value.length - 1)
     ],
     'all': {
-        type: (BooleanType as Type),
+        type: BooleanType,
         overloads: [
             [
-                [BooleanType as Type, BooleanType as Type],
+                [BooleanType, BooleanType],
                 (ctx, [a, b]) => a.evaluate(ctx) && b.evaluate(ctx)
             ],
             [
-                varargs(BooleanType as Type),
+                varargs(BooleanType),
                 (ctx, args) => {
                     for (const arg of args) {
                         if (!arg.evaluate(ctx))
@@ -504,14 +504,14 @@ CompoundExpression.register(expressions, {
         ]
     },
     'any': {
-        type: (BooleanType as Type),
+        type: BooleanType,
         overloads: [
             [
-                [BooleanType as Type, BooleanType as Type],
+                [BooleanType, BooleanType],
                 (ctx, [a, b]) => a.evaluate(ctx) || b.evaluate(ctx)
             ],
             [
-                varargs(BooleanType as Type),
+                varargs(BooleanType),
                 (ctx, args) => {
                     for (const arg of args) {
                         if (arg.evaluate(ctx))
@@ -523,13 +523,13 @@ CompoundExpression.register(expressions, {
         ]
     },
     '!': [
-        BooleanType as Type,
-        [BooleanType as Type],
+        BooleanType,
+        [BooleanType],
         (ctx, [b]) => !b.evaluate(ctx)
     ],
     'is-supported-script': [
-        BooleanType as Type,
-        [StringType as Type],
+        BooleanType,
+        [StringType],
         // At parse time this will always return true, so we need to exclude this expression with isGlobalPropertyConstant
         (ctx, [s]) => {
             const isSupportedScript = ctx.globals && ctx.globals.isSupportedScript;
@@ -540,23 +540,23 @@ CompoundExpression.register(expressions, {
         }
     ],
     'upcase': [
-        StringType as Type,
-        [StringType as Type],
+        StringType,
+        [StringType],
         (ctx, [s]) => s.evaluate(ctx).toUpperCase()
     ],
     'downcase': [
-        StringType as Type,
-        [StringType as Type],
+        StringType,
+        [StringType],
         (ctx, [s]) => s.evaluate(ctx).toLowerCase()
     ],
     'concat': [
-        StringType as Type,
-        varargs(ValueType as Type),
+        StringType,
+        varargs(ValueType),
         (ctx, args) => args.map(arg => valueToString(arg.evaluate(ctx))).join('')
     ],
     'resolved-locale': [
-        StringType as Type,
-        [CollatorType as Type],
+        StringType,
+        [CollatorType],
         (ctx, [collator]) => collator.evaluate(ctx).resolvedLocale()
     ]
 });

--- a/src/style-spec/expression/definitions/index_of.ts
+++ b/src/style-spec/expression/definitions/index_of.ts
@@ -23,7 +23,7 @@ class IndexOf implements Expression {
     fromIndex: Expression | undefined | null;
 
     constructor(needle: Expression, haystack: Expression, fromIndex?: Expression) {
-        this.type = NumberType as Type;
+        this.type = NumberType;
         this.needle = needle;
         this.haystack = haystack;
         this.fromIndex = fromIndex;
@@ -34,17 +34,17 @@ class IndexOf implements Expression {
             return context.error(`Expected 3 or 4 arguments, but found ${args.length - 1} instead.`) as null;
         }
 
-        const needle = context.parse(args[1], 1, ValueType as Type);
+        const needle = context.parse(args[1], 1, ValueType);
 
-        const haystack = context.parse(args[2], 2, ValueType as Type);
+        const haystack = context.parse(args[2], 2, ValueType);
 
         if (!needle || !haystack) return null;
-        if (!isValidType(needle.type, [BooleanType as Type, StringType as Type, NumberType as Type, NullType as Type, ValueType as Type])) {
+        if (!isValidType(needle.type, [BooleanType, StringType, NumberType, NullType, ValueType])) {
             return context.error(`Expected first argument to be of type boolean, string, number or null, but found ${toString(needle.type)} instead`) as null;
         }
 
         if (args.length === 4) {
-            const fromIndex = context.parse(args[3], 3, NumberType as Type);
+            const fromIndex = context.parse(args[3], 3, NumberType);
             if (!fromIndex) return null;
             return new IndexOf(needle, haystack, fromIndex);
         } else {

--- a/src/style-spec/expression/definitions/interpolate.ts
+++ b/src/style-spec/expression/definitions/interpolate.ts
@@ -100,14 +100,14 @@ class Interpolate implements Expression {
             return context.error(`Expected an even number of arguments.`) as null;
         }
 
-        input = context.parse(input, 2, NumberType as Type);
+        input = context.parse(input, 2, NumberType);
         if (!input) return null;
 
         const stops: Stops = [];
 
         let outputType: Type = (null as any);
         if (operator === 'interpolate-hcl' || operator === 'interpolate-lab') {
-            outputType = ColorType as Type;
+            outputType = ColorType;
         } else if (context.expectedType && context.expectedType.kind !== 'value') {
             outputType = context.expectedType;
         }

--- a/src/style-spec/expression/definitions/length.ts
+++ b/src/style-spec/expression/definitions/length.ts
@@ -13,7 +13,7 @@ class Length implements Expression {
     input: Expression;
 
     constructor(input: Expression) {
-        this.type = NumberType as Type;
+        this.type = NumberType;
         this.input = input;
     }
 

--- a/src/style-spec/expression/definitions/match.ts
+++ b/src/style-spec/expression/definitions/match.ts
@@ -86,7 +86,7 @@ class Match implements Expression {
             outputs.push(result);
         }
 
-        const input = context.parse(args[1], 1, ValueType as Type);
+        const input = context.parse(args[1], 1, ValueType);
         if (!input) return null;
 
         const otherwise = context.parse(args[args.length - 1], args.length - 1, outputType);

--- a/src/style-spec/expression/definitions/number_format.ts
+++ b/src/style-spec/expression/definitions/number_format.ts
@@ -37,7 +37,7 @@ export default class NumberFormat implements Expression {
                 currency: Expression | null,
                 minFractionDigits: Expression | null,
                 maxFractionDigits: Expression | null) {
-        this.type = StringType as Type;
+        this.type = StringType;
         this.number = number;
         this.locale = locale;
         this.currency = currency;
@@ -49,7 +49,7 @@ export default class NumberFormat implements Expression {
         if (args.length !== 3)
             return context.error(`Expected two arguments.`) as null;
 
-        const number = context.parse(args[1], 1, NumberType as Type);
+        const number = context.parse(args[1], 1, NumberType);
         if (!number) return null;
 
         const options = (args[2] as any);
@@ -58,25 +58,25 @@ export default class NumberFormat implements Expression {
 
         let locale = null;
         if (options['locale']) {
-            locale = context.parse(options['locale'], 1, StringType as Type);
+            locale = context.parse(options['locale'], 1, StringType);
             if (!locale) return null;
         }
 
         let currency = null;
         if (options['currency']) {
-            currency = context.parse(options['currency'], 1, StringType as Type);
+            currency = context.parse(options['currency'], 1, StringType);
             if (!currency) return null;
         }
 
         let minFractionDigits = null;
         if (options['min-fraction-digits']) {
-            minFractionDigits = context.parse(options['min-fraction-digits'], 1, NumberType as Type);
+            minFractionDigits = context.parse(options['min-fraction-digits'], 1, NumberType);
             if (!minFractionDigits) return null;
         }
 
         let maxFractionDigits = null;
         if (options['max-fraction-digits']) {
-            maxFractionDigits = context.parse(options['max-fraction-digits'], 1, NumberType as Type);
+            maxFractionDigits = context.parse(options['max-fraction-digits'], 1, NumberType);
             if (!maxFractionDigits) return null;
         }
 

--- a/src/style-spec/expression/definitions/slice.ts
+++ b/src/style-spec/expression/definitions/slice.ts
@@ -34,17 +34,17 @@ class Slice implements Expression {
             return context.error(`Expected 3 or 4 arguments, but found ${args.length - 1} instead.`) as null;
         }
 
-        const input = context.parse(args[1], 1, ValueType as Type);
-        const beginIndex = context.parse(args[2], 2, NumberType as Type);
+        const input = context.parse(args[1], 1, ValueType);
+        const beginIndex = context.parse(args[2], 2, NumberType);
 
         if (!input || !beginIndex) return null;
 
-        if (!isValidType(input.type, [array(ValueType as Type), StringType as Type, ValueType as Type])) {
+        if (!isValidType(input.type, [array(ValueType), StringType, ValueType])) {
             return context.error(`Expected first argument to be of type array or string, but found ${toString(input.type)} instead`) as null;
         }
 
         if (args.length === 4) {
-            const endIndex = context.parse(args[3], 3, NumberType as Type);
+            const endIndex = context.parse(args[3], 3, NumberType);
             if (!endIndex) return null;
             return new Slice(input.type, input, beginIndex, endIndex);
         } else {

--- a/src/style-spec/expression/definitions/step.ts
+++ b/src/style-spec/expression/definitions/step.ts
@@ -36,7 +36,7 @@ class Step implements Expression {
             return context.error(`Expected an even number of arguments.`) as null;
         }
 
-        const input = context.parse(args[1], 1, NumberType as Type);
+        const input = context.parse(args[1], 1, NumberType);
         if (!input) return null;
 
         const stops: Stops = [];

--- a/src/style-spec/expression/definitions/within.ts
+++ b/src/style-spec/expression/definitions/within.ts
@@ -286,7 +286,7 @@ class Within implements Expression {
     geometries: GeoJSONPolygons;
 
     constructor(geojson: GeoJSON, geometries: GeoJSONPolygons) {
-        this.type = BooleanType as Type;
+        this.type = BooleanType;
         this.geojson = geojson;
         this.geometries = geometries;
     }

--- a/src/style-spec/expression/types.ts
+++ b/src/style-spec/expression/types.ts
@@ -45,17 +45,17 @@ export type ArrayType = {
 
 export type NativeType = "number" | "string" | "boolean" | "null" | "array" | "object";
 
-export const NullType = {kind: 'null'};
-export const NumberType = {kind: 'number'};
-export const StringType = {kind: 'string'};
-export const BooleanType = {kind: 'boolean'};
-export const ColorType = {kind: 'color'};
-export const ObjectType = {kind: 'object'};
-export const ValueType = {kind: 'value'};
-export const ErrorType = {kind: 'error'};
-export const CollatorType = {kind: 'collator'};
-export const FormattedType = {kind: 'formatted'};
-export const ResolvedImageType = {kind: 'resolvedImage'};
+export const NullType = {kind: 'null'} as NullTypeT;
+export const NumberType = {kind: 'number'} as NumberTypeT;
+export const StringType = {kind: 'string'} as StringTypeT;
+export const BooleanType = {kind: 'boolean'} as BooleanTypeT;
+export const ColorType = {kind: 'color'} as ColorTypeT;
+export const ObjectType = {kind: 'object'} as ObjectTypeT;
+export const ValueType = {kind: 'value'} as ValueTypeT;
+export const ErrorType = {kind: 'error'} as ErrorTypeT;
+export const CollatorType = {kind: 'collator'} as CollatorTypeT;
+export const FormattedType = {kind: 'formatted'} as FormattedTypeT;
+export const ResolvedImageType = {kind: 'resolvedImage'} as ResolvedImageTypeT;
 
 export function array(itemType: Type, N?: number | null): ArrayType {
     return {

--- a/src/style-spec/expression/types.ts
+++ b/src/style-spec/expression/types.ts
@@ -84,7 +84,7 @@ const valueMemberTypes = [
     ColorType,
     FormattedType,
     ObjectType,
-    array(ValueType as ValueTypeT),
+    array(ValueType),
     ResolvedImageType
 ];
 
@@ -107,7 +107,7 @@ export function checkSubtype(expected: Type, t: Type): string | undefined | null
         return null;
     } else if (expected.kind === 'value') {
         for (const memberType of valueMemberTypes) {
-            if (!checkSubtype(memberType as Type, t)) {
+            if (!checkSubtype(memberType, t)) {
                 return null;
             }
         }

--- a/src/style-spec/expression/values.ts
+++ b/src/style-spec/expression/values.ts
@@ -69,21 +69,21 @@ export function isValue(mixed: unknown): boolean {
 
 export function typeOf(value: Value): Type {
     if (value === null) {
-        return NullType as Type;
+        return NullType;
     } else if (typeof value === 'string') {
-        return StringType as Type;
+        return StringType;
     } else if (typeof value === 'boolean') {
-        return BooleanType as Type;
+        return BooleanType;
     } else if (typeof value === 'number') {
-        return NumberType as Type;
+        return NumberType;
     } else if (value instanceof Color) {
-        return ColorType as Type;
+        return ColorType;
     } else if (value instanceof Collator) {
-        return CollatorType as Type;
+        return CollatorType;
     } else if (value instanceof Formatted) {
-        return FormattedType as Type;
+        return FormattedType;
     } else if (value instanceof ResolvedImage) {
-        return ResolvedImageType as Type;
+        return ResolvedImageType;
     } else if (Array.isArray(value)) {
         const length = value.length;
         let itemType: Type | typeof undefined;
@@ -103,7 +103,7 @@ export function typeOf(value: Value): Type {
         return array(itemType || ValueType, length);
     } else {
         assert(typeof value === 'object');
-        return ObjectType as Type;
+        return ObjectType;
     }
 }
 


### PR DESCRIPTION
As @HarelM pointed out to me, instead of casting the style spec types each time we use them we can also give them the correct types in the place where they are defined first. 

 - [❤️  ] confirm your changes do not include backports from Mapbox projects (unless with compliant license)
 - [ ] briefly describe the changes in this PR
 - [ ] include before/after visuals or gifs if this PR includes visual changes
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [ ] manually test the debug page
 - [ ] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [ ] add an entry inside this element for inclusion in the `maplibre-gl-js` changelog: `<changelog></changelog>`
