### PR TITLE
Offscreencanvas error fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "maplibre-gl",
-  "version": "2.0.0-pre.1",
+  "version": "2.0.0-pre.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "maplibre-gl",
   "description": "BSD licensed community fork of mapbox-gl, a WebGL interactive maps library",
-  "version": "2.0.0-pre.1",
+  "version": "2.0.0-pre.2",
   "main": "dist/maplibre-gl.js",
   "style": "dist/maplibre-gl.css",
   "license": "BSD-3-Clause",

--- a/src/util/offscreen_canvas_supported.ts
+++ b/src/util/offscreen_canvas_supported.ts
@@ -2,7 +2,7 @@ let supportsOffscreenCanvas: boolean | undefined | null;
 
 export default function offscreenCanvasSupported(): boolean {
     if (supportsOffscreenCanvas == null) {
-        supportsOffscreenCanvas = OffscreenCanvas &&
+        supportsOffscreenCanvas = typeof OffscreenCanvas !== 'undefined' &&
             new OffscreenCanvas(1, 1).getContext('2d') &&
             typeof createImageBitmap === 'function';
     }


### PR DESCRIPTION
Fixes #305
This is probably due to when this supported method is called.
It used to be using the `window.` in the past which was removed.
This causes this kind of code to fail when using inside workers.
I hope this is the last place...
