### PR TITLE
Default handling for image.sdf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 
 ### 🐞 Bug fixes
 
-- *...Add new stuff here...*
+- Fix warning due to strict comparison of SDF property in image sprite (#303)
 
 ## 1.15.2
 

--- a/src/symbol/symbol_layout.ts
+++ b/src/symbol/symbol_layout.ts
@@ -308,10 +308,11 @@ export function performSymbolLayout(
                     imagePositions[feature.icon.name],
                     layout.get('icon-offset').evaluate(feature, {}, canonical),
                     layout.get('icon-anchor').evaluate(feature, {}, canonical));
-                isSDFIcon = image.sdf;
+                // null/undefined SDF property treated same as default (false)
+                isSDFIcon = !!image.sdf;
                 if (bucket.sdfIcons === undefined) {
-                    bucket.sdfIcons = image.sdf;
-                } else if (bucket.sdfIcons !== image.sdf) {
+                    bucket.sdfIcons = isSDFIcon;
+                } else if (bucket.sdfIcons !== isSDFIcon) {
                     warnOnce('Style sheet warning: Cannot mix SDF and non-SDF icons in one buffer');
                 }
                 if (image.pixelRatio !== bucket.pixelRatio) {

--- a/test/unit/data/symbol_bucket.test.js
+++ b/test/unit/data/symbol_bucket.test.js
@@ -13,8 +13,11 @@ import {OverscaledTileID} from '../../../rollup/build/tsc/source/tile_id';
 import Tile from '../../../rollup/build/tsc/source/tile';
 import CrossTileSymbolIndex from '../../../rollup/build/tsc/symbol/cross_tile_symbol_index';
 import FeatureIndex from '../../../rollup/build/tsc/data/feature_index';
-import {createSymbolBucket} from '../../util/create_symbol_layer';
+import {createSymbolBucket, createSymbolIconBucket} from '../../util/create_symbol_layer';
 import {fileURLToPath} from 'url';
+import {RGBAImage} from '../../../rollup/build/tsc/util/image';
+import {ImagePosition} from '../../../rollup/build/tsc/render/image_atlas';
+
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
 // Load a point feature from fixture tile.
@@ -33,6 +36,25 @@ const stacks = {'Test': glyphs};
 
 function bucketSetup(text = 'abcde') {
     return createSymbolBucket('test', 'Test', text, collisionBoxArray);
+}
+
+function createIndexedFeature(id, index, iconId) {
+    return {
+        feature: {
+            extent: 8192,
+            type: 1,
+            id,
+            properties: {
+                icon: iconId
+            },
+            loadGeometry: function () {
+                return [[{x: 0, y: 0}]]
+            }
+        },
+        id,
+        index,
+        sourceLayerIndex: 0
+    };
 }
 
 test('SymbolBucket', (t) => {
@@ -92,6 +114,85 @@ test('SymbolBucket integer overflow', (t) => {
 
     t.ok(console.warn.calledOnce);
     t.ok(console.warn.getCall(0).calledWithMatch(/Too many glyphs being rendered in a tile./));
+    t.end();
+});
+
+test('SymbolBucket image undefined sdf', (t) => {
+    t.stub(console, 'warn').callsFake(() => { });
+
+    const imageMap = {
+        a: {
+            data: new RGBAImage({ width: 0, height: 0 })
+        },
+        b: {
+            data: new RGBAImage({ width: 0, height: 0 }),
+            sdf: false
+        }
+    };
+    const imagePos = {
+        a: new ImagePosition({ x: 0, y: 0, w: 10, h: 10 }, 1, 1),
+        b: new ImagePosition({ x: 10, y: 0, w: 10, h: 10 }, 1, 1)
+    };
+    const bucket = createSymbolIconBucket('test', 'icon', collisionBoxArray);
+    const options = { iconDependencies: {}, glyphDependencies: {} };
+
+    bucket.populate(
+        [
+            createIndexedFeature(0, 0, 'a'),
+            createIndexedFeature(1, 1, 'b'),
+            createIndexedFeature(2, 2, 'a')
+        ],
+        options
+    );
+
+    const icons = options.iconDependencies;
+    t.equal(icons.a, true, 'references icon a');
+    t.equal(icons.b, true, 'references icon b');
+
+    performSymbolLayout(bucket, null, null, imageMap, imagePos);
+
+    // undefined SDF should be treated the same as false SDF - no warning raised
+    t.ok(!console.warn.calledOnce);
+    t.end();
+});
+
+test('SymbolBucket image mismatched sdf', (t) => {
+    t.stub(console, 'warn').callsFake(() => { });
+
+    const imageMap = {
+        a: {
+            data: new RGBAImage({ width: 0, height: 0 }),
+            sdf: true
+        },
+        b: {
+            data: new RGBAImage({ width: 0, height: 0 }),
+            sdf: false
+        }
+    };
+    const imagePos = {
+        a: new ImagePosition({ x: 0, y: 0, w: 10, h: 10 }, 1, 1),
+        b: new ImagePosition({ x: 10, y: 0, w: 10, h: 10 }, 1, 1)
+    };
+    const bucket = createSymbolIconBucket('test', 'icon', collisionBoxArray);
+    const options = { iconDependencies: {}, glyphDependencies: {} };
+
+    bucket.populate(
+        [
+            createIndexedFeature(0, 0, 'a'),
+            createIndexedFeature(1, 1, 'b'),
+            createIndexedFeature(2, 2, 'a')
+        ],
+        options
+    );
+
+    const icons = options.iconDependencies;
+    t.equal(icons.a, true, 'references icon a');
+    t.equal(icons.b, true, 'references icon b');
+
+    performSymbolLayout(bucket, null, null, imageMap, imagePos);
+
+    // true SDF and false SDF in same bucket should trigger warning
+    t.ok(console.warn.calledOnce);
     t.end();
 });
 

--- a/test/util/create_symbol_layer.js
+++ b/test/util/create_symbol_layer.js
@@ -18,3 +18,20 @@ export function createSymbolBucket(layerId, font, text, collisionBoxArray) {
         layers: [layer]
     });
 }
+
+export function createSymbolIconBucket(layerId, iconProperty, collisionBoxArray) {
+    const layer = new SymbolStyleLayer({
+        id: layerId,
+        type: 'symbol',
+        layout: { 'icon-image': ['get', iconProperty] },
+        filter: featureFilter()
+    });
+    layer.recalculate({ zoom: 0, zoomHistory: {} });
+
+    return new SymbolBucket({
+        overscaling: 1,
+        zoom: 0,
+        collisionBoxArray,
+        layers: [layer]
+    });
+}


### PR DESCRIPTION
Treats null/undefined the same as false for the image sdf property, eliminating a console warning in the process.

Fixes #303 

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [X] confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [X] briefly describe the changes in this PR
 - [ ] include before/after visuals or gifs if this PR includes visual changes
 - [X] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [X] manually test the debug page
 - [ ] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [ ] add an entry inside this element for inclusion in the `maplibre-gl-js` changelog: `<changelog>bug: strict comparison of SDF property within image sprite</changelog>`
