### PR TITLE
Upgrade mapbox-gl-supported library

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@mapbox/geojson-rewind": "^0.5.0",
         "@mapbox/jsonlint-lines-primitives": "^2.0.2",
-        "@mapbox/mapbox-gl-supported": "^1.5.0",
+        "@mapbox/mapbox-gl-supported": "^2.0.0",
         "@mapbox/tiny-sdf": "^2.0.2",
         "@mapbox/unitbezier": "^0.0.0",
         "@mapbox/vector-tile": "^1.3.1",
@@ -196,6 +196,10 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
       }
     },
     "node_modules/@babel/core/node_modules/@babel/compat-data": {
@@ -234,6 +238,9 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
       }
     },
     "node_modules/@babel/core/node_modules/@babel/helper-function-name": {
@@ -497,6 +504,9 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
       }
     },
     "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
@@ -523,6 +533,9 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
       }
     },
     "node_modules/@babel/helper-create-regexp-features-plugin": {
@@ -536,6 +549,9 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
       }
     },
     "node_modules/@babel/helper-define-polyfill-provider": {
@@ -552,6 +568,9 @@
         "lodash.debounce": "^4.0.8",
         "resolve": "^1.14.2",
         "semver": "^6.1.2"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.4.0-0"
       }
     },
     "node_modules/@babel/helper-define-polyfill-provider/node_modules/semver": {
@@ -973,6 +992,9 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.13.0"
       }
     },
     "node_modules/@babel/plugin-proposal-async-generator-functions": {
@@ -987,6 +1009,9 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-proposal-class-properties": {
@@ -1000,6 +1025,9 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-proposal-class-static-block": {
@@ -1014,6 +1042,9 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.12.0"
       }
     },
     "node_modules/@babel/plugin-proposal-decorators": {
@@ -1028,6 +1059,9 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-proposal-do-expressions": {
@@ -1041,6 +1075,9 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-proposal-dynamic-import": {
@@ -1054,6 +1091,9 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-proposal-export-default-from": {
@@ -1067,6 +1107,9 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-proposal-export-namespace-from": {
@@ -1080,6 +1123,9 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-proposal-function-bind": {
@@ -1093,6 +1139,9 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-proposal-function-sent": {
@@ -1107,6 +1156,9 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-proposal-json-strings": {
@@ -1120,6 +1172,9 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-proposal-logical-assignment-operators": {
@@ -1133,6 +1188,9 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-proposal-nullish-coalescing-operator": {
@@ -1146,6 +1204,9 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-proposal-numeric-separator": {
@@ -1159,6 +1220,9 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-proposal-object-rest-spread": {
@@ -1175,6 +1239,9 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-proposal-optional-catch-binding": {
@@ -1188,6 +1255,9 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-proposal-optional-chaining": {
@@ -1202,6 +1272,9 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-proposal-pipeline-operator": {
@@ -1215,6 +1288,9 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-proposal-private-methods": {
@@ -1228,6 +1304,9 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-proposal-private-property-in-object": {
@@ -1243,6 +1322,9 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-proposal-throw-expressions": {
@@ -1256,6 +1338,9 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-proposal-unicode-property-regex": {
@@ -1269,6 +1354,9 @@
       },
       "engines": {
         "node": ">=4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-syntax-async-generators": {
@@ -1278,6 +1366,9 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-syntax-class-properties": {
@@ -1287,6 +1378,9 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.12.13"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-syntax-class-static-block": {
@@ -1299,6 +1393,9 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-syntax-decorators": {
@@ -1311,6 +1408,9 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-syntax-do-expressions": {
@@ -1323,6 +1423,9 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-syntax-dynamic-import": {
@@ -1332,6 +1435,9 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-syntax-export-default-from": {
@@ -1344,6 +1450,9 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-syntax-export-namespace-from": {
@@ -1353,6 +1462,9 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.3"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-syntax-flow": {
@@ -1365,6 +1477,9 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-syntax-function-bind": {
@@ -1377,6 +1492,9 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-syntax-function-sent": {
@@ -1389,6 +1507,9 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-syntax-import-meta": {
@@ -1398,6 +1519,9 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-syntax-json-strings": {
@@ -1407,6 +1531,9 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-syntax-jsx": {
@@ -1419,6 +1546,9 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-syntax-logical-assignment-operators": {
@@ -1428,6 +1558,9 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-syntax-nullish-coalescing-operator": {
@@ -1437,6 +1570,9 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-syntax-numeric-separator": {
@@ -1446,6 +1582,9 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-syntax-object-rest-spread": {
@@ -1455,6 +1594,9 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-syntax-optional-catch-binding": {
@@ -1464,6 +1606,9 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-syntax-optional-chaining": {
@@ -1473,6 +1618,9 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-syntax-pipeline-operator": {
@@ -1485,6 +1633,9 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-syntax-private-property-in-object": {
@@ -1497,6 +1648,9 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-syntax-throw-expressions": {
@@ -1509,6 +1663,9 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-syntax-top-level-await": {
@@ -1521,6 +1678,9 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-arrow-functions": {
@@ -1533,6 +1693,9 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-async-to-generator": {
@@ -1547,6 +1710,9 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-block-scoped-functions": {
@@ -1559,6 +1725,9 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-block-scoping": {
@@ -1571,6 +1740,9 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-classes": {
@@ -1589,6 +1761,9 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-computed-properties": {
@@ -1601,6 +1776,9 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-destructuring": {
@@ -1613,6 +1791,9 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-dotall-regex": {
@@ -1626,6 +1807,9 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-duplicate-keys": {
@@ -1638,6 +1822,9 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-exponentiation-operator": {
@@ -1651,6 +1838,9 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-flow-strip-types": {
@@ -1664,6 +1854,9 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-for-of": {
@@ -1676,6 +1869,9 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-function-name": {
@@ -1689,6 +1885,9 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-literals": {
@@ -1701,6 +1900,9 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-member-expression-literals": {
@@ -1713,6 +1915,9 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-modules-amd": {
@@ -1727,6 +1932,9 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-modules-commonjs": {
@@ -1742,6 +1950,9 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-modules-systemjs": {
@@ -1758,6 +1969,9 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-modules-umd": {
@@ -1771,6 +1985,9 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-named-capturing-groups-regex": {
@@ -1783,6 +2000,9 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
       }
     },
     "node_modules/@babel/plugin-transform-new-target": {
@@ -1795,6 +2015,9 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-object-super": {
@@ -1808,6 +2031,9 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-parameters": {
@@ -1820,6 +2046,9 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-property-literals": {
@@ -1832,6 +2061,9 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-react-display-name": {
@@ -1844,6 +2076,9 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-react-jsx": {
@@ -1860,6 +2095,9 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-react-jsx-development": {
@@ -1872,6 +2110,9 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-react-pure-annotations": {
@@ -1885,6 +2126,9 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-regenerator": {
@@ -1897,6 +2141,9 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-reserved-words": {
@@ -1909,6 +2156,9 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-shorthand-properties": {
@@ -1921,6 +2171,9 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-spread": {
@@ -1934,6 +2187,9 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-sticky-regex": {
@@ -1946,6 +2202,9 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-template-literals": {
@@ -1958,6 +2217,9 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-typeof-symbol": {
@@ -1970,6 +2232,9 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-unicode-escapes": {
@@ -1982,6 +2247,9 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-unicode-regex": {
@@ -1995,6 +2263,9 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/preset-env": {
@@ -2079,6 +2350,9 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/preset-env/node_modules/semver": {
@@ -2102,6 +2376,9 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/preset-modules": {
@@ -2115,6 +2392,9 @@
         "@babel/plugin-transform-dotall-regex": "^7.4.4",
         "@babel/types": "^7.4.4",
         "esutils": "^2.0.2"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/preset-react": {
@@ -2132,6 +2412,9 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/preset-stage-0": {
@@ -2243,6 +2526,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/strip-json-comments": {
@@ -2252,6 +2538,9 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@hapi/address": {
@@ -2411,16 +2700,11 @@
         "geojson-rewind": "geojson-rewind"
       }
     },
-    "node_modules/@mapbox/geojson-types": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@mapbox/geojson-types/-/geojson-types-1.0.2.tgz",
-      "integrity": "sha512-e9EBqHHv3EORHrSfbR9DqecPNn+AmuAoQxV6aL8Xu30bJMJR1o8PZLZzpk1Wq7/NfCbuhmakHTPYRhoqLsXRnw==",
-      "peer": true
-    },
     "node_modules/@mapbox/geojsonhint": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@mapbox/geojsonhint/-/geojsonhint-2.2.0.tgz",
       "integrity": "sha512-8qQYRB+/2z2JsN5s6D0WAnpo69+3V3nvJsSFLwMB1dsaWz1V4oZeuoje9srbYAxxL8PXCwIywfhYa3GxOkBv5Q==",
+      "deprecated": "Please make plans to check GeoJSON in some other way",
       "dev": true,
       "dependencies": {
         "concat-stream": "^1.6.1",
@@ -2451,15 +2735,15 @@
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-rtl-text/-/mapbox-gl-rtl-text-0.2.3.tgz",
       "integrity": "sha512-RaCYfnxULUUUxNwcUimV9C/o2295ktTyLEUzD/+VWkqXqvaVfFcZ5slytGzb2Sd/Jj4MlbxD0DCZbfa6CzcmMw==",
-      "dev": true
-    },
-    "node_modules/@mapbox/mapbox-gl-supported": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-supported/-/mapbox-gl-supported-1.5.0.tgz",
-      "integrity": "sha512-/PT1P6DNf7vjEEiPkVIRJkvibbqWtqnyGaBz3nfRdcxclNSnSdaLU5tfAgcD7I8Yt5i+L19s406YLl1koLnLbg==",
+      "dev": true,
       "peerDependencies": {
         "mapbox-gl": ">=0.32.1 <2.0.0"
       }
+    },
+    "node_modules/@mapbox/mapbox-gl-supported": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-supported/-/mapbox-gl-supported-2.0.0.tgz",
+      "integrity": "sha512-zu4udqYiBrKMQKwpKJ4hhPON7tz0QR/JZ3iGpHnNWFmH3Sv/ysxlICATUtGCFpsyJf2v1WpFhlzaZ3GhhKmPMA=="
     },
     "node_modules/@mapbox/mvt-fixtures": {
       "version": "3.6.0",
@@ -2649,7 +2933,10 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.4.tgz",
       "integrity": "sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA==",
-      "dev": true
+      "dev": true,
+      "peerDependencies": {
+        "@octokit/core": ">=3"
+      }
     },
     "node_modules/@octokit/plugin-rest-endpoint-methods": {
       "version": "5.11.2",
@@ -2726,6 +3013,9 @@
       },
       "engines": {
         "node": ">= 8.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^2.38.3"
       }
     },
     "node_modules/@rollup/plugin-commonjs/node_modules/estree-walker": {
@@ -2741,6 +3031,9 @@
       "dev": true,
       "dependencies": {
         "@rollup/pluginutils": "^3.0.8"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0 || ^2.0.0"
       }
     },
     "node_modules/@rollup/plugin-node-resolve": {
@@ -2780,6 +3073,9 @@
       "dependencies": {
         "@rollup/pluginutils": "^3.1.0",
         "magic-string": "^0.25.7"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0 || ^2.0.0"
       }
     },
     "node_modules/@rollup/plugin-strip": {
@@ -2814,6 +3110,9 @@
       },
       "engines": {
         "node": ">= 8.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0"
       }
     },
     "node_modules/@sinonjs/commons": {
@@ -3149,6 +3448,10 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
       }
     },
     "node_modules/@types/cssnano/node_modules/source-map": {
@@ -3787,6 +4090,10 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
       }
     },
     "node_modules/@types/stylelint/node_modules/source-map": {
@@ -4105,7 +4412,10 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true
+      "dev": true,
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
     },
     "node_modules/acorn-node": {
       "version": "1.8.2",
@@ -4180,6 +4490,10 @@
         "fast-json-stable-stringify": "^2.0.0",
         "json-schema-traverse": "^0.4.1",
         "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/alphanum-sort": {
@@ -4375,6 +4689,9 @@
       },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/array-union": {
@@ -4407,6 +4724,9 @@
       },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/array.prototype.flatmap": {
@@ -4422,6 +4742,9 @@
       },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/arrify": {
