### PR TITLE
Typescript: Remove reference to @mapbox/point-geometry TBC

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "@mapbox/geojson-rewind": "^0.5.0",
     "@mapbox/jsonlint-lines-primitives": "^2.0.2",
     "@mapbox/mapbox-gl-supported": "^1.5.0",
-    "@mapbox/point-geometry": "^0.1.0",
     "@mapbox/tiny-sdf": "^1.1.1",
     "@mapbox/unitbezier": "^0.0.0",
     "@mapbox/vector-tile": "^1.3.1",

--- a/src/data/array_types.ts
+++ b/src/data/array_types.ts
@@ -2,7 +2,7 @@
 import assert from 'assert';
 import {Struct, StructArray} from '../util/struct_array';
 import {register} from '../util/web_worker_transfer';
-import Point from '@mapbox/point-geometry';
+import Point from '../symbol/point';
 
 /**
  * Implementation of the StructArray layout:

--- a/src/data/bucket.ts
+++ b/src/data/bucket.ts
@@ -6,7 +6,7 @@ import type Context from '../gl/context';
 import type {FeatureStates} from '../source/source_state';
 import type {ImagePosition} from '../render/image_atlas';
 import type {CanonicalTileID} from '../source/tile_id';
-import Point from '@mapbox/point-geometry';
+import Point from '../symbol/point';
 
 export type BucketParameters<Layer extends TypedStyleLayer> = {
   index: number,

--- a/src/data/bucket/circle_bucket.ts
+++ b/src/data/bucket/circle_bucket.ts
@@ -23,7 +23,7 @@ import type HeatmapStyleLayer from '../../style/style_layer/heatmap_style_layer'
 import type Context from '../../gl/context';
 import type IndexBuffer from '../../gl/index_buffer';
 import type VertexBuffer from '../../gl/vertex_buffer';
-import type Point from '@mapbox/point-geometry';
+import type Point from '../../symbol/point';
 import type {FeatureStates} from '../../source/source_state';
 import type {ImagePosition} from '../../render/image_atlas';
 

--- a/src/data/bucket/fill_bucket.ts
+++ b/src/data/bucket/fill_bucket.ts
@@ -26,7 +26,7 @@ import type FillStyleLayer from '../../style/style_layer/fill_style_layer';
 import type Context from '../../gl/context';
 import type IndexBuffer from '../../gl/index_buffer';
 import type VertexBuffer from '../../gl/vertex_buffer';
-import type Point from '@mapbox/point-geometry';
+import type Point from '../../symbol/point';
 import type {FeatureStates} from '../../source/source_state';
 import type {ImagePosition} from '../../render/image_atlas';
 

--- a/src/data/bucket/fill_extrusion_bucket.ts
+++ b/src/data/bucket/fill_extrusion_bucket.ts
@@ -30,7 +30,7 @@ import type FillExtrusionStyleLayer from '../../style/style_layer/fill_extrusion
 import type Context from '../../gl/context';
 import type IndexBuffer from '../../gl/index_buffer';
 import type VertexBuffer from '../../gl/vertex_buffer';
-import type Point from '@mapbox/point-geometry';
+import type Point from '../../symbol/point';
 import type {FeatureStates} from '../../source/source_state';
 import type {ImagePosition} from '../../render/image_atlas';
 

--- a/src/data/bucket/line_bucket.ts
+++ b/src/data/bucket/line_bucket.ts
@@ -23,7 +23,7 @@ import type {
     PopulateParameters
 } from '../bucket';
 import type LineStyleLayer from '../../style/style_layer/line_style_layer';
-import type Point from '@mapbox/point-geometry';
+import type Point from '../../symbol/point';
 import type {Segment} from '../segment';
 import {RGBAImage} from '../../util/image';
 import type Context from '../../gl/context';

--- a/src/data/bucket/symbol_bucket.ts
+++ b/src/data/bucket/symbol_bucket.ts
@@ -16,7 +16,7 @@ import {SymbolLayoutArray,
     SymbolLineVertexArray
 } from '../array_types';
 
-import Point from '@mapbox/point-geometry';
+import Point from '../../symbol/point';
 import SegmentVector from '../segment';
 import {ProgramConfigurationSet} from '../program_configuration';
 import {TriangleIndexArray, LineIndexArray} from '../index_array_type';

--- a/src/data/evaluation_feature.ts
+++ b/src/data/evaluation_feature.ts
@@ -1,4 +1,5 @@
 import loadGeometry from './load_geometry';
+import type Point from '../symbol/point';
 
 type EvaluationFeature = {
   readonly type: 1 | 2 | 3 | "Unknown" | "Point" | "MultiPoint" | "LineString" | "MultiLineString" | "Polygon" | "MultiPolygon",

--- a/src/data/feature_index.ts
+++ b/src/data/feature_index.ts
@@ -1,4 +1,4 @@
-import Point from '@mapbox/point-geometry';
+import Point from '../symbol/point';
 
 import loadGeometry from './load_geometry';
 import toEvaluationFeature from './evaluation_feature';

--- a/src/data/load_geometry.ts
+++ b/src/data/load_geometry.ts
@@ -2,7 +2,7 @@ import {warnOnce, clamp} from '../util/util';
 
 import EXTENT from './extent';
 
-import type Point from '@mapbox/point-geometry';
+import type Point from '../symbol/point';
 
 // These bounds define the minimum and maximum supported coordinate values.
 // While visible coordinates are within [0, EXTENT], tiles may theoretically

--- a/src/geo/edge_insets.ts
+++ b/src/geo/edge_insets.ts
@@ -1,5 +1,5 @@
 import {number} from "../style-spec/util/interpolate";
-import Point  from "@mapbox/point-geometry";
+import Point from '../symbol/point';
 import {clamp} from "../util/util";
 
 /**

--- a/src/geo/transform.ts
+++ b/src/geo/transform.ts
@@ -1,7 +1,7 @@
 import LngLat from './lng_lat';
 import LngLatBounds from './lng_lat_bounds';
 import MercatorCoordinate, {mercatorXfromLng, mercatorYfromLat, mercatorZfromAltitude} from './mercator_coordinate';
-import Point from '@mapbox/point-geometry';
+import Point from '../symbol/point';
 import {wrap, clamp} from '../util/util';
 import {number as interpolate} from '../style-spec/util/interpolate';
 import EXTENT from '../data/extent';

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ import Marker from './ui/marker';
 import Style from './style/style';
 import LngLat from './geo/lng_lat';
 import LngLatBounds from './geo/lng_lat_bounds';
-import Point from '@mapbox/point-geometry';
+import Point from './symbol/point';
 import MercatorCoordinate from './geo/mercator_coordinate';
 import {Evented} from './util/evented';
 import config from './util/config';

--- a/src/render/draw_symbol.ts
+++ b/src/render/draw_symbol.ts
@@ -1,4 +1,4 @@
-import Point from '@mapbox/point-geometry';
+import Point from '../symbol/point';
 import drawCollisionDebug from './draw_collision_debug';
 
 import SegmentVector from '../data/segment';

--- a/src/source/geojson_wrapper.ts
+++ b/src/source/geojson_wrapper.ts
@@ -1,4 +1,4 @@
-import Point from '@mapbox/point-geometry';
+import Point from '../symbol/point';
 
 import mvt from '@mapbox/vector-tile';
 const toGeoJSON = mvt.VectorTileFeature.prototype.toGeoJSON;

--- a/src/source/query_features.ts
+++ b/src/source/query_features.ts
@@ -4,6 +4,7 @@ import type CollisionIndex from '../symbol/collision_index';
 import type Transform from '../geo/transform';
 import type {RetainedQueryData} from '../symbol/placement';
 import type {FilterSpecification} from '../style-spec/types';
+import type Point from '../symbol/point';
 import assert from 'assert';
 import {mat4} from 'gl-matrix';
 

--- a/src/source/source_cache.ts
+++ b/src/source/source_cache.ts
@@ -7,7 +7,7 @@ import MercatorCoordinate from '../geo/mercator_coordinate';
 import {keysDifference, values} from '../util/util';
 import EXTENT from '../data/extent';
 import Context from '../gl/context';
-import Point from '@mapbox/point-geometry';
+import Point from '../symbol/point';
 import browser from '../util/browser';
 import {OverscaledTileID} from './tile_id';
 import assert from 'assert';

--- a/src/source/tile.ts
+++ b/src/source/tile.ts
@@ -29,6 +29,7 @@ import type Transform from '../geo/transform';
 import type {LayerFeatureStates} from './source_state';
 import type {Cancelable} from '../types/cancelable';
 import type {FilterSpecification} from '../style-spec/types';
+import type Point from '../symbol/point';
 
 export type TileState = // Tile data is in the process of loading.
 "loading" | // Tile data has been loaded. Tile can be rendered.

--- a/src/source/tile_id.ts
+++ b/src/source/tile_id.ts
@@ -1,6 +1,6 @@
 import {getTileBBox} from '@mapbox/whoots-js';
 import EXTENT from '../data/extent';
-import Point from '@mapbox/point-geometry';
+import Point from '../symbol/point';
 import MercatorCoordinate from '../geo/mercator_coordinate';
 
 import assert from 'assert';

--- a/src/style-spec/expression/definitions/within.ts
+++ b/src/style-spec/expression/definitions/within.ts
@@ -4,7 +4,7 @@ import {BooleanType} from '../types';
 import type {Expression} from '../expression';
 import type ParsingContext from '../parsing_context';
 import type EvaluationContext from '../evaluation_context';
-import Point from '@mapbox/point-geometry';
+import Point from '../../../symbol/point';
 import type {CanonicalTileID} from '../../../source/tile_id';
 
 type GeoJSONPolygons = GeoJSON.Polygon | GeoJSON.MultiPolygon;
@@ -225,8 +225,8 @@ function getTileLines(geometry, lineBBox, polyBBox, canonical) {
 }
 
 function pointsWithinPolygons(ctx: EvaluationContext, polygonGeometry: GeoJSONPolygons) {
-    const pointBBox = [Infinity, Infinity, -Infinity, -Infinity];
-    const polyBBox = [Infinity, Infinity, -Infinity, -Infinity];
+    const pointBBox: BBox = [Infinity, Infinity, -Infinity, -Infinity];
+    const polyBBox: BBox = [Infinity, Infinity, -Infinity, -Infinity];
 
     const canonical = ctx.canonicalID();
 
@@ -253,8 +253,8 @@ function pointsWithinPolygons(ctx: EvaluationContext, polygonGeometry: GeoJSONPo
 }
 
 function linesWithinPolygons(ctx: EvaluationContext, polygonGeometry: GeoJSONPolygons) {
-    const lineBBox = [Infinity, Infinity, -Infinity, -Infinity];
-    const polyBBox = [Infinity, Infinity, -Infinity, -Infinity];
+    const lineBBox: BBox = [Infinity, Infinity, -Infinity, -Infinity];
+    const polyBBox: BBox = [Infinity, Infinity, -Infinity, -Infinity];
 
     const canonical = ctx.canonicalID();
 

--- a/src/style-spec/expression/index.ts
+++ b/src/style-spec/expression/index.ts
@@ -23,7 +23,7 @@ import type {Result} from '../util/result';
 import type {InterpolationType} from './definitions/interpolate';
 import type {PropertyValueSpecification} from '../types';
 import type {FormattedSection} from './types/formatted';
-import type Point from '@mapbox/point-geometry';
+import type Point from '../../symbol/point';
 import type {CanonicalTileID} from '../../source/tile_id';
 
 export type Feature = {

--- a/src/style/query_utils.ts
+++ b/src/style/query_utils.ts
@@ -1,4 +1,4 @@
-import Point from '@mapbox/point-geometry';
+import Point from '../symbol/point';
 
 import type {PossiblyEvaluatedPropertyValue} from "./properties";
 import type StyleLayer from '../style/style_layer';

--- a/src/style/style_layer.ts
+++ b/src/style/style_layer.ts
@@ -13,7 +13,7 @@ import {supportsPropertyExpression} from '../style-spec/util/properties';
 
 import type {FeatureState} from '../style-spec/expression';
 import type {Bucket} from '../data/bucket';
-import type Point from '@mapbox/point-geometry';
+import type Point from '../symbol/point';
 import type {FeatureFilter} from '../style-spec/feature_filter';
 import type {TransitionParameters, PropertyValue} from './properties';
 import EvaluationParameters, {CrossfadeParameters} from './evaluation_parameters';

--- a/src/style/style_layer/circle_style_layer.ts
+++ b/src/style/style_layer/circle_style_layer.ts
@@ -6,8 +6,7 @@ import {getMaximumPaintValue, translateDistance, translate} from '../query_utils
 import properties, {LayoutPropsPossiblyEvaluated, PaintPropsPossiblyEvaluated} from './circle_style_layer_properties';
 import {Transitionable, Transitioning, Layout, PossiblyEvaluated} from '../properties';
 import {vec4} from 'gl-matrix';
-import Point from '@mapbox/point-geometry';
-
+import Point from '../../symbol/point';
 import type {FeatureState} from '../../style-spec/expression';
 import type Transform from '../../geo/transform';
 import type {Bucket, BucketParameters} from '../../data/bucket';

--- a/src/style/style_layer/fill_extrusion_style_layer.ts
+++ b/src/style/style_layer/fill_extrusion_style_layer.ts
@@ -6,7 +6,7 @@ import {translateDistance, translate} from '../query_utils';
 import properties, {PaintPropsPossiblyEvaluated} from './fill_extrusion_style_layer_properties';
 import {Transitionable, Transitioning, PossiblyEvaluated} from '../properties';
 import {vec4} from 'gl-matrix';
-import Point from '@mapbox/point-geometry';
+import Point from '../../symbol/point';
 
 import type {FeatureState} from '../../style-spec/expression';
 import type {BucketParameters} from '../../data/bucket';

--- a/src/style/style_layer/fill_style_layer.ts
+++ b/src/style/style_layer/fill_style_layer.ts
@@ -8,7 +8,7 @@ import {Transitionable, Transitioning, Layout, PossiblyEvaluated} from '../prope
 
 import type {FeatureState} from '../../style-spec/expression';
 import type {BucketParameters} from '../../data/bucket';
-import type Point from '@mapbox/point-geometry';
+import type Point from '../../symbol/point';
 import type {LayoutProps, PaintProps} from './fill_style_layer_properties';
 import type EvaluationParameters from '../evaluation_parameters';
 import type Transform from '../../geo/transform';

--- a/src/style/style_layer/line_style_layer.ts
+++ b/src/style/style_layer/line_style_layer.ts
@@ -1,4 +1,4 @@
-import Point from '@mapbox/point-geometry';
+import Point from '../../symbol/point';
 
 import StyleLayer from '../style_layer';
 import LineBucket from '../../data/bucket/line_bucket';

--- a/src/symbol/anchor.ts
+++ b/src/symbol/anchor.ts
@@ -1,10 +1,10 @@
-import Point from '@mapbox/point-geometry';
+import Point from '../symbol/point';
 
 import {register} from '../util/web_worker_transfer';
 
 class Anchor extends Point {
     angle: any;
-    segment: number | void;
+    segment?: number;
 
     constructor(x: number, y: number, angle: number, segment?: number) {
         super(x, y);

--- a/src/symbol/check_max_angle.ts
+++ b/src/symbol/check_max_angle.ts
@@ -1,6 +1,6 @@
 export default checkMaxAngle;
 
-import type Point from '@mapbox/point-geometry';
+import type Point from '../symbol/point';
 import type Anchor from './anchor';
 
 /**

--- a/src/symbol/clip_line.ts
+++ b/src/symbol/clip_line.ts
@@ -1,4 +1,4 @@
-import Point from '@mapbox/point-geometry';
+import Point from '../symbol/point';
 
 export default clipLine;
 

--- a/src/symbol/collision_feature.ts
+++ b/src/symbol/collision_feature.ts
@@ -1,5 +1,5 @@
 import type {CollisionBoxArray} from '../data/array_types';
-import Point from '@mapbox/point-geometry';
+import Point from '../symbol/point';
 import type Anchor from './anchor';
 
 /**

--- a/src/symbol/collision_index.ts
+++ b/src/symbol/collision_index.ts
@@ -1,4 +1,4 @@
-import Point from '@mapbox/point-geometry';
+import Point from '../symbol/point';
 import clipLine from './clip_line';
 import PathInterpolator from './path_interpolator';
 

--- a/src/symbol/get_anchors.ts
+++ b/src/symbol/get_anchors.ts
@@ -3,7 +3,7 @@ import {number as interpolate} from '../style-spec/util/interpolate';
 import Anchor from '../symbol/anchor';
 import checkMaxAngle from './check_max_angle';
 
-import type Point from '@mapbox/point-geometry';
+import type Point from '../symbol/point';
 import type {Shaping, PositionedIcon} from './shaping';
 
 export {getAnchors, getCenterAnchor};

--- a/src/symbol/path_interpolator.ts
+++ b/src/symbol/path_interpolator.ts
@@ -1,5 +1,5 @@
 import {clamp} from '../util/util';
-import Point from '@mapbox/point-geometry';
+import Point from '../symbol/point';
 import assert from 'assert';
 
 class PathInterpolator {

--- a/src/symbol/placement.ts
+++ b/src/symbol/placement.ts
@@ -7,7 +7,7 @@ import {getAnchorAlignment, WritingMode} from './shaping';
 import {mat4} from 'gl-matrix';
 import assert from 'assert';
 import pixelsToTileUnits from '../source/pixels_to_tile_units';
-import Point from '@mapbox/point-geometry';
+import Point from '../symbol/point';
 import type Transform from '../geo/transform';
 import type StyleLayer from '../style/style_layer';
 

--- a/src/symbol/point.ts
+++ b/src/symbol/point.ts
@@ -1,0 +1,337 @@
+// based on '@mapbox/point-geometry';
+
+/*
+Copyright (c) 2015, Mapbox <>
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+
+import {register} from '../util/web_worker_transfer';
+
+/**
+ * A standalone point geometry with useful accessor, comparison, and
+ * modification methods.
+ *
+ * @class Point
+ * @param {Number} x the x-coordinate. this could be longitude or screen
+ * pixels, or any other sort of unit.
+ * @param {Number} y the y-coordinate. this could be latitude or screen
+ * pixels, or any other sort of unit.
+ * @example
+ * var point = new Point(-77, 38);
+ */
+
+class Point {
+    x: number;
+    y: number;
+
+    constructor(x: number, y: number) {
+        this.x = x;
+        this.y = y;
+    }
+
+    /**
+     * Clone this point, returning a new point that can be modified
+     * without affecting the old one.
+     * @returns {Point} the clone
+     */
+    clone() { return new Point(this.x, this.y); }
+
+    /**
+     * Add this point's x & y coordinates to another point,
+     * yielding a new point.
+     * @param {Point} p the other point
+     * @returns {Point} output point
+     */
+    add(p) { return this.clone()._add(p); }
+
+    /**
+     * Subtract this point's x & y coordinates to from point,
+     * yielding a new point.
+     * @param {Point} p the other point
+     * @returns {Point} output point
+     */
+    sub(p) { return this.clone()._sub(p); }
+
+    /**
+     * Multiply this point's x & y coordinates by point,
+     * yielding a new point.
+     * @param {Point} p the other point
+     * @returns {Point} output point
+     */
+    multByPoint(p) { return this.clone()._multByPoint(p); }
+
+    /**
+     * Divide this point's x & y coordinates by point,
+     * yielding a new point.
+     * @param {Point} p the other point
+     * @returns {Point} output point
+     */
+    divByPoint(p) { return this.clone()._divByPoint(p); }
+
+    /**
+     * Multiply this point's x & y coordinates by a factor,
+     * yielding a new point.
+     * @param {Point} k factor
+     * @returns {Point} output point
+     */
+    mult(k) { return this.clone()._mult(k); }
+
+    /**
+     * Divide this point's x & y coordinates by a factor,
+     * yielding a new point.
+     * @param {Point} k factor
+     * @returns {Point} output point
+     */
+    div(k) { return this.clone()._div(k); }
+
+    /**
+     * Rotate this point around the 0, 0 origin by an angle a,
+     * given in radians
+     * @param {Number} a angle to rotate around, in radians
+     * @returns {Point} output point
+     */
+    rotate(a) { return this.clone()._rotate(a); }
+
+    /**
+     * Rotate this point around p point by an angle a,
+     * given in radians
+     * @param {Number} a angle to rotate around, in radians
+     * @param {Point} p Point to rotate around
+     * @returns {Point} output point
+     */
+    rotateAround(a, p) { return this.clone()._rotateAround(a, p); }
+
+    /**
+     * Multiply this point by a 4x1 transformation matrix
+     * @param {Array<Number>} m transformation matrix
+     * @returns {Point} output point
+     */
+    matMult(m) { return this.clone()._matMult(m); }
+
+    /**
+     * Calculate this point but as a unit vector from 0, 0, meaning
+     * that the distance from the resulting point to the 0, 0
+     * coordinate will be equal to 1 and the angle from the resulting
+     * point to the 0, 0 coordinate will be the same as before.
+     * @returns {Point} unit vector point
+     */
+    unit() { return this.clone()._unit(); }
+
+    /**
+     * Compute a perpendicular point, where the new y coordinate
+     * is the old x coordinate and the new x coordinate is the old y
+     * coordinate multiplied by -1
+     * @returns {Point} perpendicular point
+     */
+    perp() { return this.clone()._perp(); }
+
+    /**
+     * Return a version of this point with the x & y coordinates
+     * rounded to integers.
+     * @returns {Point} rounded point
+     */
+    round() { return this.clone()._round(); }
+
+    /**
+     * Return the magitude of this point: this is the Euclidean
+     * distance from the 0, 0 coordinate to this point's x and y
+     * coordinates.
+     * @returns {Number} magnitude
+     */
+    mag() {
+        return Math.sqrt(this.x * this.x + this.y * this.y);
+    }
+
+    /**
+     * Judge whether this point is equal to another point, returning
+     * true or false.
+     * @param {Point} other the other point
+     * @returns {boolean} whether the points are equal
+     */
+    equals(other) {
+        return this.x === other.x &&
+               this.y === other.y;
+    }
+
+    /**
+     * Calculate the distance from this point to another point
+     * @param {Point} p the other point
+     * @returns {Number} distance
+     */
+    dist(p) {
+        return Math.sqrt(this.distSqr(p));
+    }
+
+    /**
+     * Calculate the distance from this point to another point,
+     * without the square root step. Useful if you're comparing
+     * relative distances.
+     * @param {Point} p the other point
+     * @returns {Number} distance
+     */
+    distSqr(p) {
+        const dx = p.x - this.x;
+        const dy = p.y - this.y;
+        return dx * dx + dy * dy;
+    }
+
+    /**
+     * Get the angle from the 0, 0 coordinate to this point, in radians
+     * coordinates.
+     * @returns {Number} angle
+     */
+    angle() {
+        return Math.atan2(this.y, this.x);
+    }
+
+    /**
+     * Get the angle from this point to another point, in radians
+     * @param {Point} b the other point
+     * @returns {Number} angle
+     */
+    angleTo(b) {
+        return Math.atan2(this.y - b.y, this.x - b.x);
+    }
+
+    /**
+     * Get the angle between this point and another point, in radians
+     * @param {Point} b the other point
+     * @returns {Number} angle
+     */
+    angleWith(b) {
+        return this.angleWithSep(b.x, b.y);
+    }
+
+    /*
+     * Find the angle of the two vectors, solving the formula for
+     * the cross product a x b = |a||b|sin(θ) for θ.
+     * @param {Number} x the x-coordinate
+     * @param {Number} y the y-coordinate
+     * @returns {Number} the angle in radians
+     */
+    angleWithSep(x, y) {
+        return Math.atan2(
+            this.x * y - this.y * x,
+            this.x * x + this.y * y);
+    }
+
+    _matMult(m) {
+        const x = m[0] * this.x + m[1] * this.y;
+        const y = m[2] * this.x + m[3] * this.y;
+        this.x = x;
+        this.y = y;
+        return this;
+    }
+
+    _add(p) {
+        this.x += p.x;
+        this.y += p.y;
+        return this;
+    }
+
+    _sub(p) {
+        this.x -= p.x;
+        this.y -= p.y;
+        return this;
+    }
+
+    _mult(k) {
+        this.x *= k;
+        this.y *= k;
+        return this;
+    }
+
+    _div(k) {
+        this.x /= k;
+        this.y /= k;
+        return this;
+    }
+
+    _multByPoint(p) {
+        this.x *= p.x;
+        this.y *= p.y;
+        return this;
+    }
+
+    _divByPoint(p) {
+        this.x /= p.x;
+        this.y /= p.y;
+        return this;
+    }
+
+    _unit() {
+        this._div(this.mag());
+        return this;
+    }
+
+    _perp() {
+        const y = this.y;
+        this.y = this.x;
+        this.x = -y;
+        return this;
+    }
+
+    _rotate(angle) {
+        const cos = Math.cos(angle);
+        const sin = Math.sin(angle);
+        const x = cos * this.x - sin * this.y;
+        const y = sin * this.x + cos * this.y;
+
+        this.x = x;
+        this.y = y;
+        return this;
+    }
+
+    _rotateAround(angle, p) {
+        const cos = Math.cos(angle);
+        const sin = Math.sin(angle);
+        const x = p.x + cos * (this.x - p.x) - sin * (this.y - p.y);
+        const y = p.y + sin * (this.x - p.x) + cos * (this.y - p.y);
+
+        this.x = x;
+        this.y = y;
+        return this;
+    }
+
+    _round() {
+        this.x = Math.round(this.x);
+        this.y = Math.round(this.y);
+        return this;
+    }
+
+    /**
+     * Construct a point from an array if necessary, otherwise if the input
+     * is already a Point, or an unknown type, return it unchanged
+     * @param {Array<Number>|Point|*} a any kind of input value
+     * @returns {Point} constructed point, or passed-through value.
+     * @example
+     * // this
+     * var point = Point.convert([0, 1]);
+     * // is equivalent to
+     * var point = new Point(0, 1);
+     */
+    static convert = function (a) {
+        if (a instanceof Point) {
+            return a;
+        }
+        if (Array.isArray(a)) {
+            return new Point(a[0], a[1]);
+        }
+        return a;
+    };
+}
+
+register('Point', Point);
+
+export default Point;

