### PR TITLE
Set padding-top: 15px for popup card.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - ** Breaking Change ** removed all code related to `accessToken` and mapbox specific urls, including telemetry etc.  Please do not use mapbox servers with this library.
 - ** Breaking Change ** removed `baseApiUrl` as it was used only for mapbox related urls
 - Added redraw function to map (#206)
+- Fix padding-top of the popup to improve readability of popup text (#354).
 - *...Add new stuff here...*
 
 ### 🐞 Bug fixes

--- a/src/css/maplibre-gl.css
+++ b/src/css/maplibre-gl.css
@@ -798,7 +798,7 @@ a.mapboxgl-ctrl-logo.mapboxgl-compact {
     background: #fff;
     border-radius: 3px;
     box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
-    padding: 10px 10px 15px;
+    padding: 15px 10px;
     pointer-events: auto;
 }
 


### PR DESCRIPTION
Close #338

When I set a popup on a marker and click on it, the focus is on the close button (x) and part of the text in the popup is hidden. This happens only when you click on the marker for the first time.

So, I changed the padding-top of the popup from 10px to 15px.


### Before
![スクリーンショット 2021-09-18 15 42 08](https://user-images.githubusercontent.com/8760841/133879157-14d0d335-6cde-43d7-ae7e-cae56e3d2274.png)

### After
![スクリーンショット 2021-09-18 15 42 51](https://user-images.githubusercontent.com/8760841/133879162-cf45a3cf-2fe7-4226-8087-7eb509e163cd.png)


## Changelog

`<changelog>Fix padding-top of the popup to improve readability of popup text (#354).</changelog>`

## Launch Checklist
 - [x] confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] briefly describe the changes in this PR
 - [x] include before/after visuals or gifs if this PR includes visual changes
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [ ] manually test the debug page
 - [ ] apply changelog label ('bug', 'feature', 'docs', etc) or use the label 'skip changelog'
 - [X] add an entry inside this element for inclusion in the `maplibre-gl-js` changelog: `<changelog></changelog>`