@@ -4589,6 +4912,10 @@
       },
       "bin": {
         "autoprefixer": "bin/autoprefixer"
+      },
+      "funding": {
+        "type": "tidelift",
+        "url": "https://tidelift.com/funding/github/npm/autoprefixer"
       }
     },
     "node_modules/autoprefixer/node_modules/chalk": {
@@ -4629,6 +4956,10 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
       }
     },
     "node_modules/autoprefixer/node_modules/source-map": {
@@ -4683,6 +5014,7 @@
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.1.0.tgz",
       "integrity": "sha512-ifWaTHQ0ce+448CYop8AdrQiBsGrnC+bMgfyKFdi6EsPLTAWG+QfyDeM6OH+FmWnKvEq5NnBMLvlBUPKQZoDSg==",
+      "deprecated": "babel-eslint is now @babel/eslint-parser. This package will no longer receive updates.",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
@@ -4694,6 +5026,9 @@
       },
       "engines": {
         "node": ">=6"
+      },
+      "peerDependencies": {
+        "eslint": ">= 4.12.1"
       }
     },
     "node_modules/babel-plugin-dynamic-import-node": {
@@ -4714,6 +5049,9 @@
         "@babel/compat-data": "^7.13.11",
         "@babel/helper-define-polyfill-provider": "^0.2.2",
         "semver": "^6.1.1"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/babel-plugin-polyfill-corejs2/node_modules/semver": {
@@ -4733,6 +5071,9 @@
       "dependencies": {
         "@babel/helper-define-polyfill-provider": "^0.2.2",
         "core-js-compat": "^3.14.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/babel-plugin-polyfill-regenerator": {
@@ -4742,6 +5083,9 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-define-polyfill-provider": "^0.2.2"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/babelify": {
@@ -4751,6 +5095,9 @@
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
       }
     },
     "node_modules/backbone": {
@@ -4772,7 +5119,11 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/bail/-/bail-1.0.5.tgz",
       "integrity": "sha512-xFbRxM1tahm08yHBP16MMjVUAvDaBMD38zsM9EMAUN61omwLmKlOpB/Zku5QkjZ8TZ4vn53pj+t518cH0S03RQ==",
-      "dev": true
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -4861,7 +5212,21 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "dev": true
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
     },
     "node_modules/base64id": {
       "version": "2.0.0",
@@ -4943,6 +5308,20 @@
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
       "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
@@ -5277,7 +5656,21 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
     },
     "node_modules/browserify-zlib": {
       "version": "0.2.0",
@@ -5305,6 +5698,10 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/browserslist"
       }
     },
     "node_modules/btoa": {
@@ -5378,6 +5775,9 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/builtin-status-codes": {
@@ -5453,6 +5853,9 @@
       "dependencies": {
         "function-bind": "^1.1.1",
         "get-intrinsic": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/call-matcher": {
@@ -5519,13 +5922,18 @@
       "version": "1.0.30001245",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001245.tgz",
       "integrity": "sha512-768fM9j1PKXpOCKws6eTo3RHmvTUsG9UrpT4WoREFeZgJBTi4/X9g565azS/rVUGtqb8nt7FjLeF5u4kukERnA==",
-      "dev": true
+      "dev": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/browserslist"
+      }
     },
     "node_modules/canvas": {
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/canvas/-/canvas-2.8.0.tgz",
       "integrity": "sha512-gLTi17X8WY9Cf5GZ2Yns8T5lfBOcGgFehDFb+JQwDqdOoBOcECS9ZWMEAqMSVcMYwXD659J8NyzjRY/2aE+C2Q==",
       "dev": true,
+      "hasInstallScript": true,
       "dependencies": {
         "@mapbox/node-pre-gyp": "^1.0.0",
         "nan": "^2.14.0",
@@ -5554,7 +5962,11 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/ccount/-/ccount-1.1.0.tgz",
       "integrity": "sha512-vlNK021QdI7PNeiUh/lKkC/mNHHfV0m/Ad5JoI0TYtlBnJAslM/JIkm/tGC88bkLIwO6OQ5uV6ztS6kVAtCDlg==",
-      "dev": true
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -5582,6 +5994,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/chalk/node_modules/color-convert": {
@@ -5627,25 +6042,41 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.4.tgz",
       "integrity": "sha512-iBMyeEHxfVnIakwOuDXpVkc54HijNgCyQB2w0VfGQThle6NXn50zU6V/u+LDhxHcDUPojn6Kpga3PTAD8W1bQw==",
-      "dev": true
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/character-entities-html4": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-1.1.4.tgz",
       "integrity": "sha512-HRcDxZuZqMx3/a+qrzxdBKBPUpxWEq9xw2OPZ3a/174ihfrQKVsFhqtthBInFy1zZ9GgZyFXOatNujm8M+El3g==",
-      "dev": true
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/character-entities-legacy": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.1.4.tgz",
       "integrity": "sha512-3Xnr+7ZFS1uxeiUDvV02wQ+QDbc55o97tIV5zHScSPJpcLm/r0DFPcoY3tYRp+VZukxuMeKgXYmsXQHO05zQeA==",
-      "dev": true
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/character-reference-invalid": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.4.tgz",
       "integrity": "sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg==",
-      "dev": true
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/charm": {
       "version": "1.0.2",
@@ -5824,7 +6255,11 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-1.0.6.tgz",
       "integrity": "sha512-jEovNnrhMuqyCcjfEJA56v0Xq8SkIoPKDyaHahwo3POf4qcSXqMYuwNcOTzp74vTsR9Tn08z4MxWqAhcekogkQ==",
-      "dev": true
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/collection-visit": {
       "version": "1.0.0",
@@ -5918,7 +6353,11 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-1.0.8.tgz",
       "integrity": "sha512-GHuDRO12Sypu2cV70d1dkA2EUmXHgntrzbpvOB+Qy+49ypNfGgFQIC2fhhXbnyrJRynDCAARsT7Ou0M6hirpfw==",
-      "dev": true
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/commander": {
       "version": "2.20.3",
@@ -6120,6 +6559,10 @@
       "dependencies": {
         "browserslist": "^4.16.6",
         "semver": "7.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
       }
     },
     "node_modules/core-js-compat/node_modules/semver": {
@@ -6924,6 +7367,11 @@
       },
       "engines": {
         "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
     "node_modules/decamelize": {
@@ -6981,6 +7429,9 @@
         "object-is": "^1.0.1",
         "object-keys": "^1.1.1",
         "regexp.prototype.flags": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/deep-extend": {
@@ -7174,6 +7625,10 @@
       "dev": true,
       "dependencies": {
         "repeat-string": "^1.5.4"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/detect-libc": {
@@ -7479,6 +7934,7 @@
       "version": "2.1.8",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
       "integrity": "sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==",
+      "deprecated": "Chokidar 2 will break on node v14+. Upgrade to chokidar 3 with 15x less dependencies.",
       "dev": true,
       "dependencies": {
         "anymatch": "^2.0.0",
@@ -7544,7 +8000,9 @@
       "version": "1.2.13",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
       "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
+      "deprecated": "fsevents 1 will break on node v14+ and could be using insecure binaries. Upgrade to fsevents 2.",
       "dev": true,
+      "hasInstallScript": true,
       "optional": true,
       "os": [
         "darwin"
@@ -7763,6 +8221,10 @@
         "unist-util-stringify-position": "^2.0.0",
         "vfile-sort": "^2.1.2",
         "vfile-statistics": "^1.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/documentation/node_modules/vfile-reporter/node_modules/supports-color": {
@@ -7791,7 +8253,13 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.2.0.tgz",
       "integrity": "sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A==",
-      "dev": true
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ]
     },
     "node_modules/domain-browser": {
       "version": "1.2.0",
@@ -8024,6 +8492,18 @@
       "dev": true,
       "engines": {
         "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/enquirer": {
@@ -8042,7 +8522,10 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
       "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
-      "dev": true
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/env-paths": {
       "version": "2.2.1",
@@ -8140,6 +8623,9 @@
       },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/es6-error": {
@@ -8256,6 +8742,9 @@
       },
       "engines": {
         "node": "^10.12.0 || >=12.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/eslint-config-mourner": {
@@ -8433,6 +8922,9 @@
       },
       "engines": {
         "node": ">=4"
+      },
+      "peerDependencies": {
+        "eslint": "^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0"
       }
     },
     "node_modules/eslint-plugin-import/node_modules/debug": {
@@ -8475,6 +8967,9 @@
       "dev": true,
       "dependencies": {
         "has": "^1.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/eslint-plugin-import/node_modules/locate-path": {
@@ -8622,6 +9117,9 @@
       "dependencies": {
         "is-core-module": "^2.2.0",
         "path-parse": "^1.0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/eslint-plugin-react/node_modules/semver": {
@@ -8721,6 +9219,9 @@
       "dev": true,
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/eslint/node_modules/eslint-utils": {
@@ -8733,6 +9234,9 @@
       },
       "engines": {
         "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
       }
     },
     "node_modules/eslint/node_modules/eslint-utils/node_modules/eslint-visitor-keys": {
@@ -8763,6 +9267,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/eslint/node_modules/levn": {
@@ -8853,6 +9360,9 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/eslint/node_modules/type-check": {
@@ -9687,8 +10197,19 @@
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.3.tgz",
       "integrity": "sha512-3MkHxknWMUtb23apkgz/83fDoe+y+qr0TdgacGIA7bew+QLBo3vdgEN2xEsuXNivpFy4CyDhBBZnNZOtalmenw==",
       "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
       "engines": {
         "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
       }
     },
     "node_modules/for-each": {
@@ -9886,6 +10407,7 @@
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
       "dev": true,
+      "hasInstallScript": true,
       "optional": true,
       "os": [
         "darwin"
@@ -10049,6 +10571,9 @@
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
         "has-symbols": "^1.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/get-npm-tarball-url": {
@@ -10096,6 +10621,9 @@
       "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/get-symbol-description": {
@@ -10171,6 +10699,7 @@
       "resolved": "https://registry.npmjs.org/gl/-/gl-4.9.2.tgz",
       "integrity": "sha512-lLYaicQxsRPxOnKWX9pIGmtKRuw0epvI089yl9uBvemYxR9xE01eRuXJgje1U0/06Df7bdOmmcW87IPOsu52Ow==",
       "dev": true,
+      "hasInstallScript": true,
       "dependencies": {
         "bindings": "^1.5.0",
         "bit-twiddle": "^1.0.2",
@@ -10326,6 +10855,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/globby/node_modules/ignore": {
@@ -10459,6 +10991,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/har-schema": {
@@ -10474,6 +11009,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
       "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
+      "deprecated": "this library is no longer supported",
       "dev": true,
       "dependencies": {
         "ajv": "^6.12.3",
@@ -10508,7 +11044,10 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.1.tgz",
       "integrity": "sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA==",
-      "dev": true
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/has-color": {
       "version": "0.1.7",
@@ -10547,6 +11086,9 @@
       "dev": true,
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/has-tostringtag": {
@@ -10671,7 +11213,21 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
     },
     "node_modules/hash.js": {
       "version": "1.1.7",
@@ -10724,7 +11280,11 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-1.1.0.tgz",
       "integrity": "sha512-oUmNua0bFbdrD/ELDSSEadRVtWZOf3iF6Lbv81naqsIV99RnSCieTbWuWCY8BAeEfKJTKl0gRdokv+dELutHGQ==",
-      "dev": true
+      "dev": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
     },
     "node_modules/hast-util-sanitize": {
       "version": "1.3.1",
@@ -10763,7 +11323,11 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-1.0.4.tgz",
       "integrity": "sha512-I5GTdSfhYfAPNztx2xJRQpG8cuDSNt599/7YUn7Gx/WxNMsG+a835k97TDkFgk123cwjfwINaZknkKkphx/f2A==",
-      "dev": true
+      "dev": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
     },
     "node_modules/he": {
       "version": "1.2.0",
@@ -10778,7 +11342,9 @@
       "version": "9.18.5",
       "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.18.5.tgz",
       "integrity": "sha512-a5bFyofd/BHCX52/8i8uJkjr9DYwXIPnM/plwI6W7ezItLGqzt7X2G2nXuYSfsIJdkwwj/g9DG1LkcGJI/dDoA==",
+      "deprecated": "Support has ended for 9.x series. Upgrade to @latest",
       "dev": true,
+      "hasInstallScript": true,
       "engines": {
         "node": "*"
       }
@@ -10828,7 +11394,11 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-1.0.5.tgz",
       "integrity": "sha512-uE/TxKuyNIcx44cIWnjr/rfIATDH7ZaOMmstu0CwhFG1Dunhlp4OC6/NMbhiwoq5BpW0ubi303qnEk/PZj614w==",
-      "dev": true
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/htmlescape": {
       "version": "1.1.1",
@@ -10964,7 +11534,21 @@
     "node_modules/ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
     },
     "node_modules/ignore": {
       "version": "4.0.6",
@@ -11218,7 +11802,11 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.4.tgz",
       "integrity": "sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg==",
-      "dev": true
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/is-alphanumeric": {
       "version": "1.0.0",
@@ -11237,6 +11825,10 @@
       "dependencies": {
         "is-alphabetical": "^1.0.0",
         "is-decimal": "^1.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/is-arguments": {
@@ -11249,6 +11841,9 @@
       },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-arrayish": {
@@ -11261,7 +11856,10 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.2.tgz",
       "integrity": "sha512-0JV5+SOCQkIdzjBK9buARcV804Ddu7A0Qet6sHi3FimE9ne6m4BGQZfRn+NZiXbBk4F4XmHfDZIipLj9pX8dSA==",
-      "dev": true
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
@@ -11285,6 +11883,9 @@
       },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-buffer": {
@@ -11292,6 +11893,20 @@
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
       "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
       "engines": {
         "node": ">=4"
       }
@@ -11327,6 +11942,9 @@
       "dev": true,
       "dependencies": {
         "has": "^1.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-data-descriptor": {
@@ -11366,13 +11984,20 @@
       "dev": true,
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-decimal": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.4.tgz",
       "integrity": "sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw==",
-      "dev": true
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/is-descriptor": {
       "version": "0.1.6",
@@ -11407,6 +12032,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-extendable": {
@@ -11434,6 +12062,9 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-fullwidth-code-point": {
@@ -11476,7 +12107,11 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.4.tgz",
       "integrity": "sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw==",
-      "dev": true
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/is-map": {
       "version": "2.0.2",
@@ -11509,6 +12144,9 @@
       "dev": true,
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-number": {
@@ -11527,6 +12165,9 @@
       "dev": true,
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-plain-obj": {
@@ -11669,6 +12310,9 @@
       },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-type": {
@@ -11772,7 +12416,11 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-whitespace-character/-/is-whitespace-character-1.0.4.tgz",
       "integrity": "sha512-SDweEzfIZM0SJV0EUga669UTKlmL0Pq8Lno0QDQsPnvECB3IM2aP0gdx5TrU0A01MAPfViaZiI2V1QMZLaKK5w==",
-      "dev": true
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/is-windows": {
       "version": "1.0.2",
@@ -11787,7 +12435,11 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-word-character/-/is-word-character-1.0.4.tgz",
       "integrity": "sha512-5SMO8RVennx3nZrqtKwCGyyetPE9VDba5ugvKLaD4KopPG5kR4mQ7tNt/r7feL5yt5h3lpuBbIUmCOG2eSzXHA==",
-      "dev": true
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/is-wsl": {
       "version": "2.2.0",
@@ -12349,7 +13001,10 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/JSV/-/JSV-4.0.2.tgz",
       "integrity": "sha1-0Hf2glVx+CEy+d/67Vh7QCn+/1c=",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/jsx-ast-utils": {
       "version": "3.2.0",
@@ -12834,7 +13489,11 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-2.0.4.tgz",
       "integrity": "sha512-vM6rUVCVUJJt33bnmHiZEvr7wPT78ztX7rojL+LW51bHtLh6HTjx84LA5W4+oa6aKEJA7jJu5LR6vQRBpA5DVg==",
-      "dev": true
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
@@ -12912,6 +13571,7 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.2.tgz",
       "integrity": "sha512-FCEhQ/4rE1zYv9rYXJw/msRqsnmlje5jHP6huWeBZ704jUTy02c5AZyWujpMR1ax6mVw9NyJMfuK2CMDWVIfgA==",
+      "deprecated": "This version of tar is no longer supported, and will not receive security updates. Please upgrade asap.",
       "dev": true,
       "dependencies": {
         "block-stream": "*",
@@ -12938,6 +13598,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/make-dir/node_modules/semver": {
@@ -12997,44 +13660,11 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/mapbox-gl": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-1.13.1.tgz",
-      "integrity": "sha512-GSyubcoSF5MyaP8z+DasLu5v7KmDK2pp4S5+VQ5WdVQUOaAqQY4jwl4JpcdNho3uWm2bIKs7x1l7q3ynGmW60g==",
-      "peer": true,
-      "dependencies": {
-        "@mapbox/geojson-rewind": "^0.5.0",
-        "@mapbox/geojson-types": "^1.0.2",
-        "@mapbox/jsonlint-lines-primitives": "^2.0.2",
-        "@mapbox/mapbox-gl-supported": "^1.5.0",
-        "@mapbox/point-geometry": "^0.1.0",
-        "@mapbox/tiny-sdf": "^1.1.1",
-        "@mapbox/unitbezier": "^0.0.0",
-        "@mapbox/vector-tile": "^1.3.1",
-        "@mapbox/whoots-js": "^3.1.0",
-        "csscolorparser": "~1.0.3",
-        "earcut": "^2.2.2",
-        "geojson-vt": "^3.2.1",
-        "gl-matrix": "^3.2.1",
-        "grid-index": "^1.1.0",
-        "minimist": "^1.2.5",
-        "murmurhash-js": "^1.0.0",
-        "pbf": "^3.2.1",
-        "potpack": "^1.0.1",
-        "quickselect": "^2.0.0",
-        "rw": "^1.3.3",
-        "supercluster": "^7.1.0",
-        "tinyqueue": "^2.0.3",
-        "vt-pbf": "^3.1.1"
-      },
-      "engines": {
-        "node": ">=6.4.0"
-      }
-    },
     "node_modules/mapbox-gl-styles": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/mapbox-gl-styles/-/mapbox-gl-styles-2.0.2.tgz",
       "integrity": "sha1-u1Jbd+oNwrBBu4BRZFF283g+KUo=",
+      "deprecated": "This package has moved to the @mapbox namespace. All new version are available via @mapbox/mapbox-gl-styles",
       "dev": true,
       "dependencies": {
         "glob": "^5.0.14"
@@ -13056,17 +13686,15 @@
         "node": "*"
       }
     },
-    "node_modules/mapbox-gl/node_modules/@mapbox/tiny-sdf": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-1.2.5.tgz",
-      "integrity": "sha512-cD8A/zJlm6fdJOk6DqPUV8mcpyJkRz2x2R+/fYcWDYG3oWbG7/L7Yl/WqQ1VZCjnL9OTIMAn6c+BC5Eru4sQEw==",
-      "peer": true
-    },
     "node_modules/markdown-escapes": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/markdown-escapes/-/markdown-escapes-1.0.4.tgz",
       "integrity": "sha512-8z4efJYk43E0upd0NbVXwgSTQs6cT3T06etieCMEg7dRbzCbxUCK/GHlX8mhHRDcp+OLlHkPKsvqQTCvsRl2cg==",
-      "dev": true
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/markdown-table": {
       "version": "1.1.3",
@@ -13078,7 +13706,11 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/mathml-tag-names/-/mathml-tag-names-2.1.3.tgz",
       "integrity": "sha512-APMBEanjybaPzUrfqU0IMU5I0AswKMH7k8OTLs0vvV4KZpExkTkY87nR/zpbuTPj+gARop7aGUbl11pnDfW6xg==",
-      "dev": true
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/md5.js": {
       "version": "1.3.5",
@@ -13098,6 +13730,10 @@
       "dev": true,
       "dependencies": {
         "unist-util-visit": "^1.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/mdast-util-definitions": {
@@ -13107,6 +13743,10 @@
       "dev": true,
       "dependencies": {
         "unist-util-visit": "^1.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/mdast-util-from-markdown": {
@@ -13232,7 +13872,11 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-1.1.0.tgz",
       "integrity": "sha512-jVU0Nr2B9X3MU4tSK7JP1CMkSvOj7X5l/GboG1tKRw52lLF1x2Ju92Ms9tNetCcbfX3hzlM73zYo2NKkWSfF/A==",
-      "dev": true
+      "dev": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
     },
     "node_modules/mdast-util-toc": {
       "version": "3.1.0",
@@ -13704,6 +14348,9 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/min-indent": {
@@ -14145,6 +14792,7 @@
       "resolved": "https://registry.npmjs.org/node-plantuml/-/node-plantuml-0.9.0.tgz",
       "integrity": "sha512-bUnntTGjbpYu1pvXZI/GS6ctcXf3AOMqJxBMO8vFzTT5RwH8Cj/J5Ca6Dy+PEfMiMDdSBCFKSGnvYyBvYnucXg==",
       "dev": true,
+      "hasInstallScript": true,
       "dependencies": {
         "commander": "^2.8.1",
         "node-nailgun-client": "^0.1.0",
@@ -14180,6 +14828,7 @@
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.8.1.tgz",
       "integrity": "sha1-IVH3Ikcrp55Qp2/BJbuMjy5Nwqc=",
+      "deprecated": "Package no longer supported. Contact support@npmjs.com for more info.",
       "dev": true,
       "dependencies": {
         "chalk": "~0.4.0",
@@ -14823,7 +15472,10 @@
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.11.0.tgz",
       "integrity": "sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg==",
-      "dev": true
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/object-is": {
       "version": "1.1.5",
@@ -14836,6 +15488,9 @@
       },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/object-keys": {
@@ -14872,6 +15527,9 @@
       },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/object.entries": {
@@ -14901,6 +15559,9 @@
       },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/object.hasown": {
@@ -14940,6 +15601,9 @@
       },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/on-finished": {
@@ -14983,6 +15647,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/opener": {
@@ -15110,6 +15777,9 @@
       },
       "engines": {
         "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/p-locate": {
@@ -15456,6 +16126,9 @@
       "dev": true,
       "engines": {
         "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/pidtree": {
@@ -15920,6 +16593,13 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
       }
     },
     "node_modules/postcss-cli/node_modules/postcss-reporter/node_modules/colorette": {
@@ -16107,6 +16787,10 @@
       "dev": true,
       "dependencies": {
         "htmlparser2": "^3.10.0"
+      },
+      "peerDependencies": {
+        "postcss": ">=5.0.0",
+        "postcss-syntax": ">=0.36.0"
       }
     },
     "node_modules/postcss-inline-svg": {
@@ -16119,6 +16803,9 @@
         "dom-serializer": "^1.1.0",
         "htmlparser2": "^5.0.1",
         "postcss-value-parser": "^4.0.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.4"
       }
     },
     "node_modules/postcss-inline-svg/node_modules/css-select": {
@@ -16132,6 +16819,9 @@
         "domhandler": "^4.0.0",
         "domutils": "^2.4.3",
         "nth-check": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
       }
     },
     "node_modules/postcss-inline-svg/node_modules/css-what": {
@@ -16141,6 +16831,9 @@
       "dev": true,
       "engines": {
         "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
       }
     },
     "node_modules/postcss-inline-svg/node_modules/dom-serializer": {
@@ -16152,13 +16845,22 @@
         "domelementtype": "^2.0.1",
         "domhandler": "^4.2.0",
         "entities": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
       }
     },
     "node_modules/postcss-inline-svg/node_modules/domelementtype": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.2.0.tgz",
       "integrity": "sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A==",
-      "dev": true
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ]
     },
     "node_modules/postcss-inline-svg/node_modules/domhandler": {
       "version": "4.2.0",
@@ -16170,6 +16872,9 @@
       },
       "engines": {
         "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
       }
     },
     "node_modules/postcss-inline-svg/node_modules/domutils": {
@@ -16181,6 +16886,9 @@
         "dom-serializer": "^1.0.1",
         "domelementtype": "^2.2.0",
         "domhandler": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
       }
     },
     "node_modules/postcss-inline-svg/node_modules/htmlparser2": {
@@ -16193,6 +16901,9 @@
         "domhandler": "^3.3.0",
         "domutils": "^2.4.2",
         "entities": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/htmlparser2?sponsor=1"
       }
     },
     "node_modules/postcss-inline-svg/node_modules/htmlparser2/node_modules/domhandler": {
@@ -16205,6 +16916,9 @@
       },
       "engines": {
         "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
       }
     },
     "node_modules/postcss-less": {
@@ -16257,6 +16971,10 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
       }
     },
     "node_modules/postcss-less/node_modules/source-map": {
@@ -16292,6 +17010,18 @@
       },
       "engines": {
         "node": ">= 10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
+      },
+      "peerDependencies": {
+        "ts-node": ">=9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ts-node": {
+          "optional": true
+        }
       }
     },
     "node_modules/postcss-media-query-parser": {
@@ -16645,6 +17375,10 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
       }
     },
     "node_modules/postcss-safe-parser/node_modules/source-map": {
@@ -16760,6 +17494,10 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
       }
     },
     "node_modules/postcss-scss/node_modules/source-map": {
@@ -16816,7 +17554,10 @@
       "version": "0.36.2",
       "resolved": "https://registry.npmjs.org/postcss-syntax/-/postcss-syntax-0.36.2.tgz",
       "integrity": "sha512-nBRg/i7E3SOHWxF3PpF5WnJM/jQ1YpY9000OaVXlAQj6Zp/kIqJxEDWIZ67tAd7NLuk7zqN4yqe9nc0oNAOs1w==",
-      "dev": true
+      "dev": true,
+      "peerDependencies": {
+        "postcss": ">=5.0.0"
+      }
     },
     "node_modules/postcss-unique-selectors": {
       "version": "5.0.1",
@@ -16906,6 +17647,9 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/pretty-hrtime": {
@@ -17259,6 +18003,9 @@
       },
       "engines": {
         "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/query-string": {
@@ -17274,12 +18021,16 @@
       },
       "engines": {
         "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/querystring": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
       "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
+      "deprecated": "The querystring API is considered Legacy. new code should use the URLSearchParams API instead.",
       "dev": true,
       "engines": {
         "node": ">=0.4.x"
@@ -17298,7 +18049,21 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-      "dev": true
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
     },
     "node_modules/quick-lru": {
       "version": "4.0.1",
@@ -17560,6 +18325,9 @@
       },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/regexpp": {
@@ -17569,6 +18337,9 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
       }
     },
     "node_modules/regexpu-core": {
@@ -17828,6 +18599,7 @@
       "version": "2.88.2",
       "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
       "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
+      "deprecated": "request has been deprecated, see https://github.com/request/request/issues/3142",
       "dev": true,
       "dependencies": {
         "aws-sign2": "~0.7.0",
@@ -17865,12 +18637,16 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      },
+      "peerDependencies": {
+        "request": "^2.34"
       }
     },
     "node_modules/request-promise-native": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.9.tgz",
       "integrity": "sha512-wcW+sIUiWnKgNY0dqCpOZkUbF/I+YPi+f09JZIDa39Ec+q82CpSYniDp+ISgTTbKmnpJWASeJBPZmoxH84wt3g==",
+      "deprecated": "request-promise-native has been deprecated because it extends the now deprecated request package, see https://github.com/request/request/issues/3142",
       "dev": true,
       "dependencies": {
         "request-promise-core": "1.1.4",
@@ -17879,6 +18655,9 @@
       },
       "engines": {
         "node": ">=0.12.0"
+      },
+      "peerDependencies": {
+        "request": "^2.34"
       }
     },
     "node_modules/request/node_modules/qs": {
@@ -17928,6 +18707,9 @@
       "dependencies": {
         "is-core-module": "^2.2.0",
         "path-parse": "^1.0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/resolve-from": {
@@ -17963,6 +18745,7 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
       "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
+      "deprecated": "https://github.com/lydell/resolve-url#deprecated",
       "dev": true
     },
     "node_modules/resumer": {
@@ -18003,6 +18786,9 @@
       },
       "bin": {
         "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/ripemd160": {
@@ -18041,6 +18827,15 @@
       },
       "engines": {
         "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=10.0.0",
+        "rollup": ">=0.31.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/rollup-plugin-sourcemaps/node_modules/source-map-resolve": {
@@ -18063,6 +18858,9 @@
         "jest-worker": "^26.2.1",
         "serialize-javascript": "^4.0.0",
         "terser": "^5.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^2.0.0"
       }
     },
     "node_modules/rollup-plugin-unassert": {
@@ -18111,6 +18909,20 @@
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
       "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
       "dependencies": {
         "queue-microtask": "^1.2.2"
       }
@@ -18209,6 +19021,18 @@
       "dev": true,
       "engines": {
         "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/semver": {
@@ -18440,6 +19264,9 @@
         "call-bind": "^1.0.0",
         "get-intrinsic": "^1.0.2",
         "object-inspect": "^1.9.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/signal-exit": {
@@ -18452,7 +19279,21 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
       "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
-      "dev": true
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
     },
     "node_modules/simple-get": {
       "version": "3.1.0",
@@ -18828,6 +19669,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/source-map-explorer/node_modules/cliui": {
@@ -18930,6 +19774,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/source-map-explorer/node_modules/y18n": {
@@ -19025,7 +19872,11 @@
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-1.1.5.tgz",
       "integrity": "sha512-q/JSVd1Lptzhf5bkYm4ob4iWPjx0KiRe3sRFBNrVqbJkFaBm5vbbowy1mymoPNLRa52+oadOhJ+K49wsSeSjTA==",
-      "dev": true
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/spawn-args": {
       "version": "0.2.0",
@@ -19206,6 +20057,11 @@
         "safer-buffer": "^2.0.2",
         "tweetnacl": "~0.14.0"
       },
+      "bin": {
+        "sshpk-conv": "bin/sshpk-conv",
+        "sshpk-sign": "bin/sshpk-sign",
+        "sshpk-verify": "bin/sshpk-verify"
+      },
       "engines": {
         "node": ">=0.10.0"
       }
@@ -19309,7 +20165,11 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/state-toggle/-/state-toggle-1.0.3.tgz",
       "integrity": "sha512-d/5Z4/2iiCnHw6Xzghyhb+GcmF89bxwgXG60wjIiZaxnymbyOmI8Hk4VqHXiVVp6u2ysaskFfXg3ekCj4WNftQ==",
-      "dev": true
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/static-extend": {
       "version": "0.1.2",
@@ -19532,6 +20392,9 @@
         "internal-slot": "^1.0.3",
         "regexp.prototype.flags": "^1.3.1",
         "side-channel": "^1.0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/string.prototype.padend": {
@@ -19546,6 +20409,9 @@
       },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/string.prototype.trim": {
@@ -19560,6 +20426,9 @@
       },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/string.prototype.trimend": {
@@ -19570,6 +20439,9 @@
       "dependencies": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/string.prototype.trimstart": {
@@ -19580,6 +20452,9 @@
       "dependencies": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/stringify-entities": {
@@ -19796,18 +20671,74 @@
       }
     },
     "node_modules/stylelint/node_modules/chalk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
       "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
+    },
+    "node_modules/stylelint/node_modules/chalk/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/stylelint/node_modules/chalk/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/stylelint/node_modules/chalk/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/stylelint/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/stylelint/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
     },
     "node_modules/stylelint/node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -20008,6 +20939,36 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
+      }
+    },
+    "node_modules/stylelint/node_modules/postcss/node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/stylelint/node_modules/postcss/node_modules/chalk/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/stylelint/node_modules/postcss/node_modules/supports-color": {
@@ -20257,6 +21218,10 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
       }
     },
     "node_modules/sugarss/node_modules/source-map": {
@@ -20499,12 +21464,14 @@
         "escape-string-regexp": "^1.0.3",
         "glob": "^7.0.5",
         "js-yaml": "^3.3.1",
-        "readable-stream": "^2.1.5",
         "tap-parser": "^5.1.0",
         "unicode-length": "^1.0.0"
       },
       "bin": {
         "tap-mocha-reporter": "index.js"
+      },
+      "optionalDependencies": {
+        "readable-stream": "^2.1.5"
       }
     },
     "node_modules/tap-mocha-reporter/node_modules/debug": {
@@ -20538,11 +21505,13 @@
       "dev": true,
       "dependencies": {
         "events-to-array": "^1.0.1",
-        "js-yaml": "^3.2.7",
-        "readable-stream": "^2"
+        "js-yaml": "^3.2.7"
       },
       "bin": {
         "tap-parser": "bin/cmd.js"
+      },
+      "optionalDependencies": {
+        "readable-stream": "^2"
       }
     },
     "node_modules/tap-parser": {
@@ -20625,130 +21594,27 @@
       "resolved": "https://registry.npmjs.org/nyc/-/nyc-13.3.0.tgz",
       "integrity": "sha512-P+FwIuro2aFG6B0Esd9ZDWUd51uZrAEoGutqZxzrVmYl3qSfkLgcQpBPBjtDFsUQLFY1dvTQJPOyeqr8S9GF8w==",
       "bundleDependencies": [
-        "ansi-regex",
-        "append-transform",
         "archy",
         "arrify",
-        "async",
-        "balanced-match",
-        "brace-expansion",
         "caching-transform",
-        "camelcase",
-        "cliui",
-        "code-point-at",
-        "commander",
-        "commondir",
-        "concat-map",
         "convert-source-map",
-        "cross-spawn",
-        "debug",
-        "decamelize",
-        "default-require-extensions",
-        "end-of-stream",
-        "error-ex",
-        "es6-error",
-        "execa",
         "find-cache-dir",
         "find-up",
         "foreground-child",
-        "fs.realpath",
-        "get-caller-file",
-        "get-stream",
         "glob",
-        "graceful-fs",
-        "handlebars",
-        "has-flag",
-        "hasha",
-        "hosted-git-info",
-        "imurmurhash",
-        "inflight",
-        "inherits",
-        "invert-kv",
-        "is-arrayish",
-        "is-fullwidth-code-point",
-        "is-stream",
-        "isexe",
         "istanbul-lib-coverage",
         "istanbul-lib-hook",
         "istanbul-lib-report",
         "istanbul-lib-source-maps",
         "istanbul-reports",
-        "json-parse-better-errors",
-        "lcid",
-        "load-json-file",
-        "locate-path",
-        "lodash",
-        "lodash.flattendeep",
-        "lru-cache",
         "make-dir",
-        "map-age-cleaner",
-        "mem",
         "merge-source-map",
-        "mimic-fn",
-        "minimatch",
-        "minimist",
-        "mkdirp",
-        "ms",
-        "nice-try",
-        "normalize-package-data",
-        "npm-run-path",
-        "number-is-nan",
-        "once",
-        "optimist",
-        "os-homedir",
-        "os-locale",
-        "p-defer",
-        "p-finally",
-        "p-is-promise",
-        "p-limit",
-        "p-locate",
-        "p-try",
-        "package-hash",
-        "parse-json",
-        "path-exists",
-        "path-is-absolute",
-        "path-key",
-        "path-parse",
-        "path-type",
-        "pify",
-        "pkg-dir",
-        "pseudomap",
-        "pump",
-        "read-pkg",
-        "read-pkg-up",
-        "release-zalgo",
-        "require-directory",
-        "require-main-filename",
-        "resolve",
         "resolve-from",
         "rimraf",
-        "safe-buffer",
-        "semver",
-        "set-blocking",
-        "shebang-command",
-        "shebang-regex",
         "signal-exit",
         "spawn-wrap",
-        "spdx-correct",
-        "spdx-exceptions",
-        "spdx-expression-parse",
-        "spdx-license-ids",
-        "string-width",
-        "strip-ansi",
-        "strip-bom",
-        "strip-eof",
         "test-exclude",
-        "uglify-js",
         "uuid",
-        "validate-npm-package-license",
-        "which",
-        "which-module",
-        "wordwrap",
-        "wrap-ansi",
-        "wrappy",
-        "write-file-atomic",
-        "y18n",
-        "yallist",
         "yargs",
         "yargs-parser"
       ],
@@ -20788,8 +21654,6 @@
     },
     "node_modules/tap/node_modules/nyc/node_modules/ansi-regex": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -20799,8 +21663,6 @@
     },
     "node_modules/tap/node_modules/nyc/node_modules/append-transform": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/append-transform/-/append-transform-1.0.0.tgz",
