### PR TITLE
Run only `build-dev` and `test-render`

### DIFF
--- a/.github/workflows/ci-test-render.yml
+++ b/.github/workflows/ci-test-render.yml
@@ -24,18 +24,9 @@ jobs:
       - name: Install
         run: npm ci
 
-      - name: Lint
-        run: |
-          npm run lint
-          npm run lint-docs
-          npm run lint-css
-
       - name: Build
         run: npm run build-dev
 
       - name: Test
         run: |
-          npm run test-unit
           npm run test-render
-          npm run test-query
-          npm run test-expressions


### PR DESCRIPTION
Reduces steps in `ci-test-render.yml` which saves time and console output.