--- a/src/symbol/projection.ts
+++ b/src/symbol/projection.ts
@@ -1,4 +1,4 @@
-import Point from '@mapbox/point-geometry';
+import Point from '../symbol/point';
 
 import {mat4, vec4} from 'gl-matrix';
 import * as symbolSize from './symbol_size';

--- a/src/symbol/quads.ts
+++ b/src/symbol/quads.ts
@@ -1,4 +1,4 @@
-import Point from '@mapbox/point-geometry';
+import Point from '../symbol/point';
 
 import {GLYPH_PBF_BORDER} from '../style/parse_glyph_pbf';
 

--- a/src/symbol/symbol_layout.ts
+++ b/src/symbol/symbol_layout.ts
@@ -28,7 +28,7 @@ import type {ImagePosition} from '../render/image_atlas';
 import type {GlyphPosition} from '../render/glyph_atlas';
 import type {PossiblyEvaluatedPropertyValue} from '../style/properties';
 
-import Point from '@mapbox/point-geometry';
+import Point from './point';
 import murmur3 from 'murmurhash-js';
 
 // The symbol layout process needs `text-size` evaluated at up to five different zoom levels, and
@@ -145,25 +145,27 @@ export function evaluateVariableOffset(anchor: TextAnchor, offset: [number, numb
     return (offset[1] !== INVALID_TEXT_OFFSET) ? fromTextOffset(anchor, offset[0], offset[1]) : fromRadialOffset(anchor, offset[0]);
 }
 
-export function performSymbolLayout(bucket: SymbolBucket,
-                             glyphMap: {
-                               [_: string]: {
-                                 [x: number]: StyleGlyph | undefined | null
-                               }
-                             },
-                             glyphPositions: {
-                               [_: string]: {
-                                 [x: number]: GlyphPosition
-                               }
-                             },
-                             imageMap: {
-                               [_: string]: StyleImage
-                             },
-                             imagePositions: {
-                               [_: string]: ImagePosition
-                             },
-                             showCollisionBoxes: boolean,
-                             canonical: CanonicalTileID) {
+export function performSymbolLayout(
+    bucket: SymbolBucket,
+    glyphMap: {
+        [_: string]: {
+            [x: number]: StyleGlyph | undefined | null
+        }
+    },
+    glyphPositions: {
+        [_: string]: {
+            [x: number]: GlyphPosition
+        }
+    },
+    imageMap: {
+        [_: string]: StyleImage
+    },
+    imagePositions: {
+        [_: string]: ImagePosition
+    },
+    showCollisionBoxes: boolean,
+    canonical: CanonicalTileID
+) {
     bucket.createArrays();
 
     const tileSize = 512 * bucket.overscaling;

--- a/src/types/non-typed-modules.d.ts
+++ b/src/types/non-typed-modules.d.ts
@@ -1,5 +1,4 @@
 import type Pbf from 'pbf';
-import type Point from '@mapbox/point-geometry';
 
 declare module "@mapbox/mapbox-gl-supported" {
     type isSupported = {
@@ -28,51 +27,6 @@ declare module "@mapbox/unitbezier" {
     let __exports: typeof UnitBezier;
     export = __exports
 }
-
-declare module "@mapbox/point-geometry" {
-    type PointLike = Point | [number, number];
-
-    export default class Point {
-        x: number;
-        y: number;
-        constructor(x: number, y: number);
-        clone(): Point;
-        add(point: Point): Point;
-        sub(point: Point): Point;
-        multByPoint(point: Point): Point;
-        divByPoint(point: Point): Point;
-        mult(k: number): Point;
-        div(k: number): Point;
-        rotate(angle: number): Point;
-        rotateAround(angle: number, point: Point): Point;
-        matMult(matrix: [number, number, number, number]): Point;
-        unit(): Point;
-        perp(): Point;
-        round(): Point;
-        mag(): number;
-        equals(point: Point): boolean;
-        dist(point: Point): number;
-        distSqr(point: Point): number;
-        angle(): number;
-        angleTo(point: Point): number;
-        angleWith(point: Point): number;
-        angleWithSep(x: number, y: number): number;
-        _matMult(matrix: [number, number, number, number]): Point;
-        _add(point: Point): Point;
-        _sub(point: Point): Point;
-        _mult(k: number): Point;
-        _div(k: number): Point;
-        _multByPoint(point: Point): Point;
-        _divByPoint(point: Point): Point;
-        _unit(): Point;
-        _perp(): Point;
-        _rotate(angle: number): Point;
-        _rotateAround(angle: number, point: Point): Point;
-        _round(): Point;
-        static convert(a: PointLike): Point;
-    }
-}
-
 declare module "potpack" {
     type Bin = {
         x: number,

--- a/src/ui/camera.ts
+++ b/src/ui/camera.ts
@@ -3,7 +3,7 @@ import {number as interpolate} from '../style-spec/util/interpolate';
 import browser from '../util/browser';
 import LngLat from '../geo/lng_lat';
 import LngLatBounds from '../geo/lng_lat_bounds';
-import Point from '@mapbox/point-geometry';
+import Point from '../symbol/point';
 import {Event, Evented} from '../util/evented';
 import assert from 'assert';
 import {Debug} from '../util/debug';

--- a/src/ui/control/navigation_control.ts
+++ b/src/ui/control/navigation_control.ts
@@ -1,4 +1,4 @@
-import Point from '@mapbox/point-geometry';
+import Point from '../../symbol/point';
 
 import DOM from '../../util/dom';
 import {extend, bindAll} from '../../util/util';

--- a/src/ui/events.ts
+++ b/src/ui/events.ts
@@ -1,7 +1,7 @@
 import {Event} from '../util/evented';
 
 import DOM from '../util/dom';
-import Point from '@mapbox/point-geometry';
+import Point from '../symbol/point';
 import {extend} from '../util/util';
 
 import type Map from './map';

--- a/src/ui/handler/box_zoom.ts
+++ b/src/ui/handler/box_zoom.ts
@@ -3,6 +3,7 @@ import DOM from '../../util/dom';
 import {Event} from '../../util/evented';
 
 import type Map from '../map';
+import type Point from '../../symbol/point';
 
 /**
  * The `BoxZoomHandler` allows the user to zoom the map to fit within a bounding box.

--- a/src/ui/handler/click_zoom.ts
+++ b/src/ui/handler/click_zoom.ts
@@ -1,4 +1,4 @@
-import type Point from '@mapbox/point-geometry';
+import type Point from '../../symbol/point';
 import type Map from '../map';
 
 export default class ClickZoomHandler {

--- a/src/ui/handler/handler_util.ts
+++ b/src/ui/handler/handler_util.ts
@@ -1,4 +1,5 @@
 import assert from 'assert';
+import Point from '../../symbol/point';
 
 export function indexTouches(touches: Array<Touch>, points: Array<Point>) {
     assert(touches.length === points.length);

--- a/src/ui/handler/map_event.ts
+++ b/src/ui/handler/map_event.ts
@@ -1,6 +1,6 @@
 import {MapMouseEvent, MapTouchEvent, MapWheelEvent} from '../events';
 import type Map from '../map';
-
+import type Point from '../../symbol/point';
 export class MapEventHandler {
 
     _mousedownPos: Point;

--- a/src/ui/handler/mouse.ts
+++ b/src/ui/handler/mouse.ts
@@ -1,5 +1,5 @@
 import DOM from '../../util/dom';
-import type Point from '@mapbox/point-geometry';
+import type Point from '../../symbol/point';
 
 const LEFT_BUTTON = 0;
 const RIGHT_BUTTON = 2;

--- a/src/ui/handler/scroll_zoom.ts
+++ b/src/ui/handler/scroll_zoom.ts
@@ -9,7 +9,7 @@ import LngLat from '../../geo/lng_lat';
 
 import type Map from '../map';
 import type HandlerManager from '../handler_manager';
-import type Point from '@mapbox/point-geometry';
+import type Point from '../../symbol/point';
 
 // deltaY value for mouse scroll wheel identification
 const wheelZoomDelta = 4.000244140625;

--- a/src/ui/handler/tap_drag_zoom.ts
+++ b/src/ui/handler/tap_drag_zoom.ts
@@ -1,5 +1,5 @@
 import {TapRecognizer, MAX_TAP_INTERVAL} from './tap_recognizer';
-import type Point from '@mapbox/point-geometry';
+import type Point from '../../symbol/point';
 
 export default class TapDragZoomHandler {
 

--- a/src/ui/handler/tap_recognizer.ts
+++ b/src/ui/handler/tap_recognizer.ts
@@ -1,4 +1,4 @@
-import Point from '@mapbox/point-geometry';
+import Point from '../../symbol/point';
 import {indexTouches} from './handler_util';
 
 function getCentroid(points: Array<Point>) {

--- a/src/ui/handler/tap_zoom.ts
+++ b/src/ui/handler/tap_zoom.ts
@@ -1,5 +1,5 @@
 import {TapRecognizer} from './tap_recognizer';
-import type Point from '@mapbox/point-geometry';
+import type Point from '../../symbol/point';
 import type Map from '../map';
 
 export default class TapZoomHandler {

--- a/src/ui/handler/touch_pan.ts
+++ b/src/ui/handler/touch_pan.ts
@@ -1,4 +1,4 @@
-import Point from '@mapbox/point-geometry';
+import Point from '../../symbol/point';
 import {indexTouches} from './handler_util';
 
 export default class TouchPanHandler {

--- a/src/ui/handler/touch_zoom_rotate.ts
+++ b/src/ui/handler/touch_zoom_rotate.ts
@@ -1,4 +1,4 @@
-import Point from '@mapbox/point-geometry';
+import Point from '../../symbol/point';
 import DOM from '../../util/dom';
 
 class TwoTouchHandler {

--- a/src/ui/handler_inertia.ts
+++ b/src/ui/handler_inertia.ts
@@ -1,7 +1,7 @@
 import browser from '../util/browser';
 import type Map from './map';
 import {bezier, clamp, extend} from '../util/util';
-import Point from '@mapbox/point-geometry';
+import Point from '../symbol/point';
 import type {DragPanOptions} from './handler/shim/drag_pan';
 
 const defaultInertiaOptions = {

--- a/src/ui/handler_manager.ts
+++ b/src/ui/handler_manager.ts
@@ -18,7 +18,7 @@ import DragRotateHandler from './handler/shim/drag_rotate';
 import TouchZoomRotateHandler from './handler/shim/touch_zoom_rotate';
 import {bindAll, extend} from '../util/util';
 import window from '../util/window';
-import Point from '@mapbox/point-geometry';
+import Point from '../symbol/point';
 import assert from 'assert';
 
 export type InputEvent = MouseEvent | TouchEvent | KeyboardEvent | WheelEvent;

--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -14,7 +14,7 @@ import HandlerManager from './handler_manager';
 import Camera from './camera';
 import LngLat from '../geo/lng_lat';
 import LngLatBounds from '../geo/lng_lat_bounds';
-import Point from '@mapbox/point-geometry';
+import Point from '../symbol/point';
 import AttributionControl from './control/attribution_control';
 import LogoControl from './control/logo_control';
 import isSupported from '@mapbox/mapbox-gl-supported';

--- a/src/ui/marker.ts
+++ b/src/ui/marker.ts
@@ -1,7 +1,7 @@
 import DOM from '../util/dom';
 import window from '../util/window';
 import LngLat from '../geo/lng_lat';
-import Point from '@mapbox/point-geometry';
+import Point from '../symbol/point';
 import smartWrap from '../util/smart_wrap';
 import {bindAll, extend} from '../util/util';
 import {anchorTranslate, applyAnchorClass} from './anchor';

--- a/src/ui/popup.ts
+++ b/src/ui/popup.ts
@@ -3,7 +3,7 @@ import {Event, Evented} from '../util/evented';
 import {MapMouseEvent} from '../ui/events';
 import DOM from '../util/dom';
 import LngLat from '../geo/lng_lat';
-import Point from '@mapbox/point-geometry';
+import Point from '../symbol/point';
 import window from '../util/window';
 import smartWrap from '../util/smart_wrap';
 import {anchorTranslate, applyAnchorClass} from './anchor';

--- a/src/util/browser.ts
+++ b/src/util/browser.ts
@@ -5,15 +5,15 @@ const now = window.performance && window.performance.now ?
     window.performance.now.bind(window.performance) :
     Date.now.bind(Date);
 
-const raf = window.requestAnimationFrame ||
-    window.mozRequestAnimationFrame ||
-    window.webkitRequestAnimationFrame ||
-    window.msRequestAnimationFrame;
+const raf = window.requestAnimationFrame; // ||
+// window.mozRequestAnimationFrame ||
+// window.webkitRequestAnimationFrame ||
+// window.msRequestAnimationFrame;
 
-const cancel = window.cancelAnimationFrame ||
-    window.mozCancelAnimationFrame ||
-    window.webkitCancelAnimationFrame ||
-    window.msCancelAnimationFrame;
+const cancel = window.cancelAnimationFrame; // ||
+// window.mozCancelAnimationFrame ||
+// window.webkitCancelAnimationFrame ||
+// window.msCancelAnimationFrame;
 
 let linkEl;
 

--- a/src/util/browser/window.ts
+++ b/src/util/browser/window.ts
@@ -1,5 +1,5 @@
 /* eslint-env browser */
-import type {Window} from '../../types/window';
+// import type {Window} from '../../types/window';
 
 // shim window for the case of requiring the browser bundle in Node
 export default typeof self !== 'undefined' ? (self as Window) : ({} as any as Window);

--- a/src/util/classify_rings.ts
+++ b/src/util/classify_rings.ts
@@ -2,7 +2,7 @@ import quickselect from 'quickselect';
 
 import {calculateSignedArea} from './util';
 
-import type Point from '@mapbox/point-geometry';
+import type Point from '../symbol/point';
 
 // classifies an array of rings into polygons with outer rings and holes
 export default function classifyRings(rings: Array<Array<Point>>, maxRings: number) {

--- a/src/util/dom.ts
+++ b/src/util/dom.ts
@@ -1,4 +1,4 @@
-import Point from '@mapbox/point-geometry';
+import Point from '../symbol/point';
 
 import window from './window';
 import assert from 'assert';
@@ -152,13 +152,15 @@ DOM.touchPos = function (el: HTMLElement, touches: TouchList) {
 
 DOM.mouseButton = function (e: MouseEvent) {
     assert(e.type === 'mousedown' || e.type === 'mouseup');
-    if (typeof window.InstallTrigger !== 'undefined' && e.button === 2 && e.ctrlKey &&
-        window.navigator.platform.toUpperCase().indexOf('MAC') >= 0) {
-        // Fix for https://github.com/mapbox/mapbox-gl-js/issues/3131:
-        // Firefox (detected by InstallTrigger) on Mac determines e.button = 2 when
-        // using Control + left click
-        return 0;
-    }
+    // this issue is a fix for FF 50 on mac, current version is 90
+    // confirm unsupported InstallTrigger does not cause this bug in modern versions
+    // if (typeof window.InstallTrigger !== 'undefined' && e.button === 2 && e.ctrlKey &&
+    //     window.navigator.platform.toUpperCase().indexOf('MAC') >= 0) {
+    //     // Fix for https://github.com/mapbox/mapbox-gl-js/issues/3131:
+    //     // Firefox (detected by InstallTrigger) on Mac determines e.button = 2 when
+    //     // using Control + left click
+    //     return 0;
+    // }
     return e.button;
 };
 

--- a/src/util/find_pole_of_inaccessibility.ts
+++ b/src/util/find_pole_of_inaccessibility.ts
@@ -1,6 +1,6 @@
 import Queue from 'tinyqueue';
 
-import Point from '@mapbox/point-geometry';
+import Point from '../symbol/point';
 import {distToSegmentSquared} from './intersection_tests';
 
 /**

--- a/src/util/intersection_tests.ts
+++ b/src/util/intersection_tests.ts
@@ -1,6 +1,6 @@
 import {isCounterClockwise} from './util';
 
-import Point from '@mapbox/point-geometry';
+import Point from '../symbol/point';
 
 export {polygonIntersectsBufferedPoint, polygonIntersectsMultiPolygon, polygonIntersectsBufferedMultiLine, polygonIntersectsPolygon, distToSegmentSquared, polygonIntersectsBox};
 

--- a/src/util/smart_wrap.ts
+++ b/src/util/smart_wrap.ts
@@ -1,6 +1,6 @@
 import LngLat from '../geo/lng_lat';
 
-import type Point from '@mapbox/point-geometry';
+import type Point from '../symbol/point';
 import type Transform from '../geo/transform';
 
 /**

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -1,6 +1,6 @@
 import UnitBezier from '@mapbox/unitbezier';
 
-import Point from '@mapbox/point-geometry';
+import Point from '../symbol/point';
 import window from './window';
 
 import type {Callback} from '../types/callback';

--- a/src/util/window.ts
+++ b/src/util/window.ts
@@ -9,7 +9,7 @@ import jsdom from 'jsdom';
 import gl from 'gl';
 import sinon from 'sinon';
 
-import type {Window} from '../types/window';
+// import type {Window} from '../types/window';
 
 const {window: _window} = new jsdom.JSDOM('', {
     virtualConsole: new jsdom.VirtualConsole().sendTo(console)

--- a/test/unit/data/fill_bucket.test.js
+++ b/test/unit/data/fill_bucket.test.js
@@ -3,7 +3,7 @@ import fs from 'fs';
 import path from 'path';
 import Protobuf from 'pbf';
 import {VectorTile} from '@mapbox/vector-tile';
-import Point from '@mapbox/point-geometry';
+import Point from '../../../src/symbol/point';
 import segment from '../../../src/data/segment';
 import FillBucket from '../../../src/data/bucket/fill_bucket';
 import FillStyleLayer from '../../../src/style/style_layer/fill_style_layer';

--- a/test/unit/data/line_bucket.test.js
+++ b/test/unit/data/line_bucket.test.js
@@ -3,7 +3,7 @@ import fs from 'fs';
 import path from 'path';
 import Protobuf from 'pbf';
 import {VectorTile} from '@mapbox/vector-tile';
-import Point from '@mapbox/point-geometry';
+import Point from '../../../src/symbol/point';
 import segment from '../../../src/data/segment';
 import LineBucket from '../../../src/data/bucket/line_bucket';
 import LineStyleLayer from '../../../src/style/style_layer/line_style_layer';

--- a/test/unit/geo/transform.test.js
+++ b/test/unit/geo/transform.test.js
@@ -1,5 +1,5 @@
 import {test} from '../../util/test';
-import Point from '@mapbox/point-geometry';
+import Point from '../../../src/symbol/point';
 import Transform from '../../../src/geo/transform';
 import LngLat from '../../../src/geo/lng_lat';
 import {OverscaledTileID, CanonicalTileID} from '../../../src/source/tile_id';

--- a/test/unit/source/source_cache.test.js
+++ b/test/unit/source/source_cache.test.js
@@ -5,7 +5,7 @@ import Tile from '../../../src/source/tile';
 import {OverscaledTileID} from '../../../src/source/tile_id';
 import Transform from '../../../src/geo/transform';
 import LngLat from '../../../src/geo/lng_lat';
-import Point from '@mapbox/point-geometry';
+import Point from '../../../src/symbol/point';
 import {Event, ErrorEvent, Evented} from '../../../src/util/evented';
 import {extend} from '../../../src/util/util';
 import browser from '../../../src/util/browser';

--- a/test/unit/style-spec/feature_filter.test.js
+++ b/test/unit/style-spec/feature_filter.test.js
@@ -2,7 +2,7 @@ import {test} from '../../util/test';
 import {default as createFilter, isExpressionFilter} from '../../../src/style-spec/feature_filter';
 
 import convertFilter from '../../../src/style-spec/feature_filter/convert';
-import Point from '@mapbox/point-geometry';
+import Point from '../../../src/symbol/point';
 import MercatorCoordinate from '../../../src/geo/mercator_coordinate';
 import EXTENT from '../../../src/data/extent';
 

--- a/test/unit/style/style_layer/fill_extrusion_style_layer.js
+++ b/test/unit/style/style_layer/fill_extrusion_style_layer.js
@@ -1,6 +1,6 @@
 import {test} from '../../../util/test';
 import {getIntersectionDistance} from '../../../../src/style/style_layer/fill_extrusion_style_layer';
-import Point from '@mapbox/point-geometry';
+import Point from '../../../../src/symbol/point';
 
 test('getIntersectionDistance', (t) => {
     const queryPoint = [new Point(100, 100)];

--- a/test/unit/symbol/check_max_angle.test.js
+++ b/test/unit/symbol/check_max_angle.test.js
@@ -1,5 +1,5 @@
 import {test} from '../../util/test';
-import Point from '@mapbox/point-geometry';
+import Point from '../../../src/symbol/point';
 import checkMaxAngle from '../../../src/symbol/check_max_angle';
 import Anchor from '../../../src/symbol/anchor';
 

--- a/test/unit/symbol/clip_line.test.js
+++ b/test/unit/symbol/clip_line.test.js
@@ -1,5 +1,5 @@
 import {test} from '../../util/test';
-import Point from '@mapbox/point-geometry';
+import Point from '../../../src/symbol/point';
 import clipLine from '../../../src/symbol/clip_line';
 
 test('clipLines', (t) => {

--- a/test/unit/symbol/collision_feature.js
+++ b/test/unit/symbol/collision_feature.js
@@ -1,7 +1,7 @@
 import {test} from '../../util/test';
 import CollisionFeature from '../../../src/symbol/collision_feature';
 import Anchor from '../../../src/symbol/anchor';
-import Point from '@mapbox/point-geometry';
+import Point from '../../../src/symbol/point';
 import {CollisionBoxArray} from '../../../src/data/array_types';
 
 test('CollisionFeature', (t) => {

--- a/test/unit/symbol/get_anchors.test.js
+++ b/test/unit/symbol/get_anchors.test.js
@@ -1,5 +1,5 @@
 import {test} from '../../util/test';
-import Point from '@mapbox/point-geometry';
+import Point from '../../../src/symbol/point';
 import {getAnchors, getCenterAnchor} from '../../../src/symbol/get_anchors';
 
 const TILE_EXTENT = 4096;

--- a/test/unit/symbol/mergelines.test.js
+++ b/test/unit/symbol/mergelines.test.js
@@ -1,6 +1,6 @@
 import {test} from '../../util/test';
 import mergeLines from '../../../src/symbol/mergelines';
-import Point from '@mapbox/point-geometry';
+import Point from '../../../src/symbol/point';
 
 function makeFeatures(lines) {
     const features = [];

--- a/test/unit/symbol/path_interpolator.test.js
+++ b/test/unit/symbol/path_interpolator.test.js
@@ -1,5 +1,5 @@
 import {test} from '../../util/test';
-import Point from '@mapbox/point-geometry';
+import Point from '../../../src/symbol/point';
 import PathInterpolator from '../../../src/symbol/path_interpolator';
 
 test('PathInterpolator', (t) => {

--- a/test/unit/ui/marker.test.js
+++ b/test/unit/ui/marker.test.js
@@ -4,7 +4,7 @@ import {createMap as globalCreateMap} from '../../util';
 import Marker from '../../../src/ui/marker';
 import Popup from '../../../src/ui/popup';
 import LngLat from '../../../src/geo/lng_lat';
-import Point from '@mapbox/point-geometry';
+import Point from '../../../src/symbol/point';
 import simulate from '../../util/simulate_interaction';
 
 function createMap(t, options = {}) {

--- a/test/unit/ui/popup.test.js
+++ b/test/unit/ui/popup.test.js
@@ -3,7 +3,7 @@ import window from '../../../src/util/window';
 import {createMap as globalCreateMap} from '../../util';
 import Popup from '../../../src/ui/popup';
 import LngLat from '../../../src/geo/lng_lat';
-import Point from '@mapbox/point-geometry';
+import Point from '../../../src/symbol/point';
 import simulate from '../../util/simulate_interaction';
 
 const containerWidth = 512;

--- a/test/unit/util/find_pole_of_inaccessibility.test.js
+++ b/test/unit/util/find_pole_of_inaccessibility.test.js
@@ -1,5 +1,5 @@
 import {test} from '../../util/test';
-import Point from '@mapbox/point-geometry';
+import Point from '../../../src/symbol/point';
 import findPoleOfInaccessibility from '../../../src/util/find_pole_of_inaccessibility';
 
 test('polygon_poi', (t) => {

--- a/test/unit/util/util.test.js
+++ b/test/unit/util/util.test.js
@@ -3,7 +3,7 @@
 import {test} from '../../util/test';
 
 import {easeCubicInOut, keysDifference, extend, pick, uniqueId, bindAll, asyncAll, clamp, wrap, bezier, endsWith, mapObject, filterObject, deepEqual, clone, arraysIntersect, isCounterClockwise, isClosedPolygon, parseCacheControl, uuid, validateUuid, nextPowerOfTwo, isPowerOfTwo} from '../../../src/util/util';
-import Point from '@mapbox/point-geometry';
+import Point from '../../../src/symbol/point';
 
 test('util', (t) => {
     t.equal(easeCubicInOut(0), 0, 'easeCubicInOut=0');


### PR DESCRIPTION
 - [x] confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] briefly describe the changes in this PR
 
Somehow this change seems to be **increasing** the number of errors compared to latest `typescript` branch although I'm not yet sure which errors. Before rebase it was an improvement but maybe the required changes are not as simple as just reducing a single set of errors.