### PR TITLE
Escape quotes around stylelint file argument

### DIFF
--- a/package.json
+++ b/package.json
@@ -182,7 +182,7 @@
     "diff-tarball": "node build/diff-tarball.js",
     "lint": "eslint --ext \".ts,.js,.html\" --ignore-path .gitignore src build debug/*.html",
     "lint-docs": "documentation lint src/index.ts",
-    "lint-css": "stylelint 'src/css/maplibre-gl.css'",
+    "lint-css": "stylelint \"src/css/maplibre-gl.css\"",
     "test": "run-s lint lint-css lint-docs test-unit",
     "test-suite": "run-s test-render test-query test-expressions",
     "test-suite-clean": "find test/integration/{render,query, expressions}-tests -mindepth 2 -type d -exec test -e \"{}/actual.png\" \\; -not \\( -exec test -e \"{}/style.json\" \\; \\) -print | xargs -t rm -r",


### PR DESCRIPTION
I hope this fixes the release workflow error

```
Error: No files matching the pattern "'src/css/maplibre-gl.css'" were found.
    at D:\a\maplibre-gl-js\maplibre-gl-js\node_modules\stylelint\lib\standalone.js:212:12
    at processTicksAndRejections (internal/process/task_queues.js:95:5)
```

(https://github.com/maplibre/maplibre-gl-js/runs/3517866490?check_suite_focus=true)