### PR TITLE
Run `flowts --no-prettier` on `lib` and `benchmarks`

### DIFF
--- a/bench/benchmarks/expressions.ts
+++ b/bench/benchmarks/expressions.ts
@@ -1,5 +1,3 @@
-// @flow
-
 import Benchmark from '../lib/benchmark';
 
 import spec from '../../src/style-spec/reference/latest';
@@ -14,11 +12,11 @@ import type {StylePropertyExpression} from '../../src/style-spec/expression';
 
 class ExpressionBenchmark extends Benchmark {
     data: Array<{
-        propertySpec: StylePropertySpecification,
-        rawValue: mixed,
-        rawExpression: mixed,
-        compiledFunction: StylePropertyExpression,
-        compiledExpression: StylePropertyExpression
+      propertySpec: StylePropertySpecification,
+      rawValue: unknown,
+      rawExpression: unknown,
+      compiledFunction: StylePropertyExpression,
+      compiledExpression: StylePropertyExpression
     }>;
     style: string | StyleSpecification;
 

--- a/bench/benchmarks/filter_create.ts
+++ b/bench/benchmarks/filter_create.ts
@@ -1,5 +1,3 @@
-// @flow
-
 import Benchmark from '../lib/benchmark';
 
 import createFilter from '../../src/style-spec/feature_filter';

--- a/bench/benchmarks/hillshade_load.ts
+++ b/bench/benchmarks/hillshade_load.ts
@@ -1,5 +1,3 @@
-// @flow
-
 import Benchmark from '../lib/benchmark';
 import createMap from '../lib/create_map';
 import type {StyleSpecification} from '../../src/style-spec/types';

--- a/bench/benchmarks/layout.ts
+++ b/bench/benchmarks/layout.ts
@@ -1,18 +1,19 @@
-// @flow
-
-import type {StyleSpecification} from '../../src/style-spec/types';
+import type { StyleSpecification } from '../../src/style-spec/types';
 import Benchmark from '../lib/benchmark';
 import fetchStyle from '../lib/fetch_style';
 import TileParser from '../lib/tile_parser';
 import {OverscaledTileID} from '../../src/source/tile_id';
 
 export default class Layout extends Benchmark {
-    tiles: Array<{tileID: OverscaledTileID, buffer: ArrayBuffer}>;
+    tiles: Array<{
+      tileID: OverscaledTileID,
+      buffer: ArrayBuffer
+    }>;
     parser: TileParser;
     style: string | StyleSpecification;
     tileIDs: Array<OverscaledTileID>;
 
-    constructor(style: string | StyleSpecification, tileIDs: ?Array<OverscaledTileID>) {
+    constructor(style: string | StyleSpecification, tileIDs?: Array<OverscaledTileID> | null) {
         super();
         this.style = style;
         this.tileIDs = tileIDs || [

--- a/bench/benchmarks/layout_dds.ts
+++ b/bench/benchmarks/layout_dds.ts
@@ -1,5 +1,3 @@
-// @flow
-
 import Benchmark from '../lib/benchmark';
 import TileParser from '../lib/tile_parser';
 import {OverscaledTileID} from '../../src/source/tile_id';
@@ -7,7 +5,10 @@ import {OverscaledTileID} from '../../src/source/tile_id';
 const LAYER_COUNT = 2;
 
 export default class LayoutDDS extends Benchmark {
-    tiles: Array<{tileID: OverscaledTileID, buffer: ArrayBuffer}>;
+    tiles: Array<{
+      tileID: OverscaledTileID,
+      buffer: ArrayBuffer
+    }>;
     parser: TileParser;
 
     setup(): Promise<void> {
@@ -82,7 +83,7 @@ export default class LayoutDDS extends Benchmark {
 
         while (styleJSON.layers.length < LAYER_COUNT) {
             for (const layer of layers) {
-                styleJSON.layers.push(Object.assign(({}: any), layer, {
+                styleJSON.layers.push(Object.assign((({} as any)), layer, {
                     id: layer.id + styleJSON.layers.length
                 }));
             }

--- a/bench/benchmarks/paint.ts
+++ b/bench/benchmarks/paint.ts
@@ -1,5 +1,3 @@
-// @flow
-
 import Benchmark from '../lib/benchmark';
 import createMap from '../lib/create_map';
 import type Map from '../../src/ui/map';
@@ -9,10 +7,10 @@ const height = 768;
 
 export default class Paint extends Benchmark {
     style: string;
-    locations: Array<Object>;
+    locations: Array<any>;
     maps: Array<Map>;
 
-    constructor(style: string, locations: Array<Object>) {
+    constructor(style: string, locations: Array<any>) {
         super();
         this.style = style;
         this.locations = locations;

--- a/bench/benchmarks/placement.ts
+++ b/bench/benchmarks/placement.ts
@@ -1,5 +1,3 @@
-// @flow
-
 import Benchmark from '../lib/benchmark';
 import createMap from '../lib/create_map';
 import type Map from '../../src/ui/map';
@@ -7,12 +5,12 @@ import type Map from '../../src/ui/map';
 const width = 1024;
 const height = 768;
 
-export default class QueryBox extends Benchmark {
+export default class Paint extends Benchmark {
     style: string;
-    locations: Array<Object>;
+    locations: Array<any>;
     maps: Array<Map>;
 
-    constructor(style: string, locations: Array<Object>) {
+    constructor(style: string, locations: Array<any>) {
         super();
         this.style = style;
         this.locations = locations;
@@ -25,7 +23,8 @@ export default class QueryBox extends Benchmark {
                 width,
                 height,
                 center: location.center,
-                style: this.style
+                style: this.style,
+                idle: true
             });
         }))
             .then(maps => {
@@ -38,7 +37,17 @@ export default class QueryBox extends Benchmark {
 
     bench() {
         for (const map of this.maps) {
-            map.queryRenderedFeatures({});
+            const showCollisionBoxes = false;
+            const fadeDuration = 300;
+            const crossSourceCollisions = true;
+            const forceFullPlacement = true;
+
+            map.style._updatePlacement(
+                map.transform,
+                showCollisionBoxes,
+                fadeDuration,
+                crossSourceCollisions,
+                forceFullPlacement);
         }
     }
 

--- a/bench/benchmarks/query_box.ts
+++ b/bench/benchmarks/query_box.ts
@@ -1,5 +1,3 @@
-// @flow
-
 import Benchmark from '../lib/benchmark';
 import createMap from '../lib/create_map';
 import type Map from '../../src/ui/map';
@@ -7,23 +5,12 @@ import type Map from '../../src/ui/map';
 const width = 1024;
 const height = 768;
 
-const points = [];
-const d = 4;
-for (let x = 0; x < d; x++) {
-    for (let y = 0; y < d; y++) {
-        points.push([
-            (x / d) * width,
-            (y / d) * height
-        ]);
-    }
-}
-
-export default class QueryPoint extends Benchmark {
+export default class QueryBox extends Benchmark {
     style: string;
-    locations: Array<Object>;
+    locations: Array<any>;
     maps: Array<Map>;
 
-    constructor(style: string, locations: Array<Object>) {
+    constructor(style: string, locations: Array<any>) {
         super();
         this.style = style;
         this.locations = locations;
@@ -49,9 +36,7 @@ export default class QueryPoint extends Benchmark {
 
     bench() {
         for (const map of this.maps) {
-            for (const point of points) {
-                map.queryRenderedFeatures(point, {});
-            }
+            map.queryRenderedFeatures({});
         }
     }
 

--- a/bench/benchmarks/query_point.ts
+++ b/bench/benchmarks/query_point.ts
@@ -1,5 +1,3 @@
-// @flow
-
 import Benchmark from '../lib/benchmark';
 import createMap from '../lib/create_map';
 import type Map from '../../src/ui/map';
@@ -7,12 +5,23 @@ import type Map from '../../src/ui/map';
 const width = 1024;
 const height = 768;
 
-export default class Paint extends Benchmark {
+const points = [];
+const d = 4;
+for (let x = 0; x < d; x++) {
+    for (let y = 0; y < d; y++) {
+        points.push([
+            (x / d) * width,
+            (y / d) * height
+        ]);
+    }
+}
+
+export default class QueryPoint extends Benchmark {
     style: string;
-    locations: Array<Object>;
+    locations: Array<any>;
     maps: Array<Map>;
 
-    constructor(style: string, locations: Array<Object>) {
+    constructor(style: string, locations: Array<any>) {
         super();
         this.style = style;
         this.locations = locations;
@@ -25,8 +34,7 @@ export default class Paint extends Benchmark {
                 width,
                 height,
                 center: location.center,
-                style: this.style,
-                idle: true
+                style: this.style
             });
         }))
             .then(maps => {
@@ -39,17 +47,9 @@ export default class Paint extends Benchmark {
 
     bench() {
         for (const map of this.maps) {
-            const showCollisionBoxes = false;
-            const fadeDuration = 300;
-            const crossSourceCollisions = true;
-            const forceFullPlacement = true;
-
-            map.style._updatePlacement(
-                map.transform,
-                showCollisionBoxes,
-                fadeDuration,
-                crossSourceCollisions,
-                forceFullPlacement);
+            for (const point of points) {
+                map.queryRenderedFeatures(point, {});
+            }
         }
     }
 

--- a/bench/benchmarks/style_layer_create.ts
+++ b/bench/benchmarks/style_layer_create.ts
@@ -1,6 +1,4 @@
-// @flow
-
-import type {StyleSpecification} from '../../src/style-spec/types';
+import type { StyleSpecification } from '../../src/style-spec/types';
 import Benchmark from '../lib/benchmark';
 import createStyleLayer from '../../src/style/create_style_layer';
 import deref from '../../src/style-spec/deref';
@@ -8,7 +6,7 @@ import fetchStyle from '../lib/fetch_style';
 
 export default class StyleLayerCreate extends Benchmark {
     style: string | StyleSpecification;
-    layers: Array<Object>;
+    layers: Array<any>;
 
     constructor(style: string | StyleSpecification) {
         super();

--- a/bench/benchmarks/style_validate.ts
+++ b/bench/benchmarks/style_validate.ts
@@ -1,6 +1,4 @@
-// @flow
-
-import type {StyleSpecification} from '../../src/style-spec/types';
+import type { StyleSpecification } from '../../src/style-spec/types';
 import Benchmark from '../lib/benchmark';
 import validateStyle from '../../src/style-spec/validate_style.min';
 import fetchStyle from '../lib/fetch_style';

--- a/bench/benchmarks/symbol_layout.ts
+++ b/bench/benchmarks/symbol_layout.ts
@@ -1,5 +1,3 @@
-// @flow
-
 import Layout from './layout';
 import SymbolBucket from '../../src/data/bucket/symbol_bucket';
 import {performSymbolLayout} from '../../src/symbol/symbol_layout';
@@ -8,7 +6,7 @@ import {OverscaledTileID} from '../../src/source/tile_id';
 export default class SymbolLayout extends Layout {
     parsedTiles: Array<any>;
 
-    constructor(style: string, locations: ?Array<OverscaledTileID>) {
+    constructor(style: string, locations?: Array<OverscaledTileID> | null) {
         super(style, locations);
         this.parsedTiles = [];
     }

--- a/bench/benchmarks/worker_transfer.ts
+++ b/bench/benchmarks/worker_transfer.ts
@@ -1,6 +1,4 @@
-// @flow
-
-import type {StyleSpecification} from '../../src/style-spec/types';
+import type { StyleSpecification } from '../../src/style-spec/types';
 import Benchmark from '../lib/benchmark';
 import fetchStyle from '../lib/fetch_style';
 import TileParser from '../lib/tile_parser';

--- a/bench/lib/benchmark.ts
+++ b/bench/lib/benchmark.ts
@@ -1,4 +1,3 @@
-// @flow
 // According to https://developer.mozilla.org/en-US/docs/Web/API/Performance/now,
 // performance.now() should be accurate to 0.005ms. Set the minimum running
 // time for a single measurement at 5ms, so that the error due to timer
@@ -6,8 +5,8 @@
 const minTimeForMeasurement = 0.005 * 1000;
 
 export type Measurement = {
-    iterations: number,
-    time: number
+  iterations: number,
+  time: number
 };
 
 class Benchmark {
@@ -48,7 +47,7 @@ class Benchmark {
      * Run the benchmark by executing `setup` once, sampling the execution time of `bench` some number of
      * times, and then executing `teardown`. Yields an array of execution times.
      */
-    run(): Promise<?Array<Measurement>> {
+    run(): Promise<Array<Measurement> | undefined | null> {
         return Promise.resolve(this.setup())
             .then(() => this._begin())
             .catch(e => {
@@ -72,7 +71,7 @@ class Benchmark {
         if (bench instanceof Promise) {
             return bench.then(this._measureAsync);
         } else {
-            return (this._measureSync(): any);
+            return this._measureSync() as any;
         }
     }
 
@@ -112,7 +111,7 @@ class Benchmark {
     }
 
     _runAsync(n: number): Promise<void> {
-        const bench = ((this.bench(): any): Promise<void>);
+        const bench = (this.bench() as any as Promise<void>);
         if (n === 1) {
             return bench;
         } else {

--- a/bench/lib/create_map.ts
+++ b/bench/lib/create_map.ts
@@ -1,8 +1,6 @@
-// @flow
-
 import Map from '../../src/ui/map';
 
-export default function (options: any): Promise<Map> {
+export default function(options: any): Promise<Map> {
     return new Promise((resolve, reject) => {
         if (options) {
             options.stubRender = options.stubRender == null ? true : options.stubRender;
@@ -18,7 +16,7 @@ export default function (options: any): Promise<Map> {
         if (!options.showMap) {
             container.style.visibility = 'hidden';
         }
-        (document.body: any).appendChild(container);
+        (document.body as any).appendChild(container);
 
         const map = new Map(Object.assign({
             container,

--- a/bench/lib/fetch_style.ts
+++ b/bench/lib/fetch_style.ts
@@ -1,6 +1,4 @@
-// @flow
-
-import type {StyleSpecification} from '../../src/style-spec/types';
+import type { StyleSpecification } from '../../src/style-spec/types';
 import {RequestManager} from '../../src/util/request_manager';
 
 const requestManager = new RequestManager();

--- a/bench/lib/tile_parser.ts
+++ b/bench/lib/tile_parser.ts
@@ -1,5 +1,3 @@
-// @flow
-
 import Protobuf from 'pbf';
 import VT from '@mapbox/vector-tile';
 import assert from 'assert';
@@ -29,7 +27,7 @@ const mapStub = new StubMap();
 
 function createStyle(styleJSON: StyleSpecification): Promise<Style> {
     return new Promise((resolve, reject) => {
-        const style = new Style((mapStub: any));
+        const style = new Style((mapStub as any));
         style.loadJSON(styleJSON);
         style
             .on('style.load', () => resolve(style))
@@ -47,10 +45,12 @@ export default class TileParser {
     tileJSON: TileJSON;
     sourceID: string;
     layerIndex: StyleLayerIndex;
-    icons: Object;
-    glyphs: Object;
+    icons: any;
+    glyphs: any;
     style: Style;
-    actor: { send: Function };
+    actor: {
+      send: Function
+    };
 
     constructor(styleJSON: StyleSpecification, sourceID: string) {
         this.styleJSON = styleJSON;
@@ -60,7 +60,7 @@ export default class TileParser {
         this.icons = {};
     }
 
-    loadImages(params: Object, callback: Function) {
+    loadImages(params: any, callback: Function) {
         const key = JSON.stringify(params);
         if (this.icons[key]) {
             callback(null, this.icons[key]);
@@ -72,7 +72,7 @@ export default class TileParser {
         }
     }
 
-    loadGlyphs(params: Object, callback: Function) {
+    loadGlyphs(params: any, callback: Function) {
         const key = JSON.stringify(params);
         if (this.glyphs[key]) {
             callback(null, this.glyphs[key]);
@@ -100,8 +100,8 @@ export default class TileParser {
 
         return Promise.all([
             createStyle(this.styleJSON),
-            fetchTileJSON(mapStub._requestManager, (this.styleJSON.sources[this.sourceID]: any).url)
-        ]).then(([style: Style, tileJSON: TileJSON]) => {
+            fetchTileJSON(mapStub._requestManager, (this.styleJSON.sources[this.sourceID] as any).url)
+        ]).then(([style, tileJSON]) => {
             this.style = style;
             this.tileJSON = tileJSON;
         });
@@ -113,7 +113,13 @@ export default class TileParser {
             .then(buffer => ({tileID, buffer}));
     }
 
-    parseTile(tile: {tileID: OverscaledTileID, buffer: ArrayBuffer}, returnDependencies?: boolean): Promise<?WorkerTileResult> {
+    parseTile(
+      tile: {
+        tileID: OverscaledTileID,
+        buffer: ArrayBuffer
+      },
+      returnDependencies?: boolean
+    ): Promise<WorkerTileResult | undefined | null> {
         const workerTile = new WorkerTile({
             tileID: tile.tileID,
             zoom: tile.tileID.overscaledZ,
@@ -136,7 +142,7 @@ export default class TileParser {
         const vectorTile = new VT.VectorTile(new Protobuf(tile.buffer));
 
         return new Promise((resolve, reject) => {
-            workerTile.parse(vectorTile, this.layerIndex, [], (this.actor: any), (err, result) => {
+            workerTile.parse(vectorTile, this.layerIndex, [], ((this.actor as any)), (err, result) => {
                 if (err) {
                     reject(err);
                 } else {


### PR DESCRIPTION
For consistency with the typescript migration I propose to migrate the benchmarks with `flowts`, as @HarelM suggested.