### PR TITLE
Typescript: fix lint and update .eslintrc with alternate TS rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -20,7 +20,6 @@
     "@typescript-eslint/restrict-plus-operands": "off",
     "@typescript-eslint/restrict-template-expressions": "off",
     "@typescript-eslint/explicit-module-boundary-types": "off",
-    // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-dupe-class-members.md
     "no-dupe-class-members": "off",
     "@typescript-eslint/no-dupe-class-members": ["error"],
     "@typescript-eslint/no-unused-vars": [

--- a/.eslintrc
+++ b/.eslintrc
@@ -20,6 +20,9 @@
     "@typescript-eslint/restrict-plus-operands": "off",
     "@typescript-eslint/restrict-template-expressions": "off",
     "@typescript-eslint/explicit-module-boundary-types": "off",
+    // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-dupe-class-members.md
+    "no-dupe-class-members": "off",
+    "@typescript-eslint/no-dupe-class-members": ["error"],
     "@typescript-eslint/no-unused-vars": [
       "warn",
       { "argsIgnorePattern": "^_" }

--- a/src/geo/transform.ts
+++ b/src/geo/transform.ts
@@ -5,7 +5,7 @@ import Point from '../symbol/point';
 import {wrap, clamp} from '../util/util';
 import {number as interpolate} from '../style-spec/util/interpolate';
 import EXTENT from '../data/extent';
-import {vec4, mat4, mat2, vec2, vec3} from 'gl-matrix';
+import {vec4, mat4, mat2, vec2} from 'gl-matrix';
 import {Aabb, Frustum} from "../util/primitives";
 import EdgeInsets from './edge_insets';
 

--- a/src/ui/control/fullscreen_control.ts
+++ b/src/ui/control/fullscreen_control.ts
@@ -22,7 +22,7 @@ type Options = {
  * @see [View a fullscreen map](https://maplibre.org/maplibre-gl-js-docs/example/fullscreen/)
  */
 
-class FullscreenControl implements IControl {
+class FullscreenControl implements IControl {
     _map: Map;
     _controlContainer: HTMLElement;
     _fullscreen: boolean;


### PR DESCRIPTION
 - [x] confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] briefly describe the changes in this PR
 
JavaScript behaves slightly differently with overriding class members. In JS they are just overridden completely, in TS they are overridden in type, so it is fine to have multiple similarly named members. This change to .eslintrc switches off the JS rule and adds the relevant TS rule to allow correct behavior.