### PR TITLE
Change focusAfteropen default value to false

### DIFF
--- a/src/ui/popup.ts
+++ b/src/ui/popup.ts
@@ -15,7 +15,7 @@ import type {LngLatLike} from '../geo/lng_lat';
 const defaultOptions = {
     closeButton: true,
     closeOnClick: true,
-    focusAfterOpen: true,
+    focusAfterOpen: false,
     className: '',
     maxWidth: '240px'
 };

--- a/test/unit/ui/popup.test.js
+++ b/test/unit/ui/popup.test.js
@@ -668,11 +668,11 @@ test('Popup closes on Map#remove', (t) => {
     t.end();
 });
 
-test('Adding popup with no focusable content (Popup#setText) does not change the active element', (t) => {
+test('Adding popup with enabled focusing and no focusable content (Popup#setText) does not change the active element', (t) => {
     const dummyFocusedEl = window.document.createElement('button');
     dummyFocusedEl.focus();
 
-    new Popup({closeButton: false})
+    new Popup({closeButton: false, focusAfterOpen: true})
         .setText('Test')
         .setLngLat([0, 0])
         .addTo(createMap(t));
@@ -681,11 +681,11 @@ test('Adding popup with no focusable content (Popup#setText) does not change the
     t.end();
 });
 
-test('Adding popup with no focusable content (Popup#setHTML) does not change the active element', (t) => {
+test('Adding popup with enabled focusing no focusable content (Popup#setHTML) does not change the active element', (t) => {
     const dummyFocusedEl = window.document.createElement('button');
     dummyFocusedEl.focus();
 
-    new Popup({closeButton: false})
+    new Popup({closeButton: false, focusAfterOpen: true})
         .setHTML('<span>Test</span>')
         .setLngLat([0, 0])
         .addTo(createMap(t));
@@ -698,7 +698,7 @@ test('Close button is focused if it is the only focusable element', (t) => {
     const dummyFocusedEl = window.document.createElement('button');
     dummyFocusedEl.focus();
 
-    const popup = new Popup({closeButton: true})
+    const popup = new Popup({closeButton: true, focusAfterOpen: true})
         .setHTML('<span>Test</span>')
         .setLngLat([0, 0])
         .addTo(createMap(t));
@@ -711,7 +711,7 @@ test('Close button is focused if it is the only focusable element', (t) => {
 });
 
 test('If popup content contains a focusable element it is focused', (t) => {
-    const popup = new Popup({closeButton: true})
+    const popup = new Popup({closeButton: true, focusAfterOpen: true})
         .setHTML('<span tabindex="0" data-testid="abc">Test</span>')
         .setLngLat([0, 0])
         .addTo(createMap(t));
@@ -723,7 +723,7 @@ test('If popup content contains a focusable element it is focused', (t) => {
 });
 
 test('Element with tabindex="-1" is not focused', (t) => {
-    const popup = new Popup({closeButton: true})
+    const popup = new Popup({closeButton: true, focusAfterOpen: true})
         .setHTML('<span tabindex="-1" data-testid="abc">Test</span>')
         .setLngLat([0, 0])
         .addTo(createMap(t));
@@ -737,7 +737,7 @@ test('Element with tabindex="-1" is not focused', (t) => {
 });
 
 test('If popup contains a disabled button and a focusable element then the latter is focused', (t) => {
-    const popup = new Popup({closeButton: true})
+    const popup = new Popup({closeButton: true, focusAfterOpen: true})
         .setHTML(`
             <button disabled>No focus here</button>
             <select data-testid="abc">


### PR DESCRIPTION
Close https://github.com/maplibre/maplibre-gl-js/issues/338


## Problem

When I set a popup on a marker and click on it, the focus is on the close button (x) and part of the text in the popup is hidden. This happens only when you click on the marker for the first time.

https://user-images.githubusercontent.com/8760841/133375189-6e17a229-41c7-4e03-a493-4ab5da528463.mov

## Solution

When I set false to options.focusAfterOpen, it did not happen.

![スクリーンショット 2021-09-16 12 04 40](https://user-images.githubusercontent.com/8760841/133542741-5b74796b-ae1b-4397-99ee-d676ef755099.png)

### Demo [FocusAfterOpen = false]
https://codepen.io/naogify/pen/dyRZrKo


## Test

I run `npm run test` and this PR passed the tests. But I can't run `npm run test-suite` because of the error below. I'm glad if someone run the `npm run test-suite` to test this PR. (I will fix the error later. )

```
file:///Users/naoppy/naogify/maplibre-gl-js/test/suite_implementation.js:160
                now += operation[1];
                ^

ReferenceError: now is not defined
    at applyOperations (file:///Users/naoppy/naogify/maplibre-gl-js/test/suite_implementation.js:160:17)
    at applyOperations (file:///Users/naoppy/naogify/maplibre-gl-js/test/suite_implementation.js:211:13)
    at Map.<anonymous> (file:///Users/naoppy/naogify/maplibre-gl-js/test/suite_implementation.js:110:9)
    at Map.fire (file:///Users/naoppy/naogify/maplibre-gl-js/rollup/build/tsc/util/evented.js:92:26)
    at Map._render (file:///Users/naoppy/naogify/maplibre-gl-js/rollup/build/tsc/ui/map.js:2002:18)
    at Immediate.<anonymous> (file:///Users/naoppy/naogify/maplibre-gl-js/rollup/build/tsc/ui/map.js:2124:22)
    at processImmediate (internal/timers.js:466:21)
```




## Launch Checklist

 - [x] confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] briefly describe the changes in this PR
 - [x] include before/after visuals or gifs if this PR includes visual changes
 - [x] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [ ] manually test the debug page
 - [ ] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [ ] add an entry inside this element for inclusion in the `maplibre-gl-js` changelog: `<changelog></changelog>`
