### PR TITLE
Fix for uninitialized UniformMatrix4f

### DIFF
--- a/src/render/uniform_binding.ts
+++ b/src/render/uniform_binding.ts
@@ -109,7 +109,7 @@ class UniformColor extends Uniform<Color> {
     }
 }
 
-const emptyMat4 = mat4.create();
+const emptyMat4 = new Float32Array(16) as mat4;
 class UniformMatrix4f extends Uniform<mat4> {
     constructor(context: Context, location: WebGLUniformLocation) {
         super(context, location);

--- a/test/unit/render/uniform_binding.test.js
+++ b/test/unit/render/uniform_binding.test.js
@@ -4,7 +4,8 @@ import {
     Uniform1f,
     Uniform2f,
     Uniform3f,
-    Uniform4f
+    Uniform4f,
+    UniformMatrix4f
 } from '../../../rollup/build/tsc/render/uniform_binding';
 
 test('Uniform1i', (t) => {
@@ -100,5 +101,24 @@ test('Uniform4f', (t) => {
     t.deepEqual(u.current, [1, 1, 1, 1], 'correctly set value');
     u.set([1, 1, 1, 1]);
     u.set([2, 1, 1, 1]);
+    t.end();
+});
+
+test('UniformMatrix4f', (t) => {
+    t.plan(4);
+
+    const context = {
+        gl: {
+            uniformMatrix4fv: () => { t.ok(true, 'sets value when unique'); }
+        }
+    };
+
+    const u = new UniformMatrix4f(context, 0);
+    const ident = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1];
+    t.same(u.current, [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], 'not set upon initialization');
+    u.set(ident);
+    t.same(u.current, ident, 'correctly set value');
+    u.set(ident);
+    u.set([2, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]);
     t.end();
 });


### PR DESCRIPTION
UniformMatrix4f expects to be initialized with an all-zeros array, while mat4.create() creates an identity matrix. Subsequent calls to UniformMatrix4f.set with an identity matrix will become no-op as gl.uniformMatrix4fv won't be called.

Fixes #341 

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [X] confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [X] briefly describe the changes in this PR
 - [ ] include before/after visuals or gifs if this PR includes visual changes
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [ ] manually test the debug page
 - [ ] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [ ] add an entry inside this element for inclusion in the `maplibre-gl-js` changelog: `<changelog></changelog>`
