### PR TITLE
Typescript: Remove @mapbox/geojson-types and replace with @types/GeoJSON'

### DIFF
--- a/flow-typed/vector-tile.js
+++ b/flow-typed/vector-tile.js
@@ -1,6 +1,5 @@
 import type Pbf from 'pbf';
 import type Point from '@mapbox/point-geometry';
-import type { GeoJSONFeature } from '@mapbox/geojson-types';
 
 declare interface VectorTile {
     layers: {[_: string]: VectorTileLayer};
@@ -21,7 +20,7 @@ declare interface VectorTileFeature {
     properties: {[_: string]: string | number | boolean};
 
     loadGeometry(): Array<Array<Point>>;
-    toGeoJSON(x: number, y: number, z: number): GeoJSONFeature;
+    toGeoJSON(x: number, y: number, z: number): GeoJSON.Feature;
 }
 
 declare module "@mapbox/vector-tile" {
@@ -31,7 +30,7 @@ declare module "@mapbox/vector-tile" {
 
     declare class VectorTileFeatureImpl {
         static types: ['Unknown', 'Point', 'LineString', 'Polygon'];
-        toGeoJSON(x: number, y: number, z: number): GeoJSONFeature;
+        toGeoJSON(x: number, y: number, z: number): GeoJSON.Feature;
     }
 
     declare module.exports: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1458,11 +1458,6 @@
         "minimist": "^1.2.5"
       }
     },
-    "@mapbox/geojson-types": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@mapbox/geojson-types/-/geojson-types-1.0.2.tgz",
-      "integrity": "sha512-e9EBqHHv3EORHrSfbR9DqecPNn+AmuAoQxV6aL8Xu30bJMJR1o8PZLZzpk1Wq7/NfCbuhmakHTPYRhoqLsXRnw=="
-    },
     "@mapbox/geojsonhint": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@mapbox/geojsonhint/-/geojsonhint-2.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
   "types": "src/index.d.ts",
   "dependencies": {
     "@mapbox/geojson-rewind": "^0.5.0",
-    "@mapbox/geojson-types": "^1.0.2",
     "@mapbox/jsonlint-lines-primitives": "^2.0.2",
     "@mapbox/mapbox-gl-supported": "^1.5.0",
     "@mapbox/point-geometry": "^0.1.0",

--- a/src/source/geojson_source.ts
+++ b/src/source/geojson_source.ts
@@ -11,7 +11,6 @@ import type Dispatcher from '../util/dispatcher';
 import type Tile from './tile';
 import type Actor from '../util/actor';
 import type {Callback} from '../types/callback';
-import type {GeoJSON, GeoJSONFeature} from '@mapbox/geojson-types';
 import type {GeoJSONSourceSpecification, PromoteIdSpecification} from '../style-spec/types';
 
 /**
@@ -71,7 +70,7 @@ class GeoJSONSource extends Evented implements Source {
 
     isTileClipped: boolean;
     reparseOverscaled: boolean;
-    _data: GeoJSON | string;
+    _data: GeoJSON.GeoJSON | string;
     _options: any;
     workerOptions: any;
     map: Map;
@@ -181,7 +180,7 @@ class GeoJSONSource extends Evented implements Source {
      * @param {Object|string} data A GeoJSON data object or a URL to one. The latter is preferable in the case of large GeoJSON files.
      * @returns {GeoJSONSource} this
      */
-    setData(data: GeoJSON | string) {
+    setData(data: GeoJSON.GeoJSON | string) {
         this._data = data;
         this.fire(new Event('dataloading', {dataType: 'source'}));
         this._updateWorkerData((err) => {
@@ -220,7 +219,7 @@ class GeoJSONSource extends Evented implements Source {
      * @param callback A callback to be called when the features are retrieved (`(error, features) => { ... }`).
      * @returns {GeoJSONSource} this
      */
-    getClusterChildren(clusterId: number, callback: Callback<Array<GeoJSONFeature>>) {
+    getClusterChildren(clusterId: number, callback: Callback<Array<GeoJSON.Feature>>) {
         this.actor.send('geojson.getClusterChildren', {clusterId, source: this.id}, callback);
         return this;
     }
@@ -250,7 +249,7 @@ class GeoJSONSource extends Evented implements Source {
      *   })
      * });
      */
-    getClusterLeaves(clusterId: number, limit: number, offset: number, callback: Callback<Array<GeoJSONFeature>>) {
+    getClusterLeaves(clusterId: number, limit: number, offset: number, callback: Callback<Array<GeoJSON.Feature>>) {
         this.actor.send('geojson.getClusterLeaves', {
             source: this.id,
             clusterId,

--- a/src/source/geojson_worker_source.ts
+++ b/src/source/geojson_worker_source.ts
@@ -21,7 +21,6 @@ import type StyleLayerIndex from '../style/style_layer_index';
 import type {LoadVectorDataCallback} from './vector_tile_worker_source';
 import type {RequestParameters, ResponseCallback} from '../util/ajax';
 import type {Callback} from '../types/callback';
-import type {GeoJSONFeature} from '@mapbox/geojson-types';
 
 export type LoadGeoJSONParameters = {
   request?: RequestParameters,
@@ -40,8 +39,8 @@ export interface GeoJSONIndex {
   getTile(z: number, x: number, y: number): any;
   // supercluster methods
   getClusterExpansionZoom(clusterId: number): number;
-  getChildren(clusterId: number): Array<GeoJSONFeature>;
-  getLeaves(clusterId: number, limit: number, offset: number): Array<GeoJSONFeature>;
+  getChildren(clusterId: number): Array<GeoJSON.Feature>;
+  getLeaves(clusterId: number, limit: number, offset: number): Array<GeoJSON.Feature>;
 }
 
 function loadGeoJSONTile(params: WorkerTileParameters, callback: LoadVectorDataCallback) {
@@ -312,7 +311,7 @@ class GeoJSONWorkerSource extends VectorTileWorkerSource {
 
     getClusterChildren(params: {
       clusterId: number
-    }, callback: Callback<Array<GeoJSONFeature>>) {
+    }, callback: Callback<Array<GeoJSON.Feature>>) {
         try {
             callback(null, this._geoJSONIndex.getChildren(params.clusterId));
         } catch (e) {
@@ -324,7 +323,7 @@ class GeoJSONWorkerSource extends VectorTileWorkerSource {
       clusterId: number,
       limit: number,
       offset: number
-    }, callback: Callback<Array<GeoJSONFeature>>) {
+    }, callback: Callback<Array<GeoJSON.Feature>>) {
         try {
             callback(null, this._geoJSONIndex.getLeaves(params.clusterId, params.limit, params.offset));
         } catch (e) {

--- a/src/style-spec/expression/definitions/within.ts
+++ b/src/style-spec/expression/definitions/within.ts
@@ -4,11 +4,10 @@ import {BooleanType} from '../types';
 import type {Expression} from '../expression';
 import type ParsingContext from '../parsing_context';
 import type EvaluationContext from '../evaluation_context';
-import type {GeoJSON, GeoJSONPolygon, GeoJSONMultiPolygon} from '@mapbox/geojson-types';
 import Point from '@mapbox/point-geometry';
 import type {CanonicalTileID} from '../../../source/tile_id';
 
-type GeoJSONPolygons = GeoJSONPolygon | GeoJSONMultiPolygon;
+type GeoJSONPolygons = GeoJSON.Polygon | GeoJSON.MultiPolygon;
 
 // minX, minY, maxX, maxY
 type BBox = [number, number, number, number];
@@ -282,10 +281,10 @@ function linesWithinPolygons(ctx: EvaluationContext, polygonGeometry: GeoJSONPol
 
 class Within implements Expression {
     type: Type;
-    geojson: GeoJSON;
+    geojson: GeoJSON.GeoJSON;
     geometries: GeoJSONPolygons;
 
-    constructor(geojson: GeoJSON, geometries: GeoJSONPolygons) {
+    constructor(geojson: GeoJSON.GeoJSON, geometries: GeoJSONPolygons) {
         this.type = BooleanType;
         this.geojson = geojson;
         this.geometries = geometries;

--- a/src/style/style.ts
+++ b/src/style/style.ts
@@ -52,7 +52,6 @@ import type EvaluationParameters from './evaluation_parameters';
 import type {Placement} from '../symbol/placement';
 import type {Cancelable} from '../types/cancelable';
 import type {RequestParameters, ResponseCallback} from '../util/ajax';
-import type {GeoJSON} from '@mapbox/geojson-types';
 import type {
     LayerSpecification,
     FilterSpecification,
@@ -635,7 +634,7 @@ class Style extends Evented {
     * @param {string} id id of the source
     * @param {GeoJSON|string} data GeoJSON source
     */
-    setGeoJSONSourceData(id: string, data: GeoJSON | string) {
+    setGeoJSONSourceData(id: string, data: GeoJSON.GeoJSON | string) {
         this._checkLoaded();
 
         assert(this.sourceCaches[id] !== undefined, 'There is no source with this ID');

--- a/src/types/non-typed-modules.d.ts
+++ b/src/types/non-typed-modules.d.ts
@@ -1,6 +1,5 @@
 import type Pbf from 'pbf';
 import type Point from '@mapbox/point-geometry';
-import type {GeoJSONFeature} from '@mapbox/geojson-types';
 
 declare module "@mapbox/mapbox-gl-supported" {
     type isSupported = {
@@ -151,7 +150,7 @@ declare global {
             [_: string]: string | number | boolean
         };
         loadGeometry(): Array<Array<Point>>;
-        toGeoJSON(x: number, y: number, z: number): GeoJSONFeature;
+        toGeoJSON(x: number, y: number, z: number): GeoJSON.Feature;
     }
 }
 
@@ -163,7 +162,7 @@ declare module "@mapbox/vector-tile" {
 
     class VectorTileFeatureImpl {
         static types: ["Unknown", "Point", "LineString", "Polygon"];
-        toGeoJSON(x: number, y: number, z: number): GeoJSONFeature;
+        toGeoJSON(x: number, y: number, z: number): GeoJSON.Feature;
     }
 
     let __exports: {

--- a/src/util/vectortile_to_geojson.ts
+++ b/src/util/vectortile_to_geojson.ts
@@ -1,8 +1,6 @@
-import type {GeoJSONGeometry} from '@mapbox/geojson-types';
-
 class Feature {
     type: "Feature";
-    _geometry: GeoJSONGeometry | undefined | null;
+    _geometry: GeoJSON.Geometry | undefined | null;
     properties: {};
     id: number | string | void;
 
@@ -20,7 +18,7 @@ class Feature {
         this.id = id;
     }
 
-    get geometry(): GeoJSONGeometry | undefined | null {
+    get geometry(): GeoJSON.Geometry | undefined | null {
         if (this._geometry === undefined) {
             this._geometry = this._vectorTileFeature.toGeoJSON(
                 (this._vectorTileFeature as any)._x,
@@ -30,7 +28,7 @@ class Feature {
         return this._geometry;
     }
 
-    set geometry(g: GeoJSONGeometry | undefined | null) {
+    set geometry(g: GeoJSON.Geometry | undefined | null) {
         this._geometry = g;
     }
 
@@ -40,7 +38,7 @@ class Feature {
         };
         for (const i in this) {
             if (i === '_geometry' || i === '_vectorTileFeature') continue;
-            json[i] = (this as any)[i];
+            json[i.toString()] = (this as any)[i];
         }
         return json;
     }

--- a/src/util/vectortile_to_geojson.ts
+++ b/src/util/vectortile_to_geojson.ts
@@ -33,13 +33,9 @@ class Feature {
     }
 
     toJSON() {
-        const json = {
-            geometry: this.geometry
-        };
-        for (const i in this) {
-            if (i === '_geometry' || i === '_vectorTileFeature') continue;
-            json[i.toString()] = (this as any)[i];
-        }
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        const {_geometry, _vectorTileFeature, ...json} = this;
+        json.geometry = this.geometry;
         return json;
     }
 }


### PR DESCRIPTION
 - [x] confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!

- Remove imports of @mapbox/geojson-types
- Update GeoJSON types (untested build as TS WIP, but reduces tsc errors)
- Errors from 615 -> 609
- Marked as draft because currently difficult to test. I will try to improve the PR when I can get things building and more stable

 - [ ] add an entry inside this element for inclusion in the `maplibre-gl-js` changelog: `<changelog></changelog>`
