### PR TITLE
Improve tile URL placeholder support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@
 
 ### 🐞 Bug fixes
 
-- Fix tile placeholder replacement to allow for placeholders to be in a URL more than once. (#348)
 - *...Add new stuff here...*
 
 ## 2.0.0
@@ -24,6 +23,7 @@
 ### 🐞 Bug fixes
 
 - Fix warning due to strict comparison of SDF property in image sprite (#303)
+- Fix tile placeholder replacement to allow for placeholders to be in a URL more than once. (#348)
 
 ## 1.15.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,10 @@
 ### Features and improvements
 
 - *...Add new stuff here...*
+
 ### 🐞 Bug fixes
 
+- Fix tile placeholder replacement to allow for placeholders to be in a URL more than once. (#348)
 - *...Add new stuff here...*
 
 ## 2.0.0

--- a/src/source/tile_id.ts
+++ b/src/source/tile_id.ts
@@ -33,12 +33,12 @@ export class CanonicalTileID {
         const quadkey = getQuadkey(this.z, this.x, this.y);
 
         return urls[(this.x + this.y) % urls.length]
-            .replace('{prefix}', (this.x % 16).toString(16) + (this.y % 16).toString(16))
-            .replace('{z}', String(this.z))
-            .replace('{x}', String(this.x))
-            .replace('{y}', String(scheme === 'tms' ? (Math.pow(2, this.z) - this.y - 1) : this.y))
-            .replace('{quadkey}', quadkey)
-            .replace('{bbox-epsg-3857}', bbox);
+            .replace(/{prefix}/g, (this.x % 16).toString(16) + (this.y % 16).toString(16))
+            .replace(/{z}/g, String(this.z))
+            .replace(/{x}/g, String(this.x))
+            .replace(/{y}/g, String(scheme === 'tms' ? (Math.pow(2, this.z) - this.y - 1) : this.y))
+            .replace(/{quadkey}/g, quadkey)
+            .replace(/{bbox-epsg-3857}/g, bbox);
     }
 
     getTilePoint(coord: MercatorCoordinate) {

--- a/test/unit/source/tile_id.test.js
+++ b/test/unit/source/tile_id.test.js
@@ -60,6 +60,12 @@ test('CanonicalTileID', (t) => {
             t.end();
         });
 
+        //Tests that multiple values of the same placeholder are replaced.
+        t.test('replaces {z}/{x}/{y}/{z}/{x}/{y}}', (t) => {
+            t.equal(new CanonicalTileID(1, 0, 0).url(['{z}/{x}/{y}/{z}/{x}/{y}.json']), '1/0/0/1/0/0.json');
+            t.end();
+        });
+
         t.end();
     });
 

--- a/test/unit/source/tile_id.test.js
+++ b/test/unit/source/tile_id.test.js
@@ -38,7 +38,7 @@ test('CanonicalTileID', (t) => {
 
     t.test('.url', (t) => {
         t.test('replaces {z}/{x}/{y}', (t) => {
-            t.equal(new CanonicalTileID(1, 0, 0).url(['{z}/{x}/{y}.json']), '1/0/0.json');
+            t.equal(new CanonicalTileID(2, 1, 0).url(['{z}/{x}/{y}.json']), '2/1/0.json');
             t.end();
         });
 
@@ -61,8 +61,8 @@ test('CanonicalTileID', (t) => {
         });
 
         //Tests that multiple values of the same placeholder are replaced.
-        t.test('replaces {z}/{x}/{y}/{z}/{x}/{y}}', (t) => {
-            t.equal(new CanonicalTileID(1, 0, 0).url(['{z}/{x}/{y}/{z}/{x}/{y}.json']), '1/0/0/1/0/0.json');
+        t.test('replaces {z}/{x}/{y}/{z}/{x}/{y}', (t) => {
+            t.equal(new CanonicalTileID(2, 1, 0).url(['{z}/{x}/{y}/{z}/{x}/{y}.json']), '2/1/0/2/1/0.json');
             t.end();
         });
 


### PR DESCRIPTION
Currently tile URL placeholders are replaced only once in a URL. If the placeholder appears more than once, it additional placeholder doesn't get replaced. This is due to the replace function only replacing the first instance of a string. The simple solution is to us a global regex with the replace function. Performance wise there is little difference (regex is actually a tad bit faster in nearly all browsers).

I came across this issue on a project a couple years ago, but thought it was an edge case and workaround it with a transform request, but just saw this issue:  https://github.com/maplibre/maplibre-gl-js/issues/346 and see I'm not the only one who ran into this. This fix works for both raster and vector tile URLs.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [x] confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] briefly describe the changes in this PR
 - [ N/A ] include before/after visuals or gifs if this PR includes visual changes
 - [x] write tests for all new functionality
 - [ N/A ] document any changes to public APIs
 - [ N/A - no perf difference ] post benchmark scores
 - [x] manually test the debug page
 - [ won't let me set labels for some reason ] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [ N/A - likely too small a change ] add an entry inside this element for inclusion in the `maplibre-gl-js` changelog: `<changelog></changelog>`