-      "integrity": "sha512-P009oYkeHyU742iSZJzZZywj4QRJdnTWffaKuJQLablCZ1uz6/cW4yaRgcDaoQ+uwOxxnt0gRUcwfsNP2ri0gw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -20813,16 +21675,12 @@
     },
     "node_modules/tap/node_modules/nyc/node_modules/archy": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
-      "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/tap/node_modules/nyc/node_modules/arrify": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -20832,8 +21690,6 @@
     },
     "node_modules/tap/node_modules/nyc/node_modules/async": {
       "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.2.tgz",
-      "integrity": "sha512-H1qVYh1MYhEEFLsP97cVKqCGo7KfCyTt6uEWqsTBr9SO84oK9Uwbyd/yCW+6rKJLHksBNUVWZDAjfS+Ccx0Bbg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -20843,16 +21699,12 @@
     },
     "node_modules/tap/node_modules/nyc/node_modules/balanced-match": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/tap/node_modules/nyc/node_modules/brace-expansion": {
       "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -20863,8 +21715,6 @@
     },
     "node_modules/tap/node_modules/nyc/node_modules/caching-transform": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/caching-transform/-/caching-transform-3.0.1.tgz",
-      "integrity": "sha512-Y1KTLNwSPd4ljsDrFOtyXVmm7Gnk42yQitNq43AhE+cwUR/e4T+rmOHs1IPtzBg8066GBJfTOj1rQYFSWSsH2g==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -20880,8 +21730,6 @@
     },
     "node_modules/tap/node_modules/nyc/node_modules/camelcase": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.0.0.tgz",
