### PR TITLE
Bump style spec to v14.0.1-rc.1

### DIFF
--- a/src/style-spec/CHANGELOG.md
+++ b/src/style-spec/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 14.0.1
+
+### ✨ Features and improvements
+* Migrate MapLibre GL JS and the style specification to TypeScript [#209](https://github.com/maplibre/maplibre-gl-js/pull/209)
+
 ## 14.0.0
 
 ### Breaking changes

--- a/src/style-spec/package.json
+++ b/src/style-spec/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@maplibre/maplibre-gl-style-spec",
   "description": "a specification for maplibre gl styles",
-  "version": "14.1.0-dev",
+  "version": "14.0.1-rc.1",
   "author": "MapLibre",
   "keywords": [
     "mapbox",


### PR DESCRIPTION
This pull request checks if we can still publish `@maplibre/maplibre-gl-style-spec` on NPM after the typescript migration. Closes https://github.com/maplibre/maplibre-gl-js/issues/275.