### PR TITLE
Typescript: fix running of test-expression

### DIFF
--- a/package.json
+++ b/package.json
@@ -199,7 +199,7 @@
     "test-query-node": "node test/query.test.js",
     "watch-query": "testem -f test/integration/testem.js",
     "test-query": "testem ci -f test/integration/testem.js -R xunit > test/integration/query-tests/test-results.xml",
-    "test-expressions": "cross-env build/run-node test/expression.test.js",
+    "test-expressions": "node --experimental-specifier-resolution=node test/expression.test.js",
     "test-cov": "nyc --reporter=text-summary --reporter=lcov --cache run-s test-unit test-expressions test-query test-render",
     "prepublishOnly": "run-s prepare-publish build-dev build-prod-min build-prod build-csp build-css build-style-spec test-build diff-tarball",
     "print-release-url": "node build/print-release-url.js",

--- a/test/expression.test.js
+++ b/test/expression.test.js
@@ -1,11 +1,13 @@
+import {fileURLToPath} from 'url';
+
 import {run} from './integration/lib/expression';
-import {createPropertyExpression} from '../src/style-spec/expression';
-import {isFunction} from '../src/style-spec/function';
-import convertFunction from '../src/style-spec/function/convert';
-import {toString} from '../src/style-spec/expression/types';
+import {createPropertyExpression} from '../rollup/build/tsc/style-spec/expression';
+import {isFunction} from '../rollup/build/tsc/style-spec/function';
+import convertFunction from '../rollup/build/tsc/style-spec/function/convert';
+import {toString} from '../rollup/build/tsc/style-spec/expression/types';
 import ignores from './ignores.json';
-import {CanonicalTileID} from '../src/source/tile_id';
-import MercatorCoordinate from '../src/geo/mercator_coordinate';
+import {CanonicalTileID} from '../rollup/build/tsc/source/tile_id';
+import MercatorCoordinate from '../rollup/build/tsc/geo/mercator_coordinate';
 
 function getPoint(coord, canonical) {
     const p = canonical.getTilePoint(MercatorCoordinate.fromLngLat({lng: coord[0], lat: coord[1]}, 0));
@@ -68,6 +70,8 @@ function getGeometry(feature, geometry, canonical) {
 }
 
 let tests;
+
+const __filename = fileURLToPath(import.meta.url);
 
 if (process.argv[1] === __filename && process.argv.length > 2) {
     tests = process.argv.slice(2);


### PR DESCRIPTION
- [x] confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [ ] briefly describe the changes in this PR

very minor changes to get `npm run test-expression` working
- point file imports to built js files in rollup/build/tsc (requires build before running tests), not original paths which were renamed to .ts 
- call node directly rather than using run-node with it's flow removal script and `esm`
- add node flags as mentioned by @HarelM (only `--experimental-specifier-resolution=node` appears necessary, tests still run and pass without `--experimental-json-modules`)
- update `__filename` which is no longer available in node 14 to `fileURLToPath` from `url` library