### PR TITLE
Remove undefined as any casts

### DIFF
--- a/src/data/bucket/line_bucket.ts
+++ b/src/data/bucket/line_bucket.ts
@@ -295,11 +295,11 @@ class LineBucket implements Bucket {
         // we could be more precise, but it would only save a negligible amount of space
         const segment = this.segments.prepareSegment(len * 10, this.layoutVertexArray, this.indexArray);
 
-        let currentVertex;
-        let prevVertex = undefined as Point;
-        let nextVertex = undefined as Point;
-        let prevNormal = undefined as Point;
-        let nextNormal = undefined as Point;
+        let currentVertex: Point;
+        let prevVertex: Point;
+        let nextVertex: Point;
+        let prevNormal: Point;
+        let nextNormal: Point;
 
         // the last two vertices added
         this.e1 = this.e2 = -1;

--- a/src/render/texture.ts
+++ b/src/render/texture.ts
@@ -104,7 +104,7 @@ class Texture {
     destroy() {
         const {gl} = this.context;
         gl.deleteTexture(this.texture);
-        this.texture = (null as any);
+        this.texture = null;
     }
 }
 

--- a/src/source/source_cache.ts
+++ b/src/source/source_cache.ts
@@ -719,18 +719,18 @@ class SourceCache extends Evented {
             }
         }
 
-        const cached = Boolean(tile);
-        if (!cached) {
+        const cached = tile;
+
+        if (!tile) {
             tile = new Tile(tileID, this._source.tileSize * tileID.overscaleFactor());
             this._loadTile(tile, this._tileLoaded.bind(this, tile, tileID.key, tile.state));
         }
 
-        // Impossible, but silence flow.
-        if (!tile) return null as any;
-
         tile.uses++;
         this._tiles[tileID.key] = tile;
-        if (!cached) this._source.fire(new Event('dataloading', {tile, coord: tile.tileID, dataType: 'source'}));
+        if (!cached) {
+            this._source.fire(new Event('dataloading', {tile, coord: tile.tileID, dataType: 'source'}));
+        }
 
         return tile;
     }

--- a/src/style-spec/expression/compound_expression.ts
+++ b/src/style-spec/expression/compound_expression.ts
@@ -70,7 +70,7 @@ class CompoundExpression implements Expression {
             signature.length === args.length - 1 // correct param count
         ));
 
