### PR TITLE
Remove support of IE11

### DIFF
--- a/bench/benchmarks/worker_transfer.js
+++ b/bench/benchmarks/worker_transfer.js
@@ -6,7 +6,6 @@ import fetchStyle from '../lib/fetch_style';
 import TileParser from '../lib/tile_parser';
 import {OverscaledTileID} from '../../src/source/tile_id';
 import {serialize, deserialize} from '../../src/util/web_worker_transfer';
-import {values} from '../../src/util/util';
 
 export default class WorkerTransfer extends Benchmark {
     parser: TileParser;
@@ -48,8 +47,8 @@ export default class WorkerTransfer extends Benchmark {
                 return Promise.all(tiles.map(tile => this.parser.parseTile(tile)));
             }).then((tileResults) => {
                 const payload = tileResults
-                    .concat(values(this.parser.icons))
-                    .concat(values(this.parser.glyphs)).map((obj) => serialize(obj, []));
+                    .concat(Object.values(this.parser.icons))
+                    .concat(Object.values(this.parser.glyphs)).map((obj) => serialize(obj, []));
                 this.payloadJSON = payload.map(barePayload);
                 this.payloadTiles = payload.slice(0, tileResults.length);
             });

--- a/src/data/feature_position_map.ts
+++ b/src/data/feature_position_map.ts
@@ -82,11 +82,9 @@ export default class FeaturePositionMap {
     }
 }
 
