### PR TITLE
Run CI on all pull requests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
 
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,6 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
 
 jobs:
   lint_build_test:


### PR DESCRIPTION
So far we were running CI only against pull requests that want to be merged to the `main` branch. This is inconvenient for development on the `typescript` branch. 

With this change here, CI will run on all pull requests, independent of the target branch.