-      "integrity": "sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -20891,8 +21739,6 @@
     },
     "node_modules/tap/node_modules/nyc/node_modules/cliui": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
-      "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -20904,8 +21750,6 @@
     },
     "node_modules/tap/node_modules/nyc/node_modules/code-point-at": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -20915,8 +21759,6 @@
     },
     "node_modules/tap/node_modules/nyc/node_modules/commander": {
       "version": "2.17.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
-      "integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -20924,24 +21766,18 @@
     },
     "node_modules/tap/node_modules/nyc/node_modules/commondir": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
-      "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/tap/node_modules/nyc/node_modules/concat-map": {
       "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/tap/node_modules/nyc/node_modules/convert-source-map": {
       "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz",
-      "integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -20951,8 +21787,6 @@
     },
     "node_modules/tap/node_modules/nyc/node_modules/cross-spawn": {
       "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
-      "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -20963,8 +21797,6 @@
     },
     "node_modules/tap/node_modules/nyc/node_modules/debug": {
       "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-      "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -20974,8 +21806,6 @@
     },
     "node_modules/tap/node_modules/nyc/node_modules/decamelize": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -20985,8 +21815,6 @@
     },
     "node_modules/tap/node_modules/nyc/node_modules/default-require-extensions": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-2.0.0.tgz",
-      "integrity": "sha1-9fj7sYp9bVCyH2QfZJ67Uiz+JPc=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -20999,8 +21827,6 @@
     },
     "node_modules/tap/node_modules/nyc/node_modules/end-of-stream": {
       "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
-      "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -21010,8 +21836,6 @@
     },
     "node_modules/tap/node_modules/nyc/node_modules/error-ex": {
       "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
-      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -21021,16 +21845,12 @@
     },
     "node_modules/tap/node_modules/nyc/node_modules/es6-error": {
       "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
-      "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/tap/node_modules/nyc/node_modules/execa": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
-      "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -21049,8 +21869,6 @@
     },
     "node_modules/tap/node_modules/nyc/node_modules/execa/node_modules/cross-spawn": {
       "version": "6.0.5",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-      "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -21067,8 +21885,6 @@
     },
     "node_modules/tap/node_modules/nyc/node_modules/find-cache-dir": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.0.0.tgz",
-      "integrity": "sha512-LDUY6V1Xs5eFskUVYtIwatojt6+9xC9Chnlk/jYOOvn3FAFfSaWddxahDGyNHh0b2dMXa6YW2m0tk8TdVaXHlA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -21083,8 +21899,6 @@
     },
     "node_modules/tap/node_modules/nyc/node_modules/find-up": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -21097,8 +21911,6 @@
     },
     "node_modules/tap/node_modules/nyc/node_modules/foreground-child": {
       "version": "1.5.6",
-      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-1.5.6.tgz",
-      "integrity": "sha1-T9ca0t/elnibmApcCilZN8svXOk=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -21109,24 +21921,18 @@
     },
     "node_modules/tap/node_modules/nyc/node_modules/fs.realpath": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/tap/node_modules/nyc/node_modules/get-caller-file": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
-      "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/tap/node_modules/nyc/node_modules/get-stream": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
-      "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -21139,8 +21945,6 @@
     },
     "node_modules/tap/node_modules/nyc/node_modules/glob": {
       "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-      "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -21158,16 +21962,12 @@
     },
     "node_modules/tap/node_modules/nyc/node_modules/graceful-fs": {
       "version": "4.1.15",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
-      "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/tap/node_modules/nyc/node_modules/handlebars": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.0.tgz",
-      "integrity": "sha512-l2jRuU1NAWK6AW5qqcTATWQJvNPEwkM7NEKSiv/gqOsoSQbVoWyqVEY5GS+XPQ88zLNmqASRpzfdm8d79hJS+w==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -21188,8 +21988,6 @@
     },
     "node_modules/tap/node_modules/nyc/node_modules/handlebars/node_modules/source-map": {
       "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "dev": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
@@ -21199,8 +21997,6 @@
     },
     "node_modules/tap/node_modules/nyc/node_modules/has-flag": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -21210,8 +22006,6 @@
     },
     "node_modules/tap/node_modules/nyc/node_modules/hasha": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/hasha/-/hasha-3.0.0.tgz",
