### PR TITLE
One forgotten yarn install?

### DIFF
--- a/package.json
+++ b/package.json
@@ -148,7 +148,7 @@
     "start-bench": "run-p watch-benchmarks start-server",
     "start-release": "run-s build-prod-min build-css print-release-url start-server",
     "diff-tarball": "cross-env build/run-node build/diff-tarball",
-    "prepare-publish": "git clean -fdx && yarn install",
+    "prepare-publish": "git clean -fdx & npm install",
     "lint": "eslint --cache --ignore-path .gitignore src test bench build debug/*.html",
     "lint-docs": "documentation lint src/index.js",
     "lint-css": "stylelint 'src/css/maplibre-gl.css'",


### PR DESCRIPTION
## Launch Checklist

We changed `yarn `to `npm `in  https://github.com/maplibre/maplibre-gl-js/pull/213
So we should change the script `prepare-publish` too