### PR TITLE
Default handling for image.sdf

### DIFF
--- a/src/symbol/symbol_layout.js
+++ b/src/symbol/symbol_layout.js
@@ -300,10 +300,10 @@ export function performSymbolLayout(bucket: SymbolBucket,
                     imagePositions[feature.icon.name],
                     layout.get('icon-offset').evaluate(feature, {}, canonical),
                     layout.get('icon-anchor').evaluate(feature, {}, canonical));
-                isSDFIcon = image.sdf;
+                isSDFIcon = !!image.sdf;
                 if (bucket.sdfIcons === undefined) {
-                    bucket.sdfIcons = image.sdf;
-                } else if (bucket.sdfIcons !== image.sdf) {
+                    bucket.sdfIcons = isSDFIcon;
+                } else if (bucket.sdfIcons !== isSDFIcon) {
                     warnOnce('Style sheet warning: Cannot mix SDF and non-SDF icons in one buffer');
                 }
                 if (image.pixelRatio !== bucket.pixelRatio) {


### PR DESCRIPTION
## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [X] confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask! 
 Confirmed!
 - [X] briefly describe the changes in this PR
Strict comparison of image.sdf leads to warning logged to debug console. Images defined in the base MVT style may have the SDF property left undefined; images inserted through addImage (i.e., in response to styleimagemissing event) have the SDF property coerced to false when left undefined. When both types of image occur within the same tile, the existing code triggers the warning.

 - [X] manually test the debug page
 