-      "integrity": "sha1-UqMvq4Vp1BymmmH/GiFPjrfIvTk=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -21224,16 +22018,12 @@
     },
     "node_modules/tap/node_modules/nyc/node_modules/hosted-git-info": {
       "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
-      "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/tap/node_modules/nyc/node_modules/imurmurhash": {
       "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -21243,8 +22033,6 @@
     },
     "node_modules/tap/node_modules/nyc/node_modules/inflight": {
       "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -21255,16 +22043,12 @@
     },
     "node_modules/tap/node_modules/nyc/node_modules/inherits": {
       "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/tap/node_modules/nyc/node_modules/invert-kv": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
-      "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -21274,16 +22058,12 @@
     },
     "node_modules/tap/node_modules/nyc/node_modules/is-arrayish": {
       "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/tap/node_modules/nyc/node_modules/is-fullwidth-code-point": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -21293,8 +22073,6 @@
     },
     "node_modules/tap/node_modules/nyc/node_modules/is-stream": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -21304,16 +22082,12 @@
     },
     "node_modules/tap/node_modules/nyc/node_modules/isexe": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/tap/node_modules/nyc/node_modules/istanbul-lib-coverage": {
       "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz",
-      "integrity": "sha512-dKWuzRGCs4G+67VfW9pBFFz2Jpi4vSp/k7zBcJ888ofV5Mi1g5CUML5GvMvV6u9Cjybftu+E8Cgp+k0dI1E5lw==",
       "dev": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
@@ -21323,8 +22097,6 @@
     },
     "node_modules/tap/node_modules/nyc/node_modules/istanbul-lib-hook": {
       "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-2.0.3.tgz",
-      "integrity": "sha512-CLmEqwEhuCYtGcpNVJjLV1DQyVnIqavMLFHV/DP+np/g3qvdxu3gsPqYoJMXm15sN84xOlckFB3VNvRbf5yEgA==",
       "dev": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
@@ -21337,8 +22109,6 @@
     },
     "node_modules/tap/node_modules/nyc/node_modules/istanbul-lib-report": {
       "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-2.0.4.tgz",
-      "integrity": "sha512-sOiLZLAWpA0+3b5w5/dq0cjm2rrNdAfHWaGhmn7XEFW6X++IV9Ohn+pnELAl9K3rfpaeBfbmH9JU5sejacdLeA==",
       "dev": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
@@ -21353,8 +22123,6 @@
     },
     "node_modules/tap/node_modules/nyc/node_modules/istanbul-lib-report/node_modules/supports-color": {
       "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-      "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -21367,8 +22135,6 @@
     },
     "node_modules/tap/node_modules/nyc/node_modules/istanbul-lib-source-maps": {
       "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-3.0.2.tgz",
-      "integrity": "sha512-JX4v0CiKTGp9fZPmoxpu9YEkPbEqCqBbO3403VabKjH+NRXo72HafD5UgnjTEqHL2SAjaZK1XDuDOkn6I5QVfQ==",
       "dev": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
@@ -21385,8 +22151,6 @@
     },
     "node_modules/tap/node_modules/nyc/node_modules/istanbul-lib-source-maps/node_modules/source-map": {
       "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "dev": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
@@ -21396,8 +22160,6 @@
     },
     "node_modules/tap/node_modules/nyc/node_modules/istanbul-reports": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-2.1.1.tgz",
-      "integrity": "sha512-FzNahnidyEPBCI0HcufJoSEoKykesRlFcSzQqjH9x0+LC8tnnE/p/90PBLu8iZTxr8yYZNyTtiAujUqyN+CIxw==",
       "dev": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
@@ -21410,16 +22172,12 @@
     },
     "node_modules/tap/node_modules/nyc/node_modules/json-parse-better-errors": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
-      "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/tap/node_modules/nyc/node_modules/lcid": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
-      "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -21432,8 +22190,6 @@
     },
     "node_modules/tap/node_modules/nyc/node_modules/load-json-file": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
-      "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -21449,8 +22205,6 @@
     },
     "node_modules/tap/node_modules/nyc/node_modules/locate-path": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -21464,24 +22218,18 @@
     },
     "node_modules/tap/node_modules/nyc/node_modules/lodash": {
       "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/tap/node_modules/nyc/node_modules/lodash.flattendeep": {
       "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
-      "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/tap/node_modules/nyc/node_modules/lru-cache": {
       "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-      "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -21492,8 +22240,6 @@
     },
     "node_modules/tap/node_modules/nyc/node_modules/make-dir": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
-      "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -21506,8 +22252,6 @@
     },
     "node_modules/tap/node_modules/nyc/node_modules/map-age-cleaner": {
       "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
-      "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -21520,8 +22264,6 @@
     },
     "node_modules/tap/node_modules/nyc/node_modules/mem": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/mem/-/mem-4.1.0.tgz",
-      "integrity": "sha512-I5u6Q1x7wxO0kdOpYBB28xueHADYps5uty/zg936CiG8NTe5sJL8EjrCuLneuDW3PlMdZBGDIn8BirEVdovZvg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -21536,8 +22278,6 @@
     },
     "node_modules/tap/node_modules/nyc/node_modules/merge-source-map": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/merge-source-map/-/merge-source-map-1.1.0.tgz",
-      "integrity": "sha512-Qkcp7P2ygktpMPh2mCQZaf3jhN6D3Z/qVZHSdWvQ+2Ef5HgRAPBO57A77+ENm0CPx2+1Ce/MYKi3ymqdfuqibw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -21547,8 +22287,6 @@
     },
     "node_modules/tap/node_modules/nyc/node_modules/merge-source-map/node_modules/source-map": {
       "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "dev": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
@@ -21558,8 +22296,6 @@
     },
     "node_modules/tap/node_modules/nyc/node_modules/mimic-fn": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -21569,8 +22305,6 @@
     },
     "node_modules/tap/node_modules/nyc/node_modules/minimatch": {
       "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -21583,16 +22317,12 @@
     },
     "node_modules/tap/node_modules/nyc/node_modules/minimist": {
       "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-      "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/tap/node_modules/nyc/node_modules/mkdirp": {
       "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -21605,32 +22335,24 @@
     },
     "node_modules/tap/node_modules/nyc/node_modules/mkdirp/node_modules/minimist": {
       "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/tap/node_modules/nyc/node_modules/ms": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/tap/node_modules/nyc/node_modules/nice-try": {
       "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
-      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/tap/node_modules/nyc/node_modules/normalize-package-data": {
       "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
-      "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
@@ -21643,8 +22365,6 @@
     },
     "node_modules/tap/node_modules/nyc/node_modules/npm-run-path": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
-      "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -21657,8 +22377,6 @@
     },
     "node_modules/tap/node_modules/nyc/node_modules/number-is-nan": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -21668,8 +22386,6 @@
     },
     "node_modules/tap/node_modules/nyc/node_modules/once": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -21679,8 +22395,6 @@
     },
     "node_modules/tap/node_modules/nyc/node_modules/optimist": {
       "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "dev": true,
       "inBundle": true,
       "license": "MIT/X11",
@@ -21691,8 +22405,6 @@
     },
     "node_modules/tap/node_modules/nyc/node_modules/os-homedir": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -21702,8 +22414,6 @@
     },
     "node_modules/tap/node_modules/nyc/node_modules/os-locale": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
-      "integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -21718,8 +22428,6 @@
     },
     "node_modules/tap/node_modules/nyc/node_modules/p-defer": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
-      "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -21729,8 +22437,6 @@
     },
     "node_modules/tap/node_modules/nyc/node_modules/p-finally": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -21740,8 +22446,6 @@
     },
     "node_modules/tap/node_modules/nyc/node_modules/p-is-promise": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.0.0.tgz",
-      "integrity": "sha512-pzQPhYMCAgLAKPWD2jC3Se9fEfrD9npNos0y150EeqZll7akhEgGhTW/slB6lHku8AvYGiJ+YJ5hfHKePPgFWg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -21751,8 +22455,6 @@
     },
     "node_modules/tap/node_modules/nyc/node_modules/p-limit": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.1.0.tgz",
-      "integrity": "sha512-NhURkNcrVB+8hNfLuysU8enY5xn2KXphsHBaC2YmRNTZRc7RWusw6apSpdEj3jo4CMb6W9nrF6tTnsJsJeyu6g==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -21765,8 +22467,6 @@
     },
     "node_modules/tap/node_modules/nyc/node_modules/p-locate": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -21779,8 +22479,6 @@
     },
     "node_modules/tap/node_modules/nyc/node_modules/p-try": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.0.0.tgz",
-      "integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -21790,8 +22488,6 @@
     },
     "node_modules/tap/node_modules/nyc/node_modules/package-hash": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/package-hash/-/package-hash-3.0.0.tgz",
-      "integrity": "sha512-lOtmukMDVvtkL84rJHI7dpTYq+0rli8N2wlnqUcBuDWCfVhRUfOmnR9SsoHFMLpACvEV60dX7rd0rFaYDZI+FA==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -21807,8 +22503,6 @@
     },
     "node_modules/tap/node_modules/nyc/node_modules/parse-json": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
-      "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -21822,8 +22516,6 @@
     },
     "node_modules/tap/node_modules/nyc/node_modules/path-exists": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -21833,8 +22525,6 @@
     },
     "node_modules/tap/node_modules/nyc/node_modules/path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -21844,8 +22534,6 @@
     },
     "node_modules/tap/node_modules/nyc/node_modules/path-key": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -21855,16 +22543,12 @@
     },
     "node_modules/tap/node_modules/nyc/node_modules/path-parse": {
       "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/tap/node_modules/nyc/node_modules/path-type": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
-      "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -21877,8 +22561,6 @@
     },
     "node_modules/tap/node_modules/nyc/node_modules/pify": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-      "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -21888,8 +22570,6 @@
     },
     "node_modules/tap/node_modules/nyc/node_modules/pkg-dir": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
-      "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -21902,16 +22582,12 @@
     },
     "node_modules/tap/node_modules/nyc/node_modules/pseudomap": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/tap/node_modules/nyc/node_modules/pump": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -21922,8 +22598,6 @@
     },
     "node_modules/tap/node_modules/nyc/node_modules/read-pkg": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
-      "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -21938,8 +22612,6 @@
     },
     "node_modules/tap/node_modules/nyc/node_modules/read-pkg-up": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-4.0.0.tgz",
-      "integrity": "sha512-6etQSH7nJGsK0RbG/2TeDzZFa8shjQ1um+SwQQ5cwKy0dhSXdOncEhb1CPpvQG4h7FyOV6EB6YlV0yJvZQNAkA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -21953,8 +22625,6 @@
     },
     "node_modules/tap/node_modules/nyc/node_modules/release-zalgo": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/release-zalgo/-/release-zalgo-1.0.0.tgz",
-      "integrity": "sha1-CXALflB0Mpc5Mw5TXFqQ+2eFFzA=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -21967,8 +22637,6 @@
     },
     "node_modules/tap/node_modules/nyc/node_modules/require-directory": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -21978,16 +22646,12 @@
     },
     "node_modules/tap/node_modules/nyc/node_modules/require-main-filename": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-      "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/tap/node_modules/nyc/node_modules/resolve": {
       "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz",
-      "integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -21997,8 +22661,6 @@
     },
     "node_modules/tap/node_modules/nyc/node_modules/resolve-from": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -22008,8 +22670,6 @@
     },
     "node_modules/tap/node_modules/nyc/node_modules/rimraf": {
       "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
-      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -22022,16 +22682,12 @@
     },
     "node_modules/tap/node_modules/nyc/node_modules/safe-buffer": {
       "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/tap/node_modules/nyc/node_modules/semver": {
       "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
-      "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -22041,16 +22697,12 @@
     },
     "node_modules/tap/node_modules/nyc/node_modules/set-blocking": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/tap/node_modules/nyc/node_modules/shebang-command": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -22063,8 +22715,6 @@
     },
     "node_modules/tap/node_modules/nyc/node_modules/shebang-regex": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -22074,16 +22724,12 @@
     },
     "node_modules/tap/node_modules/nyc/node_modules/signal-exit": {
       "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/tap/node_modules/nyc/node_modules/spawn-wrap": {
       "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/spawn-wrap/-/spawn-wrap-1.4.2.tgz",
-      "integrity": "sha512-vMwR3OmmDhnxCVxM8M+xO/FtIp6Ju/mNaDfCMMW7FDcLRTPFWUswec4LXJHTJE2hwTI9O0YBfygu4DalFl7Ylg==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -22098,8 +22744,6 @@
     },
     "node_modules/tap/node_modules/nyc/node_modules/spdx-correct": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
-      "integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
@@ -22110,16 +22754,12 @@
     },
     "node_modules/tap/node_modules/nyc/node_modules/spdx-exceptions": {
       "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
-      "integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA==",
       "dev": true,
       "inBundle": true,
       "license": "CC-BY-3.0"
     },
     "node_modules/tap/node_modules/nyc/node_modules/spdx-expression-parse": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
