### PR TITLE
Bump style spec to v14.0.1

### DIFF
--- a/src/style-spec/package.json
+++ b/src/style-spec/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@maplibre/maplibre-gl-style-spec",
   "description": "a specification for maplibre gl styles",
-  "version": "14.0.1-rc.1",
+  "version": "14.0.1",
   "author": "MapLibre",
   "keywords": [
     "mapbox",


### PR DESCRIPTION
Follow-up on https://github.com/maplibre/maplibre-gl-js/pull/310 to publish the actual new version of the style spec.