### PR TITLE
Typescript: unit tests Frustum issues

### DIFF
--- a/src/util/primitives.ts
+++ b/src/util/primitives.ts
@@ -2,7 +2,13 @@ import {mat4, vec3, vec4} from 'gl-matrix';
 import assert from 'assert';
 
 class Frustum {
-    constructor(public points: vec4[], public planes: vec4[]) { }
+    points: vec4[];
+    planes: vec4[];
+
+    constructor(points: vec4[], planes: vec4[]) {
+        this.points = points;
+        this.planes = planes;
+    }
 
     public static fromInvProjectionMatrix(invProj: mat4, worldSize: number, zoom: number): Frustum {
         const clipSpaceCorners = [
@@ -24,15 +30,15 @@ class Frustum {
             .map(v => vec4.scale(vec4.create(), v, 1.0 / v[3] / worldSize * scale));
 
         const frustumPlanePointIndices = [
-            vec3.fromValues(0, 1, 2),  // near
-            vec3.fromValues(6, 5, 4),  // far
-            vec3.fromValues(0, 3, 7),  // left
-            vec3.fromValues(2, 1, 5),  // right
-            vec3.fromValues(3, 2, 6),  // bottom
-            vec3.fromValues(0, 4, 5)   // top
+            [0, 1, 2],  // near
+            [6, 5, 4],  // far
+            [0, 3, 7],  // left
+            [2, 1, 5],  // right
+            [3, 2, 6],  // bottom
+            [0, 4, 5]   // top
         ];
 
-        const frustumPlanes = frustumPlanePointIndices.map((p: vec3) => {
+        const frustumPlanes = frustumPlanePointIndices.map((p: number[]) => {
             const a = vec3.sub(vec3.create(), frustumCoords[p[0]] as vec3, frustumCoords[p[1]] as vec3);
             const b = vec3.sub(vec3.create(), frustumCoords[p[2]] as vec3, frustumCoords[p[1]] as vec3);
             const n = vec3.normalize(vec3.create(), vec3.cross(vec3.create(), a, b));

--- a/test/unit/util/primitives.test.js
+++ b/test/unit/util/primitives.test.js
@@ -50,6 +50,7 @@ test('primitives', (t) => {
         const createTestCameraFrustum = (fovy, aspectRatio, zNear, zFar, elevation, rotation) => {
             const proj = new Float64Array(16);
             const invProj = new Float64Array(16);
+
             // Note that left handed coordinate space is used where z goes towards the sky.
             // Y has to be flipped as well because it's part of the projection/camera matrix used in transform.js
             mat4.perspective(proj, fovy, aspectRatio, zNear, zFar);
@@ -92,7 +93,7 @@ test('primitives', (t) => {
         });
 
         t.test('No intersection between aabb and frustum', (t) => {
-            const frustum = createTestCameraFrustum(Math.PI / 2, 1.0, 0.1, 100.0, -5);
+            const frustum = createTestCameraFrustum(Math.PI / 2, 1.0, 0.1, 100.0, -5, 0);
 
             const aabbList = [
                 new Aabb(vec3.fromValues(-6, 0, 0), vec3.fromValues(-5.5, 0, 0)),
@@ -111,13 +112,14 @@ test('primitives', (t) => {
 
     t.test('frustum', (t) => {
         t.test('Create a frustum from inverse projection matrix', (t) => {
-            const proj = new Float64Array(16);
-            const invProj = new Float64Array(16);
+            const proj = new Float64Array(16); // [] also passes test
+            const invProj = new Float64Array(16); // [] also passes test
+            // FAIL const proj = mat4.create(); // Float32Array also fails
+            // FAIL const invProj = mat4.create(); // Float32Array also fails
             mat4.perspective(proj, Math.PI / 2, 1.0, 0.1, 100.0);
             mat4.invert(invProj, proj);
 
             const frustum = Frustum.fromInvProjectionMatrix(invProj, 1.0, 0.0);
-
             // mat4.perspective generates a projection matrix for right handed coordinate space.
             // This means that forward direction will be -z
             const expectedFrustumPoints = [
@@ -132,8 +134,11 @@ test('primitives', (t) => {
             ];
 
             // Round numbers to mitigate the precision loss
-            frustum.points = frustum.points.map(array => array.map(n => Math.round(n * 10) / 10));
-            frustum.planes = frustum.planes.map(array => array.map(n => Math.round(n * 1000) / 1000));
+            // this is just for test so convert to regular non typed Array for test comparison
+            // frustum.points = frustum.points.map(array => array.map(n => Math.round(n * 10) / 10));
+            // frustum.planes = frustum.planes.map(array => array.map(n => Math.round(n * 1000) / 1000));
+            frustum.points = frustum.points.map(array => Array.from(array).map(n => Math.round(n * 10) / 10));
+            frustum.planes = frustum.planes.map(array => Array.from(array).map(n => Math.round(n * 1000) / 1000));
 
             const expectedFrustumPlanes = [
                 [0, 0, 1.0, 0.1],


### PR DESCRIPTION
 - [x] confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!

Fix to frustum tests (only addresses tests run with `npm run test-unit-file test/unit/util/primitives.test.js`)

- I'm not 100% convinced these tests are representative
- Failing was due to rounding and saving back into typed array, however WHY was it being rounded? Well so that the tests could compare with less precision.. however real world usage this is not an issue.
- Test projection and inverseProjection matrix are different Array types to actual class.. to get the tests to pass it needs to be either Float64Array or [] (JS native Array), using either Float32Array or mat4 (using Float32Array internally) is off by a very small amount so tests with hard coded expected values fail. Again what is the real world affect of this is not clear.. would be good to verify this outside of tests or create more/better tests to do that.


Also fix to some lint/typo issues in stub_loader.js