### PR TITLE
`test-render` for 1.x branch

### DIFF
--- a/.github/workflows/ci-test-render.yml
+++ b/.github/workflows/ci-test-render.yml
@@ -24,16 +24,10 @@ jobs:
       - name: Install
         run: yarn install --frozen-lockfile
 
-      - name: Lint
+      - name: Build
         run: |
-          yarn run lint
-          yarn run lint-docs
-          yarn run lint-css
+          yarn run build-dev
 
       - name: Test
         run: |
-          yarn run test-flow
-          yarn run test-unit
           yarn run test-render
-          yarn run test-query
-          yarn run test-expressions

--- a/.github/workflows/ci-test-render.yml
+++ b/.github/workflows/ci-test-render.yml
@@ -1,0 +1,38 @@
+name: CI Test Render
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test_render:
+    name: Test Render
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Use Node.js 14 x64
+        uses: actions/setup-node@v2
+        with:
+          node-version: 14
+          architecture: x64
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install
+        run: npm ci
+
+      - name: Lint
+        run: |
+          npm run lint
+          npm run lint-docs
+          npm run lint-css
+
+      - name: Test
+        run: |
+          npm run test-unit
+          npm run test-render
+          npm run test-query
+          npm run test-expressions

--- a/.github/workflows/ci-test-render.yml
+++ b/.github/workflows/ci-test-render.yml
@@ -22,17 +22,18 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install
-        run: npm ci
+        run: yarn install --frozen-lockfile
 
       - name: Lint
         run: |
-          npm run lint
-          npm run lint-docs
-          npm run lint-css
+          yarn run lint
+          yarn run lint-docs
+          yarn run lint-css
 
       - name: Test
         run: |
-          npm run test-unit
-          npm run test-render
-          npm run test-query
-          npm run test-expressions
+          yarn run test-flow
+          yarn run test-unit
+          yarn run test-render
+          yarn run test-query
+          yarn run test-expressions

--- a/.github/workflows/ci-test-render.yml
+++ b/.github/workflows/ci-test-render.yml
@@ -14,10 +14,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Use Node.js 14 x64
+      - name: Use Node.js 10 x64
         uses: actions/setup-node@v2
         with:
-          node-version: 14
+          node-version: 10
           architecture: x64
           registry-url: 'https://registry.npmjs.org'
 


### PR DESCRIPTION
Runs `test-render` on the `1.x` branch. We want to find out if this test is sometimes failing due to the typescript migration.