### PR TITLE
Non dom environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 
 - Fix warning due to strict comparison of SDF property in image sprite (#303)
 - Fix tile placeholder replacement to allow for placeholders to be in a URL more than once. (#348)
+- Fix type check for non dom environment. (#334)
 
 ## 1.15.2
 

--- a/src/util/browser.ts
+++ b/src/util/browser.ts
@@ -41,7 +41,7 @@ const exported = {
         return linkEl.href;
     },
 
-    hardwareConcurrency: navigator && navigator.hardwareConcurrency || 4,
+    hardwareConcurrency: typeof navigator !== 'undefined' && navigator && navigator.hardwareConcurrency || 4,
 
     get prefersReducedMotion(): boolean {
         if (!matchMedia) return false;

--- a/src/util/dom.ts
+++ b/src/util/dom.ts
@@ -38,7 +38,7 @@ DOM.createNS = function (namespaceURI: string, tagName: string) {
     return el;
 };
 
-const docStyle = window.document && window.document.documentElement.style;
+const docStyle = typeof window !== 'undefined' && window.document && window.document.documentElement.style;
 
 function testProp(props) {
     if (!docStyle) return props[0];


### PR DESCRIPTION
Hello,
In this PR, I'm talking about the isomorphic side dealt at the end of the discussion #334.

If we wants to use maplibre-gl in an app who makes SSR (like with SvelteKit), we encounters 2 errors due to navigator and window are not defined.
with this additional check, we allow transparent reading of the library on the server side.