-const MAX_SAFE_INTEGER = Math.pow(2, 53) - 1;
-
 function getNumericId(value: unknown) {
     const numValue = +value;
-    if (!isNaN(numValue) && numValue <= MAX_SAFE_INTEGER) {
+    if (!isNaN(numValue) && numValue <= Number.MAX_SAFE_INTEGER) {
         return numValue;
     }
     return murmur3(String(value));

--- a/src/render/painter.ts
+++ b/src/render/painter.ts
@@ -6,7 +6,6 @@ import EXTENT from '../data/extent';
 import pixelsToTileUnits from '../source/pixels_to_tile_units';
 import SegmentVector from '../data/segment';
 import {RasterBoundsArray, PosArray, TriangleIndexArray, LineStripIndexArray} from '../data/array_types';
-import {values} from '../util/util';
 import rasterBoundsAttributes from '../data/raster_bounds_attributes';
 import posAttributes from '../data/pos_attributes';
 import ProgramConfiguration from '../data/program_configuration';
@@ -458,7 +457,7 @@ class Painter {
             //Use source with highest maxzoom
             let selectedSource;
             let sourceCache;
-            const layers = values(this.style._layers);
+            const layers = Object.values(this.style._layers);
             layers.forEach((layer) => {
                 if (layer.source && !layer.isHidden(this.transform.zoom)) {
                     if (layer.source !== (sourceCache && sourceCache.id)) {

--- a/src/source/source_cache.ts
+++ b/src/source/source_cache.ts
@@ -4,7 +4,7 @@ import Tile from './tile';
 import {Event, ErrorEvent, Evented} from '../util/evented';
 import TileCache from './tile_cache';
 import MercatorCoordinate from '../geo/mercator_coordinate';
-import {keysDifference, values} from '../util/util';
+import {keysDifference} from '../util/util';
 import EXTENT from '../data/extent';
 import Context from '../gl/context';
 import Point from '../symbol/point';
@@ -185,7 +185,7 @@ class SourceCache extends Evented {
      * @private
      */
     getIds(): Array<string> {
-        return (values(this._tiles) as any).map((tile: Tile) => tile.tileID).sort(compareTileId).map(id => id.key);
+        return (Object.values(this._tiles) as any).map((tile: Tile) => tile.tileID).sort(compareTileId).map(id => id.key);
     }
 
     getRenderableIds(symbolLayer?: boolean): Array<string> {

--- a/src/source/worker_tile.ts
+++ b/src/source/worker_tile.ts
@@ -7,7 +7,7 @@ import SymbolBucket from '../data/bucket/symbol_bucket';
 import LineBucket from '../data/bucket/line_bucket';
 import FillBucket from '../data/bucket/fill_bucket';
 import FillExtrusionBucket from '../data/bucket/fill_extrusion_bucket';
-import {warnOnce, mapObject, values} from '../util/util';
+import {warnOnce, mapObject} from '../util/util';
 import assert from 'assert';
 import ImageAtlas from '../render/image_atlas';
 import GlyphAtlas from '../render/glyph_atlas';
@@ -200,7 +200,7 @@ class WorkerTile {
 
                 this.status = 'done';
                 callback(null, {
-                    buckets: values(buckets).filter(b => !b.isEmpty()),
+                    buckets: Object.values(buckets).filter(b => !b.isEmpty()),
                     featureIndex,
                     collisionBoxArray: this.collisionBoxArray,
                     glyphAtlasImage: glyphAtlas.image,

--- a/src/style/light.ts
+++ b/src/style/light.ts
@@ -1,6 +1,6 @@
 import styleSpec from '../style-spec/reference/latest';
 
-import {endsWith, extend, sphericalToCartesian} from '../util/util';
+import {extend, sphericalToCartesian} from '../util/util';
 import {Evented} from '../util/evented';
 import {
     validateStyle,
@@ -101,7 +101,7 @@ class Light extends Evented {
 
         for (const name in light) {
             const value = light[name];
-            if (endsWith(name, TRANSITION_SUFFIX)) {
+            if (name.endsWith(TRANSITION_SUFFIX)) {
                 this._transitionable.setTransition(name.slice(0, -TRANSITION_SUFFIX.length) as keyof Props, value);
             } else {
                 this._transitionable.setValue(name as keyof Props, value);

--- a/src/style/style_layer.ts
+++ b/src/style/style_layer.ts
@@ -1,4 +1,4 @@
-import {endsWith, filterObject} from '../util/util';
+import {filterObject} from '../util/util';
 
 import styleSpec from '../style-spec/reference/latest';
 import {
@@ -140,7 +140,7 @@ class StyleLayer extends Evented {
     }
 
     getPaintProperty(name: string) {
-        if (endsWith(name, TRANSITION_SUFFIX)) {
+        if (name.endsWith(TRANSITION_SUFFIX)) {
             return this._transitionablePaint.getTransition(name.slice(0, -TRANSITION_SUFFIX.length));
         } else {
             return this._transitionablePaint.getValue(name);
@@ -155,7 +155,7 @@ class StyleLayer extends Evented {
             }
         }
 
-        if (endsWith(name, TRANSITION_SUFFIX)) {
+        if (name.endsWith(TRANSITION_SUFFIX)) {
             this._transitionablePaint.setTransition(name.slice(0, -TRANSITION_SUFFIX.length), (value as any) || undefined);
             return false;
         } else {

--- a/src/style/style_layer/line_style_layer.ts
+++ b/src/style/style_layer/line_style_layer.ts
@@ -5,7 +5,7 @@ import LineBucket from '../../data/bucket/line_bucket';
 import {polygonIntersectsBufferedMultiLine} from '../../util/intersection_tests';
 import {getMaximumPaintValue, translateDistance, translate} from '../query_utils';
 import properties, {LayoutPropsPossiblyEvaluated, PaintPropsPossiblyEvaluated} from './line_style_layer_properties';
-import {extend, MAX_SAFE_INTEGER} from '../../util/util';
+import {extend} from '../../util/util';
 import EvaluationParameters from '../evaluation_parameters';
 import {Transitionable, Transitioning, Layout, PossiblyEvaluated, DataDrivenProperty} from '../properties';
 
@@ -58,7 +58,7 @@ class LineStyleLayer extends StyleLayer {
         if (name === 'line-gradient') {
             const expression: ZoomConstantExpression<"source"> = (this._transitionablePaint._values['line-gradient'].value.expression as any);
             this.stepInterpolant = expression._styleExpression.expression instanceof Step;
-            this.gradientVersion = (this.gradientVersion + 1) % MAX_SAFE_INTEGER;
+            this.gradientVersion = (this.gradientVersion + 1) % Number.MAX_SAFE_INTEGER;
         }
     }
 

--- a/src/style/style_layer_index.ts
+++ b/src/style/style_layer_index.ts
@@ -1,7 +1,6 @@
 import StyleLayer from './style_layer';
 import createStyleLayer from './create_style_layer';
 
-import {values} from '../util/util';
 import featureFilter from '../style-spec/feature_filter';
 import groupByLayout from '../style-spec/group_by_layout';
 
@@ -52,7 +51,7 @@ class StyleLayerIndex {
 
         this.familiesBySource = {};
 
-        const groups = groupByLayout(values(this._layerConfigs), this.keyCache);
+        const groups = groupByLayout(Object.values(this._layerConfigs), this.keyCache);
 
         for (const layerConfigs of groups) {
             const layers = layerConfigs.map((layerConfig) => this._layers[layerConfig.id]);

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -4,9 +4,6 @@ import Point from '../symbol/point';
 
 import type {Callback} from '../types/callback';
 
-// Number.MAX_SAFE_INTEGER not available in IE
-export const MAX_SAFE_INTEGER = Math.pow(2, 53) - 1;
-
 /**
  * @module util
  * @private

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -337,7 +337,7 @@ export function isCounterClockwise(a: Point, b: Point, c: Point): boolean {
 }
 
 /**
- * Returns the signed area for the polygon ring.  Postive areas are exterior rings and
+ * Returns the signed area for the polygon ring.  Positive areas are exterior rings and
  * have a clockwise winding.  Negative areas are interior rings and have a counter clockwise
  * ordering.
  *
@@ -409,7 +409,7 @@ export function sphericalToCartesian([r, azimuthal, polar]: [number, number, num
 
 /* global self, WorkerGlobalScope */
 /**
- *  Retuns true if the when run in the web-worker context.
+ *  Returns true if the when run in the web-worker context.
  *
  * @private
  * @returns {boolean}
@@ -499,13 +499,4 @@ export function b64DecodeUnicode(str: string) {
     return decodeURIComponent(atob(str).split('').map((c) => {
         return '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2); //eslint-disable-line
     }).join(''));
-}
-
-const mapboxHTTPURLRe = /^((https?:)?\/\/)?([^\/]+\.)?mapbox\.c(n|om)(\/|\?|$)/i;
-export function isMapboxHTTPURL(url: string): boolean {
-    return mapboxHTTPURLRe.test(url);
-}
-
-export function hasCacheDefeatingSku(url: string) {
-    return url.indexOf('sku=') > 0 && isMapboxHTTPURL(url);
 }

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -109,22 +109,6 @@ export function asyncAll<Item, Result>(
 }
 
 /*
- * Polyfill for Object.values. Not fully spec compliant, but we don't
- * need it to be.
- *
- * @private
- */
-export function values<T>(
-  obj: {[key: string]: T}
-): Array<T> {
-    const result = [];
-    for (const k in obj) {
-        result.push(obj[k]);
-    }
-    return result;
-}
-
-/*
  * Compute the difference between the keys in one object and the keys
  * in another object.
  *

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -270,15 +270,6 @@ export function bindAll(fns: Array<string>, context: any): void {
 }
 
 /**
- * Determine if a string ends with a particular substring
- *
- * @private
- */
-export function endsWith(string: string, suffix: string): boolean {
-    return string.indexOf(suffix, string.length - suffix.length) !== -1;
-}
-
-/**
  * Create an object by mapping all the values of an existing object while
  * preserving their keys.
  *

--- a/test/unit/util/util.test.js
+++ b/test/unit/util/util.test.js
@@ -1,6 +1,6 @@
 import {test} from '../../util/test';
 
-import {easeCubicInOut, keysDifference, extend, pick, uniqueId, bindAll, asyncAll, clamp, wrap, bezier, endsWith, mapObject, filterObject, deepEqual, clone, arraysIntersect, isCounterClockwise, isClosedPolygon, parseCacheControl, uuid, validateUuid, nextPowerOfTwo, isPowerOfTwo} from '../../../rollup/build/tsc/util/util';
+import {easeCubicInOut, keysDifference, extend, pick, uniqueId, bindAll, asyncAll, clamp, wrap, bezier, mapObject, filterObject, deepEqual, clone, arraysIntersect, isCounterClockwise, isClosedPolygon, parseCacheControl, uuid, validateUuid, nextPowerOfTwo, isPowerOfTwo} from '../../../rollup/build/tsc/util/util';
 import Point from '../../../rollup/build/tsc/symbol/point';
 
 test('util', (t) => {
@@ -142,12 +142,6 @@ test('util', (t) => {
         }, () => {
             t.end();
         });
-    });
-
-    t.test('endsWith', (t) => {
-        t.ok(endsWith('mapbox', 'box'));
-        t.notOk(endsWith('mapbox', 'map'));
-        t.end();
     });
 
     t.test('mapObject', (t) => {


### PR DESCRIPTION
## Launch Checklist

This pull request removes polyfill functions used for IE11 support.
And 368d3800665866bbbe957d1c7e4d514eb377913e removes two unused functions from `src/util.ts` (alreads present in `src/util/mapbox.ts`): they are not used in the code and are not(?) part of the api.

 - [ ] confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [ ] briefly describe the changes in this PR
 - [ ] include before/after visuals or gifs if this PR includes visual changes
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [ ] manually test the debug page
 - [ ] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [ ] add an entry inside this element for inclusion in the `maplibre-gl-js` changelog: `<changelog></changelog>`