-      "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -22130,16 +22770,12 @@
     },
     "node_modules/tap/node_modules/nyc/node_modules/spdx-license-ids": {
       "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.3.tgz",
-      "integrity": "sha512-uBIcIl3Ih6Phe3XHK1NqboJLdGfwr1UN3k6wSD1dZpmPsIkb8AGNbZYJ1fOBk834+Gxy8rpfDxrS6XLEMZMY2g==",
       "dev": true,
       "inBundle": true,
       "license": "CC0-1.0"
     },
     "node_modules/tap/node_modules/nyc/node_modules/string-width": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -22153,8 +22789,6 @@
     },
     "node_modules/tap/node_modules/nyc/node_modules/strip-ansi": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -22167,8 +22801,6 @@
     },
     "node_modules/tap/node_modules/nyc/node_modules/strip-bom": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -22178,8 +22810,6 @@
     },
     "node_modules/tap/node_modules/nyc/node_modules/strip-eof": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -22189,8 +22819,6 @@
     },
     "node_modules/tap/node_modules/nyc/node_modules/test-exclude": {
       "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-5.1.0.tgz",
-      "integrity": "sha512-gwf0S2fFsANC55fSeSqpb8BYk6w3FDvwZxfNjeF6FRgvFa43r+7wRiA/Q0IxoRU37wB/LE8IQ4221BsNucTaCA==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -22206,8 +22834,6 @@
     },
     "node_modules/tap/node_modules/nyc/node_modules/uglify-js": {
       "version": "3.4.9",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.9.tgz",
-      "integrity": "sha512-8CJsbKOtEbnJsTyv6LE6m6ZKniqMiFWmm9sRbopbkGs3gMPPfd3Fh8iIA4Ykv5MgaTbqHr4BaoGLJLZNhsrW1Q==",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
@@ -22225,8 +22851,6 @@
     },
     "node_modules/tap/node_modules/nyc/node_modules/uglify-js/node_modules/source-map": {
       "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "dev": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
@@ -22237,8 +22861,6 @@
     },
     "node_modules/tap/node_modules/nyc/node_modules/uuid": {
       "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -22248,8 +22870,6 @@
     },
     "node_modules/tap/node_modules/nyc/node_modules/validate-npm-package-license": {
       "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
-      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
@@ -22260,8 +22880,6 @@
     },
     "node_modules/tap/node_modules/nyc/node_modules/which": {
       "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -22274,16 +22892,12 @@
     },
     "node_modules/tap/node_modules/nyc/node_modules/which-module": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/tap/node_modules/nyc/node_modules/wordwrap": {
       "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -22293,8 +22907,6 @@
     },
     "node_modules/tap/node_modules/nyc/node_modules/wrap-ansi": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-      "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -22308,8 +22920,6 @@
     },
     "node_modules/tap/node_modules/nyc/node_modules/wrap-ansi/node_modules/ansi-regex": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -22319,8 +22929,6 @@
     },
     "node_modules/tap/node_modules/nyc/node_modules/wrap-ansi/node_modules/is-fullwidth-code-point": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -22333,8 +22941,6 @@
     },
     "node_modules/tap/node_modules/nyc/node_modules/wrap-ansi/node_modules/string-width": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -22349,8 +22955,6 @@
     },
     "node_modules/tap/node_modules/nyc/node_modules/wrap-ansi/node_modules/strip-ansi": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -22363,16 +22967,12 @@
     },
     "node_modules/tap/node_modules/nyc/node_modules/wrappy": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/tap/node_modules/nyc/node_modules/write-file-atomic": {
       "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.2.tgz",
-      "integrity": "sha512-s0b6vB3xIVRLWywa6X9TOMA7k9zio0TMOsl9ZnDkliA/cfJlpHXAscj0gbHVJiTdIuAYpIyqS5GW91fqm6gG5g==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -22384,24 +22984,18 @@
     },
     "node_modules/tap/node_modules/nyc/node_modules/y18n": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/tap/node_modules/nyc/node_modules/yallist": {
       "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/tap/node_modules/nyc/node_modules/yargs": {
       "version": "12.0.5",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
-      "integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -22422,8 +23016,6 @@
     },
     "node_modules/tap/node_modules/nyc/node_modules/yargs-parser": {
       "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
-      "integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -23111,7 +23703,11 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-1.1.3.tgz",
       "integrity": "sha512-E0ZosSWYK2mkSu+KEtQ9/KqarVjA9HztOSX+9FDdNacRAq29RRV6ZQNgob3iuW8Htar9vAfEa6yyt5qBAHZDBA==",
-      "dev": true
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/trim-newlines": {
       "version": "1.0.0",
@@ -23126,7 +23722,11 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/trim-trailing-lines/-/trim-trailing-lines-1.1.4.tgz",
       "integrity": "sha512-rjUWSqnfTNrjbB9NQWfPMH/xRK1deHeGsHoVfpxJ++XeYXE0d6B1En37AHfw3jtfTU7dzMzZL2jjpe8Qb5gLIQ==",
-      "dev": true
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/trivial-deferred": {
       "version": "1.0.1",
@@ -23138,7 +23738,11 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/trough/-/trough-1.0.5.tgz",
       "integrity": "sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA==",
-      "dev": true
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/ts-node": {
       "version": "8.10.2",
@@ -23160,6 +23764,9 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=2.7"
       }
     },
     "node_modules/tsame": {
@@ -23208,6 +23815,9 @@
       },
       "engines": {
         "node": ">= 6"
+      },
+      "peerDependencies": {
+        "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
       }
     },
     "node_modules/tty-browserify": {
@@ -23262,6 +23872,9 @@
       "dev": true,
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/type-is": {
@@ -23339,6 +23952,9 @@
         "has-bigints": "^1.0.1",
         "has-symbols": "^1.0.2",
         "which-boxed-primitive": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/unbzip2-stream": {
@@ -23390,6 +24006,10 @@
       "dependencies": {
         "inherits": "^2.0.0",
         "xtend": "^4.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
@@ -23577,7 +24197,11 @@
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/unist-util-generated/-/unist-util-generated-1.1.6.tgz",
       "integrity": "sha512-cln2Mm1/CZzN5ttGK7vkoGw+RZ8VcUH6BtGbq98DDtRGquAAOXig1mrBQYelOwMXYS8rK+vZDyyojSjp7JX+Lg==",
-      "dev": true
+      "dev": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
     },
     "node_modules/unist-util-is": {
       "version": "3.0.0",
@@ -23589,7 +24213,11 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-3.1.0.tgz",
       "integrity": "sha512-w+PkwCbYSFw8vpgWD0v7zRCl1FpY3fjDSQ3/N/wNd9Ffa4gPi8+4keqt99N3XW6F99t/mUzp2xAhNmfKWp95QA==",
-      "dev": true
+      "dev": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
     },
     "node_modules/unist-util-remove-position": {
       "version": "1.1.4",
@@ -23598,6 +24226,10 @@
       "dev": true,
       "dependencies": {
         "unist-util-visit": "^1.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/unist-util-stringify-position": {
@@ -23607,6 +24239,10 @@
       "dev": true,
       "dependencies": {
         "@types/unist": "^2.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/unist-util-visit": {
@@ -23740,6 +24376,7 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
       "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
+      "deprecated": "Please see https://github.com/lydell/urix#deprecated",
       "dev": true
     },
     "node_modules/url": {
@@ -23812,6 +24449,7 @@
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
       "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
       "dev": true,
       "bin": {
         "uuid": "bin/uuid"
@@ -23885,13 +24523,21 @@
         "is-buffer": "^2.0.0",
         "unist-util-stringify-position": "^2.0.0",
         "vfile-message": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/vfile-location": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-2.0.6.tgz",
       "integrity": "sha512-sSFdyCP3G6Ka0CEmN83A2YCMKIieHx0EDaj5IDP4g1pa5ZJ4FJDvpO0WODLxo4LUX4oe52gmSCK7Jw4SBghqxA==",
-      "dev": true
+      "dev": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
     },
     "node_modules/vfile-message": {
       "version": "2.0.4",
@@ -23901,6 +24547,10 @@
       "dependencies": {
         "@types/unist": "^2.0.0",
         "unist-util-stringify-position": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/vfile-reporter": {
@@ -23921,13 +24571,21 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/vfile-sort/-/vfile-sort-2.2.2.tgz",
       "integrity": "sha512-tAyUqD2R1l/7Rn7ixdGkhXLD3zsg+XLAeUDUhXearjfIcpL1Hcsj5hHpCoy/gvfK/Ws61+e972fm0F7up7hfYA==",
-      "dev": true
+      "dev": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
     },
     "node_modules/vfile-statistics": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/vfile-statistics/-/vfile-statistics-1.1.4.tgz",
       "integrity": "sha512-lXhElVO0Rq3frgPvFBwahmed3X03vjPF8OcjKMy8+F1xU/3Q3QU3tKEDp743SFtb74PdF0UWpxPvtOP0GCLheA==",
-      "dev": true
+      "dev": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
     },
     "node_modules/vinyl": {
       "version": "2.2.1",
@@ -24128,6 +24786,9 @@
         "is-number-object": "^1.0.4",
         "is-string": "^1.0.5",
         "is-symbol": "^1.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/which-collection": {
@@ -26217,12 +26878,6 @@
         "minimist": "^1.2.5"
       }
     },
-    "@mapbox/geojson-types": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@mapbox/geojson-types/-/geojson-types-1.0.2.tgz",
-      "integrity": "sha512-e9EBqHHv3EORHrSfbR9DqecPNn+AmuAoQxV6aL8Xu30bJMJR1o8PZLZzpk1Wq7/NfCbuhmakHTPYRhoqLsXRnw==",
-      "peer": true
-    },
     "@mapbox/geojsonhint": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@mapbox/geojsonhint/-/geojsonhint-2.2.0.tgz",
@@ -26253,13 +26908,13 @@
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-rtl-text/-/mapbox-gl-rtl-text-0.2.3.tgz",
       "integrity": "sha512-RaCYfnxULUUUxNwcUimV9C/o2295ktTyLEUzD/+VWkqXqvaVfFcZ5slytGzb2Sd/Jj4MlbxD0DCZbfa6CzcmMw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@mapbox/mapbox-gl-supported": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-supported/-/mapbox-gl-supported-1.5.0.tgz",
-      "integrity": "sha512-/PT1P6DNf7vjEEiPkVIRJkvibbqWtqnyGaBz3nfRdcxclNSnSdaLU5tfAgcD7I8Yt5i+L19s406YLl1koLnLbg==",
-      "requires": {}
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-supported/-/mapbox-gl-supported-2.0.0.tgz",
+      "integrity": "sha512-zu4udqYiBrKMQKwpKJ4hhPON7tz0QR/JZ3iGpHnNWFmH3Sv/ysxlICATUtGCFpsyJf2v1WpFhlzaZ3GhhKmPMA=="
     },
     "@mapbox/mvt-fixtures": {
       "version": "3.6.0",
@@ -26424,7 +27079,8 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.4.tgz",
       "integrity": "sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@octokit/plugin-rest-endpoint-methods": {
       "version": "5.11.2",
@@ -27722,7 +28378,8 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "acorn-node": {
       "version": "1.8.2",
@@ -28259,7 +28916,8 @@
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/babelify/-/babelify-10.0.0.tgz",
       "integrity": "sha512-X40FaxyH7t3X+JFAKvb1H9wooWKLRCi8pg3m8poqtdZaIng+bjzp9RvKQCvRjF9isHiPkXspbbXT/zwXLtwgwg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "backbone": {
       "version": "1.4.0",
@@ -31073,7 +31731,8 @@
           "version": "7.4.6",
           "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
           "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         }
       }
     },
@@ -35160,45 +35819,6 @@
         "object-visit": "^1.0.0"
       }
     },
-    "mapbox-gl": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-1.13.1.tgz",
-      "integrity": "sha512-GSyubcoSF5MyaP8z+DasLu5v7KmDK2pp4S5+VQ5WdVQUOaAqQY4jwl4JpcdNho3uWm2bIKs7x1l7q3ynGmW60g==",
-      "peer": true,
-      "requires": {
-        "@mapbox/geojson-rewind": "^0.5.0",
-        "@mapbox/geojson-types": "^1.0.2",
-        "@mapbox/jsonlint-lines-primitives": "^2.0.2",
-        "@mapbox/mapbox-gl-supported": "^1.5.0",
-        "@mapbox/point-geometry": "^0.1.0",
-        "@mapbox/tiny-sdf": "^1.1.1",
-        "@mapbox/unitbezier": "^0.0.0",
-        "@mapbox/vector-tile": "^1.3.1",
-        "@mapbox/whoots-js": "^3.1.0",
-        "csscolorparser": "~1.0.3",
-        "earcut": "^2.2.2",
-        "geojson-vt": "^3.2.1",
-        "gl-matrix": "^3.2.1",
-        "grid-index": "^1.1.0",
-        "minimist": "^1.2.5",
-        "murmurhash-js": "^1.0.0",
-        "pbf": "^3.2.1",
-        "potpack": "^1.0.1",
-        "quickselect": "^2.0.0",
-        "rw": "^1.3.3",
-        "supercluster": "^7.1.0",
-        "tinyqueue": "^2.0.3",
-        "vt-pbf": "^3.1.1"
-      },
-      "dependencies": {
-        "@mapbox/tiny-sdf": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-1.2.5.tgz",
-          "integrity": "sha512-cD8A/zJlm6fdJOk6DqPUV8mcpyJkRz2x2R+/fYcWDYG3oWbG7/L7Yl/WqQ1VZCjnL9OTIMAn6c+BC5Eru4sQEw==",
-          "peer": true
-        }
-      }
-    },
     "mapbox-gl-styles": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/mapbox-gl-styles/-/mapbox-gl-styles-2.0.2.tgz",
@@ -38185,7 +38805,8 @@
       "version": "0.36.2",
       "resolved": "https://registry.npmjs.org/postcss-syntax/-/postcss-syntax-0.36.2.tgz",
       "integrity": "sha512-nBRg/i7E3SOHWxF3PpF5WnJM/jQ1YpY9000OaVXlAQj6Zp/kIqJxEDWIZ67tAd7NLuk7zqN4yqe9nc0oNAOs1w==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-unique-selectors": {
       "version": "5.0.1",
@@ -39351,7 +39972,8 @@
           "version": "8.2.1",
           "resolved": "https://registry.npmjs.org/ws/-/ws-8.2.1.tgz",
           "integrity": "sha512-XkgWpJU3sHU7gX8f13NqTn6KQ85bd1WU7noBHTT8fSohx7OS1TPY8k+cyRPCzFkia7C4mM229yeHr1qK9sM4JQ==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         }
       }
     },
