### PR TITLE
Typescript: add glsl.d.ts to allow import of .glsl files

### DIFF
--- a/src/types/glsl.d.ts
+++ b/src/types/glsl.d.ts
@@ -1,0 +1,4 @@
+declare module '*.glsl' {
+    const value: string;
+    export default value;
+}


### PR DESCRIPTION
 - [x] confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] briefly describe the changes in this PR
Adding d.ts file so Typescript knows what to do importing .glsl files
https://stackoverflow.com/questions/48741570/how-can-i-import-glsl-as-string-in-typescript

Reduces 629 -> 575 (54 errors removed)

 - [ ] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [ ] add an entry inside this element for inclusion in the `maplibre-gl-js` changelog: `<changelog></changelog>`
