### PR TITLE
Use organization secret NPM_ORG_TOKEN

### DIFF
--- a/.github/workflows/publish-style-spec.yml
+++ b/.github/workflows/publish-style-spec.yml
@@ -39,4 +39,4 @@ jobs:
           node -e "if(require('./package').version.includes('dev')) { process.exit(1) }"
           npm publish --access=public
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_ORG_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -172,4 +172,4 @@ jobs:
         run: |
           yarn publish --non-interactive
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_ORG_TOKEN }}

--- a/RELEASE-PROCESS.md
+++ b/RELEASE-PROCESS.md
@@ -28,4 +28,4 @@ Release candidate versions do not generate release notes.
 
 The changelog should be updated on every PR - there is a placeholder at the top of the document - and heading should be renamed to the same version which is going to be set in the version tag during release.
 
-The workflow expects `NODE_AUTH_TOKEN` repo secret in order to push to NPM registry.
+The workflow expects `${{ secrets.NPM_ORG_TOKEN }}` organization secret in order to push to NPM registry.


### PR DESCRIPTION
In the past we have used personal NPM access tokens to publish this library. With the number of packages growing (`maplibre-gl-style-spec`, `maplibre-gl-leaflet`, `maplibre-gl-geocoder`) @nyurik created now an npm organization access token for `@maplibre` which is stored in the organization secrets of the GitHub `maplibre` org. The name of the secret is `NPM_ORG_TOKEN`. This token is shared with selected projects in the GitHub `maplibre` org (`maplibre-gl-js` and `maplibre-gl-geocoder`). If additional projects need access to this token, please contact @nyurik on slack.



 - [✅  ] confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [ ] briefly describe the changes in this PR
 - [ ] include before/after visuals or gifs if this PR includes visual changes
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [ ] manually test the debug page
 - [🐋  ] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog' **skip changelog, this is CI only**
 - [ ] add an entry inside this element for inclusion in the `maplibre-gl-js` changelog: `<changelog></changelog>`
