### PR TITLE
Publish pre-releases on npm with `next` tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -163,8 +163,16 @@ jobs:
         run: |
           rm -f ${{ steps.prepare_release.outputs.release_notes }}
 
-      - name: Publish NPM package
+      - name: Publish NPM package (regular)
+        if: ${{ steps.prepare_release.outputs.release_type == 'regular' }}
         run: |
           npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_ORG_TOKEN }}
+
+      - name: Publish NPM package (pre-release)
+        if: ${{ steps.prepare_release.outputs.release_type == 'prerelease' }}
+        run: |
+          npm publish --tag next
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_ORG_TOKEN }}


### PR DESCRIPTION
We have published MapLibre GL JS version `2.0.0-pre.1` on NPM with the intention that this would be a pre-release which is unstable. However, currently `npm install maplibre-gl --save` will indeed get the unstable pre-release instead of the latest stable release. This is not what we want but we are also not the first ones to fall into this trap, see https://medium.com/@mbostock/prereleases-and-npm-e778fc5e2420.

This pull requests add a `--tag next` to `npm publish` if it is a pre-release. Like this the version will not be tagged as `latest` (which is the default).