### PR TITLE
Typescript: !! hacky fixes.. down to 0 errors !! DO NOT MERGE !! WIP

### DIFF
--- a/src/data/program_configuration.ts
+++ b/src/data/program_configuration.ts
@@ -28,6 +28,7 @@ import type {
 } from '../style-spec/expression';
 import type {FeatureStates} from '../source/source_state';
 import type {FormattedSection} from '../style-spec/expression/types/formatted';
+import {StylePropertyTypeType} from '../style-spec/style-spec';
 
 export type BinderUniform = {
   name: string,
@@ -106,10 +107,10 @@ interface UniformBinder {
 
 class ConstantBinder implements UniformBinder {
     value: unknown;
-    type: string;
+    type: StylePropertyTypeType;
     uniformNames: Array<string>;
 
-    constructor(value: unknown, names: Array<string>, type: string) {
+    constructor(value: unknown, names: Array<string>, type: StylePropertyTypeType) {
         this.value = value;
         this.uniformNames = names.map(name => `u_${name}`);
         this.type = type;
@@ -124,7 +125,7 @@ class ConstantBinder implements UniformBinder {
     }
 
     getBinding(context: Context, location: WebGLUniformLocation, _: string): Partial<Uniform<any>> {
-        return (this.type === 'color') ?
+        return (this.type === StylePropertyTypeType.color) ?
             new UniformColor(context, location) :
             new Uniform1f(context, location);
     }
@@ -170,14 +171,14 @@ class CrossFadedConstantBinder implements UniformBinder {
 
 class SourceExpressionBinder implements AttributeBinder {
     expression: SourceExpression;
-    type: string;
+    type: StylePropertyTypeType;
     maxValue: number;
 
     paintVertexArray: StructArray;
     paintVertexAttributes: Array<StructArrayMember>;
     paintVertexBuffer: VertexBuffer | undefined | null;
 
-    constructor(expression: SourceExpression, names: Array<string>, type: string, PaintVertexArray: {
+    constructor(expression: SourceExpression, names: Array<string>, type: StylePropertyTypeType, PaintVertexArray: {
       new (...args: any): StructArray
     }) {
         this.expression = expression;
@@ -186,7 +187,7 @@ class SourceExpressionBinder implements AttributeBinder {
         this.paintVertexAttributes = names.map((name) => ({
             name: `a_${name}`,
             type: 'Float32',
-            components: type === 'color' ? 2 : 1,
+            components: type === StylePropertyTypeType.color ? 2 : 1,
             offset: 0
         }));
         this.paintVertexArray = new PaintVertexArray();
@@ -327,7 +328,7 @@ class CompositeExpressionBinder implements AttributeBinder, UniformBinder {
 
 class CrossFadedCompositeBinder implements AttributeBinder {
     expression: CompositeExpression;
-    type: string;
+    type: StylePropertyTypeType;
     useIntegerZoom: boolean;
     zoom: number;
     layerId: string;
@@ -338,7 +339,7 @@ class CrossFadedCompositeBinder implements AttributeBinder {
     zoomOutPaintVertexBuffer: VertexBuffer | undefined | null;
     paintVertexAttributes: Array<StructArrayMember>;
 
-    constructor(expression: CompositeExpression, type: string, useIntegerZoom: boolean, zoom: number, PaintVertexArray: {
+    constructor(expression: CompositeExpression, type: StylePropertyTypeType, useIntegerZoom: boolean, zoom: number, PaintVertexArray: {
       new (...args: any): StructArray
     }, layerId: string) {
         this.expression = expression;

--- a/src/style-spec/expression/index.ts
+++ b/src/style-spec/expression/index.ts
@@ -18,7 +18,7 @@ import {supportsPropertyExpression, supportsZoomExpression, supportsInterpolatio
 import type {Type, EvaluationKind} from './types';
 import type {Value} from './values';
 import type {Expression} from './expression';
-import type {StylePropertySpecification} from '../style-spec';
+import {StylePropertySpecification, StylePropertyTypeType} from '../style-spec';
 import type {Result} from '../util/result';
 import type {InterpolationType} from './definitions/interpolate';
 import type {PropertyValueSpecification} from '../types';
@@ -451,7 +451,7 @@ function getExpectedType(spec: StylePropertySpecification): Type {
         resolvedImage: ResolvedImageType
     };
 
-    if (spec.type === 'array') {
+    if (spec.type === StylePropertyTypeType.numberArray || spec.type === StylePropertyTypeType.stringArray) {
         return array(types[spec.value] || ValueType, spec.length);
     }
 

--- a/src/style-spec/style-spec.ts
+++ b/src/style-spec/style-spec.ts
@@ -6,58 +6,126 @@ type ExpressionSpecification = {
   parameters: ExpressionParameters
 };
 
+export enum StylePropertyTypeType {
+    number = "number",
+    string = "string",
+    boolean = "boolean",
+    enum = "enum",
+    color = "color",
+
+    // these are new types because they have different value type
+    stringArray = "stringArray",
+    numberArray = "numberArray",
+}
+
+// temporarily break into types to understand better what is the issue
 export type StylePropertySpecification = {
-  type: "number",
-  'property-type': ExpressionType,
-  expression?: ExpressionSpecification,
-  transition: boolean,
-  default?: number
+    type: StylePropertyTypeType.number,
+    'property-type': ExpressionType,
+    expression?: ExpressionSpecification,
+    transition: boolean,
+    default?: number
 } | {
-  type: "string",
-  'property-type': ExpressionType,
-  expression?: ExpressionSpecification,
-  transition: boolean,
-  default?: string,
-  tokens?: boolean
+    type: StylePropertyTypeType.string,
+    'property-type': ExpressionType,
+    expression?: ExpressionSpecification,
+    transition: boolean,
+    default?: string,
+    tokens?: boolean
 } | {
-  type: "boolean",
-  'property-type': ExpressionType,
-  expression?: ExpressionSpecification,
-  transition: boolean,
-  default?: boolean
+    type: StylePropertyTypeType.boolean,
+    'property-type': ExpressionType,
+    expression?: ExpressionSpecification,
+    transition: boolean,
+    default?: boolean
 } | {
-  type: "enum",
-  'property-type': ExpressionType,
-  expression?: ExpressionSpecification,
-  values: {
-    [_: string]: {}
-  },
-  transition: boolean,
-  default?: string
+    type: StylePropertyTypeType.enum,
+    'property-type': ExpressionType,
+    expression?: ExpressionSpecification,
+    values: {
+      [_: string]: {}
+    },
+    transition: boolean,
+    default?: string
 } | {
-  type: "color",
-  'property-type': ExpressionType,
-  expression?: ExpressionSpecification,
-  transition: boolean,
-  default?: string,
-  overridable: boolean
+    type: StylePropertyTypeType.color,
+    'property-type': ExpressionType,
+    expression?: ExpressionSpecification,
+    transition: boolean,
+    default?: string,
+    overridable: boolean
 } | {
-  type: "array",
-  value: "number",
-  'property-type': ExpressionType,
-  expression?: ExpressionSpecification,
-  length?: number,
-  transition: boolean,
-  default?: Array<number>
+    // use different types to help ts with discriminated union
+    type: StylePropertyTypeType.numberArray,
+    value: "number",
+    'property-type': ExpressionType,
+    expression?: ExpressionSpecification,
+    length?: number,
+    transition: boolean,
+    default?: Array<number>
 } | {
-  type: "array",
-  value: "string",
-  'property-type': ExpressionType,
-  expression?: ExpressionSpecification,
-  length?: number,
-  transition: boolean,
-  default?: Array<string>
+    // use different types to help ts with discriminated union
+    type: StylePropertyTypeType.stringArray,
+    value: "string",
+    'property-type': ExpressionType,
+    expression?: ExpressionSpecification,
+    length?: number,
+    transition: boolean,
+    default?: Array<string>
 };
+
+// export type StylePropertySpecification = {
+//   type: "number",
+//   'property-type': ExpressionType,
+//   expression?: ExpressionSpecification,
+//   transition: boolean,
+//   default?: number
+// } | {
+//   type: "string",
+//   'property-type': ExpressionType,
+//   expression?: ExpressionSpecification,
+//   transition: boolean,
+//   default?: string,
+//   tokens?: boolean
+// } | {
+//   type: "boolean",
+//   'property-type': ExpressionType,
+//   expression?: ExpressionSpecification,
+//   transition: boolean,
+//   default?: boolean
+// } | {
+//   type: "enum",
+//   'property-type': ExpressionType,
+//   expression?: ExpressionSpecification,
+//   values: {
+//     [_: string]: {}
+//   },
+//   transition: boolean,
+//   default?: string
+// } | {
+//   type: "color",
+//   'property-type': ExpressionType,
+//   expression?: ExpressionSpecification,
+//   transition: boolean,
+//   default?: string,
+//   overridable: boolean
+// } | {
+//   type: "array",
+//   value: "number",
+//   'property-type': ExpressionType,
+//   expression?: ExpressionSpecification,
+//   length?: number,
+//   transition: boolean,
+//   default?: Array<number>
+// } | {
+//   type: "array",
+//   value: "string",
+//   'property-type': ExpressionType,
+//   expression?: ExpressionSpecification,
+//   length?: number,
+//   transition: boolean,
+//   default?: Array<string>
+// };
 
 import v8 from './reference/v8.json';
 import latest from './reference/latest';

--- a/src/style/light.ts
+++ b/src/style/light.ts
@@ -33,7 +33,7 @@ class LightPositionProperty implements Property<[number, number, number], LightP
     specification: StylePropertySpecification;
 
     constructor() {
-        this.specification = styleSpec.light.position;
+        this.specification = styleSpec.light.position as any;
     }
 
     possiblyEvaluate(
@@ -60,10 +60,10 @@ type Props = {
 };
 
 const properties: Properties<Props> = new Properties({
-    "anchor": new DataConstantProperty(styleSpec.light.anchor),
+    "anchor": new DataConstantProperty(styleSpec.light.anchor as any),
     "position": new LightPositionProperty(),
-    "color": new DataConstantProperty(styleSpec.light.color),
-    "intensity": new DataConstantProperty(styleSpec.light.intensity),
+    "color": new DataConstantProperty(styleSpec.light.color as any),
+    "intensity": new DataConstantProperty(styleSpec.light.intensity as any),
 });
 
 const TRANSITION_SUFFIX = '-transition';
@@ -74,7 +74,7 @@ const TRANSITION_SUFFIX = '-transition';
 class Light extends Evented {
     _transitionable: Transitionable<Props>;
     _transitioning: Transitioning<Props>;
-    properties: PossiblyEvaluated<Props>;
+    properties: any; // PossiblyEvaluated<Props>;
 
     constructor(lightOptions?: LightSpecification) {
         super();

--- a/src/style/properties.ts
+++ b/src/style/properties.ts
@@ -9,7 +9,7 @@ import {CanonicalTileID} from '../source/tile_id';
 import {StylePropertySpecification} from '../style-spec/style-spec';
 import {
     TransitionSpecification,
-    PropertyValueSpecification
+    // PropertyValueSpecification
 } from '../style-spec/types';
 
 import {
@@ -95,10 +95,11 @@ export interface Property<T, R> {
  */
 export class PropertyValue<T, R> {
     property: Property<T, R>;
-    value: PropertyValueSpecification<T> | void;
+    value: any; // PropertyValueSpecification<T> | void;
     expression: StylePropertyExpression;
 
-    constructor(property: Property<T, R>, value: PropertyValueSpecification<T> | void) {
+    // constructor(property: Property<T, R>, value: PropertyValueSpecification<T> | void) {
+    constructor(property, value) {
         this.property = property;
         this.value = value;
         this.expression = normalizePropertyExpression(value === undefined ? property.specification.default : value, property.specification);
@@ -165,18 +166,20 @@ class TransitionablePropertyValue<T, R> {
  */
 export class Transitionable<Props> {
     _properties: Properties<Props>;
-    _values: TransitionablePropertyValues<Props>;
+    _values: any // TransitionablePropertyValues<Props>;
 
     constructor(properties: Properties<Props>) {
         this._properties = properties;
         this._values = (Object.create(properties.defaultTransitionablePropertyValues) as any);
     }
 
-    getValue<S extends keyof Props, T>(name: S): PropertyValueSpecification<T> | void {
+    // getValue<S extends keyof Props, T>(name: S): PropertyValueSpecification<T> | void {
+    getValue(name) {
         return clone(this._values[name].value.value);
     }
 
-    setValue<S extends keyof Props, T>(name: S, value: PropertyValueSpecification<T> | void) {
+    // setValue<S extends keyof Props, T>(name: S, value: PropertyValueSpecification<T> | void) {
+    setValue(name, value) {
         if (!Object.prototype.hasOwnProperty.call(this._values, name)) {
             this._values[name] = new TransitionablePropertyValue(this._values[name].property);
         }
@@ -185,11 +188,13 @@ export class Transitionable<Props> {
         this._values[name].value = new PropertyValue(this._values[name].property, value === null ? undefined : clone(value));
     }
 
-    getTransition<S extends keyof Props>(name: S): TransitionSpecification | void {
+    // getTransition<S extends keyof Props>(name: S): TransitionSpecification | void {
+    getTransition(name) {
         return clone(this._values[name].transition);
     }
 
-    setTransition<S extends keyof Props>(name: S, value: TransitionSpecification | void) {
+    // setTransition<S extends keyof Props>(name: S, value: TransitionSpecification | void) {
+    setTransition(name, value) {
         if (!Object.prototype.hasOwnProperty.call(this._values, name)) {
             this._values[name] = new TransitionablePropertyValue(this._values[name].property);
         }
@@ -302,7 +307,7 @@ class TransitioningPropertyValue<T, R> {
  */
 export class Transitioning<Props> {
     _properties: Properties<Props>;
-    _values: TransitioningPropertyValues<Props>;
+    _values: any; // TransitioningPropertyValues<Props>;
 
     constructor(properties: Properties<Props>) {
         this._properties = properties;
@@ -313,7 +318,8 @@ export class Transitioning<Props> {
       parameters: EvaluationParameters,
       canonical?: CanonicalTileID,
       availableImages?: Array<string>
-    ): PossiblyEvaluated<Props> {
+    ) {
+    // ): PossiblyEvaluated<Props> {
         const result = new PossiblyEvaluated(this._properties); // eslint-disable-line no-use-before-define
         for (const property of Object.keys(this._values)) {
             result._values[property] = this._values[property].possiblyEvaluate(parameters, canonical, availableImages);
@@ -346,14 +352,15 @@ export class Transitioning<Props> {
  */
 export class Layout<Props> {
     _properties: Properties<Props>;
-    _values: PropertyValues<Props>;
+    _values: any; // PropertyValues<Props>;
 
     constructor(properties: Properties<Props>) {
         this._properties = properties;
         this._values = (Object.create(properties.defaultPropertyValues) as any);
     }
 
-    getValue<S extends (keyof Props)>(name: S) {
+    // getValue<S extends (keyof Props)>(name: S) {
+    getValue(name) {
         return clone(this._values[name].value);
     }
 
@@ -364,7 +371,8 @@ export class Layout<Props> {
     serialize() {
         const result: any = {};
         for (const property of Object.keys(this._values)) {
-            const value = this.getValue(property as keyof PropertyValues<Props>);
+            const value = this.getValue(property);
+            // const value = this.getValue(property as keyof PropertyValues<Props>);
             if (value !== undefined) {
                 result[property] = value;
             }
@@ -376,7 +384,8 @@ export class Layout<Props> {
       parameters: EvaluationParameters,
       canonical?: CanonicalTileID,
       availableImages?: Array<string>
-    ): PossiblyEvaluated<Props> {
+    // ): PossiblyEvaluated<Props> {
+    ) {
         const result = new PossiblyEvaluated(this._properties); // eslint-disable-line no-use-before-define
         for (const property of Object.keys(this._values)) {
             result._values[property] = this._values[property].possiblyEvaluate(parameters, canonical, availableImages);
@@ -725,12 +734,15 @@ export class ColorRampProperty implements Property<Color, boolean> {
  *
  * @private
  */
+
+// props is an array of keys and string values
+
 export class Properties<Props> {
     properties: Props;
-    defaultPropertyValues: PropertyValues<Props>;
-    defaultTransitionablePropertyValues: TransitionablePropertyValues<Props>;
-    defaultTransitioningPropertyValues: TransitioningPropertyValues<Props>;
-    defaultPossiblyEvaluatedValues: PossiblyEvaluatedPropertyValues<Props>;
+    defaultPropertyValues: any; // PropertyValues<Props>;
+    defaultTransitionablePropertyValues: any; // TransitionablePropertyValues<Props>;
+    defaultTransitioningPropertyValues: any; // TransitioningPropertyValues<Props>;
+    defaultPossiblyEvaluatedValues: any; // PossiblyEvaluatedPropertyValues<Props>;
     overridableProperties: Array<string>;
 
     constructor(properties: Props) {
@@ -739,22 +751,39 @@ export class Properties<Props> {
         this.defaultTransitionablePropertyValues = ({} as any);
         this.defaultTransitioningPropertyValues = ({} as any);
         this.defaultPossiblyEvaluatedValues = ({} as any);
-        this.overridableProperties = ([] as any);
+        this.overridableProperties = [];
 
-        for (const property in properties) {
-            const prop = properties[property];
-            if (prop.specification.overridable) {
-                this.overridableProperties.push(property);
+        Object.entries(properties).forEach(([k, v]) => {
+            if (v.specification.overridable) {
+                this.overridableProperties.push(k);
             }
-            const defaultPropertyValue = this.defaultPropertyValues[property] =
-                new PropertyValue(prop, undefined);
-            const defaultTransitionablePropertyValue = this.defaultTransitionablePropertyValues[property] =
-                new TransitionablePropertyValue(prop);
-            this.defaultTransitioningPropertyValues[property] =
+
+            const defaultPropertyValue = this.defaultPropertyValues[k] =
+                new PropertyValue(v, undefined);
+            const defaultTransitionablePropertyValue = this.defaultTransitionablePropertyValues[k] =
+                new TransitionablePropertyValue(v);
+            this.defaultTransitioningPropertyValues[k] =
                 defaultTransitionablePropertyValue.untransitioned();
-            this.defaultPossiblyEvaluatedValues[property] =
+            this.defaultPossiblyEvaluatedValues[k] =
                 defaultPropertyValue.possiblyEvaluate((({} as any)));
-        }
+        });
+
+        // why don't we just use Object.values?
+        // for (const property in properties) {
+        //     const prop = properties[property];
+        //     // if value has specification.overridable === true
+        //     if (prop.specification.overridable) {
+        //         this.overridableProperties.push(property);
+        //     }
+        //     const defaultPropertyValue = this.defaultPropertyValues[property] =
+        //         new PropertyValue(prop, undefined);
+        //     const defaultTransitionablePropertyValue = this.defaultTransitionablePropertyValues[property] =
+        //         new TransitionablePropertyValue(prop as any);
+        //     this.defaultTransitioningPropertyValues[property] =
+        //         defaultTransitionablePropertyValue.untransitioned();
+        //     this.defaultPossiblyEvaluatedValues[property] =
+        //         defaultPropertyValue.possiblyEvaluate((({} as any)));
+        // }
     }
 }
 

--- a/src/util/worker_pool.ts
+++ b/src/util/worker_pool.ts
@@ -26,7 +26,8 @@ export default class WorkerPool {
             // client code has had a chance to set it.
             this.workers = [];
             while (this.workers.length < WorkerPool.workerCount) {
-                this.workers.push(new WebWorker());
+                // eslint-disable-next-line new-cap
+                this.workers.push(WebWorker());
             }
         }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,7 +23,7 @@
       "WebWorker"
     ],
     "outDir": "lib",
-    "rootDir": "src",
+    "rootDir": "",
   },
   "include": [
     "src/**/*.ts"


### PR DESCRIPTION
 - [x] confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [ ] briefly describe the changes in this PR
 
After discussion with @HarelM about how to move forward, we decided it would be good to just get types fixed in _any_ way at all so we could continue with changes to the build and tests as necessary. So to that end, I squashed the last 25 or so errors in any way possible. I don't particularly like these 'fixes' but it does mean we can work in parallel to get the other tooling/testing and changes moving while refining types and refactoring etc.

The main problem is that without being able to run the tests we can't easily see if our changes are ok or not. The hacky changes are mostly removing typings or casting to any to ignore them, since we can assume that before we started moving to TS things built and generally worked fine.

This mostly likely is a step sideways so this shouldn't be merged into anything we plan to release until all of these issues are confirmed ok and proper typings have been put where possible. Hopefully it's useful to check out as is and work on top of.. please use at your own discretion!