### PR TITLE
Add pull request demo workflow

### DIFF
--- a/.github/workflows/create-demo.yml
+++ b/.github/workflows/create-demo.yml
@@ -1,0 +1,36 @@
+name: Create Pull Request Demo
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  build-deploy:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set-up node
+      uses: actions/setup-node@v2
+      with:
+        node-version: 14
+
+    - name: Build
+      run: |
+        npm ci
+        npm run build-prod-min
+        npm run build-css
+        cp debug/pull-request-demo.html dist/index.html
+
+    - name: Deploy
+      uses: JamesIves/github-pages-deploy-action@4.1.0
+      with:
+        branch: gh-pages
+        folder: dist
+        target-folder: ${{ github.event.number }}
+    
+    - name: Add comment
+      uses: marocchino/sticky-pull-request-comment@v2
+      with:
+        message: |
+          Live demo of this pull request is available at <https://maplibre.github.io/maplibre-gl-js/${{ github.event.number }}>.

--- a/.github/workflows/create-demo.yml
+++ b/.github/workflows/create-demo.yml
@@ -32,5 +32,6 @@ jobs:
     - name: Add comment
       uses: marocchino/sticky-pull-request-comment@v2
       with:
+        header: demo
         message: |
           Live demo of this pull request is available at <https://maplibre.github.io/maplibre-gl-js/${{ github.event.number }}>.

--- a/.github/workflows/delete-demo.yml
+++ b/.github/workflows/delete-demo.yml
@@ -1,0 +1,29 @@
+name: Delete Pull Request Demo
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  delete:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        ref: gh-pages
+    
+    - name: Remove folder 
+      run: git rm -rf ${{ github.event.number }}
+    
+    - name: Commit and push
+      run: |
+        git config --global user.name 'bot'
+        git config --global user.email 'email@example.com'
+        git commit -am "Remove ${{ github.event.number }}"
+        git push
+
+    - name: Add comment
+      uses: marocchino/sticky-pull-request-comment@v2
+      with:
+        message: |
+          Live demo was deleted.

--- a/.github/workflows/delete-demo.yml
+++ b/.github/workflows/delete-demo.yml
@@ -25,5 +25,6 @@ jobs:
     - name: Add comment
       uses: marocchino/sticky-pull-request-comment@v2
       with:
+        header: demo
         message: |
           Live demo was deleted.

--- a/debug/pull-request-demo.html
+++ b/debug/pull-request-demo.html
@@ -15,10 +15,10 @@
 <div id="map"></div>
 <script>
 var map = new maplibregl.Map({
-container: 'map', // container id
-style: 'https://demotiles.maplibre.org/style.json', // style URL
-center: [0, 0], // starting position [lng, lat]
-zoom: 1 // starting zoom
+    container: 'map', // container id
+    style: 'https://demotiles.maplibre.org/style.json', // style URL
+    center: [0, 0], // starting position [lng, lat]
+    zoom: 1 // starting zoom
 });
 </script>
  

--- a/debug/pull-request-demo.html
+++ b/debug/pull-request-demo.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8" />
+<title>Display a map</title>
+<meta name="viewport" content="initial-scale=1,maximum-scale=1,user-scalable=no" />
+<script src="maplibre-gl.js"></script>
+<link href="maplibre-gl.css" rel="stylesheet" />
+<style>
+	body { margin: 0; padding: 0; }
+	#map { position: absolute; top: 0; bottom: 0; width: 100%; }
+</style>
+</head>
+<body>
+<div id="map"></div>
+<script>
+var map = new maplibregl.Map({
+container: 'map', // container id
+style: 'https://demotiles.maplibre.org/style.json', // style URL
+center: [0, 0], // starting position [lng, lat]
+zoom: 1 // starting zoom
+});
+</script>
+ 
+</body>
+</html>


### PR DESCRIPTION
After the typescript migration we received some bug reports from people who tested the pre-release versions on different browsers and operating systems. Thanks to everyone who helped with this so far. I found these reports extremely useful and noticed that the browser tests in [`test/browser`](https://github.com/maplibre/maplibre-gl-js/tree/main/test/browser) are actually quite limited. Mapbox seems to have added them only in the beginning of 2020. So we need some better browser testing I thought.

A simple way to do manual testing of pull requests is to publish their build output files, i.e. their `maplibre-gl.css` and `maplibre-gl.js` in a folder in the `gh-pages` branch. A demo page can then show a map using the build files of the pull request. Once the pull request gets closed these files can be removed again from the `gh-pages` branch.

I have something like this set-up in my fork. If you make a pull request against `wipfli/maplibre-gl-js` it will look like this:

See https://github.com/wipfli/maplibre-gl-js/pull/10

![image](https://user-images.githubusercontent.com/53421382/132751828-c0df95eb-1b5e-45e1-9dea-085cbe16d9b8.png)

Once the pull request gets closed, the files get deleted again and the message looks like this:

![image](https://user-images.githubusercontent.com/53421382/132751739-aa9d52e9-af32-456c-a5db-683e6e58ae53.png)




 - [🐳  ] confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [🐟  ] briefly describe the changes in this PR
 - [😸  ] include before/after visuals or gifs if this PR includes visual changes