### PR TITLE
updating config wip

### DIFF
--- a/bench/rollup_config_benchmarks.js
+++ b/bench/rollup_config_benchmarks.js
@@ -23,7 +23,7 @@ const allPlugins = plugins(true, true).concat(replace(replaceConfig));
 const intro = fs.readFileSync('rollup/bundle_prelude.js', 'utf8');
 
 const splitConfig = (name) => [{
-    input: [`bench/${name}/benchmarks.js`, 'src/source/worker.js'],
+    input: [`bench/${name}/benchmarks.js`, 'rollup/build/tsc/source/worker.js'],
     output: {
         dir: `rollup/build/benchmarks/${name}`,
         format: 'amd',

--- a/bench/versions/benchmarks.js
+++ b/bench/versions/benchmarks.js
@@ -1,4 +1,4 @@
-import maplibregl from '../../src';
+import maplibregl from '../../rollup/build/tsc';
 import locationsWithTileID from '../lib/locations_with_tile_id';
 import styleBenchmarkLocations from '@mapbox/gazetteer/benchmark/style-benchmark-locations.json';
 import Layout from '../benchmarks/layout';


### PR DESCRIPTION
- [x] confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 
first part pointing benchmark config to worker.js output from worker.ts in rollup/build/tsc folder

NOTE:
This is just to try and address the immediate problem and share how to move forward so we can work on fixing other bits.

I think the better solution might be to set the benchmarks up to accept Typescript files directly (using node-ts or whatever) so we don't have to compile every time or risk running against old files etc. Makes debugging a bit easier too with a single source of truth