### PR TITLE
Typescript: updates to gl-matrix (Draft - hard to test as tsc failing)

### DIFF
--- a/src/data/bucket/symbol_bucket.ts
+++ b/src/data/bucket/symbol_bucket.ts
@@ -362,8 +362,9 @@ class SymbolBucket implements Bucket {
         this.sortKeyRanges = [];
 
         this.collisionCircleArray = [];
-        this.placementInvProjMatrix = mat4.identity([]);
-        this.placementViewportMatrix = mat4.identity([]);
+        // NOTE mat4.create() creates a mat4.identity()
+        this.placementInvProjMatrix = mat4.create();
+        this.placementViewportMatrix = mat4.create();
 
         const layer = this.layers[0];
         const unevaluatedLayoutValues = layer._unevaluatedLayout._values;

--- a/src/data/feature_index.ts
+++ b/src/data/feature_index.ts
@@ -23,10 +23,11 @@ import type Transform from '../geo/transform';
 import type {FilterSpecification, PromoteIdSpecification} from '../style-spec/types';
 
 import {FeatureIndexArray} from './array_types';
+import {mat4} from 'gl-matrix';
 
 type QueryParameters = {
   scale: number,
-  pixelPosMatrix: Float32Array,
+  pixelPosMatrix: mat4,
   transform: Transform,
   tileSize: number,
   queryGeometry: Array<Point>,

--- a/src/render/draw_symbol.ts
+++ b/src/render/draw_symbol.ts
@@ -6,7 +6,6 @@ import pixelsToTileUnits from '../source/pixels_to_tile_units';
 import * as symbolProjection from '../symbol/projection';
 import * as symbolSize from '../symbol/symbol_size';
 import {mat4} from 'gl-matrix';
-const identityMat4 = mat4.identity(new Float32Array(16));
 import StencilMode from '../gl/stencil_mode';
 import DepthMode from '../gl/depth_mode';
 import CullFaceMode from '../gl/cull_face_mode';
@@ -49,6 +48,9 @@ type SymbolTileRenderState = {
     hasHalo: boolean
   }
 };
+
+// create() creates an identity matrix https://github.com/toji/gl-matrix/blob/master/src/mat4.js#L13
+const identityMat4 = mat4.create();
 
 function drawSymbols(painter: Painter, sourceCache: SourceCache, layer: SymbolStyleLayer, coords: Array<OverscaledTileID>, variableOffsets: {
   [_ in CrossTileID]: VariableOffset;

--- a/src/render/painter.ts
+++ b/src/render/painter.ts
@@ -1,7 +1,7 @@
 import browser from '../util/browser';
 import window from '../util/window';
 
-import {mat4} from 'gl-matrix';
+import {mat4, vec3} from 'gl-matrix';
 import SourceCache from '../source/source_cache';
 import EXTENT from '../data/extent';
 import pixelsToTileUnits from '../source/pixels_to_tile_units';
@@ -553,10 +553,10 @@ class Painter {
     /**
      * Transform a matrix to incorporate the *-translate and *-translate-anchor properties into it.
      * @param inViewportPixelUnitsUnits True when the units accepted by the matrix are in viewport pixels instead of tile units.
-     * @returns {Float32Array} matrix
+     * @returns {mat4} matrix
      * @private
      */
-    translatePosMatrix(matrix: Float32Array, tile: Tile, translate: [number, number], translateAnchor: "map" | "viewport", inViewportPixelUnitsUnits?: boolean) {
+    translatePosMatrix(matrix: mat4, tile: Tile, translate: [number, number], translateAnchor: "map" | "viewport", inViewportPixelUnitsUnits?: boolean) {
         if (!translate[0] && !translate[1]) return matrix;
 
         const angle = inViewportPixelUnitsUnits ?
@@ -572,13 +572,13 @@ class Painter {
             ];
         }
 
-        const translation = [
+        const translation = vec3.fromValues(
             inViewportPixelUnitsUnits ? translate[0] : pixelsToTileUnits(tile, translate[0], this.transform.zoom),
             inViewportPixelUnitsUnits ? translate[1] : pixelsToTileUnits(tile, translate[1], this.transform.zoom),
             0
-        ];
+        );
 
-        const translatedMatrix = new Float32Array(16);
+        const translatedMatrix = mat4.create();
         mat4.translate(translatedMatrix, matrix, translation);
         return translatedMatrix;
     }

--- a/src/render/program/background_program.ts
+++ b/src/render/program/background_program.ts
@@ -16,6 +16,7 @@ import type {CrossFaded} from '../../style/properties';
 import type {CrossfadeParameters} from '../../style/evaluation_parameters';
 import type {OverscaledTileID} from '../../source/tile_id';
 import type ResolvedImage from '../../style-spec/expression/types/resolved_image';
+import {mat4} from 'gl-matrix';
 
 export type BackgroundUniformsType = {
   'u_matrix': UniformMatrix4f,
@@ -68,14 +69,14 @@ const backgroundPatternUniforms = (context: Context, locations: UniformLocations
     'u_tile_units_to_pixels': new Uniform1f(context, locations.u_tile_units_to_pixels)
 });
 
-const backgroundUniformValues = (matrix: Float32Array, opacity: number, color: Color): UniformValues<BackgroundUniformsType> => ({
+const backgroundUniformValues = (matrix: mat4, opacity: number, color: Color): UniformValues<BackgroundUniformsType> => ({
     'u_matrix': matrix,
     'u_opacity': opacity,
     'u_color': color
 });
 
 const backgroundPatternUniformValues = (
-  matrix: Float32Array,
+  matrix: mat4,
   opacity: number,
   painter: Painter,
   image: CrossFaded<ResolvedImage>,

--- a/src/render/program/clipping_mask_program.ts
+++ b/src/render/program/clipping_mask_program.ts
@@ -2,6 +2,7 @@ import {UniformMatrix4f} from '../uniform_binding';
 
 import type Context from '../../gl/context';
 import type {UniformValues, UniformLocations} from '../uniform_binding';
+import {mat4} from 'gl-matrix';
 
 export type ClippingMaskUniformsType = {
   'u_matrix': UniformMatrix4f
@@ -11,7 +12,7 @@ const clippingMaskUniforms = (context: Context, locations: UniformLocations): Cl
     'u_matrix': new UniformMatrix4f(context, locations.u_matrix)
 });
 
-const clippingMaskUniformValues = (matrix: Float32Array): UniformValues<ClippingMaskUniformsType> => ({
+const clippingMaskUniformValues = (matrix: mat4): UniformValues<ClippingMaskUniformsType> => ({
     'u_matrix': matrix
 });
 

--- a/src/render/program/collision_program.ts
+++ b/src/render/program/collision_program.ts
@@ -5,6 +5,7 @@ import type Context from '../../gl/context';
 import type {UniformValues, UniformLocations} from '../uniform_binding';
 import type Transform from '../../geo/transform';
 import type Tile from '../../source/tile';
+import {mat4} from 'gl-matrix';
 
 export type CollisionUniformsType = {
   'u_matrix': UniformMatrix4f,
@@ -36,7 +37,7 @@ const collisionCircleUniforms = (context: Context, locations: UniformLocations):
     'u_viewport_size': new Uniform2f(context, locations.u_viewport_size)
 });
 
-const collisionUniformValues = (matrix: Float32Array, transform: Transform, tile: Tile): UniformValues<CollisionUniformsType> => {
+const collisionUniformValues = (matrix: mat4, transform: Transform, tile: Tile): UniformValues<CollisionUniformsType> => {
     const pixelRatio = pixelsToTileUnits(tile, 1, transform.zoom);
     const scale = Math.pow(2, transform.zoom - tile.tileID.overscaledZ);
     const overscaleFactor = tile.tileID.overscaleFactor();
@@ -50,7 +51,7 @@ const collisionUniformValues = (matrix: Float32Array, transform: Transform, tile
     };
 };
 
-const collisionCircleUniformValues = (matrix: Float32Array, invMatrix: Float32Array, transform: Transform): UniformValues<CollisionCircleUniformsType> => {
+const collisionCircleUniformValues = (matrix: mat4, invMatrix: mat4, transform: Transform): UniformValues<CollisionCircleUniformsType> => {
     return {
         'u_matrix': matrix,
         'u_inv_matrix': invMatrix,

--- a/src/render/program/debug_program.ts
+++ b/src/render/program/debug_program.ts
@@ -3,6 +3,7 @@ import {UniformColor, UniformMatrix4f, Uniform1i, Uniform1f} from '../uniform_bi
 import type Context from '../../gl/context';
 import type {UniformValues, UniformLocations} from '../uniform_binding';
 import type Color from '../../style-spec/util/color';
+import {mat4} from 'gl-matrix';
 
 export type DebugUniformsType = {
   'u_color': UniformColor,
@@ -18,7 +19,7 @@ const debugUniforms = (context: Context, locations: UniformLocations): DebugUnif
     'u_overlay_scale':  new Uniform1f(context, locations.u_overlay_scale)
 });
 
-const debugUniformValues = (matrix: Float32Array, color: Color, scaleRatio: number = 1): UniformValues<DebugUniformsType> => ({
+const debugUniformValues = (matrix: mat4, color: Color, scaleRatio: number = 1): UniformValues<DebugUniformsType> => ({
     'u_matrix': matrix,
     'u_color': color,
     'u_overlay': 0,

--- a/src/render/program/fill_extrusion_program.ts
+++ b/src/render/program/fill_extrusion_program.ts
@@ -7,7 +7,7 @@ import {
     UniformMatrix4f
 } from '../uniform_binding';
 
-import {mat3, vec3} from 'gl-matrix';
+import {mat3, mat4, vec3} from 'gl-matrix';
 import {extend} from '../../util/util';
 
 import type Context from '../../gl/context';
@@ -72,14 +72,14 @@ const fillExtrusionPatternUniforms = (context: Context, locations: UniformLocati
 });
 
 const fillExtrusionUniformValues = (
-  matrix: Float32Array,
+  matrix: mat4,
   painter: Painter,
   shouldUseVerticalGradient: boolean,
   opacity: number
 ): UniformValues<FillExtrusionUniformsType> => {
     const light = painter.style.light;
     const _lp = light.properties.get('position');
-    const lightPos = [_lp.x, _lp.y, _lp.z];
+    const lightPos = vec3.fromValues(_lp.x, _lp.y, _lp.z);
     const lightMat = mat3.create();
     if (light.properties.get('anchor') === 'viewport') {
         mat3.fromRotation(lightMat, -painter.transform.angle);
@@ -99,7 +99,7 @@ const fillExtrusionUniformValues = (
 };
 
 const fillExtrusionPatternUniformValues = (
-  matrix: Float32Array,
+  matrix: mat4,
   painter: Painter,
   shouldUseVerticalGradient: boolean,
   opacity: number,

--- a/src/render/program/fill_program.ts
+++ b/src/render/program/fill_program.ts
@@ -13,6 +13,7 @@ import type {UniformValues, UniformLocations} from '../uniform_binding';
 import type Context from '../../gl/context';
 import type {CrossfadeParameters} from '../../style/evaluation_parameters';
 import type Tile from '../../source/tile';
+import {mat4} from 'gl-matrix';
 
 export type FillUniformsType = {
   'u_matrix': UniformMatrix4f
@@ -76,12 +77,12 @@ const fillOutlinePatternUniforms = (context: Context, locations: UniformLocation
     'u_fade': new Uniform1f(context, locations.u_fade)
 });
 
-const fillUniformValues = (matrix: Float32Array): UniformValues<FillUniformsType> => ({
+const fillUniformValues = (matrix: mat4): UniformValues<FillUniformsType> => ({
     'u_matrix': matrix
 });
 
 const fillPatternUniformValues = (
-  matrix: Float32Array,
+  matrix: mat4,
   painter: Painter,
   crossfade: CrossfadeParameters,
   tile: Tile
@@ -90,13 +91,13 @@ const fillPatternUniformValues = (
     patternUniformValues(crossfade, painter, tile)
 );
 
-const fillOutlineUniformValues = (matrix: Float32Array, drawingBufferSize: [number, number]): UniformValues<FillOutlineUniformsType> => ({
+const fillOutlineUniformValues = (matrix: mat4, drawingBufferSize: [number, number]): UniformValues<FillOutlineUniformsType> => ({
     'u_matrix': matrix,
     'u_world': drawingBufferSize
 });
 
 const fillOutlinePatternUniformValues = (
-  matrix: Float32Array,
+  matrix: mat4,
   painter: Painter,
   crossfade: CrossfadeParameters,
   tile: Tile,

--- a/src/render/program/heatmap_program.ts
+++ b/src/render/program/heatmap_program.ts
@@ -42,7 +42,7 @@ const heatmapTextureUniforms = (context: Context, locations: UniformLocations): 
     'u_opacity': new Uniform1f(context, locations.u_opacity)
 });
 
-const heatmapUniformValues = (matrix: Float32Array, tile: Tile, zoom: number, intensity: number): UniformValues<HeatmapUniformsType> => ({
+const heatmapUniformValues = (matrix: mat4, tile: Tile, zoom: number, intensity: number): UniformValues<HeatmapUniformsType> => ({
     'u_matrix': matrix,
     'u_extrude_scale': pixelsToTileUnits(tile, 1, zoom),
     'u_intensity': intensity

--- a/src/render/program/raster_program.ts
+++ b/src/render/program/raster_program.ts
@@ -3,6 +3,7 @@ import {Uniform1i, Uniform1f, Uniform2f, Uniform3f, UniformMatrix4f} from '../un
 import type Context from '../../gl/context';
 import type {UniformValues, UniformLocations} from '../uniform_binding';
 import type RasterStyleLayer from '../../style/style_layer/raster_style_layer';
+import {mat4} from 'gl-matrix';
 
 export type RasterUniformsType = {
   'u_matrix': UniformMatrix4f,
@@ -37,7 +38,7 @@ const rasterUniforms = (context: Context, locations: UniformLocations): RasterUn
 });
 
 const rasterUniformValues = (
-  matrix: Float32Array,
+  matrix: mat4,
   parentTL: [number, number],
   parentScaleBy: number,
   fade: {

--- a/src/render/program/symbol_program.ts
+++ b/src/render/program/symbol_program.ts
@@ -5,6 +5,7 @@ import browser from '../../util/browser';
 import type Context from '../../gl/context';
 import type Painter from '../painter';
 import type {UniformValues, UniformLocations} from '../uniform_binding';
+import {mat4} from 'gl-matrix';
 
 export type SymbolIconUniformsType = {
   'u_is_size_zoom_constant': Uniform1i,
@@ -145,9 +146,9 @@ const symbolIconUniformValues = (
   rotateInShader: boolean,
   pitchWithMap: boolean,
   painter: Painter,
-  matrix: Float32Array,
-  labelPlaneMatrix: Float32Array,
-  glCoordMatrix: Float32Array,
+  matrix: mat4,
+  labelPlaneMatrix: mat4,
+  glCoordMatrix: mat4,
   isText: boolean,
   texSize: [number, number]
 ): UniformValues<SymbolIconUniformsType> => {
@@ -182,9 +183,9 @@ const symbolSDFUniformValues = (
   rotateInShader: boolean,
   pitchWithMap: boolean,
   painter: Painter,
-  matrix: Float32Array,
-  labelPlaneMatrix: Float32Array,
-  glCoordMatrix: Float32Array,
+  matrix: mat4,
+  labelPlaneMatrix: mat4,
+  glCoordMatrix: mat4,
   isText: boolean,
   texSize: [number, number],
   isHalo: boolean
@@ -209,9 +210,9 @@ const symbolTextAndIconUniformValues = (
   rotateInShader: boolean,
   pitchWithMap: boolean,
   painter: Painter,
-  matrix: Float32Array,
-  labelPlaneMatrix: Float32Array,
-  glCoordMatrix: Float32Array,
+  matrix: mat4,
+  labelPlaneMatrix: mat4,
+  glCoordMatrix: mat4,
   texSizeSDF: [number, number],
   texSizeIcon: [number, number]
 ): UniformValues<SymbolIconUniformsType> => {

--- a/src/render/uniform_binding.ts
+++ b/src/render/uniform_binding.ts
@@ -1,6 +1,7 @@
 import Color from '../style-spec/util/color';
 
 import type Context from '../gl/context';
+import {mat4, vec2, vec3, vec4} from 'gl-matrix';
 
 type $ObjMap<T extends {}, F extends (v: any) => any> = {
   [K in keyof T]: F extends (v: T[K]) => infer R ? R : never;
@@ -52,13 +53,13 @@ class Uniform1f extends Uniform<number> {
     }
 }
 
-class Uniform2f extends Uniform<[number, number]> {
+class Uniform2f extends Uniform<vec2> {
     constructor(context: Context, location: WebGLUniformLocation) {
         super(context, location);
         this.current = [0, 0];
     }
 
-    set(v: [number, number]): void {
+    set(v: vec2): void {
         if (v[0] !== this.current[0] || v[1] !== this.current[1]) {
             this.current = v;
             this.gl.uniform2f(this.location, v[0], v[1]);
@@ -66,13 +67,13 @@ class Uniform2f extends Uniform<[number, number]> {
     }
 }
 
-class Uniform3f extends Uniform<[number, number, number]> {
+class Uniform3f extends Uniform<vec3> {
     constructor(context: Context, location: WebGLUniformLocation) {
         super(context, location);
         this.current = [0, 0, 0];
     }
 
-    set(v: [number, number, number]): void {
+    set(v: vec3): void {
         if (v[0] !== this.current[0] || v[1] !== this.current[1] || v[2] !== this.current[2]) {
             this.current = v;
             this.gl.uniform3f(this.location, v[0], v[1], v[2]);
@@ -80,13 +81,13 @@ class Uniform3f extends Uniform<[number, number, number]> {
     }
 }
 
-class Uniform4f extends Uniform<[number, number, number, number]> {
+class Uniform4f extends Uniform<vec4> {
     constructor(context: Context, location: WebGLUniformLocation) {
         super(context, location);
         this.current = [0, 0, 0, 0];
     }
 
-    set(v: [number, number, number, number]): void {
+    set(v: vec4): void {
         if (v[0] !== this.current[0] || v[1] !== this.current[1] ||
             v[2] !== this.current[2] || v[3] !== this.current[3]) {
             this.current = v;
@@ -110,14 +111,14 @@ class UniformColor extends Uniform<Color> {
     }
 }
 
-const emptyMat4 = new Float32Array(16);
-class UniformMatrix4f extends Uniform<Float32Array> {
+const emptyMat4 = mat4.create();
+class UniformMatrix4f extends Uniform<mat4> {
     constructor(context: Context, location: WebGLUniformLocation) {
         super(context, location);
         this.current = emptyMat4;
     }
 
-    set(v: Float32Array): void {
+    set(v: mat4): void {
         // The vast majority of matrix comparisons that will trip this set
         // happen at i=12 or i=0, so we check those first to avoid lots of
         // unnecessary iteration:

--- a/src/source/query_features.ts
+++ b/src/source/query_features.ts
@@ -12,7 +12,7 @@ import {mat4} from 'gl-matrix';
  * Returns a matrix that can be used to convert from tile coordinates to viewport pixel coordinates.
  */
 function getPixelPosMatrix(transform, tileID) {
-    const t = mat4.identity([]);
+    const t = mat4.create();
     mat4.translate(t, t, [1, 1, 0]);
     mat4.scale(t, t, [transform.width * 0.5, transform.height * 0.5, 1]);
     return mat4.multiply(t, t, transform.calculatePosMatrix(tileID.toUnwrapped()));

--- a/src/source/tile.ts
+++ b/src/source/tile.ts
@@ -30,6 +30,7 @@ import type {LayerFeatureStates} from './source_state';
 import type {Cancelable} from '../types/cancelable';
 import type {FilterSpecification} from '../style-spec/types';
 import type Point from '../symbol/point';
+import {mat4} from 'gl-matrix';
 
 export type TileState = // Tile data is in the process of loading.
 "loading" | // Tile data has been loaded. Tile can be rendered.
@@ -286,7 +287,7 @@ class Tile {
       },
       transform: Transform,
       maxPitchScaleFactor: number,
-      pixelPosMatrix: Float32Array
+      pixelPosMatrix: mat4
     ): {
       [_: string]: Array<{
         featureIndex: number,

--- a/src/source/tile_id.ts
+++ b/src/source/tile_id.ts
@@ -5,6 +5,7 @@ import MercatorCoordinate from '../geo/mercator_coordinate';
 
 import assert from 'assert';
 import {register} from '../util/web_worker_transfer';
+import {mat4} from 'gl-matrix';
 
 export class CanonicalTileID {
     z: number;
@@ -69,7 +70,7 @@ export class OverscaledTileID {
     wrap: number;
     canonical: CanonicalTileID;
     key: string;
-    posMatrix: Float32Array;
+    posMatrix: mat4;
 
     constructor(overscaledZ: number, wrap: number, z: number, x: number, y: number) {
         assert(overscaledZ >= z);

--- a/src/style/style_layer.ts
+++ b/src/style/style_layer.ts
@@ -27,6 +27,7 @@ import type {
 import type {CustomLayerInterface} from './style_layer/custom_style_layer';
 import type Map from '../ui/map';
 import type {StyleSetterOptions} from './style';
+import {mat4} from 'gl-matrix';
 
 const TRANSITION_SUFFIX = '-transition';
 
@@ -60,7 +61,7 @@ class StyleLayer extends Evented {
       zoom: number,
       transform: Transform,
       pixelsToTileUnits: number,
-      pixelPosMatrix: Float32Array
+      pixelPosMatrix: mat4
     ) => boolean | number;
 
     readonly onAdd: ((map: Map) => void) | undefined | null;

--- a/src/style/style_layer/circle_style_layer.ts
+++ b/src/style/style_layer/circle_style_layer.ts
@@ -5,7 +5,7 @@ import {polygonIntersectsBufferedPoint} from '../../util/intersection_tests';
 import {getMaximumPaintValue, translateDistance, translate} from '../query_utils';
 import properties, {LayoutPropsPossiblyEvaluated, PaintPropsPossiblyEvaluated} from './circle_style_layer_properties';
 import {Transitionable, Transitioning, Layout, PossiblyEvaluated} from '../properties';
-import {vec4} from 'gl-matrix';
+import {mat4, vec4} from 'gl-matrix';
 import Point from '../../symbol/point';
 import type {FeatureState} from '../../style-spec/expression';
 import type Transform from '../../geo/transform';
@@ -44,7 +44,7 @@ class CircleStyleLayer extends StyleLayer {
       zoom: number,
       transform: Transform,
       pixelsToTileUnits: number,
-      pixelPosMatrix: Float32Array
+      pixelPosMatrix: mat4
     ): boolean => {
         const translatedPolygon = translate(queryGeometry,
             this.paint.get('circle-translate'),
@@ -68,7 +68,7 @@ class CircleStyleLayer extends StyleLayer {
                 const transformedPoint = alignWithMap ? point : projectPoint(point, pixelPosMatrix);
 
                 let adjustedSize = transformedSize;
-                const projectedCenter = vec4.transformMat4([], [point.x, point.y, 0, 1], pixelPosMatrix);
+                const projectedCenter = vec4.transformMat4(vec4.create(), vec4.fromValues(point.x, point.y, 0, 1), pixelPosMatrix);
                 if (this.paint.get('circle-pitch-scale') === 'viewport' && this.paint.get('circle-pitch-alignment') === 'map') {
                     adjustedSize *= projectedCenter[3] / transform.cameraToCenterDistance;
                 } else if (this.paint.get('circle-pitch-scale') === 'map' && this.paint.get('circle-pitch-alignment') === 'viewport') {
@@ -83,12 +83,12 @@ class CircleStyleLayer extends StyleLayer {
     }
 }
 
-function projectPoint(p: Point, pixelPosMatrix: Float32Array) {
-    const point = vec4.transformMat4([], [p.x, p.y, 0, 1], pixelPosMatrix);
+function projectPoint(p: Point, pixelPosMatrix: mat4) {
+    const point = vec4.transformMat4(vec4.create(), vec4.fromValues(p.x, p.y, 0, 1), pixelPosMatrix);
     return new Point(point[0] / point[3], point[1] / point[3]);
 }
 
-function projectQueryGeometry(queryGeometry: Array<Point>, pixelPosMatrix: Float32Array) {
+function projectQueryGeometry(queryGeometry: Array<Point>, pixelPosMatrix: mat4) {
     return queryGeometry.map((p) => {
         return projectPoint(p, pixelPosMatrix);
     });

--- a/src/style/style_layer/custom_style_layer.ts
+++ b/src/style/style_layer/custom_style_layer.ts
@@ -1,8 +1,11 @@
 import StyleLayer from '../style_layer';
 import type Map from '../../ui/map';
 import assert from 'assert';
+import {mat4} from 'gl-matrix';
 
-type CustomRenderMethod = (gl: WebGLRenderingContext, matrix: Array<number>) => void;
+// careful of this change from matrix from Array<number> to mat4 as custom layer can be 2D or 3D
+// this may or may not be an issue, investigate
+type CustomRenderMethod = (gl: WebGLRenderingContext, matrix: mat4) => void;
 
 /**
  * Interface for custom style layers. This is a specification for

--- a/src/style/style_layer/fill_extrusion_style_layer.ts
+++ b/src/style/style_layer/fill_extrusion_style_layer.ts
@@ -5,9 +5,8 @@ import {polygonIntersectsPolygon, polygonIntersectsMultiPolygon} from '../../uti
 import {translateDistance, translate} from '../query_utils';
 import properties, {PaintPropsPossiblyEvaluated} from './fill_extrusion_style_layer_properties';
 import {Transitionable, Transitioning, PossiblyEvaluated} from '../properties';
-import {vec4} from 'gl-matrix';
+import {mat4, vec4} from 'gl-matrix';
 import Point from '../../symbol/point';
-
 import type {FeatureState} from '../../style-spec/expression';
 import type {BucketParameters} from '../../data/bucket';
 import type {PaintProps} from './fill_extrusion_style_layer_properties';
@@ -45,7 +44,7 @@ class FillExtrusionStyleLayer extends StyleLayer {
       zoom: number,
       transform: Transform,
       pixelsToTileUnits: number,
-      pixelPosMatrix: Float32Array
+      pixelPosMatrix: mat4
     ): boolean | number => {
 
         const translatedPolygon = translate(queryGeometry,
@@ -164,10 +163,9 @@ function checkIntersection(projectedBase: Array<Array<Point3D>>, projectedTop: A
  * different points can only be done once. This produced a measurable
  * performance improvement.
  */
-function projectExtrusion(geometry: Array<Array<Point>>, zBase: number, zTop: number, m: Float32Array): [Array<Array<Point3D>>, Array<Array<Point3D>>] {
+function projectExtrusion(geometry: Array<Array<Point>>, zBase: number, zTop: number, m: mat4): [Array<Array<Point3D>>, Array<Array<Point3D>>] {
     const projectedBase = [] as Array<Array<Point3D>>;
     const projectedTop = [] as Array<Array<Point3D>>;
-
     const baseXZ = m[8] * zBase;
     const baseYZ = m[9] * zBase;
     const baseZZ = m[10] * zBase;
@@ -213,10 +211,10 @@ function projectExtrusion(geometry: Array<Array<Point>>, zBase: number, zTop: nu
     return [projectedBase, projectedTop];
 }
 
-function projectQueryGeometry(queryGeometry: Array<Point>, pixelPosMatrix: Float32Array, transform: Transform, z: number) {
+function projectQueryGeometry(queryGeometry: Array<Point>, pixelPosMatrix: mat4, transform: Transform, z: number) {
     const projectedQueryGeometry = [];
     for (const p of queryGeometry) {
-        const v = [p.x, p.y, z, 1];
+        const v = vec4.fromValues(p.x, p.y, z, 1);
         vec4.transformMat4(v, v, pixelPosMatrix);
         projectedQueryGeometry.push(new Point(v[0] / v[3], v[1] / v[3]));
     }

--- a/src/symbol/collision_index.ts
+++ b/src/symbol/collision_index.ts
@@ -4,7 +4,7 @@ import PathInterpolator from './path_interpolator';
 
 import * as intersectionTests from '../util/intersection_tests';
 import Grid from './grid_index';
-import {mat4} from 'gl-matrix';
+import {mat4, vec4} from 'gl-matrix';
 import ONE_EM from '../symbol/one_em';
 import assert from 'assert';
 
@@ -348,7 +348,7 @@ class CollisionIndex {
     }
 
     projectAndGetPerspectiveRatio(posMatrix: mat4, x: number, y: number) {
-        const p = [x, y, 0, 1];
+        const p = vec4.fromValues(x, y, 0, 1);
         projection.xyTransformMat4(p, p, posMatrix);
         const a = new Point(
             (((p[0] / p[3] + 1) / 2) * this.transform.width) + viewportPadding,
@@ -376,8 +376,8 @@ class CollisionIndex {
     * Use this function to render e.g. collision circles on the screen.
     *   example transformation: clipPos = glCoordMatrix * viewportMatrix * circle_pos
     */
-    getViewportMatrix(): mat4 {
-        const m = mat4.identity([]);
+    getViewportMatrix() {
+        const m = mat4.create(); // creates identity matrix
         mat4.translate(m, m, [-viewportPadding, -viewportPadding, 0.0]);
         return m;
     }

--- a/src/symbol/placement.ts
+++ b/src/symbol/placement.ts
@@ -289,7 +289,7 @@ export class Placement {
                 this.transform,
                 pixelsToTiles);
 
-            labelToScreenMatrix = mat4.multiply([], this.transform.labelPlaneMatrix, glMatrix);
+            labelToScreenMatrix = mat4.multiply(mat4.create(), this.transform.labelPlaneMatrix, glMatrix);
         }
 
         // As long as this placement lives, we have to hold onto this bucket's

--- a/src/symbol/projection.ts
+++ b/src/symbol/projection.ts
@@ -102,7 +102,7 @@ function getGlCoordMatrix(posMatrix: mat4,
 }
 
 function project(point: Point, matrix: mat4) {
-    const pos = [point.x, point.y, 0, 1];
+    const pos = vec4.fromValues(point.x, point.y, 0, 1);
     xyTransformMat4(pos, pos, matrix);
     const w = pos[3];
     return {
@@ -115,7 +115,7 @@ function getPerspectiveRatio(cameraToCenterDistance: number, signedDistanceFromC
     return 0.5 + 0.5 * (cameraToCenterDistance / signedDistanceFromCamera);
 }
 
-function isVisible(anchorPos: [number, number, number, number],
+function isVisible(anchorPos: vec4,
                    clippingBuffer: [number, number]) {
     const x = anchorPos[0] / anchorPos[3];
     const y = anchorPos[1] / anchorPos[3];
@@ -143,7 +143,7 @@ function updateLineLabels(bucket: SymbolBucket,
     const sizeData = isText ? bucket.textSizeData : bucket.iconSizeData;
     const partiallyEvaluatedSize = symbolSize.evaluateSizeForZoom(sizeData, painter.transform.zoom);
 
-    const clippingBuffer = [256 / painter.width * 2 + 1, 256 / painter.height * 2 + 1];
+    const clippingBuffer: [number, number] = [256 / painter.width * 2 + 1, 256 / painter.height * 2 + 1];
 
     const dynamicLayoutVertexArray = isText ?
         bucket.text.dynamicLayoutVertexArray :
@@ -158,7 +158,7 @@ function updateLineLabels(bucket: SymbolBucket,
     let useVertical = false;
 
     for (let s = 0; s < placedSymbols.length; s++) {
-        const symbol: any = placedSymbols.get(s);
+        const symbol = placedSymbols.get(s);
 
         // Don't do calculations for vertical glyphs unless the previous symbol was horizontal
         // and we determined that vertical glyphs were necessary.
@@ -170,7 +170,7 @@ function updateLineLabels(bucket: SymbolBucket,
         // Awkward... but we're counting on the paired "vertical" symbol coming immediately after its horizontal counterpart
         useVertical = false;
 
-        const anchorPos = [symbol.anchorX, symbol.anchorY, 0, 1];
+        const anchorPos = vec4.fromValues(symbol.anchorX, symbol.anchorY, 0, 1);
         vec4.transformMat4(anchorPos, anchorPos, posMatrix);
 
         // Don't bother calculating the correct point for invisible labels.

--- a/src/util/primitives.ts
+++ b/src/util/primitives.ts
@@ -1,4 +1,4 @@
-import {vec3, vec4} from 'gl-matrix';
+import {mat4, vec3, vec4} from 'gl-matrix';
 import assert from 'assert';
 
 class Frustum {
@@ -10,7 +10,7 @@ class Frustum {
         this.planes = planes_;
     }
 
-    static fromInvProjectionMatrix(invProj: Float32Array, worldSize: number, zoom: number): Frustum {
+    static fromInvProjectionMatrix(invProj: mat4, worldSize: number, zoom: number): Frustum {
         const clipSpaceCorners = [
             [-1, 1, -1, 1],
             [ 1, 1, -1, 1],
@@ -26,8 +26,8 @@ class Frustum {
 
         // Transform frustum corner points from clip space to tile space
         const frustumCoords = clipSpaceCorners
-            .map(v => vec4.transformMat4(new Float32Array(), v as vec4, invProj))
-            .map(v => vec4.scale(new Float32Array(), v, 1.0 / v[3] / worldSize * scale));
+            .map(v => vec4.transformMat4(vec4.create(), v as vec4, invProj))
+            .map(v => vec4.scale(vec4.create(), v, 1.0 / v[3] / worldSize * scale));
 
         const frustumPlanePointIndices = [
             [0, 1, 2],  // near
@@ -39,9 +39,9 @@ class Frustum {
         ];
 
         const frustumPlanes = frustumPlanePointIndices.map((p: Array<number>) => {
-            const a = vec3.sub(new Float32Array(), frustumCoords[p[0]] as vec3, frustumCoords[p[1]] as vec3);
-            const b = vec3.sub(new Float32Array(), frustumCoords[p[2]] as vec3, frustumCoords[p[1]] as vec3);
-            const n = vec3.normalize(new Float32Array(), vec3.cross(new Float32Array(), a, b));
+            const a = vec3.sub(vec3.create(), frustumCoords[p[0]] as vec3, frustumCoords[p[1]] as vec3);
+            const b = vec3.sub(vec3.create(), frustumCoords[p[2]] as vec3, frustumCoords[p[1]] as vec3);
+            const n = vec3.normalize(vec3.create(), vec3.cross(vec3.create(), a, b));
             const d = -vec3.dot(n, frustumCoords[p[1]] as vec3);
             return (n as number[]).concat(d);
         });
@@ -58,7 +58,7 @@ class Aabb {
     constructor(min_: vec3, max_: vec3) {
         this.min = min_;
         this.max = max_;
-        this.center = vec3.scale(new Float32Array(), vec3.add(new Float32Array(), this.min, this.max), 0.5);
+        this.center = vec3.scale(vec3.create(), vec3.add(vec3.create(), this.min, this.max), 0.5);
     }
 
     quadrant(index: number): Aabb {

--- a/src/util/window.ts
+++ b/src/util/window.ts
@@ -96,5 +96,5 @@ function restore(): Window {
     window.WebGLFramebuffer = window.WebGLFramebuffer || Object;
     Object.assign(_window, window); // eslint-disable-line no-restricted-properties
 
-    return window;
+    return window as Window;
 }


### PR DESCRIPTION
 - [x] confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [ ] briefly describe the changes in this PR

Some types seem to be Float32Array when it seems they should often be gl-matrix types and constructors.
Because we are in the middle of porting to Typescript it is hard to confirm that this doesn't break more than it fixes, however for my fork at the time of the MR the errors in tsx went from `615` down to `593`.

UPDATE: latest `226` -> `202` // this is a moving target, latest is about 20 errors fixed by this branch (I assume 4 got merged in as unrelated issues)
UPDATE: last check I see 39 errors left after the changes in this branch

The PR is WIP, please comment and I'll do my best to fix.

 - [ ] include before/after visuals or gifs if this PR includes visual changes
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [ ] manually test the debug page
 - [ ] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [ ] add an entry inside this element for inclusion in the `maplibre-gl-js` changelog: `<changelog></changelog>`
