### PR TITLE
[feature] Add redraw function to map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Migrated the production code to typescript
 - ** Breaking Change ** removed `version` from the public API
 - ** Breaking Change ** stopped supporting IE (internet explorer)
+- Added redraw function to map (#293)
 - *...Add new stuff here...*
 
 ### 🐞 Bug fixes

--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -2609,6 +2609,24 @@ class Map extends Camera {
     }
 
     /**
+    * Force a synchronous redraw of the map.
+    * @example
+    * map.redraw();
+    * @returns {Map} `this`
+    */
+    redraw(): Map {
+        if (this.style) {
+            // cancel the scheduled update
+            if (this._frame) {
+                this._frame.cancel();
+                this._frame = null;
+            }
+            this._render(0);
+        }
+        return this;
+    }
+
+    /**
      * Clean up and release all internal resources associated with this map.
      *
      * This includes DOM elements, event bindings, web workers, and WebGL resources.

--- a/test/unit/ui/map.test.js
+++ b/test/unit/ui/map.test.js
@@ -995,6 +995,16 @@ test('Map', (t) => {
         });
     });
 
+    t.test('#redraw', (t) => {
+        const map = createMap(t);
+
+        map.once('idle', () => {
+            map.once('render', () => t.end());
+
+            map.redraw();
+        });
+    });
+
     t.test('#addControl', (t) => {
         const map = createMap(t);
         const control = {


### PR DESCRIPTION
This pull request adds a new `redraw` function to the map to trigger a synchronous redraw.
The code is from the [original pull request](https://github.com/mapbox/mapbox-gl-js/issues/7893) and has been tested with OpenLayers.

I not very happy with the added test: any suggestions to improve it are welcome !

Fixes #206

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [x] confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [ ] briefly describe the changes in this PR
 - [ ] include before/after visuals or gifs if this PR includes visual changes
 - [x] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [ ] manually test the debug page
 - [x] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [ ] add an entry inside this element for inclusion in the `maplibre-gl-js` changelog: `<changelog></changelog>`
