### PR TITLE
Enforce semicolons as member delimters

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -21,6 +21,7 @@
       "warn",
       { "argsIgnorePattern": "^_" }
     ],
+    "@typescript-eslint/member-delimiter-style": ["error"],
     // Disable no-undef. It's covered by @typescript-eslint
     "no-undef": "off",
     // temporarily disabled due to https://github.com/babel/babel-eslint/issues/485

--- a/src/data/bucket.ts
+++ b/src/data/bucket.ts
@@ -9,46 +9,46 @@ import type {CanonicalTileID} from '../source/tile_id';
 import Point from '../symbol/point';
 
 export type BucketParameters<Layer extends TypedStyleLayer> = {
-  index: number,
-  layers: Array<Layer>,
-  zoom: number,
-  pixelRatio: number,
-  overscaling: number,
-  collisionBoxArray: CollisionBoxArray,
-  sourceLayerIndex: number,
-  sourceID: string
+  index: number;
+  layers: Array<Layer>;
+  zoom: number;
+  pixelRatio: number;
+  overscaling: number;
+  collisionBoxArray: CollisionBoxArray;
+  sourceLayerIndex: number;
+  sourceID: string;
 };
 
 export type PopulateParameters = {
-  featureIndex: FeatureIndex,
-  iconDependencies: {},
-  patternDependencies: {},
-  glyphDependencies: {},
-  availableImages: Array<string>
+  featureIndex: FeatureIndex;
+  iconDependencies: {};
+  patternDependencies: {};
+  glyphDependencies: {};
+  availableImages: Array<string>;
 };
 
 export type IndexedFeature = {
-  feature: VectorTileFeature,
-  id: number | string,
-  index: number,
-  sourceLayerIndex: number
+  feature: VectorTileFeature;
+  id: number | string;
+  index: number;
+  sourceLayerIndex: number;
 };
 
 export type BucketFeature = {
-  index: number,
-  sourceLayerIndex: number,
-  geometry: Array<Array<Point>>,
-  properties: any,
-  type: 1 | 2 | 3,
-  id?: any,
+  index: number;
+  sourceLayerIndex: number;
+  geometry: Array<Array<Point>>;
+  properties: any;
+  type: 1 | 2 | 3;
+  id?: any;
   readonly patterns: {
     [_: string]: {
-      "min": string,
-      "mid": string,
-      "max": string
-    }
-  },
-  sortKey?: number
+      "min": string;
+      "mid": string;
+      "max": string;
+    };
+  };
+  sortKey?: number;
 };
 
 /**

--- a/src/data/bucket/fill_bucket.ts
+++ b/src/data/bucket/fill_bucket.ts
@@ -125,14 +125,14 @@ class FillBucket implements Bucket {
     }
 
     update(states: FeatureStates, vtLayer: VectorTileLayer, imagePositions: {
-      [_: string]: ImagePosition
+      [_: string]: ImagePosition;
     }) {
         if (!this.stateDependentLayers.length) return;
         this.programConfigurations.updatePaintArrays(states, vtLayer, this.stateDependentLayers, imagePositions);
     }
 
     addFeatures(options: PopulateParameters, canonical: CanonicalTileID, imagePositions: {
-      [_: string]: ImagePosition
+      [_: string]: ImagePosition;
     }) {
         for (const feature of this.patternFeatures) {
             this.addFeature(feature, feature.geometry, feature.index, canonical, imagePositions);
@@ -167,7 +167,7 @@ class FillBucket implements Bucket {
     }
 
     addFeature(feature: BucketFeature, geometry: Array<Array<Point>>, index: number, canonical: CanonicalTileID, imagePositions: {
-      [_: string]: ImagePosition
+      [_: string]: ImagePosition;
     }) {
         for (const polygon of classifyRings(geometry, EARCUT_MAX_RINGS)) {
             let numVertices = 0;

--- a/src/data/bucket/line_bucket.ts
+++ b/src/data/bucket/line_bucket.ts
@@ -70,14 +70,14 @@ const LINE_DISTANCE_SCALE = 1 / 2;
 const MAX_LINE_DISTANCE = Math.pow(2, LINE_DISTANCE_BUFFER_BITS - 1) / LINE_DISTANCE_SCALE;
 
 type LineClips = {
-  start: number,
-  end: number
+  start: number;
+  end: number;
 };
 
 type GradientTexture = {
-  texture?: Texture,
-  gradient?: RGBAImage,
-  version?: number
+  texture?: Texture;
+  gradient?: RGBAImage;
+  version?: number;
 };
 
 /**

--- a/src/data/bucket/symbol_bucket.ts
+++ b/src/data/bucket/symbol_bucket.ts
@@ -58,41 +58,41 @@ import type {FeatureStates} from '../../source/source_state';
 import type {ImagePosition} from '../../render/image_atlas';
 
 export type SingleCollisionBox = {
-  x1: number,
-  y1: number,
-  x2: number,
-  y2: number,
-  anchorPointX: number,
-  anchorPointY: number
+  x1: number;
+  y1: number;
+  x2: number;
+  y2: number;
+  anchorPointX: number;
+  anchorPointY: number;
 };
 
 export type CollisionArrays = {
-  textBox?: SingleCollisionBox,
-  verticalTextBox?: SingleCollisionBox,
-  iconBox?: SingleCollisionBox,
-  verticalIconBox?: SingleCollisionBox,
-  textFeatureIndex?: number,
-  verticalTextFeatureIndex?: number,
-  iconFeatureIndex?: number,
-  verticalIconFeatureIndex?: number
+  textBox?: SingleCollisionBox;
+  verticalTextBox?: SingleCollisionBox;
+  iconBox?: SingleCollisionBox;
+  verticalIconBox?: SingleCollisionBox;
+  textFeatureIndex?: number;
+  verticalTextFeatureIndex?: number;
+  iconFeatureIndex?: number;
+  verticalIconFeatureIndex?: number;
 };
 
 export type SymbolFeature = {
-  sortKey: number | void,
-  text: Formatted | void,
-  icon: ResolvedImage | undefined | null,
-  index: number,
-  sourceLayerIndex: number,
-  geometry: Array<Array<Point>>,
-  properties: any,
-  type: 'Point' | 'LineString' | 'Polygon',
-  id?: any
+  sortKey: number | void;
+  text: Formatted | void;
+  icon: ResolvedImage | undefined | null;
+  index: number;
+  sourceLayerIndex: number;
+  geometry: Array<Array<Point>>;
+  properties: any;
+  type: 'Point' | 'LineString' | 'Polygon';
+  id?: any;
 };
 
 export type SortKeyRange = {
-  sortKey: number,
-  symbolInstanceStart: number,
-  symbolInstanceEnd: number
+  sortKey: number;
+  symbolInstanceStart: number;
+  symbolInstanceEnd: number;
 };
 
 // Opacity arrays are frequently updated but don't contain a lot of information, so we pack them
@@ -243,11 +243,11 @@ class CollisionBuffers {
     collisionVertexBuffer: VertexBuffer;
 
     constructor(LayoutArray: {
-      new (...args: any): StructArray
+      new (...args: any): StructArray;
     },
                 layoutAttributes: Array<StructArrayMember>,
                 IndexArray: {
-                  new (...args: any): TriangleIndexArray | LineIndexArray
+                  new (...args: any): TriangleIndexArray | LineIndexArray;
                 }) {
         this.layoutVertexArray = new LayoutArray();
         this.layoutAttributes = layoutAttributes;

--- a/src/data/evaluation_feature.ts
+++ b/src/data/evaluation_feature.ts
@@ -2,17 +2,17 @@ import loadGeometry from './load_geometry';
 import type Point from '../symbol/point';
 
 type EvaluationFeature = {
-  readonly type: 1 | 2 | 3 | "Unknown" | "Point" | "MultiPoint" | "LineString" | "MultiLineString" | "Polygon" | "MultiPolygon",
-  readonly id?: any,
-  readonly properties: {[_: string]: any},
+  readonly type: 1 | 2 | 3 | "Unknown" | "Point" | "MultiPoint" | "LineString" | "MultiLineString" | "Polygon" | "MultiPolygon";
+  readonly id?: any;
+  readonly properties: {[_: string]: any};
   readonly patterns?: {
     [_: string]: {
-      "min": string,
-      "mid": string,
-      "max": string
-    }
-  },
-  geometry: Array<Array<Point>>
+      "min": string;
+      "mid": string;
+      "max": string;
+    };
+  };
+  geometry: Array<Array<Point>>;
 };
 
 /**

--- a/src/data/feature_index.ts
+++ b/src/data/feature_index.ts
@@ -25,18 +25,18 @@ import type {FilterSpecification, PromoteIdSpecification} from '../style-spec/ty
 import type {FeatureState} from '../style-spec/expression';
 
 type QueryParameters = {
-  scale: number,
-  pixelPosMatrix: mat4,
-  transform: Transform,
-  tileSize: number,
-  queryGeometry: Array<Point>,
-  cameraQueryGeometry: Array<Point>,
-  queryPadding: number,
+  scale: number;
+  pixelPosMatrix: mat4;
+  transform: Transform;
+  tileSize: number;
+  queryGeometry: Array<Point>;
+  cameraQueryGeometry: Array<Point>;
+  queryPadding: number;
   params: {
-    filter: FilterSpecification,
-    layers: Array<string>,
-    availableImages: Array<string>
-  }
+    filter: FilterSpecification;
+    layers: Array<string>;
+    availableImages: Array<string>;
+  };
 };
 
 class FeatureIndex {
@@ -107,10 +107,10 @@ class FeatureIndex {
       styleLayers: {[_: string]: StyleLayer},
       serializedLayers: {[_: string]: any},
       sourceFeatureState: SourceFeatureState
-    ): {[_: string]: Array<{featureIndex: number, feature: GeoJSONFeature}>} {
+    ): {[_: string]: Array<{featureIndex: number; feature: GeoJSONFeature}>} {
         this.loadVTLayers();
 
-        const params = args.params || {} as { filter: any, layers: string[], availableImages: string[] },
+        const params = args.params || {} as { filter: any; layers: string[]; availableImages: string[] },
             pixelsToTileUnits = EXTENT / args.tileSize / args.scale,
             filter = featureFilter(params.filter);
 
@@ -171,10 +171,10 @@ class FeatureIndex {
     loadMatchingFeature(
         result: {
           [_: string]: Array<{
-            featureIndex: number,
-            feature: GeoJSONFeature,
-            intersectionZ?: boolean | number
-          }>
+            featureIndex: number;
+            feature: GeoJSONFeature;
+            intersectionZ?: boolean | number;
+          }>;
         },
         bucketIndex: number,
         sourceLayerIndex: number,

--- a/src/data/feature_position_map.ts
+++ b/src/data/feature_position_map.ts
@@ -3,14 +3,14 @@ import {register} from '../util/web_worker_transfer';
 import assert from 'assert';
 
 type SerializedFeaturePositionMap = {
-  ids: Float64Array,
-  positions: Uint32Array
+  ids: Float64Array;
+  positions: Uint32Array;
 };
 
 type FeaturePosition = {
-  index: number,
-  start: number,
-  end: number
+  index: number;
+  start: number;
+  end: number;
 };
 
 // A transferable data structure that maps feature ids to their indices and buffer offsets

--- a/src/data/program_configuration.ts
+++ b/src/data/program_configuration.ts
@@ -30,9 +30,9 @@ import type {FeatureStates} from '../source/source_state';
 import type {FormattedSection} from '../style-spec/expression/types/formatted';
 
 export type BinderUniform = {
-  name: string,
-  property: string,
-  binding: Uniform<any>
+  name: string;
+  property: string;
+  binding: Uniform<any>;
 };
 
 function packColor(color: Color): [number, number] {
@@ -174,7 +174,7 @@ class SourceExpressionBinder implements AttributeBinder {
     paintVertexBuffer: VertexBuffer | undefined | null;
 
     constructor(expression: SourceExpression, names: Array<string>, type: string, PaintVertexArray: {
-      new (...args: any): StructArray
+      new (...args: any): StructArray;
     }) {
         this.expression = expression;
         this.type = type;
@@ -244,7 +244,7 @@ class CompositeExpressionBinder implements AttributeBinder, UniformBinder {
     paintVertexBuffer: VertexBuffer | undefined | null;
 
     constructor(expression: CompositeExpression, names: Array<string>, type: string, useIntegerZoom: boolean, zoom: number, PaintVertexArray: {
-      new (...args: any): StructArray
+      new (...args: any): StructArray;
     }) {
         this.expression = expression;
         this.uniformNames = names.map(name => `u_${name}_t`);
@@ -331,7 +331,7 @@ class CrossFadedCompositeBinder implements AttributeBinder {
     paintVertexAttributes: Array<StructArrayMember>;
 
     constructor(expression: CompositeExpression, type: string, useIntegerZoom: boolean, zoom: number, PaintVertexArray: {
-      new (...args: any): StructArray
+      new (...args: any): StructArray;
     }, layerId: string) {
         this.expression = expression;
         this.type = type;

--- a/src/data/segment.ts
+++ b/src/data/segment.ts
@@ -6,12 +6,12 @@ import type VertexArrayObject from '../render/vertex_array_object';
 import type {StructArray} from '../util/struct_array';
 
 export type Segment = {
-  sortKey?: number,
-  vertexOffset: number,
-  primitiveOffset: number,
-  vertexLength: number,
-  primitiveLength: number,
-  vaos: {[_: string]: VertexArrayObject}
+  sortKey?: number;
+  vertexOffset: number;
+  primitiveOffset: number;
+  vertexLength: number;
+  primitiveLength: number;
+  vaos: {[_: string]: VertexArrayObject};
 };
 
 class SegmentVector {

--- a/src/geo/edge_insets.ts
+++ b/src/geo/edge_insets.ts
@@ -97,10 +97,10 @@ class EdgeInsets {
 }
 
 export type PaddingOptions = {
-  top: number | undefined | null,
-  bottom: number | undefined | null,
-  right: number | undefined | null,
-  left: number | undefined | null
+  top: number | undefined | null;
+  bottom: number | undefined | null;
+  right: number | undefined | null;
+  left: number | undefined | null;
 };
 
 export default EdgeInsets;

--- a/src/geo/lng_lat.ts
+++ b/src/geo/lng_lat.ts
@@ -161,11 +161,11 @@ class LngLat {
  * var v3 = {lon: -122.420679, lat: 37.772537};
  */
 export type LngLatLike = LngLat | {
-  lng: number,
-  lat: number
+  lng: number;
+  lat: number;
 } | {
-  lon: number,
-  lat: number
+  lon: number;
+  lat: number;
 } | [number, number];
 
 export default LngLat;