-        let signatureContext: ParsingContext = (null as any);
+        let signatureContext: ParsingContext = null;
 
         for (const [params, evaluate] of overloads) {
             // Use a fresh context for each attempted signature so that, if

--- a/src/style-spec/expression/definitions/coalesce.ts
+++ b/src/style-spec/expression/definitions/coalesce.ts
@@ -21,7 +21,7 @@ class Coalesce implements Expression {
         if (args.length < 2) {
             return context.error('Expectected at least one argument.') as null;
         }
-        let outputType: Type = (null as any);
+        let outputType: Type = null;
         const expectedType = context.expectedType;
         if (expectedType && expectedType.kind !== 'value') {
             outputType = expectedType;

--- a/src/style-spec/expression/definitions/interpolate.ts
+++ b/src/style-spec/expression/definitions/interpolate.ts
@@ -105,7 +105,7 @@ class Interpolate implements Expression {
 
         const stops: Stops = [];
 
-        let outputType: Type = (null as any);
+        let outputType: Type = null;
         if (operator === 'interpolate-hcl' || operator === 'interpolate-lab') {
             outputType = ColorType;
         } else if (context.expectedType && context.expectedType.kind !== 'value') {

--- a/src/style-spec/expression/definitions/step.ts
+++ b/src/style-spec/expression/definitions/step.ts
@@ -41,7 +41,7 @@ class Step implements Expression {
 
         const stops: Stops = [];
 
-        let outputType: Type = (null as any);
+        let outputType: Type = null;
         if (context.expectedType && context.expectedType.kind !== 'value') {
             outputType = context.expectedType;
         }

--- a/src/style-spec/expression/evaluation_context.ts
+++ b/src/style-spec/expression/evaluation_context.ts
@@ -16,7 +16,7 @@ class EvaluationContext {
     _parseColorCache: {[_: string]: Color | undefined | null};
 
     constructor() {
-        this.globals = (null as any);
+        this.globals = null;
         this.feature = null;
         this.featureState = null;
         this.formattedSection = null;

--- a/src/style-spec/visit.ts
+++ b/src/style-spec/visit.ts
@@ -20,7 +20,7 @@ function getPropertyReference(propertyName): StylePropertySpecification {
         }
     }
 
-    return null as any;
+    return null;
 }
 
 export function eachSource(style: StyleSpecification, callback: (_: SourceSpecification) => void) {

--- a/src/style/properties.ts
+++ b/src/style/properties.ts
@@ -525,7 +525,7 @@ export class DataDrivenProperty<T> implements Property<T, PossiblyEvaluatedPrope
       availableImages?: Array<string>
     ): PossiblyEvaluatedPropertyValue<T> {
         if (value.expression.kind === 'constant' || value.expression.kind === 'camera') {
-            return new PossiblyEvaluatedPropertyValue(this, {kind: 'constant', value: value.expression.evaluate(parameters, ((null as any)), {}, canonical, availableImages)}, parameters);
+            return new PossiblyEvaluatedPropertyValue(this, {kind: 'constant', value: value.expression.evaluate(parameters, null, {}, canonical, availableImages)}, parameters);
         } else {
             return new PossiblyEvaluatedPropertyValue(this, value.expression, parameters);
         }
@@ -594,7 +594,7 @@ export class CrossFadedDataDrivenProperty<T> extends DataDrivenProperty<CrossFad
         if (value.value === undefined) {
             return new PossiblyEvaluatedPropertyValue(this, {kind: 'constant', value: undefined}, parameters);
         } else if (value.expression.kind === 'constant') {
-            const evaluatedValue = value.expression.evaluate(parameters, (null as any), {}, canonical, availableImages);
+            const evaluatedValue = value.expression.evaluate(parameters, null, {}, canonical, availableImages);
             const isImageExpression = value.property.specification.type as any === 'resolvedImage';
             const constantValue = isImageExpression && typeof evaluatedValue !== 'string' ? evaluatedValue.name : evaluatedValue;
             const constant = this._calculate(constantValue, constantValue, constantValue, parameters);
@@ -665,7 +665,7 @@ export class CrossFadedProperty<T> implements Property<T, CrossFaded<T> | undefi
         if (value.value === undefined) {
             return undefined;
         } else if (value.expression.kind === 'constant') {
-            const constant = value.expression.evaluate(parameters, (null as any), {}, canonical, availableImages);
+            const constant = value.expression.evaluate(parameters, null, {}, canonical, availableImages);
             return this._calculate(constant, constant, constant, parameters);
         } else {
             assert(!value.isDataDriven());
@@ -708,7 +708,7 @@ export class ColorRampProperty implements Property<Color, boolean> {
       canonical?: CanonicalTileID,
       availableImages?: Array<string>
     ): boolean {
-        return !!value.expression.evaluate(parameters, ((null as any)), {}, canonical, availableImages);
+        return !!value.expression.evaluate(parameters, null, {}, canonical, availableImages);
     }
 
     interpolate(): boolean { return false; }

--- a/src/symbol/mergelines.ts
+++ b/src/symbol/mergelines.ts
@@ -58,7 +58,7 @@ export default function(features: Array<SymbolFeature>): Array<SymbolFeature> {
             delete rightIndex[rightKey];
 
             rightIndex[getKey(text, mergedFeatures[i].geometry, true)] = i;
-            mergedFeatures[j].geometry = (null as any);
+            mergedFeatures[j].geometry = null;
 
         } else if (leftKey in rightIndex) {
             // found mergeable line adjacent to the start of the current line, merge

--- a/src/ui/control/fullscreen_control.ts
+++ b/src/ui/control/fullscreen_control.ts
@@ -68,7 +68,7 @@ class FullscreenControl implements IControl {
 
     onRemove() {
         DOM.remove(this._controlContainer);
-        this._map = (null as any);
+        this._map = null;
         window.document.removeEventListener(this._fullscreenchange, this._changeIcon);
     }
 

--- a/src/ui/handler/box_zoom.ts
+++ b/src/ui/handler/box_zoom.ts
@@ -148,7 +148,7 @@ class BoxZoomHandler {
 
         if (this._box) {
             DOM.remove(this._box);
-            this._box = (null as any);
+            this._box = null;
         }
 
         DOM.enableDrag();

--- a/src/util/worker_pool.ts
+++ b/src/util/worker_pool.ts
@@ -40,7 +40,7 @@ export default class WorkerPool {
             this.workers.forEach((w) => {
                 w.terminate();
             });
-            this.workers = (null as any);
+            this.workers = null;
         }
     }
 


### PR DESCRIPTION
Unnecessary casts for 'undefined' or 'null' as 'any'. Searched for `undefined as any` and `null as any` across the source. All of the results could be trivially removed.

Fixes #281 

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [X] confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [X] briefly describe the changes in this PR
 - [ ] include before/after visuals or gifs if this PR includes visual changes
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [ ] manually test the debug page
 - [ ] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [ ] add an entry inside this element for inclusion in the `maplibre-gl-js` changelog: `<changelog></changelog>`
