### PR TITLE
Fix issues in suite implementation for test-render to run

### DIFF
--- a/test/suite_implementation.js
+++ b/test/suite_implementation.js
@@ -10,7 +10,7 @@ import customLayerImplementations from './integration/custom_layer_implementatio
 import {fileURLToPath} from 'url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-
+var now = 0;
 const {plugin: rtlTextPlugin} = rtlTextPluginModule;
 
 rtlTextPlugin['applyArabicShaping'] = rtlText.applyArabicShaping;
@@ -50,7 +50,7 @@ export default function(style, options, _callback) {
         }
     }
 
-    window.devicePixelRatio = options.pixelRatio;
+    global.devicePixelRatio = options.pixelRatio;
     window.useFakeXMLHttpRequest();
     XMLHttpRequest.onCreate = req => {
         setTimeout(() => {
@@ -91,6 +91,10 @@ export default function(style, options, _callback) {
 
     // Configure the map to never stop the render loop
     map.repaint = true;
+    now = 0;
+    browser.now = () => {
+        return now;
+    }
 
     if (options.debug) map.showTileBoundaries = true;
     if (options.showOverdrawInspector) map.showOverdrawInspector = true;
@@ -115,11 +119,11 @@ export default function(style, options, _callback) {
             const pixels = new Uint8Array(w * h * 4);
             gl.readPixels(0, 0, w, h, gl.RGBA, gl.UNSIGNED_BYTE, pixels);
 
-            const data = new Buffer(pixels);
+            const data = new Buffer.from(pixels);
 
             // Flip the scanlines.
             const stride = w * 4;
-            const tmp = new Buffer(stride);
+            const tmp = new Buffer.alloc(stride);
             for (let i = 0, j = h - 1; i < j; i++, j--) {
                 const start = i * stride;
                 const end = j * stride;


### PR DESCRIPTION
Fix some broken implementation in suite_implementation due to the removal of `window` and the migration to `global`.
This allows the `test-render` to run to completion without throwing exceptions.
Having said that, `test-render` doesn't seem to fully pass and I get an out of memory when I run it locally, I don't know how this will behave in the CI though.
I think it might be worth looking into the failing tests as they seem to point on issues that might be real, but might existed before typescript migration. I don't know, I'll open a different issue about it... 