### PR TITLE
fix #334 add esm export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - ** Breaking Change ** removed `baseApiUrl` as it was used only for mapbox related urls
 - Added redraw function to map (#206)
 - *...Add new stuff here...*
+- Add module entrypoint for ESM (#334)
 
 ### 🐞 Bug fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,8 @@
 - ** Breaking Change ** removed all code related to `accessToken` and mapbox specific urls, including telemetry etc.  Please do not use mapbox servers with this library.
 - ** Breaking Change ** removed `baseApiUrl` as it was used only for mapbox related urls
 - Added redraw function to map (#206)
-- *...Add new stuff here...*
 - Add module entrypoint for ESM (#334)
+- *...Add new stuff here...*
 
 ### 🐞 Bug fixes
 

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "description": "BSD licensed community fork of mapbox-gl, a WebGL interactive maps library",
   "version": "2.0.0-pre.4",
   "main": "dist/maplibre-gl.js",
+  "module": "dist/maplibre-gl.module.js",
   "style": "dist/maplibre-gl.css",
   "license": "BSD-3-Clause",
   "repository": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -6,7 +6,7 @@ import banner from './build/banner.js';
 const {BUILD, MINIFY} = process.env;
 const minified = MINIFY === 'true';
 const production = BUILD === 'production';
-const outputFile =
+const outputFilePrefix =
     !production ? 'dist/maplibre-gl-dev' :
     minified ? 'dist/maplibre-gl' : 'dist/maplibre-gl-unminified';
 
@@ -37,7 +37,7 @@ export default [{
     output: [
         {
             name: 'maplibregl',
-            file: `${outputFile}.js`,
+            file: `${outputFilePrefix}.js`,
             format: 'umd',
             sourcemap: production ? true : 'inline',
             indent: false,
@@ -46,7 +46,7 @@ export default [{
         },
         {
             name: 'maplibregl',
-            file: `${outputFile}.module.js`,
+            file: `${outputFilePrefix}.module.js`,
             format: 'esm',
             sourcemap: production ? true : 'inline',
             indent: false,

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -7,8 +7,8 @@ const {BUILD, MINIFY} = process.env;
 const minified = MINIFY === 'true';
 const production = BUILD === 'production';
 const outputFile =
-    !production ? 'dist/maplibre-gl-dev.js' :
-    minified ? 'dist/maplibre-gl.js' : 'dist/maplibre-gl-unminified.js';
+    !production ? 'dist/maplibre-gl-dev' :
+    minified ? 'dist/maplibre-gl' : 'dist/maplibre-gl-unminified';
 
 export default [{
     // Before rollup you should run build-tsc to transpile from typescript to javascript
@@ -34,15 +34,26 @@ export default [{
     // into a single, final bundle. See rollup/bundle_prelude.js and
     // rollup/maplibregl.js for details.
     input: 'rollup/maplibregl.js',
-    output: {
-        name: 'maplibregl',
-        file: outputFile,
-        format: 'umd',
-        sourcemap: production ? true : 'inline',
-        indent: false,
-        intro: fs.readFileSync('./rollup/bundle_prelude.js', 'utf8'),
-        banner
-    },
+    output: [
+        {
+            name: 'maplibregl',
+            file: `${outputFile}.js`,
+            format: 'umd',
+            sourcemap: production ? true : 'inline',
+            indent: false,
+            intro: fs.readFileSync('./rollup/bundle_prelude.js', 'utf8'),
+            banner
+        },
+        {
+            name: 'maplibregl',
+            file: `${outputFile}.module.js`,
+            format: 'esm',
+            sourcemap: production ? true : 'inline',
+            indent: false,
+            intro: fs.readFileSync('./rollup/bundle_prelude.js', 'utf8'),
+            banner
+        }
+    ],
     treeshake: false,
     plugins: [
         // Ingest the sourcemaps produced in the first step of the build.


### PR DESCRIPTION
in order to continue the discussion #334

In my opinion, there is an issue with the default export of the package.
According to the `package.json` 
```json
{
  "main": "dist/maplibre-gl.js",
  "type": "module",
}
```
The maplibre-gl package is using the ESM modules but the output is an UMD file.

If I build an app who follows the esm specification and who wants to import maplibre-gl
The application will apply the [esm resolver algorithm](https://nodejs.org/api/esm.html#esm_resolver_algorithm)
```
ESM_FORMAT(url)

  Assert: url corresponds to an existing file.
  Let pjson be the result of READ_PACKAGE_SCOPE(url).
  If url ends in ".mjs", then
      Return "module".
  If url ends in ".cjs", then
      Return "commonjs".
  If pjson?.type exists and is "module", then
      If url ends in ".js", then
          Return "module".
      Throw an Unsupported File Extension error.
  Otherwise,
      Throw an Unsupported File Extension error.
```
the application will retrieve the `dist/maplibre-gl.js` file but will consider it to be an esm file.
I suggest adding a module entry in the `package.json` who provides a esm export. By keeping the current main entry, we have a way to easily implement maplibre and with the module entry we allow bundlers (like ViteJS) following the esm specification to find the right export format.

What do you think about that ?

I'm not talking about the isomorphic side dealt with at the end of the discussion #334  which is another discussion.
