### PR TITLE
Copy-paste `test-render` from release workflow

### DIFF
--- a/.github/workflows/ci-test-render.yml
+++ b/.github/workflows/ci-test-render.yml
@@ -1,0 +1,38 @@
+name: CI Test Render
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test_render:
+    name: Test Render
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Use Node.js 14 x64
+        uses: actions/setup-node@v2
+        with:
+          node-version: 14
+          architecture: x64
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install
+        run: npm ci
+
+      - name: Lint
+        run: |
+          npm run lint
+          npm run lint-docs
+          npm run lint-css
+
+      - name: Test
+        run: |
+          npm run test-unit
+          npm run test-render
+          npm run test-query
+          npm run test-expressions

--- a/.github/workflows/ci-test-render.yml
+++ b/.github/workflows/ci-test-render.yml
@@ -30,6 +30,9 @@ jobs:
           npm run lint-docs
           npm run lint-css
 
+      - name: Build
+        run: npm run build-dev
+
       - name: Test
         run: |
           npm run test-unit


### PR DESCRIPTION
This pull request adds a new workflow file which contains the `build_lint_test` job from the release workflow. This runs in particular the `test-render` script which seems to be failing at the moment. Note that `build_lint_test` in the release workflow actually does not build the library, which is strange.