@@ -40648,15 +41270,55 @@
           }
         },
         "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "4.3.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+              "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+              "dev": true,
+              "requires": {
+                "color-convert": "^2.0.1"
+              }
+            },
+            "has-flag": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+              "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+              "dev": true
+            },
+            "supports-color": {
+              "version": "7.2.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+              "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+              "dev": true,
+              "requires": {
+                "has-flag": "^4.0.0"
+              }
+            }
           }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
         },
         "emoji-regex": {
           "version": "8.0.0",
@@ -40802,6 +41464,28 @@
             "supports-color": "^6.1.0"
           },
           "dependencies": {
+            "chalk": {
+              "version": "2.4.2",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+              "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+              "dev": true,
+              "requires": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+              },
+              "dependencies": {
+                "supports-color": {
+                  "version": "5.5.0",
+                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+                  "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+                  "dev": true,
+                  "requires": {
+                    "has-flag": "^3.0.0"
+                  }
+                }
+              }
+            },
             "supports-color": {
               "version": "6.1.0",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
@@ -41285,15 +41969,11 @@
           "dependencies": {
             "ansi-regex": {
               "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-              "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
               "bundled": true,
               "dev": true
             },
             "append-transform": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/append-transform/-/append-transform-1.0.0.tgz",
-              "integrity": "sha512-P009oYkeHyU742iSZJzZZywj4QRJdnTWffaKuJQLablCZ1uz6/cW4yaRgcDaoQ+uwOxxnt0gRUcwfsNP2ri0gw==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -41302,22 +41982,16 @@
             },
             "archy": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
-              "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
               "bundled": true,
               "dev": true
             },
             "arrify": {
               "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-              "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
               "bundled": true,
               "dev": true
             },
             "async": {
               "version": "2.6.2",
-              "resolved": "https://registry.npmjs.org/async/-/async-2.6.2.tgz",
-              "integrity": "sha512-H1qVYh1MYhEEFLsP97cVKqCGo7KfCyTt6uEWqsTBr9SO84oK9Uwbyd/yCW+6rKJLHksBNUVWZDAjfS+Ccx0Bbg==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -41326,15 +42000,11 @@
             },
             "balanced-match": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-              "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
               "bundled": true,
               "dev": true
             },
             "brace-expansion": {
               "version": "1.1.11",
-              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-              "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -41344,8 +42014,6 @@
             },
             "caching-transform": {
               "version": "3.0.1",
-              "resolved": "https://registry.npmjs.org/caching-transform/-/caching-transform-3.0.1.tgz",
-              "integrity": "sha512-Y1KTLNwSPd4ljsDrFOtyXVmm7Gnk42yQitNq43AhE+cwUR/e4T+rmOHs1IPtzBg8066GBJfTOj1rQYFSWSsH2g==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -41357,15 +42025,11 @@
             },
             "camelcase": {
               "version": "5.0.0",
-              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.0.0.tgz",
-              "integrity": "sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA==",
               "bundled": true,
               "dev": true
             },
             "cliui": {
               "version": "4.1.0",
-              "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
-              "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -41376,37 +42040,27 @@
             },
             "code-point-at": {
               "version": "1.1.0",
-              "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-              "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
               "bundled": true,
               "dev": true
             },
             "commander": {
               "version": "2.17.1",
-              "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
-              "integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==",
               "bundled": true,
               "dev": true,
               "optional": true
             },
             "commondir": {
               "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
-              "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
               "bundled": true,
               "dev": true
             },
             "concat-map": {
               "version": "0.0.1",
-              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-              "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
               "bundled": true,
               "dev": true
             },
             "convert-source-map": {
               "version": "1.6.0",
-              "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz",
-              "integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -41415,8 +42069,6 @@
             },
             "cross-spawn": {
               "version": "4.0.2",
-              "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
-              "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -41426,8 +42078,6 @@
             },
             "debug": {
               "version": "4.1.1",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-              "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -41436,15 +42086,11 @@
             },
             "decamelize": {
               "version": "1.2.0",
-              "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-              "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
               "bundled": true,
               "dev": true
             },
             "default-require-extensions": {
               "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-2.0.0.tgz",
-              "integrity": "sha1-9fj7sYp9bVCyH2QfZJ67Uiz+JPc=",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -41453,8 +42099,6 @@
             },
             "end-of-stream": {
               "version": "1.4.1",
-              "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
-              "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -41463,8 +42107,6 @@
             },
             "error-ex": {
               "version": "1.3.2",
-              "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
-              "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -41473,15 +42115,11 @@
             },
             "es6-error": {
               "version": "4.1.1",
-              "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
-              "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
               "bundled": true,
               "dev": true
             },
             "execa": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