--- a/src/geo/transform.ts
+++ b/src/geo/transform.ts
@@ -262,8 +262,8 @@ class Transform {
      * @returns {number} zoom level An integer zoom level at which all tiles will be visible.
      */
     coveringZoomLevel(options: {
-      roundZoom?: boolean,
-      tileSize: number
+      roundZoom?: boolean;
+      tileSize: number;
     }) {
         const z = (options.roundZoom ? Math.round : Math.floor)(
             this.zoom + this.scaleZoom(this.tileSize / options.tileSize)
@@ -316,12 +316,12 @@ class Transform {
      */
     coveringTiles(
       options: {
-        tileSize: number,
-        minzoom?: number,
-        maxzoom?: number,
-        roundZoom?: boolean,
-        reparseOverscaled?: boolean,
-        renderWorldCopies?: boolean
+        tileSize: number;
+        minzoom?: number;
+        maxzoom?: number;
+        roundZoom?: boolean;
+        reparseOverscaled?: boolean;
+        renderWorldCopies?: boolean;
       }
     ): Array<OverscaledTileID> {
         let z = this.coveringZoomLevel(options);

--- a/src/gl/context.ts
+++ b/src/gl/context.ts
@@ -17,9 +17,9 @@ import type {
 import type Color from '../style-spec/util/color';
 
 type ClearArgs = {
-  color?: Color,
-  depth?: number,
-  stencil?: number
+  color?: Color;
+  depth?: number;
+  stencil?: number;
 };
 
 class Context {

--- a/src/gl/types.ts
+++ b/src/gl/types.ts
@@ -15,9 +15,9 @@ export type DepthRangeType = [number, number];
 export type DepthFuncType = CompareFuncType;
 
 export type StencilFuncType = {
-  func: CompareFuncType,
-  ref: number,
-  mask: number
+  func: CompareFuncType;
+  ref: number;
+  mask: number;
 };
 
 export type StencilOpConstant = WebGLRenderingContext["KEEP"] | WebGLRenderingContext["ZERO"] | WebGLRenderingContext["REPLACE"] | WebGLRenderingContext["INCR"] | WebGLRenderingContext["INCR_WRAP"] | WebGLRenderingContext["DECR"] | WebGLRenderingContext["DECR_WRAP"] | WebGLRenderingContext["INVERT"];
@@ -29,29 +29,29 @@ export type TextureUnitType = number;
 export type ViewportType = [number, number, number, number];
 
 export type StencilTest = {
-  func: WebGLRenderingContext["NEVER"],
-  mask: 0
+  func: WebGLRenderingContext["NEVER"];
+  mask: 0;
 } | {
-  func: WebGLRenderingContext["LESS"],
-  mask: number
+  func: WebGLRenderingContext["LESS"];
+  mask: number;
 } | {
-  func: WebGLRenderingContext["EQUAL"],
-  mask: number
+  func: WebGLRenderingContext["EQUAL"];
+  mask: number;
 } | {
-  func: WebGLRenderingContext["LEQUAL"],
-  mask: number
+  func: WebGLRenderingContext["LEQUAL"];
+  mask: number;
 } | {
-  func: WebGLRenderingContext["GREATER"],
-  mask: number
+  func: WebGLRenderingContext["GREATER"];
+  mask: number;
 } | {
-  func: WebGLRenderingContext["NOTEQUAL"],
-  mask: number
+  func: WebGLRenderingContext["NOTEQUAL"];
+  mask: number;
 } | {
-  func: WebGLRenderingContext["GEQUAL"],
-  mask: number
+  func: WebGLRenderingContext["GEQUAL"];
+  mask: number;
 } | {
-  func: WebGLRenderingContext["ALWAYS"],
-  mask: 0
+  func: WebGLRenderingContext["ALWAYS"];
+  mask: 0;
 };
 
 export type CullFaceModeType = WebGLRenderingContext["FRONT"] | WebGLRenderingContext["BACK"] | WebGLRenderingContext["FRONT_AND_BACK"];

--- a/src/render/draw_circle.ts
+++ b/src/render/draw_circle.ts
@@ -19,17 +19,17 @@ import type {CircleUniformsType} from './program/circle_program';
 export default drawCircles;
 
 type TileRenderState = {
-  programConfiguration: ProgramConfiguration,
-  program: Program<any>,
-  layoutVertexBuffer: VertexBuffer,
-  indexBuffer: IndexBuffer,
-  uniformValues: UniformValues<CircleUniformsType>
+  programConfiguration: ProgramConfiguration;
+  program: Program<any>;
+  layoutVertexBuffer: VertexBuffer;
+  indexBuffer: IndexBuffer;
+  uniformValues: UniformValues<CircleUniformsType>;
 };
 
 type SegmentsTileRenderState = {
-  segments: SegmentVector,
-  sortKey: number,
-  state: TileRenderState
+  segments: SegmentVector;
+  sortKey: number;
+  state: TileRenderState;
 };
 
 function drawCircles(painter: Painter, sourceCache: SourceCache, layer: CircleStyleLayer, coords: Array<OverscaledTileID>) {

--- a/src/render/draw_collision_debug.ts
+++ b/src/render/draw_collision_debug.ts
@@ -18,10 +18,10 @@ import IndexBuffer from '../gl/index_buffer';
 export default drawCollisionDebug;
 
 type TileBatch = {
-  circleArray: Array<number>,
-  circleOffset: number,
-  transform: mat4,
-  invTransform: mat4
+  circleArray: Array<number>;
+  circleOffset: number;
+  transform: mat4;
+  invTransform: mat4;
 };
 
 let quadTriangles: QuadTriangleArray | undefined | null;

--- a/src/render/draw_symbol.ts
+++ b/src/render/draw_symbol.ts
@@ -34,19 +34,19 @@ import type {CrossTileID, VariableOffset} from '../symbol/placement';
 export default drawSymbols;
 
 type SymbolTileRenderState = {
-  segments: SegmentVector,
-  sortKey: number,
+  segments: SegmentVector;
+  sortKey: number;
   state: {
-    program: any,
-    buffers: SymbolBuffers,
-    uniformValues: any,
-    atlasTexture: Texture,
-    atlasTextureIcon: Texture | null,
-    atlasInterpolation: any,
-    atlasInterpolationIcon: any,
-    isSDF: boolean,
-    hasHalo: boolean
-  }
+    program: any;
+    buffers: SymbolBuffers;
+    uniformValues: any;
+    atlasTexture: Texture;
+    atlasTextureIcon: Texture | null;
+    atlasInterpolation: any;
+    atlasInterpolationIcon: any;
+    isSDF: boolean;
+    hasHalo: boolean;
+  };
 };
 
 // create() creates an identity matrix https://github.com/toji/gl-matrix/blob/master/src/mat4.js#L13

--- a/src/render/glyph_atlas.ts
+++ b/src/render/glyph_atlas.ts
@@ -7,21 +7,21 @@ import type {GlyphMetrics, StyleGlyph} from '../style/style_glyph';
 const padding = 1;
 
 export type Rect = {
-  x: number,
-  y: number,
-  w: number,
-  h: number
+  x: number;
+  y: number;
+  w: number;
+  h: number;
 };
 
 export type GlyphPosition = {
-  rect: Rect,
-  metrics: GlyphMetrics
+  rect: Rect;
+  metrics: GlyphMetrics;
 };
 
 export type GlyphPositions = {
   [_: string]: {
-    [_: number]: GlyphPosition
-  }
+    [_: number]: GlyphPosition;
+  };
 };
 
 export default class GlyphAtlas {
@@ -30,8 +30,8 @@ export default class GlyphAtlas {
 
     constructor(stacks: {
       [_: string]: {
-        [_: number]: StyleGlyph | undefined | null
-      }
+        [_: number]: StyleGlyph | undefined | null;
+      };
     }) {
         const positions = {};
         const bins = [];

--- a/src/render/glyph_manager.ts
+++ b/src/render/glyph_manager.ts
@@ -12,31 +12,31 @@ import type {Callback} from '../types/callback';
 type Entry = {
   // null means we've requested the range, but the glyph wasn't included in the result.
   glyphs: {
-    [id: number]: StyleGlyph | null
-  },
+    [id: number]: StyleGlyph | null;
+  };
   requests: {
     [range: number]: Array<Callback<{
-      [_: number]: StyleGlyph | null
-    }>>
-  },
+      [_: number]: StyleGlyph | null;
+    }>>;
+  };
   ranges: {
-    [range: number]: boolean | null
-  },
-  tinySDF?: TinySDF
+    [range: number]: boolean | null;
+  };
+  tinySDF?: TinySDF;
 };
 
 class GlyphManager {
     requestManager: RequestManager;
     localIdeographFontFamily: string | undefined | null;
     entries: {
-      [_: string]: Entry
+      [_: string]: Entry;
     };
     url: string | undefined | null;
 
     // exposed as statics to enable stubbing in unit tests
     static loadGlyphRange: typeof loadGlyphRange;
     static TinySDF: {
-      new (...args: any): TinySDF
+      new (...args: any): TinySDF;
     };
 
     constructor(requestManager: RequestManager, localIdeographFontFamily?: string | null) {
@@ -50,11 +50,11 @@ class GlyphManager {
     }
 
     getGlyphs(glyphs: {
-      [stack: string]: Array<number>
+      [stack: string]: Array<number>;
     }, callback: Callback<{
       [stack: string]: {
-        [id: number]: StyleGlyph | undefined | null
-      }
+        [id: number]: StyleGlyph | undefined | null;
+      };
     }>) {
         const all = [];
 
@@ -65,9 +65,9 @@ class GlyphManager {
         }
 
         asyncAll(all, ({stack, id}, callback: Callback<{
-          stack: string,
-          id: number,
-          glyph: StyleGlyph | undefined | null
+          stack: string;
+          id: number;
+          glyph: StyleGlyph | undefined | null;
         }>) => {
             let entry = this.entries[stack];
             if (!entry) {
@@ -107,7 +107,7 @@ class GlyphManager {
                 requests = entry.requests[range] = [];
                 GlyphManager.loadGlyphRange(stack, range, ((this.url as any)), this.requestManager,
                     (err, response?: {
-                      [_: number]: StyleGlyph | null
+                      [_: number]: StyleGlyph | null;
                     } | null) => {
                         if (response) {
                             for (const id in response) {
@@ -125,7 +125,7 @@ class GlyphManager {
             }
 
             requests.push((err, result?: {
-              [_: number]: StyleGlyph | null
+              [_: number]: StyleGlyph | null;
             } | null) => {
                 if (err) {
                     callback(err);
@@ -134,9 +134,9 @@ class GlyphManager {
                 }
             });
         }, (err, glyphs?: Array<{
-          stack: string,
-          id: number,
-          glyph: StyleGlyph | undefined | null
+          stack: string;
+          id: number;
+          glyph: StyleGlyph | undefined | null;
         }> | null) => {
             if (err) {
                 callback(err);

--- a/src/render/image_atlas.ts
+++ b/src/render/image_atlas.ts
@@ -10,10 +10,10 @@ const IMAGE_PADDING: number = 1;
 export {IMAGE_PADDING};
 
 type Rect = {
-  x: number,
-  y: number,
-  w: number,
-  h: number
+  x: number;
+  y: number;
+  w: number;
+  h: number;
 };
 
 export class ImagePosition {

--- a/src/render/image_manager.ts
+++ b/src/render/image_manager.ts
@@ -14,8 +14,8 @@ import type {Bin} from 'potpack';
 import type {Callback} from '../types/callback';
 
 type Pattern = {
-  bin: Bin,
-  position: ImagePosition
+  bin: Bin;
+  position: ImagePosition;
 };
 
 // When copied into the atlas texture, image data is padded by one pixel on each side. Icon
@@ -41,8 +41,8 @@ class ImageManager extends Evented {
     callbackDispatchedThisFrame: {[_: string]: boolean};
     loaded: boolean;
     requestors: Array<{
-      ids: Array<string>,
-      callback: Callback<{[_: string]: StyleImage}>
+      ids: Array<string>;
+      callback: Callback<{[_: string]: StyleImage}>;
     }>;
 
     patterns: {[_: string]: Pattern};

--- a/src/render/painter.ts
+++ b/src/render/painter.ts
@@ -66,14 +66,14 @@ import type {RGBAImage} from '../util/image';
 export type RenderPass = "offscreen" | "opaque" | "translucent";
 
 type PainterOptions = {
-  showOverdrawInspector: boolean,
-  showTileBoundaries: boolean,
-  showPadding: boolean,
-  rotating: boolean,
-  zooming: boolean,
-  moving: boolean,
-  gpuTiming: boolean,
-  fadeDuration: number
+  showOverdrawInspector: boolean;
+  showTileBoundaries: boolean;
+  showPadding: boolean;
+  rotating: boolean;
+  zooming: boolean;
+  moving: boolean;
+  gpuTiming: boolean;
+  fadeDuration: number;
 };
 
 /**
@@ -86,7 +86,7 @@ class Painter {
     context: Context;
     transform: Transform;
     _tileTextures: {
-      [_: number]: Array<Texture>
+      [_: number]: Array<Texture>;
     };
     numSublayers: number;
     depthEpsilon: number;
@@ -304,7 +304,7 @@ class Painter {
      * Returns [StencilMode for tile overscaleZ map, sortedCoords].
      */
     stencilConfigForOverlap(tileIDs: Array<OverscaledTileID>): [{
-      [_: number]: Readonly<StencilMode>
+      [_: number]: Readonly<StencilMode>;
     }, Array<OverscaledTileID>] {
         const gl = this.context.gl;
         const coords = tileIDs.sort((a, b) => b.overscaledZ - a.overscaledZ);

--- a/src/render/program.ts
+++ b/src/render/program.ts
@@ -37,10 +37,10 @@ class Program<Us extends UniformBindings> {
     constructor(context: Context,
             name: string,
             source: {
-              fragmentSource: string,
-              vertexSource: string,
-              staticAttributes: Array<string>,
-              staticUniforms: Array<string>
+              fragmentSource: string;
+              vertexSource: string;
+              staticAttributes: Array<string>;
+              staticUniforms: Array<string>;
             },
             configuration: ProgramConfiguration | undefined | null,
             fixedUniforms: (b: Context, a: UniformLocations) => Us,

--- a/src/render/program/background_program.ts
+++ b/src/render/program/background_program.ts
@@ -19,29 +19,29 @@ import type ResolvedImage from '../../style-spec/expression/types/resolved_image
 import {mat4} from 'gl-matrix';
 
 export type BackgroundUniformsType = {
-  'u_matrix': UniformMatrix4f,
-  'u_opacity': Uniform1f,
-  'u_color': UniformColor
+  'u_matrix': UniformMatrix4f;
+  'u_opacity': Uniform1f;
+  'u_color': UniformColor;
 };
 
 export type BackgroundPatternUniformsType = {
-  'u_matrix': UniformMatrix4f,
-  'u_opacity': Uniform1f,
+  'u_matrix': UniformMatrix4f;
+  'u_opacity': Uniform1f;
   // pattern uniforms:
-  'u_image': Uniform1i,
-  'u_pattern_tl_a': Uniform2f,
-  'u_pattern_br_a': Uniform2f,
-  'u_pattern_tl_b': Uniform2f,
-  'u_pattern_br_b': Uniform2f,
-  'u_texsize': Uniform2f,
-  'u_mix': Uniform1f,
-  'u_pattern_size_a': Uniform2f,
-  'u_pattern_size_b': Uniform2f,
-  'u_scale_a': Uniform1f,
-  'u_scale_b': Uniform1f,
-  'u_pixel_coord_upper': Uniform2f,
-  'u_pixel_coord_lower': Uniform2f,
-  'u_tile_units_to_pixels': Uniform1f
+  'u_image': Uniform1i;
+  'u_pattern_tl_a': Uniform2f;
+  'u_pattern_br_a': Uniform2f;
+  'u_pattern_tl_b': Uniform2f;
+  'u_pattern_br_b': Uniform2f;
+  'u_texsize': Uniform2f;
+  'u_mix': Uniform1f;
+  'u_pattern_size_a': Uniform2f;
+  'u_pattern_size_b': Uniform2f;
+  'u_scale_a': Uniform1f;
+  'u_scale_b': Uniform1f;
+  'u_pixel_coord_upper': Uniform2f;
+  'u_pixel_coord_lower': Uniform2f;
+  'u_tile_units_to_pixels': Uniform1f;
 };
 
 const backgroundUniforms = (context: Context, locations: UniformLocations): BackgroundUniformsType => ({
@@ -81,8 +81,8 @@ const backgroundPatternUniformValues = (
   painter: Painter,
   image: CrossFaded<ResolvedImage>,
   tile: {
-    tileID: OverscaledTileID,
-    tileSize: number
+    tileID: OverscaledTileID;
+    tileSize: number;
   },
   crossfade: CrossfadeParameters
 ): UniformValues<BackgroundPatternUniformsType> => extend(

--- a/src/render/program/circle_program.ts
+++ b/src/render/program/circle_program.ts
@@ -10,12 +10,12 @@ import type Painter from '../painter';
 import browser from '../../util/browser';
 
 export type CircleUniformsType = {
-  'u_camera_to_center_distance': Uniform1f,
-  'u_scale_with_map': Uniform1i,
-  'u_pitch_with_map': Uniform1i,
-  'u_extrude_scale': Uniform2f,
-  'u_device_pixel_ratio': Uniform1f,
-  'u_matrix': UniformMatrix4f
+  'u_camera_to_center_distance': Uniform1f;
+  'u_scale_with_map': Uniform1i;
+  'u_pitch_with_map': Uniform1i;
+  'u_extrude_scale': Uniform2f;
+  'u_device_pixel_ratio': Uniform1f;
+  'u_matrix': UniformMatrix4f;
 };
 
 const circleUniforms = (context: Context, locations: UniformLocations): CircleUniformsType => ({

--- a/src/render/program/clipping_mask_program.ts
+++ b/src/render/program/clipping_mask_program.ts
@@ -5,7 +5,7 @@ import type {UniformValues, UniformLocations} from '../uniform_binding';
 import {mat4} from 'gl-matrix';
 
 export type ClippingMaskUniformsType = {
-  'u_matrix': UniformMatrix4f
+  'u_matrix': UniformMatrix4f;
 };
 
 const clippingMaskUniforms = (context: Context, locations: UniformLocations): ClippingMaskUniformsType => ({

--- a/src/render/program/collision_program.ts
+++ b/src/render/program/collision_program.ts
@@ -8,18 +8,18 @@ import type Tile from '../../source/tile';
 import {mat4} from 'gl-matrix';
 
 export type CollisionUniformsType = {
-  'u_matrix': UniformMatrix4f,
-  'u_camera_to_center_distance': Uniform1f,
-  'u_pixels_to_tile_units': Uniform1f,
-  'u_extrude_scale': Uniform2f,
-  'u_overscale_factor': Uniform1f
+  'u_matrix': UniformMatrix4f;
+  'u_camera_to_center_distance': Uniform1f;
+  'u_pixels_to_tile_units': Uniform1f;
+  'u_extrude_scale': Uniform2f;
+  'u_overscale_factor': Uniform1f;
 };
 
 export type CollisionCircleUniformsType = {
-  'u_matrix': UniformMatrix4f,
-  'u_inv_matrix': UniformMatrix4f,
-  'u_camera_to_center_distance': Uniform1f,
-  'u_viewport_size': Uniform2f
+  'u_matrix': UniformMatrix4f;
+  'u_inv_matrix': UniformMatrix4f;
+  'u_camera_to_center_distance': Uniform1f;
+  'u_viewport_size': Uniform2f;
 };
 
 const collisionUniforms = (context: Context, locations: UniformLocations): CollisionUniformsType => ({

--- a/src/render/program/debug_program.ts
+++ b/src/render/program/debug_program.ts
@@ -6,10 +6,10 @@ import type Color from '../../style-spec/util/color';
 import {mat4} from 'gl-matrix';
 
 export type DebugUniformsType = {
-  'u_color': UniformColor,
-  'u_matrix': UniformMatrix4f,
-  'u_overlay': Uniform1i,
-  'u_overlay_scale': Uniform1f
+  'u_color': UniformColor;
+  'u_matrix': UniformMatrix4f;
+  'u_overlay': Uniform1i;
+  'u_overlay_scale': Uniform1f;
 };
 
 const debugUniforms = (context: Context, locations: UniformLocations): DebugUniformsType => ({

--- a/src/render/program/fill_extrusion_program.ts
+++ b/src/render/program/fill_extrusion_program.ts
@@ -18,29 +18,29 @@ import type {CrossfadeParameters} from '../../style/evaluation_parameters';
 import type Tile from '../../source/tile';
 
 export type FillExtrusionUniformsType = {
-  'u_matrix': UniformMatrix4f,
-  'u_lightpos': Uniform3f,
-  'u_lightintensity': Uniform1f,
-  'u_lightcolor': Uniform3f,
-  'u_vertical_gradient': Uniform1f,
-  'u_opacity': Uniform1f
+  'u_matrix': UniformMatrix4f;
+  'u_lightpos': Uniform3f;
+  'u_lightintensity': Uniform1f;
+  'u_lightcolor': Uniform3f;
+  'u_vertical_gradient': Uniform1f;
+  'u_opacity': Uniform1f;
 };
 
 export type FillExtrusionPatternUniformsType = {
-  'u_matrix': UniformMatrix4f,
-  'u_lightpos': Uniform3f,
-  'u_lightintensity': Uniform1f,
-  'u_lightcolor': Uniform3f,
-  'u_height_factor': Uniform1f,
-  'u_vertical_gradient': Uniform1f,
+  'u_matrix': UniformMatrix4f;
+  'u_lightpos': Uniform3f;
+  'u_lightintensity': Uniform1f;
+  'u_lightcolor': Uniform3f;
+  'u_height_factor': Uniform1f;
+  'u_vertical_gradient': Uniform1f;
   // pattern uniforms:
-  'u_texsize': Uniform2f,
-  'u_image': Uniform1i,
-  'u_pixel_coord_upper': Uniform2f,
-  'u_pixel_coord_lower': Uniform2f,
-  'u_scale': Uniform3f,
-  'u_fade': Uniform1f,
-  'u_opacity': Uniform1f
+  'u_texsize': Uniform2f;
+  'u_image': Uniform1i;
+  'u_pixel_coord_upper': Uniform2f;
+  'u_pixel_coord_lower': Uniform2f;
+  'u_scale': Uniform3f;
+  'u_fade': Uniform1f;
+  'u_opacity': Uniform1f;
 };
 
 const fillExtrusionUniforms = (context: Context, locations: UniformLocations): FillExtrusionUniformsType => ({

--- a/src/render/program/fill_program.ts
+++ b/src/render/program/fill_program.ts
@@ -16,35 +16,35 @@ import type Tile from '../../source/tile';
 import {mat4} from 'gl-matrix';
 
 export type FillUniformsType = {
-  'u_matrix': UniformMatrix4f
+  'u_matrix': UniformMatrix4f;
 };
 
 export type FillOutlineUniformsType = {
-  'u_matrix': UniformMatrix4f,
-  'u_world': Uniform2f
+  'u_matrix': UniformMatrix4f;
+  'u_world': Uniform2f;
 };
 
 export type FillPatternUniformsType = {
-  'u_matrix': UniformMatrix4f,
+  'u_matrix': UniformMatrix4f;
   // pattern uniforms:
-  'u_texsize': Uniform2f,
-  'u_image': Uniform1i,
-  'u_pixel_coord_upper': Uniform2f,
-  'u_pixel_coord_lower': Uniform2f,
-  'u_scale': Uniform3f,
-  'u_fade': Uniform1f
+  'u_texsize': Uniform2f;
+  'u_image': Uniform1i;
+  'u_pixel_coord_upper': Uniform2f;
+  'u_pixel_coord_lower': Uniform2f;
+  'u_scale': Uniform3f;
+  'u_fade': Uniform1f;
 };
 
 export type FillOutlinePatternUniformsType = {
-  'u_matrix': UniformMatrix4f,
-  'u_world': Uniform2f,
+  'u_matrix': UniformMatrix4f;
+  'u_world': Uniform2f;
   // pattern uniforms:
-  'u_texsize': Uniform2f,
-  'u_image': Uniform1i,
-  'u_pixel_coord_upper': Uniform2f,
-  'u_pixel_coord_lower': Uniform2f,
-  'u_scale': Uniform3f,
-  'u_fade': Uniform1f
+  'u_texsize': Uniform2f;
+  'u_image': Uniform1i;
+  'u_pixel_coord_upper': Uniform2f;
+  'u_pixel_coord_lower': Uniform2f;
+  'u_scale': Uniform3f;
+  'u_fade': Uniform1f;
 };
 
 const fillUniforms = (context: Context, locations: UniformLocations): FillUniformsType => ({

--- a/src/render/program/heatmap_program.ts
+++ b/src/render/program/heatmap_program.ts
@@ -15,17 +15,17 @@ import type Painter from '../painter';
 import type HeatmapStyleLayer from '../../style/style_layer/heatmap_style_layer';
 
 export type HeatmapUniformsType = {
-  'u_extrude_scale': Uniform1f,
-  'u_intensity': Uniform1f,
-  'u_matrix': UniformMatrix4f
+  'u_extrude_scale': Uniform1f;
+  'u_intensity': Uniform1f;
+  'u_matrix': UniformMatrix4f;
 };
 
 export type HeatmapTextureUniformsType = {
-  'u_matrix': UniformMatrix4f,
-  'u_world': Uniform2f,
-  'u_image': Uniform1i,
-  'u_color_ramp': Uniform1i,
-  'u_opacity': Uniform1f
+  'u_matrix': UniformMatrix4f;
+  'u_world': Uniform2f;
+  'u_image': Uniform1i;
+  'u_color_ramp': Uniform1i;
+  'u_opacity': Uniform1f;
 };
 
 const heatmapUniforms = (context: Context, locations: UniformLocations): HeatmapUniformsType => ({

--- a/src/render/program/hillshade_program.ts
+++ b/src/render/program/hillshade_program.ts
@@ -20,21 +20,21 @@ import type DEMData from '../../data/dem_data';
 import type {OverscaledTileID} from '../../source/tile_id';
 
 export type HillshadeUniformsType = {
-  'u_matrix': UniformMatrix4f,
-  'u_image': Uniform1i,
-  'u_latrange': Uniform2f,
-  'u_light': Uniform2f,
-  'u_shadow': UniformColor,
-  'u_highlight': UniformColor,
-  'u_accent': UniformColor
+  'u_matrix': UniformMatrix4f;
+  'u_image': Uniform1i;
+  'u_latrange': Uniform2f;
+  'u_light': Uniform2f;
+  'u_shadow': UniformColor;
+  'u_highlight': UniformColor;
+  'u_accent': UniformColor;
 };
 
 export type HillshadePrepareUniformsType = {
-  'u_matrix': UniformMatrix4f,
-  'u_image': Uniform1i,
-  'u_dimension': Uniform2f,
-  'u_zoom': Uniform1f,
-  'u_unpack': Uniform4f
+  'u_matrix': UniformMatrix4f;
+  'u_image': Uniform1i;
+  'u_dimension': Uniform2f;
+  'u_zoom': Uniform1f;
+  'u_unpack': Uniform4f;
 };
 
 const hillshadeUniforms = (context: Context, locations: UniformLocations): HillshadeUniformsType => ({

--- a/src/render/program/line_program.ts
+++ b/src/render/program/line_program.ts
@@ -13,44 +13,44 @@ import type Painter from '../painter';
 import type {CrossfadeParameters} from '../../style/evaluation_parameters';
 
 export type LineUniformsType = {
-  'u_matrix': UniformMatrix4f,
-  'u_ratio': Uniform1f,
-  'u_device_pixel_ratio': Uniform1f,
-  'u_units_to_pixels': Uniform2f
+  'u_matrix': UniformMatrix4f;
+  'u_ratio': Uniform1f;
+  'u_device_pixel_ratio': Uniform1f;
+  'u_units_to_pixels': Uniform2f;
 };
 
 export type LineGradientUniformsType = {
-  'u_matrix': UniformMatrix4f,
-  'u_ratio': Uniform1f,
-  'u_device_pixel_ratio': Uniform1f,
-  'u_units_to_pixels': Uniform2f,
-  'u_image': Uniform1i,
-  'u_image_height': Uniform1f
+  'u_matrix': UniformMatrix4f;
+  'u_ratio': Uniform1f;
+  'u_device_pixel_ratio': Uniform1f;
+  'u_units_to_pixels': Uniform2f;
+  'u_image': Uniform1i;
+  'u_image_height': Uniform1f;
 };
 
 export type LinePatternUniformsType = {
-  'u_matrix': UniformMatrix4f,
-  'u_texsize': Uniform2f,
-  'u_ratio': Uniform1f,
-  'u_device_pixel_ratio': Uniform1f,
-  'u_units_to_pixels': Uniform2f,
-  'u_image': Uniform1i,
-  'u_scale': Uniform3f,
-  'u_fade': Uniform1f
+  'u_matrix': UniformMatrix4f;
+  'u_texsize': Uniform2f;
+  'u_ratio': Uniform1f;
+  'u_device_pixel_ratio': Uniform1f;
+  'u_units_to_pixels': Uniform2f;
+  'u_image': Uniform1i;
+  'u_scale': Uniform3f;
+  'u_fade': Uniform1f;
 };
 
 export type LineSDFUniformsType = {
-  'u_matrix': UniformMatrix4f,
-  'u_ratio': Uniform1f,
-  'u_device_pixel_ratio': Uniform1f,
-  'u_units_to_pixels': Uniform2f,
-  'u_patternscale_a': Uniform2f,
-  'u_patternscale_b': Uniform2f,
-  'u_sdfgamma': Uniform1f,
-  'u_image': Uniform1i,
-  'u_tex_y_a': Uniform1f,
-  'u_tex_y_b': Uniform1f,
-  'u_mix': Uniform1f
+  'u_matrix': UniformMatrix4f;
+  'u_ratio': Uniform1f;
+  'u_device_pixel_ratio': Uniform1f;
+  'u_units_to_pixels': Uniform2f;
+  'u_patternscale_a': Uniform2f;
+  'u_patternscale_b': Uniform2f;
+  'u_sdfgamma': Uniform1f;
+  'u_image': Uniform1i;
+  'u_tex_y_a': Uniform1f;
+  'u_tex_y_b': Uniform1f;
+  'u_mix': Uniform1f;
 };
 
 const lineUniforms = (context: Context, locations: UniformLocations): LineUniformsType => ({

--- a/src/render/program/pattern.ts
+++ b/src/render/program/pattern.ts
@@ -16,30 +16,30 @@ import type Tile from '../../source/tile';
 import type ResolvedImage from '../../style-spec/expression/types/resolved_image';
 
 type BackgroundPatternUniformsType = {
-  'u_image': Uniform1i,
-  'u_pattern_tl_a': Uniform2f,
-  'u_pattern_br_a': Uniform2f,
-  'u_pattern_tl_b': Uniform2f,
-  'u_pattern_br_b': Uniform2f,
-  'u_texsize': Uniform2f,
-  'u_mix': Uniform1f,
-  'u_pattern_size_a': Uniform2f,
-  'u_pattern_size_b': Uniform2f,
-  'u_scale_a': Uniform1f,
-  'u_scale_b': Uniform1f,
-  'u_pixel_coord_upper': Uniform2f,
-  'u_pixel_coord_lower': Uniform2f,
-  'u_tile_units_to_pixels': Uniform1f
+  'u_image': Uniform1i;
+  'u_pattern_tl_a': Uniform2f;
+  'u_pattern_br_a': Uniform2f;
+  'u_pattern_tl_b': Uniform2f;
+  'u_pattern_br_b': Uniform2f;
+  'u_texsize': Uniform2f;
+  'u_mix': Uniform1f;
+  'u_pattern_size_a': Uniform2f;
+  'u_pattern_size_b': Uniform2f;
+  'u_scale_a': Uniform1f;
+  'u_scale_b': Uniform1f;
+  'u_pixel_coord_upper': Uniform2f;
+  'u_pixel_coord_lower': Uniform2f;
+  'u_tile_units_to_pixels': Uniform1f;
 };
 
 export type PatternUniformsType = {
   // pattern uniforms:
-  'u_image': Uniform1i,
-  'u_texsize': Uniform2f,
-  'u_scale': Uniform3f,
-  'u_fade': Uniform1f,
-  'u_pixel_coord_upper': Uniform2f,
-  'u_pixel_coord_lower': Uniform2f
+  'u_image': Uniform1i;
+  'u_texsize': Uniform2f;
+  'u_scale': Uniform3f;
+  'u_fade': Uniform1f;
+  'u_pixel_coord_upper': Uniform2f;
+  'u_pixel_coord_lower': Uniform2f;
 };
 
 function patternUniformValues(crossfade: CrossfadeParameters, painter: Painter, tile: Tile): UniformValues<PatternUniformsType> {
@@ -68,8 +68,8 @@ function bgPatternUniformValues(
   crossfade: CrossfadeParameters,
   painter: Painter,
   tile: {
-    tileID: OverscaledTileID,
-    tileSize: number
+    tileID: OverscaledTileID;
+    tileSize: number;
   }
 ): UniformValues<BackgroundPatternUniformsType> {
     const imagePosA = painter.imageManager.getPattern(image.from.toString());

--- a/src/render/program/raster_program.ts
+++ b/src/render/program/raster_program.ts
@@ -6,19 +6,19 @@ import type RasterStyleLayer from '../../style/style_layer/raster_style_layer';
 import {mat4} from 'gl-matrix';
 
 export type RasterUniformsType = {
-  'u_matrix': UniformMatrix4f,
-  'u_tl_parent': Uniform2f,
-  'u_scale_parent': Uniform1f,
-  'u_buffer_scale': Uniform1f,
-  'u_fade_t': Uniform1f,
-  'u_opacity': Uniform1f,
-  'u_image0': Uniform1i,
-  'u_image1': Uniform1i,
-  'u_brightness_low': Uniform1f,
-  'u_brightness_high': Uniform1f,
-  'u_saturation_factor': Uniform1f,
-  'u_contrast_factor': Uniform1f,
-  'u_spin_weights': Uniform3f
+  'u_matrix': UniformMatrix4f;
+  'u_tl_parent': Uniform2f;
+  'u_scale_parent': Uniform1f;
+  'u_buffer_scale': Uniform1f;
+  'u_fade_t': Uniform1f;
+  'u_opacity': Uniform1f;
+  'u_image0': Uniform1i;
+  'u_image1': Uniform1i;
+  'u_brightness_low': Uniform1f;
+  'u_brightness_high': Uniform1f;
+  'u_saturation_factor': Uniform1f;
+  'u_contrast_factor': Uniform1f;
+  'u_spin_weights': Uniform3f;
 };
 
 const rasterUniforms = (context: Context, locations: UniformLocations): RasterUniformsType => ({
@@ -42,8 +42,8 @@ const rasterUniformValues = (
   parentTL: [number, number],
   parentScaleBy: number,
   fade: {
-    mix: number,
-    opacity: number
+    mix: number;
+    opacity: number;
   },
   layer: RasterStyleLayer
 ): UniformValues<RasterUniformsType> => ({

--- a/src/render/program/symbol_program.ts
+++ b/src/render/program/symbol_program.ts
@@ -8,68 +8,68 @@ import type {UniformValues, UniformLocations} from '../uniform_binding';
 import {mat4} from 'gl-matrix';
 
 export type SymbolIconUniformsType = {
-  'u_is_size_zoom_constant': Uniform1i,
-  'u_is_size_feature_constant': Uniform1i,
-  'u_size_t': Uniform1f,
-  'u_size': Uniform1f,
-  'u_camera_to_center_distance': Uniform1f,
-  'u_pitch': Uniform1f,
-  'u_rotate_symbol': Uniform1i,
-  'u_aspect_ratio': Uniform1f,
-  'u_fade_change': Uniform1f,
-  'u_matrix': UniformMatrix4f,
-  'u_label_plane_matrix': UniformMatrix4f,
-  'u_coord_matrix': UniformMatrix4f,
-  'u_is_text': Uniform1i,
-  'u_pitch_with_map': Uniform1i,
-  'u_texsize': Uniform2f,
-  'u_texture': Uniform1i
+  'u_is_size_zoom_constant': Uniform1i;
+  'u_is_size_feature_constant': Uniform1i;
+  'u_size_t': Uniform1f;
+  'u_size': Uniform1f;
+  'u_camera_to_center_distance': Uniform1f;
+  'u_pitch': Uniform1f;
+  'u_rotate_symbol': Uniform1i;
+  'u_aspect_ratio': Uniform1f;
+  'u_fade_change': Uniform1f;
+  'u_matrix': UniformMatrix4f;
+  'u_label_plane_matrix': UniformMatrix4f;
+  'u_coord_matrix': UniformMatrix4f;
+  'u_is_text': Uniform1i;
+  'u_pitch_with_map': Uniform1i;
+  'u_texsize': Uniform2f;
+  'u_texture': Uniform1i;
 };
 
 export type SymbolSDFUniformsType = {
-  'u_is_size_zoom_constant': Uniform1i,
-  'u_is_size_feature_constant': Uniform1i,
-  'u_size_t': Uniform1f,
-  'u_size': Uniform1f,
-  'u_camera_to_center_distance': Uniform1f,
-  'u_pitch': Uniform1f,
-  'u_rotate_symbol': Uniform1i,
-  'u_aspect_ratio': Uniform1f,
-  'u_fade_change': Uniform1f,
-  'u_matrix': UniformMatrix4f,
-  'u_label_plane_matrix': UniformMatrix4f,
-  'u_coord_matrix': UniformMatrix4f,
-  'u_is_text': Uniform1i,
-  'u_pitch_with_map': Uniform1i,
-  'u_texsize': Uniform2f,
-  'u_texture': Uniform1i,
-  'u_gamma_scale': Uniform1f,
-  'u_device_pixel_ratio': Uniform1f,
-  'u_is_halo': Uniform1i
+  'u_is_size_zoom_constant': Uniform1i;
+  'u_is_size_feature_constant': Uniform1i;
+  'u_size_t': Uniform1f;
+  'u_size': Uniform1f;
+  'u_camera_to_center_distance': Uniform1f;
+  'u_pitch': Uniform1f;
+  'u_rotate_symbol': Uniform1i;
+  'u_aspect_ratio': Uniform1f;
+  'u_fade_change': Uniform1f;
+  'u_matrix': UniformMatrix4f;
+  'u_label_plane_matrix': UniformMatrix4f;
+  'u_coord_matrix': UniformMatrix4f;
+  'u_is_text': Uniform1i;
+  'u_pitch_with_map': Uniform1i;
+  'u_texsize': Uniform2f;
+  'u_texture': Uniform1i;
+  'u_gamma_scale': Uniform1f;
+  'u_device_pixel_ratio': Uniform1f;
+  'u_is_halo': Uniform1i;
 };
 
 export type symbolTextAndIconUniformsType = {
-  'u_is_size_zoom_constant': Uniform1i,
-  'u_is_size_feature_constant': Uniform1i,
-  'u_size_t': Uniform1f,
-  'u_size': Uniform1f,
-  'u_camera_to_center_distance': Uniform1f,
-  'u_pitch': Uniform1f,
-  'u_rotate_symbol': Uniform1i,
-  'u_aspect_ratio': Uniform1f,
-  'u_fade_change': Uniform1f,
-  'u_matrix': UniformMatrix4f,
-  'u_label_plane_matrix': UniformMatrix4f,
-  'u_coord_matrix': UniformMatrix4f,
-  'u_is_text': Uniform1i,
-  'u_pitch_with_map': Uniform1i,
-  'u_texsize': Uniform2f,
-  'u_texsize_icon': Uniform2f,
-  'u_texture': Uniform1i,
-  'u_texture_icon': Uniform1i,
-  'u_gamma_scale': Uniform1f,
-  'u_device_pixel_ratio': Uniform1f,
-  'u_is_halo': Uniform1i
+  'u_is_size_zoom_constant': Uniform1i;
+  'u_is_size_feature_constant': Uniform1i;
+  'u_size_t': Uniform1f;
+  'u_size': Uniform1f;
+  'u_camera_to_center_distance': Uniform1f;
+  'u_pitch': Uniform1f;
+  'u_rotate_symbol': Uniform1i;
+  'u_aspect_ratio': Uniform1f;
+  'u_fade_change': Uniform1f;
+  'u_matrix': UniformMatrix4f;
+  'u_label_plane_matrix': UniformMatrix4f;
+  'u_coord_matrix': UniformMatrix4f;
+  'u_is_text': Uniform1i;
+  'u_pitch_with_map': Uniform1i;
+  'u_texsize': Uniform2f;
+  'u_texsize_icon': Uniform2f;
+  'u_texture': Uniform1i;
+  'u_texture_icon': Uniform1i;
+  'u_gamma_scale': Uniform1f;
+  'u_device_pixel_ratio': Uniform1f;
+  'u_is_halo': Uniform1i;
 };
 
 const symbolIconUniforms = (context: Context, locations: UniformLocations): SymbolIconUniformsType => ({
@@ -140,8 +140,8 @@ const symbolTextAndIconUniforms = (context: Context, locations: UniformLocations
 const symbolIconUniformValues = (
   functionType: string,
   size: {
-    uSizeT: number,
-    uSize: number
+    uSizeT: number;
+    uSize: number;
   } | undefined | null,
   rotateInShader: boolean,
   pitchWithMap: boolean,
@@ -177,8 +177,8 @@ const symbolIconUniformValues = (
 const symbolSDFUniformValues = (
   functionType: string,
   size: {
-    uSizeT: number,
-    uSize: number
+    uSizeT: number;
+    uSize: number;
   } | undefined | null,
   rotateInShader: boolean,
   pitchWithMap: boolean,
@@ -204,8 +204,8 @@ const symbolSDFUniformValues = (
 const symbolTextAndIconUniformValues = (
   functionType: string,
   size: {
-    uSizeT: number,
-    uSize: number
+    uSizeT: number;
+    uSize: number;
   } | undefined | null,
   rotateInShader: boolean,
   pitchWithMap: boolean,

--- a/src/render/texture.ts
+++ b/src/render/texture.ts
@@ -6,9 +6,9 @@ export type TextureFilter = WebGLRenderingContext["LINEAR"] | WebGLRenderingCont
 export type TextureWrap = WebGLRenderingContext["REPEAT"] | WebGLRenderingContext["CLAMP_TO_EDGE"] | WebGLRenderingContext["MIRRORED_REPEAT"];
 
 type EmptyImage = {
-  width: number,
-  height: number,
-  data: null
+  width: number;
+  height: number;
+  data: null;
 };
 
 type DataTextureImage = RGBAImage | AlphaImage | EmptyImage;
@@ -24,8 +24,8 @@ class Texture {
     useMipmap: boolean;
 
     constructor(context: Context, image: TextureImage, format: TextureFormat, options?: {
-      premultiply?: boolean,
-      useMipmap?: boolean
+      premultiply?: boolean;
+      useMipmap?: boolean;
     } | null) {
         this.context = context;
         this.format = format;
@@ -34,11 +34,11 @@ class Texture {
     }
 
     update(image: TextureImage, options?: {
-      premultiply?: boolean,
-      useMipmap?: boolean
+      premultiply?: boolean;
+      useMipmap?: boolean;
     } | null, position?: {
-      x: number,
-      y: number
+      x: number;
+      y: number;
     }) {
         const {width, height} = image;
         const resize = (!this.size || this.size[0] !== width || this.size[1] !== height) && !position;

--- a/src/source/canvas_source.ts
+++ b/src/source/canvas_source.ts
@@ -11,10 +11,10 @@ import type Dispatcher from '../util/dispatcher';
 import type {Evented} from '../util/evented';
 
 export type CanvasSourceSpecification = {
-  "type": "canvas",
-  "coordinates": [[number, number], [number, number], [number, number], [number, number]],
-  "animate"?: boolean,
-  "canvas": string | HTMLCanvasElement
+  "type": "canvas";
+  "coordinates": [[number, number], [number, number], [number, number], [number, number]];
+  "animate"?: boolean;
+  "canvas": string | HTMLCanvasElement;
 };
 
 /**

--- a/src/source/geojson_source.ts
+++ b/src/source/geojson_source.ts
@@ -84,8 +84,8 @@ class GeoJSONSource extends Evented implements Source {
      * @private
      */
     constructor(id: string, options: GeoJSONSourceSpecification & {
-      workerOptions?: any,
-      collectResourceTiming: boolean
+      workerOptions?: any;
+      collectResourceTiming: boolean;
     }, dispatcher: Dispatcher, eventedParent: Evented) {
         super();
 

--- a/src/source/geojson_worker_source.ts
+++ b/src/source/geojson_worker_source.ts
@@ -23,14 +23,14 @@ import type {RequestParameters, ResponseCallback} from '../util/ajax';
 import type {Callback} from '../types/callback';
 
 export type LoadGeoJSONParameters = {
-  request?: RequestParameters,
-  data?: string,
-  source: string,
-  cluster: boolean,
-  superclusterOptions?: any,
-  geojsonVtOptions?: any,
-  clusterProperties?: any,
-  filter?: Array<unknown>
+  request?: RequestParameters;
+  data?: string;
+  source: string;
+  cluster: boolean;
+  superclusterOptions?: any;
+  geojsonVtOptions?: any;
+  clusterProperties?: any;
+  filter?: Array<unknown>;
 };
 
 export type LoadGeoJSON = (params: LoadGeoJSONParameters, callback: ResponseCallback<any>) => void;
@@ -89,8 +89,8 @@ export type SourceState = // Source empty or data loaded
 class GeoJSONWorkerSource extends VectorTileWorkerSource {
     _state: SourceState;
     _pendingCallback: Callback<{
-      resourceTiming?: {[_: string]: Array<PerformanceResourceTiming>},
-      abandoned?: boolean
+      resourceTiming?: {[_: string]: Array<PerformanceResourceTiming>};
+      abandoned?: boolean;
     }>;
     _pendingLoadDataParams: LoadGeoJSONParameters;
     _geoJSONIndex: GeoJSONIndex;
@@ -126,8 +126,8 @@ class GeoJSONWorkerSource extends VectorTileWorkerSource {
      * @private
      */
     loadData(params: LoadGeoJSONParameters, callback: Callback<{
-      resourceTiming?: {[_: string]: Array<PerformanceResourceTiming>},
-      abandoned?: boolean
+      resourceTiming?: {[_: string]: Array<PerformanceResourceTiming>};
+      abandoned?: boolean;
     }>) {
         if (this._pendingCallback) {
             // Tell the foreground the previous call has been abandoned
@@ -285,7 +285,7 @@ class GeoJSONWorkerSource extends VectorTileWorkerSource {
     }
 
     removeSource(params: {
-      source: string
+      source: string;
     }, callback: WorkerTileCallback) {
         if (this._pendingCallback) {
             // Don't leak callbacks
@@ -295,7 +295,7 @@ class GeoJSONWorkerSource extends VectorTileWorkerSource {
     }
 
     getClusterExpansionZoom(params: {
-      clusterId: number
+      clusterId: number;
     }, callback: Callback<number>) {
         try {
             callback(null, this._geoJSONIndex.getClusterExpansionZoom(params.clusterId));
@@ -305,7 +305,7 @@ class GeoJSONWorkerSource extends VectorTileWorkerSource {
     }
 
     getClusterChildren(params: {
-      clusterId: number
+      clusterId: number;
     }, callback: Callback<Array<GeoJSON.Feature>>) {
         try {
             callback(null, this._geoJSONIndex.getChildren(params.clusterId));
@@ -315,9 +315,9 @@ class GeoJSONWorkerSource extends VectorTileWorkerSource {
     }
 
     getClusterLeaves(params: {
-      clusterId: number,
-      limit: number,
-      offset: number
+      clusterId: number;
+      limit: number;
+      offset: number;
     }, callback: Callback<Array<GeoJSON.Feature>>) {
         try {
             callback(null, this._geoJSONIndex.getLeaves(params.clusterId, params.limit, params.offset));
@@ -327,7 +327,7 @@ class GeoJSONWorkerSource extends VectorTileWorkerSource {
     }
 }
 
-function getSuperclusterOptions({superclusterOptions, clusterProperties}: { superclusterOptions?: any, clusterProperties?: any}) {
+function getSuperclusterOptions({superclusterOptions, clusterProperties}: { superclusterOptions?: any; clusterProperties?: any}) {
     if (!clusterProperties || !superclusterOptions) return superclusterOptions;
 
     const mapExpressions = {};

--- a/src/source/geojson_wrapper.ts
+++ b/src/source/geojson_wrapper.ts
@@ -7,15 +7,15 @@ import EXTENT from '../data/extent';
 // The feature type used by geojson-vt and supercluster. Should be extracted to
 // global type and used in module definitions for those two modules.
 type Feature = {
-  type: 1,
-  id: any,
-  tags: {[_: string]: string | number | boolean},
-  geometry: Array<[number, number]>
+  type: 1;
+  id: any;
+  tags: {[_: string]: string | number | boolean};
+  geometry: Array<[number, number]>;
 } | {
-  type: 2 | 3,
-  id: any,
-  tags: {[_: string]: string | number | boolean},
-  geometry: Array<Array<[number, number]>>
+  type: 2 | 3;
+  id: any;
+  tags: {[_: string]: string | number | boolean};
+  geometry: Array<Array<[number, number]>>;
 };
 
 class FeatureWrapper implements VectorTileFeature {

--- a/src/source/image_source.ts
+++ b/src/source/image_source.ts
@@ -143,8 +143,8 @@ class ImageSource extends Evented implements Source {
      * @returns {ImageSource} this
      */
     updateImage(options: {
-      url: string,
-      coordinates?: Coordinates
+      url: string;
+      coordinates?: Coordinates;
     }) {
         if (!this.image || !options.url) {
             return this;

--- a/src/source/pixels_to_tile_units.ts
+++ b/src/source/pixels_to_tile_units.ts
@@ -16,8 +16,8 @@ import type {OverscaledTileID} from './tile_id';
  */
 export default function(
   tile: {
-    tileID: OverscaledTileID,
-    tileSize: number
+    tileID: OverscaledTileID;
+    tileSize: number;
   },
   pixelValue: number,
   z: number

--- a/src/source/query_features.ts
+++ b/src/source/query_features.ts
@@ -43,9 +43,9 @@ export function queryRenderedFeatures(
     serializedLayers: {[_: string]: any},
     queryGeometry: Array<Point>,
     params: {
-        filter: FilterSpecification,
-        layers: Array<string>,
-        availableImages: Array<string>
+        filter: FilterSpecification;
+        layers: Array<string>;
+        availableImages: Array<string>;
     },
     transform: Transform
 ) {
@@ -95,13 +95,13 @@ export function queryRenderedSymbols(styleLayers: {[_: string]: StyleLayer},
                             sourceCaches: {[_: string]: SourceCache},
                             queryGeometry: Array<Point>,
                             params: {
-                              filter: FilterSpecification,
-                              layers: Array<string>,
-                              availableImages: Array<string>
+                              filter: FilterSpecification;
+                              layers: Array<string>;
+                              availableImages: Array<string>;
                             },
                             collisionIndex: CollisionIndex,
                             retainedQueryData: {
-                              [_: number]: RetainedQueryData
+                              [_: number]: RetainedQueryData;
                             }) {
     const result = {};
     const renderedSymbols = collisionIndex.queryRenderedSymbols(queryGeometry);

--- a/src/source/rtl_text_plugin.ts
+++ b/src/source/rtl_text_plugin.ts
@@ -13,8 +13,8 @@ const status = {
 };
 
 export type PluginState = {
-  pluginStatus: typeof status[keyof typeof status],
-  pluginURL: string | undefined | null
+  pluginStatus: typeof status[keyof typeof status];
+  pluginURL: string | undefined | null;
 };
 
 type ErrorCallback = (error?: Error | null) => void;
@@ -93,14 +93,14 @@ export const downloadRTLTextPlugin = function() {
 };
 
 export const plugin: {
-  applyArabicShaping: Function | undefined | null,
-  processBidirectionalText: ((b: string, a: Array<number>) => Array<string>) | undefined | null,
-  processStyledBidirectionalText: ((c: string, b: Array<number>, a: Array<number>) => Array<[string, Array<number>]>) | undefined | null,
-  isLoaded: () => boolean,
-  isLoading: () => boolean,
-  setState: (state: PluginState) => void,
-  isParsed: () => boolean,
-  getPluginURL: () => string | undefined | null
+  applyArabicShaping: Function | undefined | null;
+  processBidirectionalText: ((b: string, a: Array<number>) => Array<string>) | undefined | null;
+  processStyledBidirectionalText: ((c: string, b: Array<number>, a: Array<number>) => Array<[string, Array<number>]>) | undefined | null;
+  isLoaded: () => boolean;
+  isLoading: () => boolean;
+  setState: (state: PluginState) => void;
+  isParsed: () => boolean;
+  getPluginURL: () => string | undefined | null;
 } = {
     applyArabicShaping: null,
     processBidirectionalText: null,

--- a/src/source/source.ts
+++ b/src/source/source.ts
@@ -69,11 +69,11 @@ type SourceStatics = {
      * An optional URL to a script which, when run by a Worker, registers a {@link WorkerSource}
      * implementation for this Source type by calling `self.registerWorkerSource(workerSource: WorkerSource)`.
      */
-  workerSourceURL?: URL
+  workerSourceURL?: URL;
 };
 
 export type SourceClass = {
-  new (...args: any): Source
+  new (...args: any): Source;
 } & SourceStatics;
 
 import vector from '../source/vector_tile_source';
@@ -122,7 +122,7 @@ export const getType = function (name: string) {
 };
 
 export const setType = function (name: string, type: {
-  new (...args: any): Source
+  new (...args: any): Source;
 }) {
     sourceTypes[name] = type;
 };

--- a/src/source/tile.ts
+++ b/src/source/tile.ts
@@ -274,14 +274,14 @@ class Tile {
       cameraQueryGeometry: Array<Point>,
       scale: number,
       params: {
-        filter: FilterSpecification,
-        layers: Array<string>,
-        availableImages: Array<string>
+        filter: FilterSpecification;
+        layers: Array<string>;
+        availableImages: Array<string>;
       },
       transform: Transform,
       maxPitchScaleFactor: number,
       pixelPosMatrix: mat4
-    ): {[_: string]: Array<{featureIndex: number, feature: GeoJSONFeature}>} {
+    ): {[_: string]: Array<{featureIndex: number; feature: GeoJSONFeature}>} {
         if (!this.latestFeatureIndex || !this.latestFeatureIndex.rawTileData)
             return {};
 

--- a/src/source/tile_cache.ts
+++ b/src/source/tile_cache.ts
@@ -12,9 +12,9 @@ class TileCache {
     max: number;
     data: {
       [key: string]: Array<{
-        value: Tile,
-        timeout: ReturnType<typeof setTimeout> | undefined | null
-      }>
+        value: Tile;
+        timeout: ReturnType<typeof setTimeout> | undefined | null;
+      }>;
     };
     order: Array<string>;
     onRemove: (element: Tile) => void;
@@ -157,8 +157,8 @@ class TileCache {
      * @private
      */
     remove(tileID: OverscaledTileID, value?: {
-      value: Tile,
-      timeout: ReturnType<typeof setTimeout> | undefined | null
+      value: Tile;
+      timeout: ReturnType<typeof setTimeout> | undefined | null;
     } | null) {
         if (!this.has(tileID)) { return this; }
         const key = tileID.wrapped().key;

--- a/src/source/vector_tile_source.ts
+++ b/src/source/vector_tile_source.ts
@@ -66,7 +66,7 @@ class VectorTileSource extends Evented implements Source {
     _loaded: boolean;
 
     constructor(id: string, options: VectorSourceSpecification & {
-      collectResourceTiming: boolean
+      collectResourceTiming: boolean;
     }, dispatcher: Dispatcher, eventedParent: Evented) {
         super();
         this.id = id;

--- a/src/source/vector_tile_worker_source.ts
+++ b/src/source/vector_tile_worker_source.ts
@@ -18,11 +18,11 @@ import type StyleLayerIndex from '../style/style_layer_index';
 import type {Callback} from '../types/callback';
 
 export type LoadVectorTileResult = {
-  vectorTile: VectorTile,
-  rawData: ArrayBuffer,
-  expires?: any,
-  cacheControl?: any,
-  resourceTiming?: Array<PerformanceResourceTiming>
+  vectorTile: VectorTile;
+  rawData: ArrayBuffer;
+  expires?: any;
+  cacheControl?: any;
+  resourceTiming?: Array<PerformanceResourceTiming>;
 };
 
 /**
@@ -117,7 +117,7 @@ class VectorTileWorkerSource implements WorkerSource {
             }
 
             const rawTileData = response.rawData;
-            const cacheControl = {} as {expires: any, cacheControl: any};
+            const cacheControl = {} as {expires: any; cacheControl: any};
             if (response.expires) cacheControl.expires = response.expires;
             if (response.cacheControl) cacheControl.cacheControl = response.cacheControl;
 

--- a/src/source/worker.ts
+++ b/src/source/worker.ts
@@ -32,20 +32,20 @@ export default class Worker {
     availableImages: {[_: string]: Array<string>};
     workerSourceTypes: {
       [_: string]: {
-        new (...args: any): WorkerSource
-      }
+        new (...args: any): WorkerSource;
+      };
     };
     workerSources: {
       [_: string]: {
         [_: string]: {
-          [_: string]: WorkerSource
-        }
-      }
+          [_: string]: WorkerSource;
+        };
+      };
     };
     demWorkerSources: {
       [_: string]: {
-        [_: string]: RasterDEMTileWorkerSource
-      }
+        [_: string]: RasterDEMTileWorkerSource;
+      };
     };
     referrer: string | undefined | null;
 
@@ -66,7 +66,7 @@ export default class Worker {
         this.demWorkerSources = {};
 
         this.self.registerWorkerSource = (name: string, WorkerSource: {
-          new (...args: any): WorkerSource
+          new (...args: any): WorkerSource;
         }) => {
             if (this.workerSourceTypes[name]) {
                 throw new Error(`Worker source with name "${name}" already registered.`);
@@ -76,9 +76,9 @@ export default class Worker {
 
         // This is invoked by the RTL text plugin when the download via the `importScripts` call has finished, and the code has been parsed.
         this.self.registerRTLTextPlugin = (rtlTextPlugin: {
-          applyArabicShaping: Function,
-          processBidirectionalText: ((b: string, a: Array<number>) => Array<string>) | undefined | null,
-          processStyledBidirectionalText?: ((c: string, b: Array<number>, a: Array<number>) => Array<[string, Array<number>]>) | undefined | null
+          applyArabicShaping: Function;
+          processBidirectionalText: ((b: string, a: Array<number>) => Array<string>) | undefined | null;
+          processStyledBidirectionalText?: ((c: string, b: Array<number>, a: Array<number>) => Array<[string, Array<number>]>) | undefined | null;
         }) => {
             if (globalRTLTextPlugin.isParsed()) {
                 throw new Error('RTL text plugin already registered.');
@@ -110,15 +110,15 @@ export default class Worker {
     }
 
     updateLayers(mapId: string, params: {
-      layers: Array<LayerSpecification>,
-      removedIds: Array<string>
+      layers: Array<LayerSpecification>;
+      removedIds: Array<string>;
     }, callback: WorkerTileCallback) {
         this.getLayerIndex(mapId).update(params.layers, params.removedIds);
         callback();
     }
 
     loadTile(mapId: string, params: WorkerTileParameters & {
-      type: string
+      type: string;
     }, callback: WorkerTileCallback) {
         assert(params.type);
         this.getWorkerSource(mapId, params.type, params.source).loadTile(params, callback);
@@ -129,21 +129,21 @@ export default class Worker {
     }
 
     reloadTile(mapId: string, params: WorkerTileParameters & {
-      type: string
+      type: string;
     }, callback: WorkerTileCallback) {
         assert(params.type);
         this.getWorkerSource(mapId, params.type, params.source).reloadTile(params, callback);
     }
 
     abortTile(mapId: string, params: TileParameters & {
-      type: string
+      type: string;
     }, callback: WorkerTileCallback) {
         assert(params.type);
         this.getWorkerSource(mapId, params.type, params.source).abortTile(params, callback);
     }
 
     removeTile(mapId: string, params: TileParameters & {
-      type: string
+      type: string;
     }, callback: WorkerTileCallback) {
         assert(params.type);
         this.getWorkerSource(mapId, params.type, params.source).removeTile(params, callback);
@@ -154,9 +154,9 @@ export default class Worker {
     }
 
     removeSource(mapId: string, params: {
-      source: string
+      source: string;
     } & {
-      type: string
+      type: string;
     }, callback: WorkerTileCallback) {
         assert(params.type);
         assert(params.source);
@@ -184,7 +184,7 @@ export default class Worker {
      *  @private
      */
     loadWorkerSource(map: string, params: {
-      url: string
+      url: string;
     }, callback: Callback<void>) {
         try {
             this.self.importScripts(params.url);

--- a/src/source/worker_source.ts
+++ b/src/source/worker_source.ts
@@ -12,52 +12,52 @@ import type {StyleImage} from '../style/style_image';
 import type {PromoteIdSpecification} from '../style-spec/types';
 
 export type TileParameters = {
-  source: string,
-  uid: string
+  source: string;
+  uid: string;
 };
 
 export type WorkerTileParameters = TileParameters & {
-  tileID: OverscaledTileID,
-  request: RequestParameters,
-  zoom: number,
-  maxZoom: number,
-  tileSize: number,
-  promoteId: PromoteIdSpecification | undefined | null,
-  pixelRatio: number,
-  showCollisionBoxes: boolean,
-  collectResourceTiming?: boolean,
-  returnDependencies?: boolean
+  tileID: OverscaledTileID;
+  request: RequestParameters;
+  zoom: number;
+  maxZoom: number;
+  tileSize: number;
+  promoteId: PromoteIdSpecification | undefined | null;
+  pixelRatio: number;
+  showCollisionBoxes: boolean;
+  collectResourceTiming?: boolean;
+  returnDependencies?: boolean;
 };
 
 export type WorkerDEMTileParameters = TileParameters & {
   coord: {
-    z: number,
-    x: number,
-    y: number,
-    w: number
-  },
-  rawImageData: RGBAImage | ImageBitmap,
-  encoding: "mapbox" | "terrarium"
+    z: number;
+    x: number;
+    y: number;
+    w: number;
+  };
+  rawImageData: RGBAImage | ImageBitmap;
+  encoding: "mapbox" | "terrarium";
 };
 
 export type WorkerTileResult = {
-  buckets: Array<Bucket>,
-  imageAtlas: ImageAtlas,
-  glyphAtlasImage: AlphaImage,
-  featureIndex: FeatureIndex,
-  collisionBoxArray: CollisionBoxArray,
-  rawTileData?: ArrayBuffer,
-  resourceTiming?: Array<PerformanceResourceTiming>,
+  buckets: Array<Bucket>;
+  imageAtlas: ImageAtlas;
+  glyphAtlasImage: AlphaImage;
+  featureIndex: FeatureIndex;
+  collisionBoxArray: CollisionBoxArray;
+  rawTileData?: ArrayBuffer;
+  resourceTiming?: Array<PerformanceResourceTiming>;
   // Only used for benchmarking:
   glyphMap?: {
     [_: string]: {
-      [_: number]: StyleGlyph | undefined | null
-    }
-  } | null,
+      [_: number]: StyleGlyph | undefined | null;
+    };
+  } | null;
   iconMap?: {
-    [_: string]: StyleImage
-  } | null,
-  glyphPositions?: GlyphPositions | null
+    [_: string]: StyleImage;
+  } | null;
+  glyphPositions?: GlyphPositions | null;
 };
 
 export type WorkerTileCallback = (error?: Error | null, result?: WorkerTileResult | null) => void;
@@ -108,7 +108,7 @@ export interface WorkerSource {
      */
   removeSource?: (
     params: {
-      source: string
+      source: string;
     },
     callback: WorkerTileCallback
   ) => void;

--- a/src/source/worker_tile.ts
+++ b/src/source/worker_tile.ts
@@ -130,8 +130,8 @@ class WorkerTile {
         let error: Error | undefined | null;
         let glyphMap: {
           [_: string]: {
-            [_: number]: StyleGlyph | undefined | null
-          }
+            [_: number]: StyleGlyph | undefined | null;
+          };
         } | undefined | null;
         let iconMap: {[_: string]: StyleImage} | undefined | null;
         let patternMap: {[_: string]: StyleImage} | undefined | null;

--- a/src/style-spec/error/validation_error.ts
+++ b/src/style-spec/error/validation_error.ts
@@ -6,7 +6,7 @@ export default class ValidationError {
     line: number | undefined | null;
 
     constructor(key: string | undefined | null, value: {
-      __line__: number
+      __line__: number;
     } | undefined | null, message: string, identifier?: string | null) {
         this.message = (key ? `${key}: ` : '') + message;
         if (identifier) this.identifier = identifier;

--- a/src/style-spec/expression/compound_expression.ts
+++ b/src/style-spec/expression/compound_expression.ts
@@ -9,14 +9,14 @@ import type {Type} from './types';
 import type {Value} from './values';
 
 export type Varargs = {
-  type: Type
+  type: Type;
 };
 type Signature = Array<Type> | Varargs;
 type Evaluate = (b: EvaluationContext, a: Array<Expression>) => Value;
 
 type Definition = [Type, Signature, Evaluate] | {
-  type: Type,
-  overloads: Array<[Signature, Evaluate]>
+  type: Type;
+  overloads: Array<[Signature, Evaluate]>;
 };
 
 class CompoundExpression implements Expression {

--- a/src/style-spec/expression/definitions/format.ts
+++ b/src/style-spec/expression/definitions/format.ts
@@ -18,10 +18,10 @@ import type {Type} from '../types';
 type FormattedSectionExpression = {
   // Content of a section may be Image expression or other
   // type of expression that is coercable to 'string'.
-  content: Expression,
-  scale: Expression | null,
-  font: Expression | null,
-  textColor: Expression | null
+  content: Expression;
+  scale: Expression | null;
+  font: Expression | null;
+  textColor: Expression | null;
 };
 
 export default class FormatExpression implements Expression {

--- a/src/style-spec/expression/definitions/interpolate.ts
+++ b/src/style-spec/expression/definitions/interpolate.ts
@@ -12,13 +12,13 @@ import type EvaluationContext from '../evaluation_context';
 import type {Type} from '../types';
 
 export type InterpolationType = {
-  name: "linear"
+  name: "linear";
 } | {
-  name: "exponential",
-  base: number
+  name: "exponential";
+  base: number;
 } | {
-  name: "cubic-bezier",
-  controlPoints: [number, number, number, number]
+  name: "cubic-bezier";
+  controlPoints: [number, number, number, number];
 };
 
 class Interpolate implements Expression {

--- a/src/style-spec/expression/definitions/match.ts
+++ b/src/style-spec/expression/definitions/match.ts
@@ -128,7 +128,7 @@ class Match implements Expression {
         // serializations of the form [case1, case2, ...] -> matchExpression
         const groupedByOutput: Array<[number, Array<number | string>]> = [];
         const outputLookup: {
-          [index: number]: number
+          [index: number]: number;
         } = {}; // lookup index into groupedByOutput for a given output expression
         for (const label of sortedLabels) {
             const outputIndex = outputLookup[this.cases[label]];

--- a/src/style-spec/expression/definitions/number_format.ts
+++ b/src/style-spec/expression/definitions/number_format.ts
@@ -7,8 +7,8 @@ import type {Type} from '../types';
 
 declare let Intl: {
   NumberFormat: {
-    new (...args: any): Intl$NumberFormat
-  }
+    new (...args: any): Intl$NumberFormat;
+  };
 };
 
 declare class Intl$NumberFormat {
@@ -18,10 +18,10 @@ declare class Intl$NumberFormat {
 }
 
 type NumberFormatOptions = {
-  style?: "decimal" | "currency" | "percent",
-  currency?: null | string,
-  minimumFractionDigits?: null | string,
-  maximumFractionDigits?: null | string
+  style?: "decimal" | "currency" | "percent";
+  currency?: null | string;
+  minimumFractionDigits?: null | string;
+  maximumFractionDigits?: null | string;
 };
 
 export default class NumberFormat implements Expression {

--- a/src/style-spec/expression/expression.ts
+++ b/src/style-spec/expression/expression.ts
@@ -18,8 +18,8 @@ export interface Expression {
 
 export type ExpressionParser = (args: ReadonlyArray<unknown>, context: ParsingContext) => Expression | undefined | null;
 export type ExpressionRegistration = {
-  new (...args: any): Expression
+  new (...args: any): Expression;
 } & {
-  readonly parse: ExpressionParser
+  readonly parse: ExpressionParser;
 };
 export type ExpressionRegistry = {[_: string]: ExpressionRegistration};

--- a/src/style-spec/expression/index.ts
+++ b/src/style-spec/expression/index.ts
@@ -27,27 +27,27 @@ import type Point from '../../symbol/point';
 import type {CanonicalTileID} from '../../source/tile_id';
 
 export type Feature = {
-  readonly type: 1 | 2 | 3 | "Unknown" | "Point" | "MultiPoint" | "LineString" | "MultiLineString" | "Polygon" | "MultiPolygon",
-  readonly id?: any,
-  readonly properties: {[_: string]: any},
+  readonly type: 1 | 2 | 3 | "Unknown" | "Point" | "MultiPoint" | "LineString" | "MultiLineString" | "Polygon" | "MultiPolygon";
+  readonly id?: any;
+  readonly properties: {[_: string]: any};
   readonly patterns?: {
     [_: string]: {
-      "min": string,
-      "mid": string,
-      "max": string
-    }
-  },
-  readonly geometry?: Array<Array<Point>>
+      "min": string;
+      "mid": string;
+      "max": string;
+    };
+  };
+  readonly geometry?: Array<Array<Point>>;
 };
 
 export type FeatureState = {[_: string]: any};
 
 export type GlobalProperties = Readonly<{
-  zoom: number,
-  heatmapDensity?: number,
-  lineProgress?: number,
-  isSupportedScript?: (_: string) => boolean,
-  accumulated?: Value
+  zoom: number;
+  heatmapDensity?: number;
+  lineProgress?: number;
+  isSupportedScript?: (_: string) => boolean;
+  accumulated?: Value;
 }>;
 
 export class StyleExpression {
@@ -232,19 +232,19 @@ export class ZoomDependentExpression<Kind extends EvaluationKind> {
 }
 
 export type ConstantExpression = {
-  kind: "constant",
+  kind: "constant";
   readonly evaluate: (
     globals: GlobalProperties,
     feature?: Feature,
     featureState?: FeatureState,
     canonical?: CanonicalTileID,
     availableImages?: Array<string>
-  ) => any
+  ) => any;
 };
 
 export type SourceExpression = {
-  kind: "source",
-  isStateDependent: boolean,
+  kind: "source";
+  isStateDependent: boolean;
   readonly evaluate: (
     globals: GlobalProperties,
     feature?: Feature,
@@ -252,26 +252,26 @@ export type SourceExpression = {
     canonical?: CanonicalTileID,
     availableImages?: Array<string>,
     formattedSection?: FormattedSection
-  ) => any
+  ) => any;
 };
 
 export type CameraExpression = {
-  kind: "camera",
+  kind: "camera";
   readonly evaluate: (
     globals: GlobalProperties,
     feature?: Feature,
     featureState?: FeatureState,
     canonical?: CanonicalTileID,
     availableImages?: Array<string>
-  ) => any,
-  readonly interpolationFactor: (input: number, lower: number, upper: number) => number,
-  zoomStops: Array<number>,
-  interpolationType: InterpolationType | undefined | null
+  ) => any;
+  readonly interpolationFactor: (input: number, lower: number, upper: number) => number;
+  zoomStops: Array<number>;
+  interpolationType: InterpolationType | undefined | null;
 };
 
 export type CompositeExpression = {
-  kind: "composite",
-  isStateDependent: boolean,
+  kind: "composite";
+  isStateDependent: boolean;
   readonly evaluate: (
     globals: GlobalProperties,
     feature?: Feature,
@@ -279,10 +279,10 @@ export type CompositeExpression = {
     canonical?: CanonicalTileID,
     availableImages?: Array<string>,
     formattedSection?: FormattedSection
-  ) => any,
-  readonly interpolationFactor: (input: number, lower: number, upper: number) => number,
-  zoomStops: Array<number>,
-  interpolationType: InterpolationType | undefined | null
+  ) => any;
+  readonly interpolationFactor: (input: number, lower: number, upper: number) => number;
+  zoomStops: Array<number>;
+  interpolationType: InterpolationType | undefined | null;
 };
 
 export type StylePropertyExpression = ConstantExpression | SourceExpression | CameraExpression | CompositeExpression;
@@ -348,8 +348,8 @@ export class StylePropertyFunction<T> {
     }
 
     static deserialize<T>(serialized: {
-      _parameters: PropertyValueSpecification<T>,
-      _specification: StylePropertySpecification
+      _parameters: PropertyValueSpecification<T>;
+      _specification: StylePropertySpecification;
     }) {
         return new StylePropertyFunction(serialized._parameters, serialized._specification) as StylePropertyFunction<T>;
     }

--- a/src/style-spec/expression/parsing_context.ts
+++ b/src/style-spec/expression/parsing_context.ts
@@ -59,7 +59,7 @@ class ParsingContext {
       expectedType?: Type | null,
       bindings?: Array<[string, Expression]>,
       options: {
-        typeAnnotation?: "assert" | "coerce" | "omit"
+        typeAnnotation?: "assert" | "coerce" | "omit";
       } = {}
     ): Expression | undefined | null {
         if (index) {
@@ -71,7 +71,7 @@ class ParsingContext {
     _parse(
       expr: unknown,
       options: {
-        typeAnnotation?: "assert" | "coerce" | "omit"
+        typeAnnotation?: "assert" | "coerce" | "omit";
       }
     ): Expression | undefined | null {
         if (expr === null || typeof expr === 'string' || typeof expr === 'boolean' || typeof expr === 'number') {

--- a/src/style-spec/expression/types.ts
+++ b/src/style-spec/expression/types.ts
@@ -1,35 +1,35 @@
 export type NullTypeT = {
-  kind: "null"
+  kind: "null";
 };
 export type NumberTypeT = {
-  kind: "number"
+  kind: "number";
 };
 export type StringTypeT = {
-  kind: "string"
+  kind: "string";
 };
 export type BooleanTypeT = {
-  kind: "boolean"
+  kind: "boolean";
 };
 export type ColorTypeT = {
-  kind: "color"
+  kind: "color";
 };
 export type ObjectTypeT = {
-  kind: "object"
+  kind: "object";
 };
 export type ValueTypeT = {
-  kind: "value"
+  kind: "value";
 };
 export type ErrorTypeT = {
-  kind: "error"
+  kind: "error";
 };
 export type CollatorTypeT = {
-  kind: "collator"
+  kind: "collator";
 };
 export type FormattedTypeT = {
-  kind: "formatted"
+  kind: "formatted";
 };
 export type ResolvedImageTypeT = {
-  kind: "resolvedImage"
+  kind: "resolvedImage";
 };
 
 export type EvaluationKind = "constant" | "source" | "camera" | "composite";
@@ -38,9 +38,9 @@ export type Type = NullTypeT | NumberTypeT | StringTypeT | BooleanTypeT | ColorT
 ArrayType | ErrorTypeT | CollatorTypeT | FormattedTypeT | ResolvedImageTypeT;
 
 export type ArrayType = {
-  kind: "array",
-  itemType: Type,
-  N: number | undefined | null
+  kind: "array";
+  itemType: Type;
+  N: number | undefined | null;
 };
 
 export type NativeType = "number" | "string" | "boolean" | "null" | "array" | "object";

--- a/src/style-spec/expression/types/collator.ts
+++ b/src/style-spec/expression/types/collator.ts
@@ -3,8 +3,8 @@
 
 declare let Intl: {
   Collator: {
-    new (...args: any): Intl$Collator
-  }
+    new (...args: any): Intl$Collator;
+  };
 };
 
 declare class Intl$Collator {
@@ -14,12 +14,12 @@ declare class Intl$Collator {
 }
 
 type CollatorOptions = {
-  localeMatcher?: "lookup" | "best fit",
-  usage?: "sort" | "search",
-  sensitivity?: "base" | "accent" | "case" | "variant",
-  ignorePunctuation?: boolean,
-  numeric?: boolean,
-  caseFirst?: "upper" | "lower" | "false"
+  localeMatcher?: "lookup" | "best fit";
+  usage?: "sort" | "search";
+  sensitivity?: "base" | "accent" | "case" | "variant";
+  ignorePunctuation?: boolean;
+  numeric?: boolean;
+  caseFirst?: "upper" | "lower" | "false";
 };
 
 export default class Collator {

--- a/src/style-spec/expression/types/resolved_image.ts
+++ b/src/style-spec/expression/types/resolved_image.ts
@@ -1,6 +1,6 @@
 export type ResolvedImageOptions = {
-  name: string,
-  available: boolean
+  name: string;
+  available: boolean;
 };
 
 export default class ResolvedImage {

--- a/src/style-spec/expression/values.ts
+++ b/src/style-spec/expression/values.ts
@@ -28,7 +28,7 @@ export function validateRGBA(r: unknown, g: unknown, b: unknown, a?: unknown): s
 }
 
 export type Value = null | string | boolean | number | Color | Collator | Formatted | ResolvedImage | ReadonlyArray<Value> | {
-  readonly [x: string]: Value
+  readonly [x: string]: Value;
 };
 
 export function isValue(mixed: unknown): boolean {

--- a/src/style-spec/feature_filter/index.ts
+++ b/src/style-spec/feature_filter/index.ts
@@ -10,8 +10,8 @@ type FilterExpression = (
 ) => boolean;
 
 export type FeatureFilter = {
-  filter: FilterExpression,
-  needGeometry: boolean
+  filter: FilterExpression;
+  needGeometry: boolean;
 };
 
 export default createFilter;

--- a/src/style-spec/style-spec.ts
+++ b/src/style-spec/style-spec.ts
@@ -2,59 +2,59 @@ type ExpressionType = "data-driven" | "cross-faded" | "cross-faded-data-driven" 
 type ExpressionParameters = Array<"zoom" | "feature" | "feature-state" | "heatmap-density" | "line-progress">;
 
 type ExpressionSpecification = {
-  interpolated: boolean,
-  parameters: ExpressionParameters
+  interpolated: boolean;
+  parameters: ExpressionParameters;
 };
 
 export type StylePropertySpecification = {
-  type: "number",
-  'property-type': ExpressionType,
-  expression?: ExpressionSpecification,
-  transition: boolean,
-  default?: number
+  type: "number";
+  'property-type': ExpressionType;
+  expression?: ExpressionSpecification;
+  transition: boolean;
+  default?: number;
 } | {
-  type: "string",
-  'property-type': ExpressionType,
-  expression?: ExpressionSpecification,
-  transition: boolean,
-  default?: string,
-  tokens?: boolean
+  type: "string";
+  'property-type': ExpressionType;
+  expression?: ExpressionSpecification;
+  transition: boolean;
+  default?: string;
+  tokens?: boolean;
 } | {
-  type: "boolean",
-  'property-type': ExpressionType,
-  expression?: ExpressionSpecification,
-  transition: boolean,
-  default?: boolean
+  type: "boolean";
+  'property-type': ExpressionType;
+  expression?: ExpressionSpecification;
+  transition: boolean;
+  default?: boolean;
 } | {
-  type: "enum",
-  'property-type': ExpressionType,
-  expression?: ExpressionSpecification,
-  values: {[_: string]: {}},
-  transition: boolean,
-  default?: string
+  type: "enum";
+  'property-type': ExpressionType;
+  expression?: ExpressionSpecification;
+  values: {[_: string]: {}};
+  transition: boolean;
+  default?: string;
 } | {
-  type: "color",
-  'property-type': ExpressionType,
-  expression?: ExpressionSpecification,
-  transition: boolean,
-  default?: string,
-  overridable: boolean
+  type: "color";
+  'property-type': ExpressionType;
+  expression?: ExpressionSpecification;
+  transition: boolean;
+  default?: string;
+  overridable: boolean;
 } | {
-  type: "array",
-  value: "number",
-  'property-type': ExpressionType,
-  expression?: ExpressionSpecification,
-  length?: number,
-  transition: boolean,
-  default?: Array<number>
+  type: "array";
+  value: "number";
+  'property-type': ExpressionType;
+  expression?: ExpressionSpecification;
+  length?: number;
+  transition: boolean;
+  default?: Array<number>;
 } | {
-  type: "array",
-  value: "string",
-  'property-type': ExpressionType,
-  expression?: ExpressionSpecification,
-  length?: number,
-  transition: boolean,
-  default?: Array<string>
+  type: "array";
+  value: "string";
+  'property-type': ExpressionType;
+  expression?: ExpressionSpecification;
+  length?: number;
+  transition: boolean;
+  default?: Array<string>;
 };
 
 import v8 from './reference/v8.json';

--- a/src/style-spec/util/color_spaces.ts
+++ b/src/style-spec/util/color_spaces.ts
@@ -3,17 +3,17 @@ import Color from './color';
 import {number as interpolateNumber} from './interpolate';
 
 type LABColor = {
-  l: number,
-  a: number,
-  b: number,
-  alpha: number
+  l: number;
+  a: number;
+  b: number;
+  alpha: number;
 };
 
 type HCLColor = {
-  h: number,
-  c: number,
-  l: number,
-  alpha: number
+  h: number;
+  c: number;
+  l: number;
+  alpha: number;
 };
 
 // Constants

--- a/src/style-spec/util/result.ts
+++ b/src/style-spec/util/result.ts
@@ -5,11 +5,11 @@
  * @private
  */
 export type Result<T, E> = {
-  result: "success",
-  value: T
+  result: "success";
+  value: T;
 } | {
-  result: "error",
-  value: E
+  result: "error";
+  value: E;
 };
 
 export function success<T, E>(value: T): Result<T, E> {

--- a/src/style-spec/visit.ts
+++ b/src/style-spec/visit.ts
@@ -37,21 +37,21 @@ export function eachLayer(style: StyleSpecification, callback: (_: LayerSpecific
 
 type PropertyCallback = (
   a: {
-    path: [string, "paint" | "layout", string] // [layerid, paint/layout, property key],
-    key: string,
-    value: PropertyValueSpecification<unknown> | DataDrivenPropertyValueSpecification<unknown>,
-    reference: StylePropertySpecification,
+    path: [string, "paint" | "layout", string]; // [layerid, paint/layout, property key],
+    key: string;
+    value: PropertyValueSpecification<unknown> | DataDrivenPropertyValueSpecification<unknown>;
+    reference: StylePropertySpecification;
     set: (
       a: PropertyValueSpecification<unknown> | DataDrivenPropertyValueSpecification<unknown>
-    ) => void
+    ) => void;
   }
 ) => void;
 
 export function eachProperty(
     style: StyleSpecification,
     options: {
-      paint?: boolean,
-      layout?: boolean
+      paint?: boolean;
+      layout?: boolean;
     },
     callback: PropertyCallback
 ) {

--- a/src/style/evaluation_parameters.ts
+++ b/src/style/evaluation_parameters.ts
@@ -5,9 +5,9 @@ import {plugin as rtlTextPlugin} from '../source/rtl_text_plugin';
 import type {TransitionSpecification} from '../style-spec/types';
 
 export type CrossfadeParameters = {
-  fromScale: number,
-  toScale: number,
-  t: number
+  fromScale: number;
+  toScale: number;
+  t: number;
 };
 
 class EvaluationParameters {

--- a/src/style/light.ts
+++ b/src/style/light.ts
@@ -24,9 +24,9 @@ import type {
 import type {LightSpecification} from '../style-spec/types';
 
 type LightPosition = {
-  x: number,
-  y: number,
-  z: number
+  x: number;
+  y: number;
+  z: number;
 };
 
 class LightPositionProperty implements Property<[number, number, number], LightPosition> {
@@ -53,17 +53,17 @@ class LightPositionProperty implements Property<[number, number, number], LightP
 }
 
 type Props = {
-  "anchor": DataConstantProperty<"map" | "viewport">,
-  "position": LightPositionProperty,
-  "color": DataConstantProperty<Color>,
-  "intensity": DataConstantProperty<number>
+  "anchor": DataConstantProperty<"map" | "viewport">;
+  "position": LightPositionProperty;
+  "color": DataConstantProperty<Color>;
+  "intensity": DataConstantProperty<number>;
 };
 
 type PropsPossiblyEvaluated = {
-    "anchor": "map" | "viewport",
-    "position": LightPosition,
-    "color": Color,
-    "intensity": number
+    "anchor": "map" | "viewport";
+    "position": LightPosition;
+    "color": Color;
+    "intensity": number;
 };
 
 const properties: Properties<Props> = new Properties({
@@ -122,7 +122,7 @@ class Light extends Evented {
     }
 
     _validate(validate: Function, value: unknown, options?: {
-      validate?: boolean
+      validate?: boolean;
     }) {
         if (options && options.validate === false) {
             return false;

--- a/src/style/load_glyph_range.ts
+++ b/src/style/load_glyph_range.ts
@@ -11,7 +11,7 @@ export default function (fontstack: string,
                            urlTemplate: string,
                            requestManager: RequestManager,
                            callback: Callback<{
-                             [_: number]: StyleGlyph | null
+                             [_: number]: StyleGlyph | null;
                            }>) {
     const begin = range * 256;
     const end = begin + 255;

--- a/src/style/properties.ts
+++ b/src/style/properties.ts
@@ -24,8 +24,8 @@ import {
 type TimePoint = number;
 
 export type CrossFaded<T> = {
-  to: T,
-  from: T
+  to: T;
+  from: T;
 };
 
 /**
@@ -120,8 +120,8 @@ export class PropertyValue<T, R> {
 // ------- Transitionable -------
 
 export type TransitionParameters = {
-  now: TimePoint,
-  transition: TransitionSpecification
+  now: TimePoint;
+  transition: TransitionSpecification;
 };
 
 /**
@@ -409,8 +409,8 @@ export class Layout<Props> {
  * @private
  */
 type PossiblyEvaluatedValue<T> = {
-  kind: "constant",
-  value: T
+  kind: "constant";
+  value: T;
 } | SourceExpression | CompositeExpression;
 
 /**

--- a/src/style/style.ts
+++ b/src/style/style.ts
@@ -38,8 +38,8 @@ import {validateCustomStyleLayer} from './style_layer/custom_style_layer';
 // to continue to allow canvas sources to be added at runtime/updated in
 // smart setStyle (see https://github.com/mapbox/mapbox-gl-js/pull/6424):
 const emitValidationErrors = (evented: Evented, errors?: ReadonlyArray<{
-  message: string,
-  identifier?: string
+  message: string;
+  identifier?: string;
 }> | null) =>
     _emitValidationErrors(evented, errors && errors.filter(error => error.identifier !== 'source.canvas'));
 
@@ -89,12 +89,12 @@ const ignoredDiffOperations = pick(diffOperations, [
 const empty = emptyStyle() as StyleSpecification;
 
 export type StyleOptions = {
-  validate?: boolean,
-  localIdeographFontFamily?: string
+  validate?: boolean;
+  localIdeographFontFamily?: string;
 };
 
 export type StyleSetterOptions = {
-  validate?: boolean
+  validate?: boolean;
 };
 /**
  * @private
@@ -204,8 +204,8 @@ class Style extends Evented {
     }
 
     loadURL(url: string, options: {
-      validate?: boolean,
-      accessToken?: string
+      validate?: boolean;
+      accessToken?: string;
     } = {}) {
         this.fire(new Event('dataloading', {dataType: 'style'}));
 
@@ -916,9 +916,9 @@ class Style extends Evented {
     }
 
     setFeatureState(target: {
-      source: string,
-      sourceLayer?: string,
-      id: string | number
+      source: string;
+      sourceLayer?: string;
+      id: string | number;
     }, state: any) {
         this._checkLoaded();
         const sourceId = target.source;
@@ -946,9 +946,9 @@ class Style extends Evented {
     }
 
     removeFeatureState(target: {
-      source: string,
-      sourceLayer?: string,
-      id?: string | number
+      source: string;
+      sourceLayer?: string;
+      id?: string | number;
     }, key?: string) {
         this._checkLoaded();
         const sourceId = target.source;
@@ -976,9 +976,9 @@ class Style extends Evented {
     }
 
     getFeatureState(target: {
-      source: string,
-      sourceLayer?: string,
-      id: string | number
+      source: string;
+      sourceLayer?: string;
+      id: string | number;
     }) {
         this._checkLoaded();
         const sourceId = target.source;
@@ -1162,9 +1162,9 @@ class Style extends Evented {
     querySourceFeatures(
         sourceID: string,
         params?: {
-            sourceLayer: string | undefined | null,
-            filter: Array<any> | undefined | null,
-            validate?: boolean
+            sourceLayer: string | undefined | null;
+            filter: Array<any> | undefined | null;
+            validate?: boolean;
         } | null
     ) {
         if (params && params.filter) {
@@ -1221,7 +1221,7 @@ class Style extends Evented {
     }
 
     _validate(validate: Validator, key: string, value: any, props: any, options: {
-      validate?: boolean
+      validate?: boolean;
     } = {}) {
         if (options && options.validate === false) {
             return false;
@@ -1359,10 +1359,10 @@ class Style extends Evented {
     getImages(
       mapId: string,
       params: {
-        icons: Array<string>,
-        source: string,
-        tileID: OverscaledTileID,
-        type: string
+        icons: Array<string>;
+        source: string;
+        tileID: OverscaledTileID;
+        type: string;
       },
       callback: Callback<{[_: string]: StyleImage}>
     ) {

--- a/src/style/style_glyph.ts
+++ b/src/style/style_glyph.ts
@@ -1,15 +1,15 @@
 import type {AlphaImage} from '../util/image';
 
 export type GlyphMetrics = {
-  width: number,
-  height: number,
-  left: number,
-  top: number,
-  advance: number
+  width: number;
+  height: number;
+  left: number;
+  top: number;
+  advance: number;
 };
 
 export type StyleGlyph = {
-  id: number,
-  bitmap: AlphaImage,
-  metrics: GlyphMetrics
+  id: number;
+  bitmap: AlphaImage;
+  metrics: GlyphMetrics;
 };

--- a/src/style/style_image.ts
+++ b/src/style/style_image.ts
@@ -3,29 +3,29 @@ import {RGBAImage} from '../util/image';
 import type Map from '../ui/map';
 
 export type StyleImageData = {
-  data: RGBAImage,
-  version: number,
-  hasRenderCallback?: boolean,
-  userImage?: StyleImageInterface
+  data: RGBAImage;
+  version: number;
+  hasRenderCallback?: boolean;
+  userImage?: StyleImageInterface;
 };
 
 export type StyleImageMetadata = {
-  pixelRatio: number,
-  sdf: boolean,
-  stretchX?: Array<[number, number]>,
-  stretchY?: Array<[number, number]>,
-  content?: [number, number, number, number]
+  pixelRatio: number;
+  sdf: boolean;
+  stretchX?: Array<[number, number]>;
+  stretchY?: Array<[number, number]>;
+  content?: [number, number, number, number];
 };
 
 export type StyleImage = StyleImageData & StyleImageMetadata;
 
 export type StyleImageInterface = {
-  width: number,
-  height: number,
-  data: Uint8Array | Uint8ClampedArray,
-  render?: () => boolean,
-  onAdd?: (map: Map, id: string) => void,
-  onRemove?: () => void
+  width: number;
+  height: number;
+  data: Uint8Array | Uint8ClampedArray;
+  render?: () => boolean;
+  onAdd?: (map: Map, id: string) => void;
+  onRemove?: () => void;
 };
 
 export function renderStyleImage(image: StyleImage) {

--- a/src/style/style_layer.ts
+++ b/src/style/style_layer.ts
@@ -68,8 +68,8 @@ class StyleLayer extends Evented {
     readonly onRemove: ((map: Map) => void) | undefined | null;
 
     constructor(layer: LayerSpecification | CustomLayerInterface, properties: Readonly<{
-      layout?: Properties<any>,
-      paint?: Properties<any>
+      layout?: Properties<any>;
+      paint?: Properties<any>;
     }>) {
         super();
 

--- a/src/style/style_layer/custom_style_layer.ts
+++ b/src/style/style_layer/custom_style_layer.ts
@@ -145,13 +145,13 @@ type CustomRenderMethod = (gl: WebGLRenderingContext, matrix: mat4) => void;
  * can be used to project a `LngLat` to a mercator coordinate.
  */
 export type CustomLayerInterface = {
-  id: string,
-  type: "custom",
-  renderingMode: "2d" | "3d",
-  render: CustomRenderMethod,
-  prerender: CustomRenderMethod | undefined | null,
-  onAdd: ((map: Map, gl: WebGLRenderingContext) => void) | undefined | null,
-  onRemove: ((map: Map, gl: WebGLRenderingContext) => void) | undefined | null
+  id: string;
+  type: "custom";
+  renderingMode: "2d" | "3d";
+  render: CustomRenderMethod;
+  prerender: CustomRenderMethod | undefined | null;
+  onAdd: ((map: Map, gl: WebGLRenderingContext) => void) | undefined | null;
+  onRemove: ((map: Map, gl: WebGLRenderingContext) => void) | undefined | null;
 };
 
 export function validateCustomStyleLayer(layerObject: CustomLayerInterface) {

--- a/src/style/style_layer_index.ts
+++ b/src/style/style_layer_index.ts
@@ -14,8 +14,8 @@ export type Family<Layer extends TypedStyleLayer> = Array<Layer>;
 class StyleLayerIndex {
     familiesBySource: {
       [source: string]: {
-        [sourceLayer: string]: Array<Family<any>>
-      }
+        [sourceLayer: string]: Array<Family<any>>;
+      };
     };
     keyCache: {[source: string]: string};
 

--- a/src/style/validate_style.ts
+++ b/src/style/validate_style.ts
@@ -4,21 +4,21 @@ import {ErrorEvent} from '../util/evented';
 import type {Evented} from '../util/evented';
 
 type ValidationError = {
-  message: string,
-  line: number,
-  identifier?: string
+  message: string;
+  line: number;
+  identifier?: string;
 };
 
 export type Validator = (a: any) => ReadonlyArray<ValidationError>;
 
 type ValidateStyle = {
-  source: Validator,
-  layer: Validator,
-  light: Validator,
-  filter: Validator,
-  paintProperty: Validator,
-  layoutProperty: Validator,
-  (b: any, a?: any | null): ReadonlyArray<ValidationError>
+  source: Validator;
+  layer: Validator;
+  light: Validator;
+  filter: Validator;
+  paintProperty: Validator;
+  layoutProperty: Validator;
+  (b: any, a?: any | null): ReadonlyArray<ValidationError>;
 };
 
 export const validateStyle = (validateStyleMin as ValidateStyle);
@@ -32,8 +32,8 @@ export const validateLayoutProperty = validateStyle.layoutProperty;
 export function emitValidationErrors(
   emitter: Evented,
   errors?: ReadonlyArray<{
-    message: string,
-    identifier?: string
+    message: string;
+    identifier?: string;
   }> | null
 ): boolean {
     let hasErrors = false;

--- a/src/symbol/collision_index.ts
+++ b/src/symbol/collision_index.ts
@@ -71,8 +71,8 @@ class CollisionIndex {
       posMatrix: mat4,
       collisionGroupPredicate?: any
     ): {
-      box: Array<number>,
-      offscreen: boolean
+      box: Array<number>;
+      offscreen: boolean;
     } {
         const projectedPoint = this.projectAndGetPerspectiveRatio(posMatrix, collisionBox.anchorPointX, collisionBox.anchorPointY);
         const tileToViewport = textPixelRatio * projectedPoint.perspectiveRatio;
@@ -110,9 +110,9 @@ class CollisionIndex {
       circlePixelDiameter: number,
       textPixelPadding: number
     ): {
-      circles: Array<number>,
-      offscreen: boolean,
-      collisionDetected: boolean
+      circles: Array<number>;
+      offscreen: boolean;
+      collisionDetected: boolean;
     } {
         const placedCollisionCircles = [];
 

--- a/src/symbol/cross_tile_symbol_index.ts
+++ b/src/symbol/cross_tile_symbol_index.ts
@@ -29,12 +29,12 @@ class TileLayerIndex {
     tileID: OverscaledTileID;
     indexedSymbolInstances: {
       [_: number]: Array<{
-        crossTileID: number,
+        crossTileID: number;
         coord: {
-          x: number,
-          y: number
-        }
-      }>
+          x: number;
+          y: number;
+        };
+      }>;
     };
     bucketInstanceId: number;
 
@@ -74,7 +74,7 @@ class TileLayerIndex {
     }
 
     findMatches(symbolInstances: SymbolInstanceArray, newTileID: OverscaledTileID, zoomCrossTileIDs: {
-      [crossTileID: number]: boolean
+      [crossTileID: number]: boolean;
     }) {
         const tolerance = this.tileID.canonical.z < newTileID.canonical.z ? 1 : Math.pow(2, this.tileID.canonical.z - newTileID.canonical.z);
 
@@ -129,7 +129,7 @@ class CrossTileSymbolLayerIndex {
     };
     usedCrossTileIDs: {
       [zoom in string | number]: {
-        [crossTileID: number]: boolean
+        [crossTileID: number]: boolean;
       };
     };
     lng: number;

--- a/src/symbol/placement.ts
+++ b/src/symbol/placement.ts
@@ -96,8 +96,8 @@ export class RetainedQueryData {
 }
 
 type CollisionGroup = {
-  ID: number,
-  predicate?: any
+  ID: number;
+  predicate?: any;
 };
 
 class CollisionGroups {
@@ -170,33 +170,33 @@ function shiftVariableCollisionBox(collisionBox: SingleCollisionBox,
 }
 
 export type VariableOffset = {
-  textOffset: [number, number],
-  width: number,
-  height: number,
-  anchor: TextAnchor,
-  textBoxScale: number,
-  prevAnchor?: TextAnchor
+  textOffset: [number, number];
+  width: number;
+  height: number;
+  anchor: TextAnchor;
+  textBoxScale: number;
+  prevAnchor?: TextAnchor;
 };
 
 type TileLayerParameters = {
-  bucket: SymbolBucket,
-  layout: any,
-  posMatrix: mat4,
-  textLabelPlaneMatrix: mat4,
-  labelToScreenMatrix: mat4,
-  scale: number,
-  textPixelRatio: number,
-  holdingForFade: boolean,
-  collisionBoxArray: CollisionBoxArray | undefined | null,
-  partiallyEvaluatedTextSize: any,
-  collisionGroup: any
+  bucket: SymbolBucket;
+  layout: any;
+  posMatrix: mat4;
+  textLabelPlaneMatrix: mat4;
+  labelToScreenMatrix: mat4;
+  scale: number;
+  textPixelRatio: number;
+  holdingForFade: boolean;
+  collisionBoxArray: CollisionBoxArray | undefined | null;
+  partiallyEvaluatedTextSize: any;
+  collisionGroup: any;
 };
 
 export type BucketPart = {
-  sortKey?: number | void,
-  symbolInstanceStart: number,
-  symbolInstanceEnd: number,
-  parameters: TileLayerParameters
+  sortKey?: number | void;
+  symbolInstanceStart: number;
+  symbolInstanceEnd: number;
+  parameters: TileLayerParameters;
 };
 
 export type CrossTileID = string | number;
@@ -222,7 +222,7 @@ export class Placement {
     stale: boolean;
     fadeDuration: number;
     retainedQueryData: {
-      [_: number]: RetainedQueryData
+      [_: number]: RetainedQueryData;
     };
     collisionGroups: CollisionGroups;
     prevPlacement: Placement | undefined | null;
@@ -345,11 +345,11 @@ export class Placement {
       orientation: number,
       iconBox?: SingleCollisionBox | null
     ): {
-      shift: Point,
+      shift: Point;
       placedGlyphBoxes: {
-        box: Array<number>,
-        offscreen: boolean
-      }
+        box: Array<number>;
+        offscreen: boolean;
+      };
     } | undefined | null {
 
         const textOffset = [symbolInstance.textOffset0, symbolInstance.textOffset1] as [number, number];
@@ -560,8 +560,8 @@ export class Placement {
                         const variableIconBox = hasIconTextFit && !iconAllowOverlap ? collisionIconBox : null;
 
                         let placedBox: {
-                          box: Array<number>,
-                          offscreen: boolean
+                          box: Array<number>;
+                          offscreen: boolean;
                         } | undefined | null  = {box: [], offscreen: false};
                         const placementAttempts = textAllowOverlap ? anchors.length * 2 : anchors.length;
                         for (let i = 0; i < placementAttempts; ++i) {

--- a/src/symbol/point.ts
+++ b/src/symbol/point.ts
@@ -323,7 +323,7 @@ class Point {
      * // is equivalent to
      * var point = new Point(0, 1);
      */
-    static convert(a: PointLike | {x: number, y: number}): Point {
+    static convert(a: PointLike | {x: number; y: number}): Point {
         if (a instanceof Point) {
             return a;
         }

--- a/src/symbol/projection.ts
+++ b/src/symbol/projection.ts
@@ -345,7 +345,7 @@ function placeGlyphAlongLine(offsetX: number,
                              lineVertexArray: SymbolLineVertexArray,
                              labelPlaneMatrix: mat4,
                              projectionCache: {
-                               [_: number]: Point
+                               [_: number]: Point;
                              }) {
 
     const combinedOffsetX = flip ?

--- a/src/symbol/quads.ts
+++ b/src/symbol/quads.ts
@@ -26,24 +26,24 @@ import {Rect} from '../render/glyph_atlas';
  * @private
  */
 export type SymbolQuad = {
-  tl: Point,
-  tr: Point,
-  bl: Point,
-  br: Point,
+  tl: Point;
+  tr: Point;
+  bl: Point;
+  br: Point;
   tex: {
-    x: number,
-    y: number,
-    w: number,
-    h: number
-  },
-  pixelOffsetTL: Point,
-  pixelOffsetBR: Point,
-  writingMode: any | void,
-  glyphOffset: [number, number],
-  sectionIndex: number,
-  isSDF: boolean,
-  minFontScaleX: number,
-  minFontScaleY: number
+    x: number;
+    y: number;
+    w: number;
+    h: number;
+  };
+  pixelOffsetTL: Point;
+  pixelOffsetBR: Point;
+  writingMode: any | void;
+  glyphOffset: [number, number];
+  sectionIndex: number;
+  isSDF: boolean;
+  minFontScaleX: number;
+  minFontScaleY: number;
 };
 
 // If you have a 10px icon that isn't perfectly aligned to the pixel grid it will cover 11 actual

--- a/src/symbol/shaping.ts
+++ b/src/symbol/shaping.ts
@@ -33,34 +33,34 @@ export {shapeText, shapeIcon, fitIconToText, getAnchorAlignment, WritingMode, SH
 
 // The position of a glyph relative to the text's anchor point.
 export type PositionedGlyph = {
-  glyph: number,
-  imageName: string | null,
-  x: number,
-  y: number,
-  vertical: boolean,
-  scale: number,
-  fontStack: string,
-  sectionIndex: number,
-  metrics: GlyphMetrics,
-  rect: Rect | null
+  glyph: number;
+  imageName: string | null;
+  x: number;
+  y: number;
+  vertical: boolean;
+  scale: number;
+  fontStack: string;
+  sectionIndex: number;
+  metrics: GlyphMetrics;
+  rect: Rect | null;
 };
 
 export type PositionedLine = {
-  positionedGlyphs: Array<PositionedGlyph>,
-  lineOffset: number
+  positionedGlyphs: Array<PositionedGlyph>;
+  lineOffset: number;
 };
 
 // A collection of positioned glyphs and some metadata
 export type Shaping = {
-  positionedLines: Array<PositionedLine>,
-  top: number,
-  bottom: number,
-  left: number,
-  right: number,
-  writingMode: WritingMode.horizontal | WritingMode.vertical,
-  text: string,
-  iconsInText: boolean,
-  verticalizable: boolean
+  positionedLines: Array<PositionedLine>;
+  top: number;
+  bottom: number;
+  left: number;
+  right: number;
+  writingMode: WritingMode.horizontal | WritingMode.vertical;
+  text: string;
+  iconsInText: boolean;
+  verticalizable: boolean;
 };
 
 function isEmpty(positionedLines: Array<PositionedLine>) {
@@ -244,13 +244,13 @@ function shapeText(
   text: Formatted,
   glyphMap: {
     [_: string]: {
-      [_: number]: StyleGlyph | undefined | null
-    }
+      [_: number]: StyleGlyph | undefined | null;
+    };
   },
   glyphPositions: {
     [_: string]: {
-      [_: number]: GlyphPosition
-    }
+      [_: number]: GlyphPosition;
+    };
   },
   imagePositions: {[_: string]: ImagePosition},
   defaultFontStack: string,
@@ -332,7 +332,7 @@ function shapeText(
 /* eslint no-useless-computed-key: 0 */
 
 const whitespace: {
-  [_: number]: boolean
+  [_: number]: boolean;
 } = {
     [0x09]: true, // tab
     [0x0a]: true, // newline
@@ -343,7 +343,7 @@ const whitespace: {
 };
 
 const breakable: {
-  [_: number]: boolean
+  [_: number]: boolean;
 } = {
     [0x0a]:   true, // newline
     [0x20]:   true, // space
@@ -369,8 +369,8 @@ function getGlyphAdvance(
   section: SectionOptions,
   glyphMap: {
     [_: string]: {
-      [_: number]: StyleGlyph | undefined | null
-    }
+      [_: number]: StyleGlyph | undefined | null;
+    };
   },
   imagePositions: {[_: string]: ImagePosition},
   spacing: number,
@@ -393,8 +393,8 @@ function determineAverageLineWidth(logicalInput: TaggedString,
                                    maxWidth: number,
                                    glyphMap: {
                                      [_: string]: {
-                                       [_: number]: StyleGlyph | undefined | null
-                                     }
+                                       [_: number]: StyleGlyph | undefined | null;
+                                     };
                                    },
                                    imagePositions: {[_: string]: ImagePosition},
                                    layoutTextSize: number) {
@@ -451,10 +451,10 @@ function calculatePenalty(codePoint: number, nextCodePoint: number, penalizableI
 }
 
 type Break = {
-  index: number,
-  x: number,
-  priorBreak: Break | undefined | null,
-  badness: number
+  index: number;
+  x: number;
+  priorBreak: Break | undefined | null;
+  badness: number;
 };
 
 function evaluateBreak(
@@ -504,8 +504,8 @@ function determineLineBreaks(
   maxWidth: number,
   glyphMap: {
     [_: string]: {
-      [_: number]: StyleGlyph | undefined | null
-    }
+      [_: number]: StyleGlyph | undefined | null;
+    };
   },
   imagePositions: {[_: string]: ImagePosition},
   symbolPlacement: string,
@@ -592,13 +592,13 @@ function getAnchorAlignment(anchor: SymbolAnchor) {
 function shapeLines(shaping: Shaping,
                     glyphMap: {
                       [_: string]: {
-                        [_: number]: StyleGlyph | undefined | null
-                      }
+                        [_: number]: StyleGlyph | undefined | null;
+                      };
                     },
                     glyphPositions: {
                       [_: string]: {
-                        [_: number]: GlyphPosition
-                      }
+                        [_: number]: GlyphPosition;
+                      };
                     },
                     imagePositions: {[_: string]: ImagePosition},
                     lines: Array<TaggedString>,
@@ -785,12 +785,12 @@ function align(positionedLines: Array<PositionedLine>,
 }
 
 export type PositionedIcon = {
-  image: ImagePosition,
-  top: number,
-  bottom: number,
-  left: number,
-  right: number,
-  collisionPadding?: [number, number, number, number]
+  image: ImagePosition;
+  top: number;
+  bottom: number;
+  left: number;
+  right: number;
+  collisionPadding?: [number, number, number, number];
 };
 
 function shapeIcon(

--- a/src/symbol/symbol_layout.ts
+++ b/src/symbol/symbol_layout.ts
@@ -46,11 +46,11 @@ import murmur3 from 'murmurhash-js';
 // (1) and (2) are stored in `bucket.layers[0].layout`. The remainder are below.
 //
 type Sizes = {
-  layoutTextSize: PossiblyEvaluatedPropertyValue<number> // (3),
-  layoutIconSize: PossiblyEvaluatedPropertyValue<number> // (3),
-  textMaxSize: PossiblyEvaluatedPropertyValue<number>    // (4),
-  compositeTextSizes: [PossiblyEvaluatedPropertyValue<number>, PossiblyEvaluatedPropertyValue<number>] // (5),
-  compositeIconSizes: [PossiblyEvaluatedPropertyValue<number>, PossiblyEvaluatedPropertyValue<number>] // (5)
+  layoutTextSize: PossiblyEvaluatedPropertyValue<number>; // (3),
+  layoutIconSize: PossiblyEvaluatedPropertyValue<number>; // (3),
+  textMaxSize: PossiblyEvaluatedPropertyValue<number>;    // (4),
+  compositeTextSizes: [PossiblyEvaluatedPropertyValue<number>, PossiblyEvaluatedPropertyValue<number>]; // (5),
+  compositeIconSizes: [PossiblyEvaluatedPropertyValue<number>, PossiblyEvaluatedPropertyValue<number>]; // (5)
 };
 
 export type TextAnchor = "center" | "left" | "right" | "top" | "bottom" | "top-left" | "top-right" | "bottom-left" | "bottom-right";
@@ -149,13 +149,13 @@ export function performSymbolLayout(
     bucket: SymbolBucket,
     glyphMap: {
         [_: string]: {
-            [x: number]: StyleGlyph | undefined | null
-        }
+            [x: number]: StyleGlyph | undefined | null;
+        };
     },
     glyphPositions: {
         [_: string]: {
-            [x: number]: GlyphPosition
-        }
+            [x: number]: GlyphPosition;
+        };
     },
     imageMap: {[_: string]: StyleImage},
     imagePositions: {[_: string]: ImagePosition},
@@ -490,8 +490,8 @@ function addTextVertices(bucket: SymbolBucket,
                          feature: SymbolFeature,
                          textOffset: [number, number],
                          lineArray: {
-                           lineStartIndex: number,
-                           lineLength: number
+                           lineStartIndex: number;
+                           lineLength: number;
                          },
                          writingMode: number,
                          placementTypes: Array<"vertical" | "center" | "left" | "right">,

--- a/src/symbol/symbol_size.ts
+++ b/src/symbol/symbol_size.ts
@@ -11,22 +11,22 @@ const SIZE_PACK_FACTOR = 128;
 export {getSizeData, evaluateSizeForFeature, evaluateSizeForZoom, SIZE_PACK_FACTOR};
 
 export type SizeData = {
-  kind: "constant",
-  layoutSize: number
+  kind: "constant";
+  layoutSize: number;
 } | {
-  kind: "source"
+  kind: "source";
 } | {
-  kind: "camera",
-  minZoom: number,
-  maxZoom: number,
-  minSize: number,
-  maxSize: number,
-  interpolationType: InterpolationType | undefined | null
+  kind: "camera";
+  minZoom: number;
+  maxZoom: number;
+  minSize: number;
+  maxSize: number;
+  interpolationType: InterpolationType | undefined | null;
 } | {
-  kind: "composite",
-  minZoom: number,
-  maxZoom: number,
-  interpolationType: InterpolationType | undefined | null
+  kind: "composite";
+  minZoom: number;
+  maxZoom: number;
+  interpolationType: InterpolationType | undefined | null;
 };
 
 // For {text,icon}-size, get the bucket-level data that will be needed by
@@ -79,15 +79,15 @@ function evaluateSizeForFeature(sizeData: SizeData,
                                     uSize,
                                     uSizeT
                                 }: {
-                                  uSize: number,
-                                  uSizeT: number
+                                  uSize: number;
+                                  uSizeT: number;
                                 },
                                 {
                                     lowerSize,
                                     upperSize
                                 }: {
-                                  lowerSize: number,
-                                  upperSize: number
+                                  lowerSize: number;
+                                  upperSize: number;
                                 }) {
     if (sizeData.kind === 'source') {
         return lowerSize / SIZE_PACK_FACTOR;

--- a/src/types/cancelable.ts
+++ b/src/types/cancelable.ts
@@ -1,3 +1,3 @@
 export type Cancelable = {
-  cancel: () => void
+  cancel: () => void;
 };

--- a/src/types/non-typed-modules.d.ts
+++ b/src/types/non-typed-modules.d.ts
@@ -2,12 +2,12 @@ import type Pbf from 'pbf';
 
 declare module "@mapbox/mapbox-gl-supported" {
     type isSupported = {
-        webGLContextAttributes: WebGLContextAttributes,
+        webGLContextAttributes: WebGLContextAttributes;
         (
             options?: {
-                failIfMajorPerformanceCaveat: boolean
+                failIfMajorPerformanceCaveat: boolean;
             }
-        ): boolean
+        ): boolean;
     };
 
     let __exports: isSupported;
@@ -29,16 +29,16 @@ declare module "@mapbox/unitbezier" {
 }
 declare module "potpack" {
     type Bin = {
-        x: number,
-        y: number,
-        w: number,
-        h: number
+        x: number;
+        y: number;
+        w: number;
+        h: number;
     };
 
     function potpack(bins: Array<Bin>): {
-        w: number,
-        h: number,
-        fill: number
+        w: number;
+        h: number;
+        fill: number;
     }
 
     let __exports: typeof potpack;
@@ -47,17 +47,17 @@ declare module "potpack" {
 
 declare module "sinon" {
     type SpyCall = {
-        args: Array<unknown>
+        args: Array<unknown>;
     };
 
     type Spy = {
-        calledOnce: number,
-        getCall(i: number): SpyCall,
-        (): any
+        calledOnce: number;
+        getCall(i: number): SpyCall;
+        (): any;
     };
 
     type Stub = {
-        callsFake(fn: unknown): Spy
+        callsFake(fn: unknown): Spy;
     };
 
     class FakeServer {
@@ -66,15 +66,15 @@ declare module "sinon" {
 
     type Sandbox = {
         xhr: {
-            supportsCORS: boolean
-        },
+            supportsCORS: boolean;
+        };
         fakeServer: {
-            create: () => FakeServer
-        },
-        createSandbox(options: unknown): Sandbox,
-        stub(obj?: unknown, prop?: string): Stub,
-        spy(obj?: unknown, prop?: string): Spy,
-        restore(): void
+            create: () => FakeServer;
+        };
+        createSandbox(options: unknown): Sandbox;
+        stub(obj?: unknown, prop?: string): Stub;
+        spy(obj?: unknown, prop?: string): Spy;
+        restore(): void;
     };
 
     let __exports: Sandbox;
@@ -116,8 +116,8 @@ declare module "@mapbox/vector-tile" {
     }
 
     let __exports: {
-        VectorTile: typeof VectorTileImpl,
-        VectorTileFeature: typeof VectorTileFeatureImpl
+        VectorTile: typeof VectorTileImpl;
+        VectorTileFeature: typeof VectorTileFeatureImpl;
     };
 
     export = __exports

--- a/src/types/tilejson.ts
+++ b/src/types/tilejson.ts
@@ -1,15 +1,15 @@
 export type TileJSON = {
-  tilejson: "2.2.0" | "2.1.0" | "2.0.1" | "2.0.0" | "1.0.0",
-  name?: string,
-  description?: string,
-  version?: string,
-  attribution?: string,
-  template?: string,
-  tiles: Array<string>,
-  grids?: Array<string>,
-  data?: Array<string>,
-  minzoom?: number,
-  maxzoom?: number,
-  bounds?: [number, number, number, number],
-  center?: [number, number, number]
+  tilejson: "2.2.0" | "2.1.0" | "2.0.1" | "2.0.0" | "1.0.0";
+  name?: string;
+  description?: string;
+  version?: string;
+  attribution?: string;
+  template?: string;
+  tiles: Array<string>;
+  grids?: Array<string>;
+  data?: Array<string>;
+  minzoom?: number;
+  maxzoom?: number;
+  bounds?: [number, number, number, number];
+  center?: [number, number, number];
 };

--- a/src/ui/camera.ts
+++ b/src/ui/camera.ts
@@ -46,14 +46,14 @@ import type {PaddingOptions} from '../geo/edge_insets';
  * @see [Display buildings in 3D](https://maplibre.org/maplibre-gl-js-docs/example/3d-buildings/)
  */
 export type CameraOptions = {
-  center?: LngLatLike,
-  zoom?: number,
-  bearing?: number,
-  pitch?: number,
-  around?: LngLatLike,
-  padding?: PaddingOptions,
-  maxZoom?: number,
-  offset?: PointLike
+  center?: LngLatLike;
+  zoom?: number;
+  bearing?: number;
+  pitch?: number;
+  around?: LngLatLike;
+  padding?: PaddingOptions;
+  maxZoom?: number;
+  offset?: PointLike;
 };
 
 /**
@@ -71,11 +71,11 @@ export type CameraOptions = {
  *   [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion).
  */
 export type AnimationOptions = {
-  duration?: number,
-  easing?: (_: number) => number,
-  offset?: PointLike,
-  animate?: boolean,
-  essential?: boolean
+  duration?: number;
+  easing?: (_: number) => number;
+  offset?: PointLike;
+  animate?: boolean;
+  essential?: boolean;
 };
 
 /**
@@ -114,8 +114,8 @@ abstract class Camera extends Evented {
     _bearingSnap: number;
     _easeStart: number;
     _easeOptions: {
-      duration: number,
-      easing: (_: number) => number
+      duration: number;
+      easing: (_: number) => number;
     };
     _easeId: string | void;
 
@@ -127,7 +127,7 @@ abstract class Camera extends Evented {
     abstract _cancelRenderFrame(_: TaskID): void;
 
     constructor(transform: Transform, options: {
-      bearingSnap: number
+      bearingSnap: number;
     }) {
         super();
         this._moving = false;
@@ -784,8 +784,8 @@ abstract class Camera extends Evented {
      * @see [Navigate the map with game-like controls](https://maplibre.org/maplibre-gl-js-docs/example/game-controls/)
      */
     easeTo(options: CameraOptions & AnimationOptions & {
-      easeId?: string,
-      noMoveStart?: boolean
+      easeId?: string;
+      noMoveStart?: boolean;
     }, eventData?: any) {
         this._stop(false, options.easeId);
 
@@ -1193,9 +1193,9 @@ abstract class Camera extends Evented {
     _ease(frame: (_: number) => void,
           finish: () => void,
           options: {
-            animate: boolean,
-            duration: number,
-            easing: (_: number) => number
+            animate: boolean;
+            duration: number;
+            easing: (_: number) => number;
           }) {
         if (options.animate === false || options.duration === 0) {
             frame(1);

--- a/src/ui/control/attribution_control.ts
+++ b/src/ui/control/attribution_control.ts
@@ -6,8 +6,8 @@ import type Map from '../map';
 import type {ControlPosition, IControl} from './control';
 
 type Options = {
-  compact?: boolean,
-  customAttribution?: string | Array<string>
+  compact?: boolean;
+  customAttribution?: string | Array<string>;
 };
 
 /**

--- a/src/ui/control/control.d.ts
+++ b/src/ui/control/control.d.ts
@@ -2,7 +2,7 @@ export type ControlPosition = "top-left" | "top-right" | "bottom-left" | "bottom
 
 /* eslint-disable no-use-before-define */
 export type IControl = {
-  onAdd(map: Map): HTMLElement,
-  onRemove(map: Map): void,
-  readonly getDefaultPosition?: () => ControlPosition
+  onAdd(map: Map): HTMLElement;
+  onRemove(map: Map): void;
+  readonly getDefaultPosition?: () => ControlPosition;
 };

--- a/src/ui/control/fullscreen_control.ts
+++ b/src/ui/control/fullscreen_control.ts
@@ -6,7 +6,7 @@ import type Map from '../map';
 import type {IControl} from './control';
 
 type Options = {
-  container?: HTMLElement
+  container?: HTMLElement;
 };
 
 /**

--- a/src/ui/control/geolocate_control.ts
+++ b/src/ui/control/geolocate_control.ts
@@ -10,11 +10,11 @@ import type {AnimationOptions, CameraOptions} from '../camera';
 import type {IControl} from './control';
 
 type Options = {
-  positionOptions?: PositionOptions,
-  fitBoundsOptions?: AnimationOptions & CameraOptions,
-  trackUserLocation?: boolean,
-  showAccuracyCircle?: boolean,
-  showUserLocation?: boolean
+  positionOptions?: PositionOptions;
+  fitBoundsOptions?: AnimationOptions & CameraOptions;
+  trackUserLocation?: boolean;
+  showAccuracyCircle?: boolean;
+  showUserLocation?: boolean;
 };
 
 const defaultOptions: Options = {

--- a/src/ui/control/navigation_control.ts
+++ b/src/ui/control/navigation_control.ts
@@ -8,9 +8,9 @@ import type Map from '../map';
 import type {IControl} from './control';
 
 type Options = {
-  showCompass?: boolean,
-  showZoom?: boolean,
-  visualizePitch?: boolean
+  showCompass?: boolean;
+  showZoom?: boolean;
+  visualizePitch?: boolean;
 };
 
 const defaultOptions: Options = {

--- a/src/ui/control/scale_control.ts
+++ b/src/ui/control/scale_control.ts
@@ -7,8 +7,8 @@ import type {ControlPosition, IControl} from './control';
 type Unit = "imperial" | "metric" | "nautical";
 
 type Options = {
-  maxWidth?: number,
-  unit?: Unit
+  maxWidth?: number;
+  unit?: Unit;
 };
 
 const defaultOptions: Options = {

--- a/src/ui/events.ts
+++ b/src/ui/events.ts
@@ -230,9 +230,9 @@ export class MapWheelEvent extends Event {
  * @property {Map} target The `Map` instance that triggerred the event
  */
 export type MapBoxZoomEvent = {
-  type: "boxzoomstart" | "boxzoomend" | "boxzoomcancel",
-  target: Map,
-  originalEvent: MouseEvent
+  type: "boxzoomstart" | "boxzoomend" | "boxzoomcancel";
+  target: Map;
+  originalEvent: MouseEvent;
 };
 
 /**
@@ -264,13 +264,13 @@ export type MapBoxZoomEvent = {
  * });
  */
 export type MapDataEvent = {
-  type: string,
-  dataType: string
+  type: string;
+  dataType: string;
 };
 
 export type MapContextEvent = {
-  type: "webglcontextlost" | "webglcontextrestored",
-  originalEvent: WebGLContextEvent
+  type: "webglcontextlost" | "webglcontextrestored";
+  originalEvent: WebGLContextEvent;
 };
 
 export type MapEvent = /**

--- a/src/ui/handler/box_zoom.ts
+++ b/src/ui/handler/box_zoom.ts
@@ -24,7 +24,7 @@ class BoxZoomHandler {
      * @private
      */
     constructor(map: Map, options: {
-      clickTolerance: number
+      clickTolerance: number;
     }) {
         this._map = map;
         this._el = map.getCanvasContainer();

--- a/src/ui/handler/map_event.ts
+++ b/src/ui/handler/map_event.ts
@@ -8,7 +8,7 @@ export class MapEventHandler {
     _map: Map;
 
     constructor(map: Map, options: {
-      clickTolerance: number
+      clickTolerance: number;
     }) {
         this._map = map;
         this._clickTolerance = options.clickTolerance;

--- a/src/ui/handler/mouse.ts
+++ b/src/ui/handler/mouse.ts
@@ -25,7 +25,7 @@ class MouseHandler {
     _clickTolerance: number;
 
     constructor(options: {
-      clickTolerance: number
+      clickTolerance: number;
     }) {
         this.reset();
         this._clickTolerance = options.clickTolerance || 1;

--- a/src/ui/handler/scroll_zoom.ts
+++ b/src/ui/handler/scroll_zoom.ts
@@ -47,9 +47,9 @@ class ScrollZoomHandler {
     _delta: number;
     _easing: ((a: number) => number) | undefined | null;
     _prevEase: {
-      start: number,
-      duration: number,
-      easing: (_: number) => number
+      start: number;
+      duration: number;
+      easing: (_: number) => number;
     } | undefined | null;
 
     _frameId: boolean | undefined | null;

--- a/src/ui/handler/shim/drag_pan.ts
+++ b/src/ui/handler/shim/drag_pan.ts
@@ -2,10 +2,10 @@ import type {MousePanHandler} from '../mouse';
 import type TouchPanHandler from './../touch_pan';
 
 export type DragPanOptions = {
-  linearity?: number,
-  easing?: (t: number) => number,
-  deceleration?: number,
-  maxSpeed?: number
+  linearity?: number;
+  easing?: (t: number) => number;
+  deceleration?: number;
+  maxSpeed?: number;
 };
 
 /**

--- a/src/ui/handler/shim/drag_rotate.ts
+++ b/src/ui/handler/shim/drag_rotate.ts
@@ -18,7 +18,7 @@ export default class DragRotateHandler {
      * @private
      */
     constructor(options: {
-      pitchWithRotate: boolean
+      pitchWithRotate: boolean;
     }, mouseRotate: MouseRotateHandler, mousePitch: MousePitchHandler) {
         this._pitchWithRotate = options.pitchWithRotate;
         this._mouseRotate = mouseRotate;

--- a/src/ui/handler/shim/touch_zoom_rotate.ts
+++ b/src/ui/handler/shim/touch_zoom_rotate.ts
@@ -41,7 +41,7 @@ export default class TouchZoomRotateHandler {
      *   map.touchZoomRotate.enable({ around: 'center' });
      */
     enable(options?: {
-      around?: "center"
+      around?: "center";
     } | null) {
         this._touchZoom.enable(options);
         if (!this._rotationDisabled) this._touchRotate.enable(options);

--- a/src/ui/handler/tap_recognizer.ts
+++ b/src/ui/handler/tap_recognizer.ts
@@ -24,7 +24,7 @@ export class SingleTapRecognizer {
     };
 
     constructor(options: {
-      numTouches: number
+      numTouches: number;
     }) {
         this.reset();
         this.numTouches = options.numTouches;
@@ -92,8 +92,8 @@ export class TapRecognizer {
     count: number;
 
     constructor(options: {
-      numTaps: number,
-      numTouches: number
+      numTaps: number;
+      numTouches: number;
     }) {
         this.singleTap = new SingleTapRecognizer(options);
         this.numTaps = options.numTaps;

--- a/src/ui/handler/touch_pan.ts
+++ b/src/ui/handler/touch_pan.ts
@@ -13,7 +13,7 @@ export default class TouchPanHandler {
     _sum: Point;
 
     constructor(options: {
-      clickTolerance: number
+      clickTolerance: number;
     }) {
         this._minTouches = 1;
         this._clickTolerance = options.clickTolerance || 1;

--- a/src/ui/handler/touch_zoom_rotate.ts
+++ b/src/ui/handler/touch_zoom_rotate.ts
@@ -70,7 +70,7 @@ class TwoTouchHandler {
     }
 
     enable(options?: {
-      around?: "center"
+      around?: "center";
     } | null) {
         this._enabled = true;
         this._aroundCenter = !!options && options.around === 'center';

--- a/src/ui/handler_inertia.ts
+++ b/src/ui/handler_inertia.ts
@@ -30,10 +30,10 @@ const defaultPitchInertiaOptions = extend({
 }, defaultInertiaOptions);
 
 export type InertiaOptions = {
-  linearity: number,
-  easing: (t: number) => number,
-  deceleration: number,
-  maxSpeed: number
+  linearity: number;
+  easing: (t: number) => number;
+  deceleration: number;
+  maxSpeed: number;
 };
 
 export type InputEvent = MouseEvent | TouchEvent | KeyboardEvent | WheelEvent;
@@ -41,8 +41,8 @@ export type InputEvent = MouseEvent | TouchEvent | KeyboardEvent | WheelEvent;
 export default class HandlerInertia {
     _map: Map;
     _inertiaBuffer: Array<{
-      time: number,
-      settings: any
+      time: number;
+      settings: any;
     }>;
 
     constructor(map: Map) {

--- a/src/ui/handler_manager.ts
+++ b/src/ui/handler_manager.ts
@@ -62,23 +62,23 @@ export interface Handler {
 
 // All handler methods that are called with events can optionally return a `HandlerResult`.
 export type HandlerResult = {
-  panDelta?: Point,
-  zoomDelta?: number,
-  bearingDelta?: number,
-  pitchDelta?: number,
+  panDelta?: Point;
+  zoomDelta?: number;
+  bearingDelta?: number;
+  pitchDelta?: number;
   // the point to not move when changing the camera
-  around?: Point | null,
+  around?: Point | null;
   // same as above, except for pinch actions, which are given higher priority
-  pinchAround?: Point | null,
+  pinchAround?: Point | null;
   // A method that can fire a one-off easing by directly changing the map's camera.
-  cameraAnimation?: (map: Map) => any,
+  cameraAnimation?: (map: Map) => any;
   // The last three properties are needed by only one handler: scrollzoom.
   // The DOM event to be used as the `originalEvent` on any camera change events.
-  originalEvent?: any,
+  originalEvent?: any;
   // Makes the manager trigger a frame, allowing the handler to return multiple results over time (see scrollzoom).
-  needsRenderFrame?: boolean,
+  needsRenderFrame?: boolean;
   // The camera changes won't get recorded for inertial zooming.
-  noInertia?: boolean
+  noInertia?: boolean;
 };
 
 function hasChange(result: HandlerResult) {
@@ -89,9 +89,9 @@ class HandlerManager {
     _map: Map;
     _el: HTMLElement;
     _handlers: Array<{
-      handlerName: string,
-      handler: Handler,
-      allowed: any
+      handlerName: string;
+      handler: Handler;
+      allowed: any;
     }>;
     _eventsInProgress: any;
     _frameId: number;
@@ -102,8 +102,8 @@ class HandlerManager {
     _changes: Array<[HandlerResult, any, any]>;
     _previousActiveHandlers: {[x: string]: Handler};
     _listeners: Array<[Window | Document | HTMLElement, string, {
-      passive?: boolean,
-      capture?: boolean
+      passive?: boolean;
+      capture?: boolean;
     } | undefined]>;
 
     constructor(map: Map, options: CompleteMapOptions) {

--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -58,49 +58,49 @@ import type {ControlPosition, IControl} from './control/control';
 /* eslint-enable no-use-before-define */
 
 export type MapOptions = {
-  hash?: boolean | string,
-  interactive?: boolean,
-  container: HTMLElement | string,
-  bearingSnap?: number,
-  attributionControl?: boolean,
-  customAttribution?: string | Array<string>,
-  logoPosition?: ControlPosition,
-  failIfMajorPerformanceCaveat?: boolean,
-  preserveDrawingBuffer?: boolean,
-  antialias?: boolean,
-  refreshExpiredTiles?: boolean,
-  maxBounds?: LngLatBoundsLike,
-  scrollZoom?: boolean,
-  minZoom?: number | null,
-  maxZoom?: number | null,
-  minPitch?: number | null,
-  maxPitch?: number | null,
-  boxZoom?: boolean,
-  dragRotate?: boolean,
-  dragPan?: DragPanOptions | boolean,
-  keyboard?: boolean,
-  doubleClickZoom?: boolean,
-  touchZoomRotate?: boolean,
-  touchPitch?: boolean,
-  trackResize?: boolean,
-  center?: LngLatLike,
-  zoom?: number,
-  bearing?: number,
-  pitch?: number,
-  renderWorldCopies?: boolean,
-  maxTileCacheSize?: number,
-  transformRequest?: RequestTransformFunction,
-  accessToken: string,
-  locale?: any,
-  fadeDuration?: number,
-  crossSourceCollisions?: boolean,
-  collectResourceTiming?: boolean,
-  clickTolerance?: number,
-  bounds?: LngLatBoundsLike,
-  fitBoundsOptions?: Object,
-  localIdeographFontFamily?: string,
-  style: StyleSpecification | string,
-  pitchWithRotate?: boolean
+  hash?: boolean | string;
+  interactive?: boolean;
+  container: HTMLElement | string;
+  bearingSnap?: number;
+  attributionControl?: boolean;
+  customAttribution?: string | Array<string>;
+  logoPosition?: ControlPosition;
+  failIfMajorPerformanceCaveat?: boolean;
+  preserveDrawingBuffer?: boolean;
+  antialias?: boolean;
+  refreshExpiredTiles?: boolean;
+  maxBounds?: LngLatBoundsLike;
+  scrollZoom?: boolean;
+  minZoom?: number | null;
+  maxZoom?: number | null;
+  minPitch?: number | null;
+  maxPitch?: number | null;
+  boxZoom?: boolean;
+  dragRotate?: boolean;
+  dragPan?: DragPanOptions | boolean;
+  keyboard?: boolean;
+  doubleClickZoom?: boolean;
+  touchZoomRotate?: boolean;
+  touchPitch?: boolean;
+  trackResize?: boolean;
+  center?: LngLatLike;
+  zoom?: number;
+  bearing?: number;
+  pitch?: number;
+  renderWorldCopies?: boolean;
+  maxTileCacheSize?: number;
+  transformRequest?: RequestTransformFunction;
+  accessToken: string;
+  locale?: any;
+  fadeDuration?: number;
+  crossSourceCollisions?: boolean;
+  collectResourceTiming?: boolean;
+  clickTolerance?: number;
+  bounds?: LngLatBoundsLike;
+  fitBoundsOptions?: Object;
+  localIdeographFontFamily?: string;
+  style: StyleSpecification | string;
+  pitchWithRotate?: boolean;
 };
 
 // See article here: https://medium.com/terria/typescript-transforming-optional-properties-to-required-properties-that-may-be-undefined-7482cb4e1585
@@ -1309,9 +1309,9 @@ class Map extends Camera {
      *
      */
     querySourceFeatures(sourceId: string, parameters?: {
-      sourceLayer: string | undefined | null,
-      filter: Array<any> | undefined | null,
-      validate?: boolean
+      sourceLayer: string | undefined | null;
+      filter: Array<any> | undefined | null;
+      validate?: boolean;
     } | null) {
         return this.style.querySourceFeatures(sourceId, parameters);
     }
@@ -1343,7 +1343,7 @@ class Map extends Camera {
      *
      */
     setStyle(style: StyleSpecification | string | null, options?: {
-      diff?: boolean
+      diff?: boolean;
     } & StyleOptions) {
         options = extend({}, {localIdeographFontFamily: this._localIdeographFontFamily}, options);
 
@@ -1382,7 +1382,7 @@ class Map extends Camera {
     }
 
     _updateStyle(style: StyleSpecification | string | null,  options?: {
-      diff?: boolean
+      diff?: boolean;
     } & StyleOptions) {
         if (this.style) {
             this.style.setEventedParent(null);
@@ -1416,7 +1416,7 @@ class Map extends Camera {
     }
 
     _diffStyle(style: StyleSpecification | string,  options?: {
-      diff?: boolean
+      diff?: boolean;
     } & StyleOptions) {
         if (typeof style === 'string') {
             const url = this._requestManager.normalizeStyleURL(style);
@@ -1434,7 +1434,7 @@ class Map extends Camera {
     }
 
     _updateDiff(style: StyleSpecification,  options?: {
-      diff?: boolean
+      diff?: boolean;
     } & StyleOptions) {
         try {
             if (this.style.setState(style)) {
@@ -1651,9 +1651,9 @@ class Map extends Camera {
      */
     addImage(id: string,
              image: HTMLImageElement | ImageBitmap | ImageData | {
-               width: number,
-               height: number,
-               data: Uint8Array | Uint8ClampedArray
+               width: number;
+               height: number;
+               data: Uint8Array | Uint8ClampedArray;
              } | StyleImageInterface,
              {
                  pixelRatio = 1,
@@ -1713,9 +1713,9 @@ class Map extends Camera {
      */
     updateImage(id: string,
         image: HTMLImageElement | ImageBitmap | ImageData | {
-          width: number,
-          height: number,
-          data: Uint8Array | Uint8ClampedArray
+          width: number;
+          height: number;
+          data: Uint8Array | Uint8ClampedArray;
         } | StyleImageInterface) {
 
         const existingImage = this.style.getImage(id);
@@ -2180,9 +2180,9 @@ class Map extends Camera {
      * @see Tutorial: [Create interactive hover effects with Mapbox GL JS](https://docs.mapbox.com/help/tutorials/create-interactive-hover-effects-with-mapbox-gl-js/)
      */
     setFeatureState(feature: {
-      source: string,
-      sourceLayer?: string,
-      id: string | number
+      source: string;
+      sourceLayer?: string;
+      id: string | number;
     }, state: any) {
         this.style.setFeatureState(feature, state);
         return this._update();
@@ -2236,9 +2236,9 @@ class Map extends Camera {
      *
     */
     removeFeatureState(target: {
-      source: string,
-      sourceLayer?: string,
-      id?: string | number
+      source: string;
+      sourceLayer?: string;
+      id?: string | number;
     }, key?: string) {
         this.style.removeFeatureState(target, key);
         return this._update();
@@ -2275,9 +2275,9 @@ class Map extends Camera {
      */
     getFeatureState(
       feature: {
-        source: string,
-        sourceLayer?: string,
-        id: string | number
+        source: string;
+        sourceLayer?: string;
+        id: string | number;
       }
     ): any {
         return this.style.getFeatureState(feature);

--- a/src/ui/marker.ts
+++ b/src/ui/marker.ts
@@ -12,16 +12,16 @@ import type {LngLatLike} from "../geo/lng_lat";
 import type {MapMouseEvent, MapTouchEvent} from './events';
 
 type Options = {
-  element?: HTMLElement,
-  offset?: PointLike,
-  anchor?: Anchor,
-  color?: string,
-  scale?: number,
-  draggable?: boolean,
-  clickTolerance?: number,
-  rotation?: number,
-  rotationAlignment?: string,
-  pitchAlignment?: string
+  element?: HTMLElement;
+  offset?: PointLike;
+  anchor?: Anchor;
+  color?: string;
+  scale?: number;
+  draggable?: boolean;
+  clickTolerance?: number;
+  rotation?: number;
+  rotationAlignment?: string;
+  pitchAlignment?: string;
 };
 
 /**
@@ -436,7 +436,7 @@ export default class Marker extends Evented {
     }
 
     _update(e?: {
-      type: "move" | "moveend"
+      type: "move" | "moveend";
     }) {
         if (!this._map) return;
 

--- a/src/ui/popup.ts
+++ b/src/ui/popup.ts
@@ -25,14 +25,14 @@ export type Offset = number | PointLike | {
 };
 
 export type PopupOptions = {
-  closeButton?: boolean,
-  closeOnClick?: boolean,
-  closeOnMove?: boolean,
-  focusAfterOpen?: boolean,
-  anchor?: Anchor,
-  offset?: Offset,
-  className?: string,
-  maxWidth?: string
+  closeButton?: boolean;
+  closeOnClick?: boolean;
+  closeOnMove?: boolean;
+  focusAfterOpen?: boolean;
+  anchor?: Anchor;
+  offset?: Offset;
+  className?: string;
+  maxWidth?: string;
 };
 
 const focusQuerySelector = [

--- a/src/util/actor.ts
+++ b/src/util/actor.ts
@@ -21,15 +21,15 @@ class Actor {
     parent: any;
     mapId: number | undefined | null;
     callbacks: {
-      number: any
+      number: any;
     };
     name: string;
     tasks: {
-      number: any
+      number: any;
     };
     taskQueue: Array<number>;
     cancelCallbacks: {
-      number: Cancelable
+      number: Cancelable;
     };
     invoker: ThrottledInvoker;
     globalScope: any;

--- a/src/util/ajax.ts
+++ b/src/util/ajax.ts
@@ -66,13 +66,13 @@ if (typeof Object.freeze == 'function') {
  *
  */
 export type RequestParameters = {
-  url: string,
-  headers?: any,
-  method?: "GET" | "POST" | "PUT",
-  body?: string,
-  type?: "string" | "json" | "arrayBuffer",
-  credentials?: "same-origin" | "include",
-  collectResourceTiming?: boolean
+  url: string;
+  headers?: any;
+  method?: "GET" | "POST" | "PUT";
+  body?: string;
+  type?: "string" | "json" | "arrayBuffer";
+  credentials?: "same-origin" | "include";
+  collectResourceTiming?: boolean;
 };
 
 export type ResponseCallback<T> = (

--- a/src/util/color_ramp.ts
+++ b/src/util/color_ramp.ts
@@ -5,11 +5,11 @@ import assert from 'assert';
 import type {StylePropertyExpression} from '../style-spec/expression/index';
 
 export type ColorRampParams = {
-  expression: StylePropertyExpression,
-  evaluationKey: string,
-  resolution?: number,
-  image?: RGBAImage,
-  clips?: Array<any>
+  expression: StylePropertyExpression;
+  evaluationKey: string;
+  resolution?: number;
+  image?: RGBAImage;
+  clips?: Array<any>;
 };
 
 /**

--- a/src/util/config.ts
+++ b/src/util/config.ts
@@ -1,11 +1,11 @@
 type Config = {
-  API_URL: string,
-  EVENTS_URL: string | undefined | null,
-  FEEDBACK_URL: string,
-  REQUIRE_ACCESS_TOKEN: boolean,
-  ACCESS_TOKEN: string | undefined | null,
-  MAX_PARALLEL_IMAGE_REQUESTS: number,
-  REGISTERED_PROTOCOLS: {[x: string]: any}
+  API_URL: string;
+  EVENTS_URL: string | undefined | null;
+  FEEDBACK_URL: string;
+  REQUIRE_ACCESS_TOKEN: boolean;
+  ACCESS_TOKEN: string | undefined | null;
+  MAX_PARALLEL_IMAGE_REQUESTS: number;
+  REGISTERED_PROTOCOLS: {[x: string]: any};
 };
 
 const config: Config = {

--- a/src/util/dispatcher.ts
+++ b/src/util/dispatcher.ts
@@ -18,7 +18,7 @@ class Dispatcher {
 
     // exposed to allow stubbing in unit tests
     static Actor: {
-      new (...args: any): Actor
+      new (...args: any): Actor;
     };
 
     constructor(workerPool: WorkerPool, parent: any) {

--- a/src/util/dom.ts
+++ b/src/util/dom.ts
@@ -9,12 +9,12 @@ interface DOMInterface {
     enableDrag();
     setTransform(el: HTMLElement, value: string);
     addEventListener(target: any, type: any, callback: any, options?: void | {
-        passive?: boolean,
-        capture?: boolean
+        passive?: boolean;
+        capture?: boolean;
       });
     removeEventListener(target: any, type: any, callback: any, options?: void | {
-        passive?: boolean,
-        capture?: boolean
+        passive?: boolean;
+        capture?: boolean;
     });
     suppressClick();
     mousePos(el: HTMLElement, e: MouseEvent | Touch);
@@ -92,8 +92,8 @@ try {
 }
 
 DOM.addEventListener = function(target: any, type: any, callback: any, options: {
-  passive?: boolean,
-  capture?: boolean
+  passive?: boolean;
+  capture?: boolean;
 } = {}) {
     if ('passive' in options && passiveSupported) {
         target.addEventListener(type, callback, options);
@@ -103,8 +103,8 @@ DOM.addEventListener = function(target: any, type: any, callback: any, options: 
 };
 
 DOM.removeEventListener = function(target: any, type: any, callback: any, options: {
-  passive?: boolean,
-  capture?: boolean
+  passive?: boolean;
+  capture?: boolean;
 } = {}) {
     if ('passive' in options && passiveSupported) {
         target.removeEventListener(type, callback, options);

--- a/src/util/image.ts
+++ b/src/util/image.ts
@@ -3,13 +3,13 @@ import assert from 'assert';
 import {register} from './web_worker_transfer';
 
 export type Size = {
-  width: number,
-  height: number
+  width: number;
+  height: number;
 };
 
 type Point = {
-  x: number,
-  y: number
+  x: number;
+  y: number;
 };
 
 function createImage(image: any, {

--- a/src/util/mapbox.ts
+++ b/src/util/mapbox.ts
@@ -27,10 +27,10 @@ type ResourceTypeEnum = keyof IResourceType;
 export type RequestTransformFunction = (url: string, resourceType?: ResourceTypeEnum) => RequestParameters;
 
 type UrlObject = {
-  protocol: string,
-  authority: string,
-  path: string,
-  params: Array<string>
+  protocol: string;
+  authority: string;
+  path: string;
+  params: Array<string>;
 };
 
 export class RequestManager {
@@ -373,8 +373,8 @@ class TelemetryEvent {
     }
 
     queueRequest(event: number | {
-      id: number,
-      timestamp: number
+      id: number;
+      timestamp: number;
     }, customAccessToken?: string | null) {
         this.queue.push(event);
         this.processRequests(customAccessToken);
@@ -383,7 +383,7 @@ class TelemetryEvent {
 
 export class MapLoadEvent extends TelemetryEvent {
     readonly success: {
-      [_: number]: boolean
+      [_: number]: boolean;
     };
     skuToken: string;
 

--- a/src/util/performance.ts
+++ b/src/util/performance.ts
@@ -1,10 +1,10 @@
 import type {RequestParameters} from '../util/ajax';
 
 export type PerformanceMetrics = {
-  loadTime: number,
-  fullLoadTime: number,
-  fps: number,
-  percentDroppedFrames: number
+  loadTime: number;
+  fullLoadTime: number;
+  fps: number;
+  percentDroppedFrames: number;
 };
 
 export enum PerformanceMarkers {
@@ -76,9 +76,9 @@ export const PerformanceUtils = {
  */
 export class RequestPerformance {
     _marks: {
-      start: string,
-      end: string,
-      measure: string
+      start: string;
+      end: string;
+      measure: string;
     };
 
     constructor (request: RequestParameters) {

--- a/src/util/resolve_tokens.ts
+++ b/src/util/resolve_tokens.ts
@@ -10,7 +10,7 @@ export default resolveTokens;
  */
 function resolveTokens(
   properties: {
-    readonly [x: string]: unknown
+    readonly [x: string]: unknown;
   },
   text: string
 ): string {

--- a/src/util/sku_token.ts
+++ b/src/util/sku_token.ts
@@ -12,8 +12,8 @@
 ******************************************************************************/
 
 type SkuTokenObject = {
-  token: string,
-  tokenExpiresAt: number
+  token: string;
+  tokenExpiresAt: number;
 };
 
 const SKU_ID = '01';

--- a/src/util/struct_array.ts
+++ b/src/util/struct_array.ts
@@ -47,21 +47,21 @@ const DEFAULT_CAPACITY = 128;
 const RESIZE_MULTIPLIER = 5;
 
 export type StructArrayMember = {
-  name: string,
-  type: ViewType,
-  components: number,
-  offset: number
+  name: string;
+  type: ViewType;
+  components: number;
+  offset: number;
 };
 
 export type StructArrayLayout = {
-  members: Array<StructArrayMember>,
-  size: number,
-  alignment: number | undefined | null
+  members: Array<StructArrayMember>;
+  size: number;
+  alignment: number | undefined | null;
 };
 
 export type SerializedStructArray = {
-  length: number,
-  arrayBuffer: ArrayBuffer
+  length: number;
+  arrayBuffer: ArrayBuffer;
 };
 
 /**
@@ -199,9 +199,9 @@ abstract class StructArray {
  */
 function createLayout(
   members: Array<{
-    name: string,
-    type: ViewType,
-    readonly components?: number
+    name: string;
+    type: ViewType;
+    readonly components?: number;
   }>,
   alignment: number = 1
 ): StructArrayLayout {

--- a/src/util/task_queue.ts
+++ b/src/util/task_queue.ts
@@ -3,9 +3,9 @@ import assert from 'assert';
 export type TaskID = number; // can't mark opaque due to https://github.com/flowtype/flow-remove-types/pull/61
 
 type Task = {
-  callback: (timeStamp: number) => void,
-  id: TaskID,
-  cancelled: boolean
+  callback: (timeStamp: number) => void;
+  id: TaskID;
+  cancelled: boolean;
 };
 
 class TaskQueue {

--- a/src/util/tile_request_cache.ts
+++ b/src/util/tile_request_cache.ts
@@ -9,9 +9,9 @@ let cacheCheckThreshold = 50;
 const MIN_TIME_UNTIL_EXPIRY = 1000 * 60 * 7; // 7 minutes. Skip caching tiles with a short enough max age.
 
 export type ResponseOptions = {
-  status: number,
-  statusText: string,
-  headers: Headers
+  status: number;
+  statusText: string;
+  headers: Headers;
 };
 
 // We're using a global shared cache object. Normally, requesting ad-hoc Cache objects is fine, but

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -416,9 +416,9 @@ export function isClosedPolygon(points: Array<Point>): boolean {
  */
 
 export function sphericalToCartesian([r, azimuthal, polar]: [number, number, number]): {
-  x: number,
-  y: number,
-  z: number
+  x: number;
+  y: number;
+  z: number;
 } {
     // We abstract "north"/"up" (compass-wise) to be 0° when really this is 90° (π/2):
     // correct for that here

--- a/src/util/web_worker.ts
+++ b/src/util/web_worker.ts
@@ -9,8 +9,8 @@ import type {WorkerSource} from '../source/worker_source';
 
 type MessageListener = (
     a: {
-        data: any,
-        target: any
+        data: any;
+        target: any;
     }
 ) => unknown;
 
@@ -28,7 +28,7 @@ export interface WorkerGlobalScopeInterface {
     registerWorkerSource: (
         b: string,
         a: {
-            new(...args: any): WorkerSource
+            new(...args: any): WorkerSource;
         }
     ) => void;
     registerRTLTextPlugin: (_: any) => void;

--- a/src/util/web_worker_transfer.ts
+++ b/src/util/web_worker_transfer.ts
@@ -10,7 +10,7 @@ import ResolvedImage from '../style-spec/expression/types/resolved_image';
 import type {Transferable} from '../types/transferable';
 
 type SerializedObject = {
-  [_: string]: Serialized
+  [_: string]: Serialized;
 }; // eslint-disable-line
 
 export type Serialized = null | void | boolean | number | string | Boolean | Number | String | Date | RegExp | ArrayBuffer | ArrayBufferView | ImageData | Array<Serialized> | SerializedObject;
@@ -18,17 +18,17 @@ export type Serialized = null | void | boolean | number | string | Boolean | Num
 type Registry = {
   [_: string]: {
     klass: {
-      new (...args: any): any,
-      deserialize?: (input: Serialized) => unknown
-    },
-    omit: ReadonlyArray<string>,
-    shallow: ReadonlyArray<string>
-  }
+      new (...args: any): any;
+      deserialize?: (input: Serialized) => unknown;
+    };
+    omit: ReadonlyArray<string>;
+    shallow: ReadonlyArray<string>;
+  };
 };
 
 type RegisterOptions<T> = {
-  omit?: ReadonlyArray<keyof T>,
-  shallow?: ReadonlyArray<keyof T>
+  omit?: ReadonlyArray<keyof T>;
+  shallow?: ReadonlyArray<keyof T>;
 };
 
 const registry: Registry = {};
@@ -45,7 +45,7 @@ const registry: Registry = {};
 export function register<T extends any>(
   name: string,
   klass: {
-    new (...args: any): T
+    new (...args: any): T;
   },
   options: RegisterOptions<T> = {}
 ) {
@@ -64,7 +64,7 @@ export function register<T extends any>(
 register('Object', Object);
 
 type SerializedGrid = {
-  buffer: ArrayBuffer
+  buffer: ArrayBuffer;
 };
 
 Grid.serialize = function serialize(grid: Grid, transferables?: Array<Transferable>): SerializedGrid {


### PR DESCRIPTION
## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

Trivial change to enable the member-delimiter-style lint rule, adopting TypeScript-standard semicolon formatting. `lint --fix` to update the existing code from comma to semicolon delimiters.

Fixes #280 


 - [X] confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [X] briefly describe the changes in this PR
 - [ ] include before/after visuals or gifs if this PR includes visual changes
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [ ] manually test the debug page
 - [ ] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [ ] add an entry inside this element for inclusion in the `maplibre-gl-js` changelog: `<changelog></changelog>`
