### PR TITLE
Typescript: unit tests remove window from window.XHRHttpRequest

### DIFF
--- a/test/unit/style/load_glyph_range.test.js
+++ b/test/unit/style/load_glyph_range.test.js
@@ -19,7 +19,7 @@ test('loadGlyphRange', (t) => {
     const manager = new RequestManager(transform);
 
     let request;
-    window.XMLHttpRequest.onCreate = (req) => { request = req; };
+    XMLHttpRequest.onCreate = (req) => { request = req; };
 
     loadGlyphRange('Arial Unicode MS', 0, 'https://localhost/fonts/v1/{fontstack}/{range}.pbf', manager, (err, result) => {
         t.ifError(err);

--- a/test/unit/style/style.test.js
+++ b/test/unit/style/style.test.js
@@ -235,7 +235,7 @@ test('Style#loadJSON', (t) => {
         // fake the image request (sinon doesn't allow non-string data for
         // server.respondWith, so we do so manually)
         const requests = [];
-        window.XMLHttpRequest.onCreate = req => { requests.push(req); };
+        XMLHttpRequest.onCreate = req => { requests.push(req); };
         const respond = () => {
             let req = requests.find(req => req.url === 'http://example.com/sprite.png');
             req.setStatus(200);


### PR DESCRIPTION
 - [x] confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [ ] briefly describe the changes in this PR

completely Harel's fix! .. I was struggling for quite a while then we did a call with screenshare and fixed straight away.. 