-              "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -41496,8 +42134,6 @@
               "dependencies": {
                 "cross-spawn": {
                   "version": "6.0.5",
-                  "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-                  "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
                   "bundled": true,
                   "dev": true,
                   "requires": {
@@ -41512,8 +42148,6 @@
             },
             "find-cache-dir": {
               "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.0.0.tgz",
-              "integrity": "sha512-LDUY6V1Xs5eFskUVYtIwatojt6+9xC9Chnlk/jYOOvn3FAFfSaWddxahDGyNHh0b2dMXa6YW2m0tk8TdVaXHlA==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -41524,8 +42158,6 @@
             },
             "find-up": {
               "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-              "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -41534,8 +42166,6 @@
             },
             "foreground-child": {
               "version": "1.5.6",
-              "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-1.5.6.tgz",
-              "integrity": "sha1-T9ca0t/elnibmApcCilZN8svXOk=",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -41545,22 +42175,16 @@
             },
             "fs.realpath": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-              "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
               "bundled": true,
               "dev": true
             },
             "get-caller-file": {
               "version": "1.0.3",
-              "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
-              "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
               "bundled": true,
               "dev": true
             },
             "get-stream": {
               "version": "4.1.0",
-              "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
-              "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -41569,8 +42193,6 @@
             },
             "glob": {
               "version": "7.1.3",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-              "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -41584,15 +42206,11 @@
             },
             "graceful-fs": {
               "version": "4.1.15",
-              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
-              "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
               "bundled": true,
               "dev": true
             },
             "handlebars": {
               "version": "4.1.0",
-              "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.0.tgz",
-              "integrity": "sha512-l2jRuU1NAWK6AW5qqcTATWQJvNPEwkM7NEKSiv/gqOsoSQbVoWyqVEY5GS+XPQ88zLNmqASRpzfdm8d79hJS+w==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -41604,8 +42222,6 @@
               "dependencies": {
                 "source-map": {
                   "version": "0.6.1",
-                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-                  "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
                   "bundled": true,
                   "dev": true
                 }
@@ -41613,15 +42229,11 @@
             },
             "has-flag": {
               "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-              "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
               "bundled": true,
               "dev": true
             },
             "hasha": {
               "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/hasha/-/hasha-3.0.0.tgz",
-              "integrity": "sha1-UqMvq4Vp1BymmmH/GiFPjrfIvTk=",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -41630,22 +42242,16 @@
             },
             "hosted-git-info": {
               "version": "2.7.1",
-              "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
-              "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
               "bundled": true,
               "dev": true
             },
             "imurmurhash": {
               "version": "0.1.4",
-              "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-              "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
               "bundled": true,
               "dev": true
             },
             "inflight": {
               "version": "1.0.6",
-              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-              "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -41655,57 +42261,41 @@
             },
             "inherits": {
               "version": "2.0.3",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
               "bundled": true,
               "dev": true
             },
             "invert-kv": {
               "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
-              "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
               "bundled": true,
               "dev": true
             },
             "is-arrayish": {
               "version": "0.2.1",
-              "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-              "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
               "bundled": true,
               "dev": true
             },
             "is-fullwidth-code-point": {
               "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-              "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
               "bundled": true,
               "dev": true
             },
             "is-stream": {
               "version": "1.1.0",
-              "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-              "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
               "bundled": true,
               "dev": true
             },
             "isexe": {
               "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-              "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
               "bundled": true,
               "dev": true
             },
             "istanbul-lib-coverage": {
               "version": "2.0.3",
-              "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz",
-              "integrity": "sha512-dKWuzRGCs4G+67VfW9pBFFz2Jpi4vSp/k7zBcJ888ofV5Mi1g5CUML5GvMvV6u9Cjybftu+E8Cgp+k0dI1E5lw==",
               "bundled": true,
               "dev": true
             },
             "istanbul-lib-hook": {
               "version": "2.0.3",
-              "resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-2.0.3.tgz",
-              "integrity": "sha512-CLmEqwEhuCYtGcpNVJjLV1DQyVnIqavMLFHV/DP+np/g3qvdxu3gsPqYoJMXm15sN84xOlckFB3VNvRbf5yEgA==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -41714,8 +42304,6 @@
             },
             "istanbul-lib-report": {
               "version": "2.0.4",
-              "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-2.0.4.tgz",
-              "integrity": "sha512-sOiLZLAWpA0+3b5w5/dq0cjm2rrNdAfHWaGhmn7XEFW6X++IV9Ohn+pnELAl9K3rfpaeBfbmH9JU5sejacdLeA==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -41726,8 +42314,6 @@
               "dependencies": {
                 "supports-color": {
                   "version": "6.1.0",
-                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-                  "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
                   "bundled": true,
                   "dev": true,
                   "requires": {
@@ -41738,8 +42324,6 @@
             },
             "istanbul-lib-source-maps": {
               "version": "3.0.2",
-              "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-3.0.2.tgz",
-              "integrity": "sha512-JX4v0CiKTGp9fZPmoxpu9YEkPbEqCqBbO3403VabKjH+NRXo72HafD5UgnjTEqHL2SAjaZK1XDuDOkn6I5QVfQ==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -41752,8 +42336,6 @@
               "dependencies": {
                 "source-map": {
                   "version": "0.6.1",
-                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-                  "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
                   "bundled": true,
                   "dev": true
                 }
@@ -41761,8 +42343,6 @@
             },
             "istanbul-reports": {
               "version": "2.1.1",
-              "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-2.1.1.tgz",
-              "integrity": "sha512-FzNahnidyEPBCI0HcufJoSEoKykesRlFcSzQqjH9x0+LC8tnnE/p/90PBLu8iZTxr8yYZNyTtiAujUqyN+CIxw==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -41771,15 +42351,11 @@
             },
             "json-parse-better-errors": {
               "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
-              "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
               "bundled": true,
               "dev": true
             },
             "lcid": {
               "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
-              "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -41788,8 +42364,6 @@
             },
             "load-json-file": {
               "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
-              "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -41801,8 +42375,6 @@
             },
             "locate-path": {
               "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-              "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -41812,22 +42384,16 @@
             },
             "lodash": {
               "version": "4.17.11",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-              "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
               "bundled": true,
               "dev": true
             },
             "lodash.flattendeep": {
               "version": "4.4.0",
-              "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
-              "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
               "bundled": true,
               "dev": true
             },
             "lru-cache": {
               "version": "4.1.5",
-              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-              "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -41837,8 +42403,6 @@
             },
             "make-dir": {
               "version": "1.3.0",
-              "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
-              "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -41847,8 +42411,6 @@
             },
             "map-age-cleaner": {
               "version": "0.1.3",
-              "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
-              "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -41857,8 +42419,6 @@
             },
             "mem": {
               "version": "4.1.0",
-              "resolved": "https://registry.npmjs.org/mem/-/mem-4.1.0.tgz",
-              "integrity": "sha512-I5u6Q1x7wxO0kdOpYBB28xueHADYps5uty/zg936CiG8NTe5sJL8EjrCuLneuDW3PlMdZBGDIn8BirEVdovZvg==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -41869,8 +42429,6 @@
             },
             "merge-source-map": {
               "version": "1.1.0",
-              "resolved": "https://registry.npmjs.org/merge-source-map/-/merge-source-map-1.1.0.tgz",
-              "integrity": "sha512-Qkcp7P2ygktpMPh2mCQZaf3jhN6D3Z/qVZHSdWvQ+2Ef5HgRAPBO57A77+ENm0CPx2+1Ce/MYKi3ymqdfuqibw==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -41879,8 +42437,6 @@
               "dependencies": {
                 "source-map": {
                   "version": "0.6.1",
-                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-                  "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
                   "bundled": true,
                   "dev": true
                 }
@@ -41888,15 +42444,11 @@
             },
             "mimic-fn": {
               "version": "1.2.0",
-              "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-              "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
               "bundled": true,
               "dev": true
             },
             "minimatch": {
               "version": "3.0.4",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-              "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -41905,15 +42457,11 @@
             },
             "minimist": {
               "version": "0.0.10",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-              "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
               "bundled": true,
               "dev": true
             },
             "mkdirp": {
               "version": "0.5.1",
-              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-              "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -41922,8 +42470,6 @@
               "dependencies": {
                 "minimist": {
                   "version": "0.0.8",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-                  "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
                   "bundled": true,
                   "dev": true
                 }
@@ -41931,22 +42477,16 @@
             },
             "ms": {
               "version": "2.1.1",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-              "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
               "bundled": true,
               "dev": true
             },
             "nice-try": {
               "version": "1.0.5",
-              "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
-              "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
               "bundled": true,
               "dev": true
             },
             "normalize-package-data": {
               "version": "2.5.0",
-              "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
-              "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -41958,8 +42498,6 @@
             },
             "npm-run-path": {
               "version": "2.0.2",
-              "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
-              "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -41968,15 +42506,11 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-              "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
               "bundled": true,
               "dev": true
             },
             "once": {
               "version": "1.4.0",
-              "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-              "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -41985,8 +42519,6 @@
             },
             "optimist": {
               "version": "0.6.1",
-              "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-              "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -41996,15 +42528,11 @@
             },
             "os-homedir": {
               "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-              "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
               "bundled": true,
               "dev": true
             },
             "os-locale": {
               "version": "3.1.0",
-              "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
-              "integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -42015,29 +42543,21 @@
             },
             "p-defer": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
-              "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=",
               "bundled": true,
               "dev": true
             },
             "p-finally": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-              "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
               "bundled": true,
               "dev": true
             },
             "p-is-promise": {
               "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.0.0.tgz",
-              "integrity": "sha512-pzQPhYMCAgLAKPWD2jC3Se9fEfrD9npNos0y150EeqZll7akhEgGhTW/slB6lHku8AvYGiJ+YJ5hfHKePPgFWg==",
               "bundled": true,
               "dev": true
             },
             "p-limit": {
               "version": "2.1.0",
-              "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.1.0.tgz",
-              "integrity": "sha512-NhURkNcrVB+8hNfLuysU8enY5xn2KXphsHBaC2YmRNTZRc7RWusw6apSpdEj3jo4CMb6W9nrF6tTnsJsJeyu6g==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -42046,8 +42566,6 @@
             },
             "p-locate": {
               "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-              "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -42056,15 +42574,11 @@
             },
             "p-try": {
               "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.0.0.tgz",
-              "integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ==",
               "bundled": true,
               "dev": true
             },
             "package-hash": {
               "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/package-hash/-/package-hash-3.0.0.tgz",
-              "integrity": "sha512-lOtmukMDVvtkL84rJHI7dpTYq+0rli8N2wlnqUcBuDWCfVhRUfOmnR9SsoHFMLpACvEV60dX7rd0rFaYDZI+FA==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -42076,8 +42590,6 @@
             },
             "parse-json": {
               "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
-              "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -42087,36 +42599,26 @@
             },
             "path-exists": {
               "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-              "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
               "bundled": true,
               "dev": true
             },
             "path-is-absolute": {
               "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-              "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
               "bundled": true,
               "dev": true
             },
             "path-key": {
               "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-              "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
               "bundled": true,
               "dev": true
             },
             "path-parse": {
               "version": "1.0.6",
-              "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-              "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
               "bundled": true,
               "dev": true
             },
             "path-type": {
               "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
-              "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -42125,15 +42627,11 @@
             },
             "pify": {
               "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-              "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
               "bundled": true,
               "dev": true
             },
             "pkg-dir": {
               "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
-              "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -42142,15 +42640,11 @@
             },
             "pseudomap": {
               "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-              "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
               "bundled": true,
               "dev": true
             },
             "pump": {
               "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-              "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -42160,8 +42654,6 @@
             },
             "read-pkg": {
               "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
-              "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -42172,8 +42664,6 @@
             },
             "read-pkg-up": {
               "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-4.0.0.tgz",
-              "integrity": "sha512-6etQSH7nJGsK0RbG/2TeDzZFa8shjQ1um+SwQQ5cwKy0dhSXdOncEhb1CPpvQG4h7FyOV6EB6YlV0yJvZQNAkA==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -42183,8 +42673,6 @@
             },
             "release-zalgo": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/release-zalgo/-/release-zalgo-1.0.0.tgz",
-              "integrity": "sha1-CXALflB0Mpc5Mw5TXFqQ+2eFFzA=",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -42193,22 +42681,16 @@
             },
             "require-directory": {
               "version": "2.1.1",
-              "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-              "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
               "bundled": true,
               "dev": true
             },
             "require-main-filename": {
               "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-              "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
               "bundled": true,
               "dev": true
             },
             "resolve": {
               "version": "1.10.0",
-              "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz",
-              "integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -42217,15 +42699,11 @@
             },
             "resolve-from": {
               "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-              "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
               "bundled": true,
               "dev": true
             },
             "rimraf": {
               "version": "2.6.3",
-              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
-              "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -42234,29 +42712,21 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
               "bundled": true,
               "dev": true
             },
             "semver": {
               "version": "5.6.0",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
-              "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
               "bundled": true,
               "dev": true
             },
             "set-blocking": {
               "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-              "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
               "bundled": true,
               "dev": true
             },
             "shebang-command": {
               "version": "1.2.0",
-              "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-              "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -42265,22 +42735,16 @@
             },
             "shebang-regex": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-              "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
               "bundled": true,
               "dev": true
             },
             "signal-exit": {
               "version": "3.0.2",
-              "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-              "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
               "bundled": true,
               "dev": true
             },
             "spawn-wrap": {
               "version": "1.4.2",
-              "resolved": "https://registry.npmjs.org/spawn-wrap/-/spawn-wrap-1.4.2.tgz",
-              "integrity": "sha512-vMwR3OmmDhnxCVxM8M+xO/FtIp6Ju/mNaDfCMMW7FDcLRTPFWUswec4LXJHTJE2hwTI9O0YBfygu4DalFl7Ylg==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -42294,8 +42758,6 @@
             },
             "spdx-correct": {
               "version": "3.1.0",
-              "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
-              "integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -42305,15 +42767,11 @@
             },
             "spdx-exceptions": {
               "version": "2.2.0",
-              "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
-              "integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA==",
               "bundled": true,
               "dev": true
             },
             "spdx-expression-parse": {
               "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
-              "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -42323,15 +42781,11 @@
             },
             "spdx-license-ids": {
               "version": "3.0.3",
-              "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.3.tgz",
-              "integrity": "sha512-uBIcIl3Ih6Phe3XHK1NqboJLdGfwr1UN3k6wSD1dZpmPsIkb8AGNbZYJ1fOBk834+Gxy8rpfDxrS6XLEMZMY2g==",
               "bundled": true,
               "dev": true
             },
             "string-width": {
               "version": "2.1.1",
-              "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-              "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -42341,8 +42795,6 @@
             },
             "strip-ansi": {
               "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -42351,22 +42803,16 @@
             },
             "strip-bom": {
               "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-              "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
               "bundled": true,
               "dev": true
             },
             "strip-eof": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-              "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
               "bundled": true,
               "dev": true
             },
             "test-exclude": {
               "version": "5.1.0",
-              "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-5.1.0.tgz",
-              "integrity": "sha512-gwf0S2fFsANC55fSeSqpb8BYk6w3FDvwZxfNjeF6FRgvFa43r+7wRiA/Q0IxoRU37wB/LE8IQ4221BsNucTaCA==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -42378,8 +42824,6 @@
             },
             "uglify-js": {
               "version": "3.4.9",
-              "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.9.tgz",
-              "integrity": "sha512-8CJsbKOtEbnJsTyv6LE6m6ZKniqMiFWmm9sRbopbkGs3gMPPfd3Fh8iIA4Ykv5MgaTbqHr4BaoGLJLZNhsrW1Q==",
               "bundled": true,
               "dev": true,
               "optional": true,
@@ -42390,8 +42834,6 @@
               "dependencies": {
                 "source-map": {
                   "version": "0.6.1",
-                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-                  "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
                   "bundled": true,
                   "dev": true,
                   "optional": true
@@ -42400,15 +42842,11 @@
             },
             "uuid": {
               "version": "3.3.2",
-              "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-              "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
               "bundled": true,
               "dev": true
             },
             "validate-npm-package-license": {
               "version": "3.0.4",
-              "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
-              "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -42418,8 +42856,6 @@
             },
             "which": {
               "version": "1.3.1",
-              "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-              "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -42428,22 +42864,16 @@
             },
             "which-module": {
               "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-              "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
               "bundled": true,
               "dev": true
             },
             "wordwrap": {
               "version": "0.0.3",
-              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-              "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
               "bundled": true,
               "dev": true
             },
             "wrap-ansi": {
               "version": "2.1.0",
-              "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-              "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -42453,15 +42883,11 @@
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.1.1",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-                  "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
                   "bundled": true,
                   "dev": true
                 },
                 "is-fullwidth-code-point": {
                   "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-                  "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
                   "bundled": true,
                   "dev": true,
                   "requires": {
@@ -42470,8 +42896,6 @@
                 },
                 "string-width": {
                   "version": "1.0.2",
-                  "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-                  "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
                   "bundled": true,
                   "dev": true,
                   "requires": {
@@ -42482,8 +42906,6 @@
                 },
                 "strip-ansi": {
                   "version": "3.0.1",
-                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                  "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                   "bundled": true,
                   "dev": true,
                   "requires": {
@@ -42494,15 +42916,11 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-              "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
               "bundled": true,
               "dev": true
             },
             "write-file-atomic": {
               "version": "2.4.2",
-              "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.2.tgz",
-              "integrity": "sha512-s0b6vB3xIVRLWywa6X9TOMA7k9zio0TMOsl9ZnDkliA/cfJlpHXAscj0gbHVJiTdIuAYpIyqS5GW91fqm6gG5g==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -42513,22 +42931,16 @@
             },
             "y18n": {
               "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-              "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
               "bundled": true,
               "dev": true
             },
             "yallist": {
               "version": "2.1.2",
-              "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-              "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
               "bundled": true,
               "dev": true
             },
             "yargs": {
               "version": "12.0.5",
-              "resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
-              "integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -42548,8 +42960,6 @@
             },
             "yargs-parser": {
               "version": "11.1.1",
-              "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
-              "integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
               "bundled": true,
               "dev": true,
               "requires": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "@mapbox/geojson-rewind": "^0.5.0",
     "@mapbox/jsonlint-lines-primitives": "^2.0.2",
-    "@mapbox/mapbox-gl-supported": "^1.5.0",
+    "@mapbox/mapbox-gl-supported": "^2.0.0",
     "@mapbox/tiny-sdf": "^2.0.2",
     "@mapbox/unitbezier": "^0.0.0",
     "@mapbox/vector-tile": "^1.3.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import supported from '@mapbox/mapbox-gl-supported';
+import {supported} from '@mapbox/mapbox-gl-supported';
 
 import Map from './ui/map';
 import NavigationControl from './ui/control/navigation_control';

--- a/src/types/non-typed-modules.d.ts
+++ b/src/types/non-typed-modules.d.ts
@@ -10,7 +10,9 @@ declare module '@mapbox/mapbox-gl-supported' {
         ): boolean;
     };
 
-    let __exports: isSupported;
+    let __exports: {
+        supported: isSupported;
+    };
     export = __exports
 }
 
@@ -42,42 +44,6 @@ declare module 'potpack' {
     }
 
     let __exports: typeof potpack;
-    export = __exports
-}
-
-declare module 'sinon' {
-    type SpyCall = {
-        args: Array<unknown>;
-    };
-
-    type Spy = {
-        calledOnce: number;
-        getCall(i: number): SpyCall;
-        (): any;
-    };
-
-    type Stub = {
-        callsFake(fn: unknown): Spy;
-    };
-
-    class FakeServer {
-        xhr: XMLHttpRequest;
-    }
-
-    type Sandbox = {
-        xhr: {
-            supportsCORS: boolean;
-        };
-        fakeServer: {
-            create: () => FakeServer;
-        };
-        createSandbox(options: unknown): Sandbox;
-        stub(obj?: unknown, prop?: string): Stub;
-        spy(obj?: unknown, prop?: string): Spy;
-        restore(): void;
-    };
-
-    let __exports: Sandbox;
     export = __exports
 }
 

--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -15,7 +15,7 @@ import LngLatBounds from '../geo/lng_lat_bounds';
 import Point, {PointLike} from '../util/point';
 import AttributionControl from './control/attribution_control';
 import LogoControl from './control/logo_control';
-import isSupported from '@mapbox/mapbox-gl-supported';
+import {supported} from '@mapbox/mapbox-gl-supported';
 import {RGBAImage} from '../util/image';
 import {Event, ErrorEvent, Listener} from '../util/evented';
 import {MapMouseEvent} from './events';
@@ -2370,7 +2370,7 @@ class Map extends Camera {
     }
 
     _setupPainter() {
-        const attributes = extend({}, isSupported.webGLContextAttributes, {
+        const attributes = extend({}, supported.webGLContextAttributes, {
             failIfMajorPerformanceCaveat: this._failIfMajorPerformanceCaveat,
             preserveDrawingBuffer: this._preserveDrawingBuffer,
             antialias: this._antialias || false


### PR DESCRIPTION
## Launch Checklist

The problem with the failing render tests is that mapbox-gl-supported 2.0 introduced breaking changes (with the right semver).
Since they don't have type definitions, definitions were added to this project "by hand",
This caused the breaking changes to be ignored when updating the package which causes the tests to fail.
This is basically a "by the book" update of this library.

 - [x] confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] briefly describe the changes in this PR
