### PR TITLE
[benchmarks] Minor cleanup of ts file formatting

### DIFF
--- a/bench/benchmarks/expressions.ts
+++ b/bench/benchmarks/expressions.ts
@@ -12,11 +12,11 @@ import type {StylePropertyExpression} from '../../src/style-spec/expression';
 
 class ExpressionBenchmark extends Benchmark {
     data: Array<{
-      propertySpec: StylePropertySpecification,
-      rawValue: unknown,
-      rawExpression: unknown,
-      compiledFunction: StylePropertyExpression,
-      compiledExpression: StylePropertyExpression
+      propertySpec: StylePropertySpecification;
+      rawValue: unknown;
+      rawExpression: unknown;
+      compiledFunction: StylePropertyExpression;
+      compiledExpression: StylePropertyExpression;
     }>;
     style: string | StyleSpecification;
 

--- a/bench/benchmarks/hillshade_load.ts
+++ b/bench/benchmarks/hillshade_load.ts
@@ -8,26 +8,26 @@ export default class HillshadeLoad extends Benchmark {
     constructor() {
         super();
         this.style = {
-            "version": 8,
-            "name": "Hillshade-only",
-            "center": [-112.81596278901452, 37.251160384573595],
-            "zoom": 11.560975632435424,
-            "bearing": 0,
-            "pitch": 0,
-            "sources": {
-                "mapbox://mapbox.terrain-rgb": {
-                    "url": "mapbox://mapbox.terrain-rgb",
-                    "type": "raster-dem",
-                    "tileSize": 256
+            version: 8,
+            name: 'Hillshade-only',
+            center: [-112.81596278901452, 37.251160384573595],
+            zoom: 11.560975632435424,
+            bearing: 0,
+            pitch: 0,
+            sources: {
+                'mapbox://mapbox.terrain-rgb': {
+                    url: 'mapbox://mapbox.terrain-rgb',
+                    type: 'raster-dem',
+                    tileSize: 256
                 }
             },
-            "layers": [
+            layers: [
                 {
-                    "id": "mapbox-terrain-rgb",
-                    "type": "hillshade",
-                    "source": "mapbox://mapbox.terrain-rgb",
-                    "layout": {},
-                    "paint": {}
+                    id: 'mapbox-terrain-rgb',
+                    type: 'hillshade',
+                    source: 'mapbox://mapbox.terrain-rgb',
+                    layout: {},
+                    paint: {}
                 }
             ]
         };

--- a/bench/benchmarks/layers.js
+++ b/bench/benchmarks/layers.js
@@ -59,9 +59,9 @@ export class LayerCircle extends LayerBenchmark {
 
         this.layerStyle = Object.assign({}, style, {
             layers: generateLayers({
-                'id': 'circlelayer',
-                'type': 'circle',
-                'source': 'composite',
+                id: 'circlelayer',
+                type: 'circle',
+                source: 'composite',
                 'source-layer': 'poi_label'
             })
         });
@@ -74,11 +74,11 @@ export class LayerFill extends LayerBenchmark {
 
         this.layerStyle = Object.assign({}, style, {
             layers: generateLayers({
-                'id': 'filllayer',
-                'type': 'fill',
-                'source': 'composite',
+                id: 'filllayer',
+                type: 'fill',
+                source: 'composite',
                 'source-layer': 'building',
-                'paint': {
+                paint: {
                     'fill-color': 'black',
                     'fill-outline-color': 'red'
                 }
@@ -93,11 +93,11 @@ export class LayerFillExtrusion extends LayerBenchmark {
 
         this.layerStyle = Object.assign({}, style, {
             layers: generateLayers({
-                'id': 'fillextrusionlayer',
-                'type': 'fill-extrusion',
-                'source': 'composite',
+                id: 'fillextrusionlayer',
+                type: 'fill-extrusion',
+                source: 'composite',
                 'source-layer': 'building',
-                'paint': {
+                paint: {
                     'fill-extrusion-height': 30
                 }
             })
@@ -112,32 +112,32 @@ export class LayerHeatmap extends LayerBenchmark {
             .then(data => {
                 this.layerStyle = Object.assign({}, style, {
                     sources: {
-                        'heatmap': {
-                            'type': 'geojson',
+                        heatmap: {
+                            type: 'geojson',
                             data,
-                            'maxzoom': 23
+                            maxzoom: 23
                         }
                     },
                     layers: generateLayers({
-                        'id': 'layer',
-                        'type': 'heatmap',
-                        'source': 'heatmap',
-                        'paint': {
-                            "heatmap-radius": 50,
-                            "heatmap-weight": {
-                                "stops": [[0, 0.5], [4, 2]]
+                        id: 'layer',
+                        type: 'heatmap',
+                        source: 'heatmap',
+                        paint: {
+                            'heatmap-radius': 50,
+                            'heatmap-weight': {
+                                stops: [[0, 0.5], [4, 2]]
                             },
-                            "heatmap-intensity": 0.9,
-                            "heatmap-color": [
-                                "interpolate",
-                                ["linear"],
-                                ["heatmap-density"],
-                                0, "rgba(0, 0, 255, 0)",
-                                0.1, "royalblue",
-                                0.3, "cyan",
-                                0.5, "lime",
-                                0.7, "yellow",
-                                1, "red"
+                            'heatmap-intensity': 0.9,
+                            'heatmap-color': [
+                                'interpolate',
+                                ['linear'],
+                                ['heatmap-density'],
+                                0, 'rgba(0, 0, 255, 0)',
+                                0.1, 'royalblue',
+                                0.3, 'cyan',
+                                0.5, 'lime',
+                                0.7, 'yellow',
+                                1, 'red'
                             ]
                         }
                     })
@@ -154,14 +154,14 @@ export class LayerHillshade extends LayerBenchmark {
         this.layerStyle = Object.assign({}, style, {
             sources: {
                 'terrain-rgb': {
-                    'type': 'raster-dem',
-                    'url': 'mapbox://mapbox.terrain-rgb'
+                    type: 'raster-dem',
+                    url: 'mapbox://mapbox.terrain-rgb'
                 }
             },
             layers: generateLayers({
-                'id': 'layer',
-                'type': 'hillshade',
-                'source': 'terrain-rgb',
+                id: 'layer',
+                type: 'hillshade',
+                source: 'terrain-rgb',
             })
         });
     }
@@ -173,9 +173,9 @@ export class LayerLine extends LayerBenchmark {
 
         this.layerStyle = Object.assign({}, style, {
             layers: generateLayers({
-                'id': 'linelayer',
-                'type': 'line',
-                'source': 'composite',
+                id: 'linelayer',
+                type: 'line',
+                source: 'composite',
                 'source-layer': 'road'
             })
         });
@@ -188,16 +188,16 @@ export class LayerRaster extends LayerBenchmark {
 
         this.layerStyle = Object.assign({}, style, {
             sources: {
-                'satellite': {
-                    'url': 'mapbox://mapbox.satellite',
-                    'type': 'raster',
-                    'tileSize': 256
+                satellite: {
+                    url: 'mapbox://mapbox.satellite',
+                    type: 'raster',
+                    tileSize: 256
                 }
             },
             layers: generateLayers({
-                'id': 'rasterlayer',
-                'type': 'raster',
-                'source': 'satellite'
+                id: 'rasterlayer',
+                type: 'raster',
+                source: 'satellite'
             })
         });
     }
@@ -209,11 +209,11 @@ export class LayerSymbol extends LayerBenchmark {
 
         this.layerStyle = Object.assign({}, style, {
             layers: generateLayers({
-                'id': 'symbollayer',
-                'type': 'symbol',
-                'source': 'composite',
+                id: 'symbollayer',
+                type: 'symbol',
+                source: 'composite',
                 'source-layer': 'poi_label',
-                'layout': {
+                layout: {
                     'icon-image': 'dot-11',
                     'text-field': '{name_en}'
                 }
@@ -228,11 +228,11 @@ export class LayerSymbolWithIcons extends LayerBenchmark {
 
         this.layerStyle = Object.assign({}, style, {
             layers: generateLayers({
-                'id': 'symbollayer',
-                'type': 'symbol',
-                'source': 'composite',
+                id: 'symbollayer',
+                type: 'symbol',
+                source: 'composite',
                 'source-layer': 'poi_label',
-                'layout': {
+                layout: {
                     'icon-image': 'dot-11',
                     'text-field': ['format', ['get', 'name_en'], ['image', 'dot-11']]
                 }
@@ -254,11 +254,11 @@ export class LayerSymbolWithSortKey extends LayerBenchmark {
         const generated = [];
         for (let i = 0; i < layerCount; i++) {
             generated.push({
-                'id': `symbollayer${i}`,
-                'type': 'symbol',
-                'source': 'composite',
+                id: `symbollayer${i}`,
+                type: 'symbol',
+                source: 'composite',
                 'source-layer': 'poi_label',
-                'layout': {
+                layout: {
                     'symbol-sort-key': i,
                     'text-field': '{name_en}'
                 }
@@ -274,11 +274,11 @@ export class LayerTextWithVariableAnchor extends LayerBenchmark {
 
         this.layerStyle = Object.assign({}, style, {
             layers: generateLayers({
-                'id': 'symbollayer',
-                'type': 'symbol',
-                'source': 'composite',
+                id: 'symbollayer',
+                type: 'symbol',
+                source: 'composite',
                 'source-layer': 'poi_label',
-                'layout': {
+                layout: {
                     'text-field': 'Test Test Test',
                     'text-justify': 'auto',
                     'text-variable-anchor': [

--- a/bench/benchmarks/layout.ts
+++ b/bench/benchmarks/layout.ts
@@ -1,4 +1,4 @@
-import type { StyleSpecification } from '../../src/style-spec/types';
+import type {StyleSpecification} from '../../src/style-spec/types';
 import Benchmark from '../lib/benchmark';
 import fetchStyle from '../lib/fetch_style';
 import TileParser from '../lib/tile_parser';
@@ -6,8 +6,8 @@ import {OverscaledTileID} from '../../src/source/tile_id';
 
 export default class Layout extends Benchmark {
     tiles: Array<{
-      tileID: OverscaledTileID,
-      buffer: ArrayBuffer
+      tileID: OverscaledTileID;
+      buffer: ArrayBuffer;
     }>;
     parser: TileParser;
     style: string | StyleSpecification;

--- a/bench/benchmarks/layout_dds.ts
+++ b/bench/benchmarks/layout_dds.ts
@@ -6,8 +6,8 @@ const LAYER_COUNT = 2;
 
 export default class LayoutDDS extends Benchmark {
     tiles: Array<{
-      tileID: OverscaledTileID,
-      buffer: ArrayBuffer
+      tileID: OverscaledTileID;
+      buffer: ArrayBuffer;
     }>;
     parser: TileParser;
 
@@ -17,64 +17,64 @@ export default class LayoutDDS extends Benchmark {
         ];
 
         const styleJSON = {
-            "version": 8,
-            "sources": {
-                "mapbox": {"type": "vector", "url": "mapbox://mapbox.mapbox-streets-v7"}
+            version: 8,
+            sources: {
+                mapbox: {type: 'vector', url: 'mapbox://mapbox.mapbox-streets-v7'}
             },
-            "layers": []
+            layers: []
         };
 
         const layers = [
             {
-                "id": "road",
-                "type": "line",
-                "source": "mapbox",
-                "source-layer": "road",
-                "paint": {
-                    "line-width": 3,
-                    "line-color":{
-                        "type": "categorical",
-                        "property": "class",
-                        "stops":[
-                            [{"zoom": 0, "value": "motorway"}, "#0000FF"],
-                            [{"zoom": 0, "value": "trunk"}, "#000FF0"],
-                            [{"zoom": 0, "value": "primary"}, "#00FF00"],
-                            [{"zoom": 0, "value": "secondary"}, "#0FF000"],
-                            [{"zoom": 0, "value": "street"}, "#FF0000"],
-                            [{"zoom": 17, "value": "motorway"}, "#000088"],
-                            [{"zoom": 17, "value": "trunk"}, "#000880"],
-                            [{"zoom": 17, "value": "primary"}, "#008800"],
-                            [{"zoom": 17, "value": "secondary"}, "#088000"],
-                            [{"zoom": 17, "value": "street"}, "#880000"]
+                id: 'road',
+                type: 'line',
+                source: 'mapbox',
+                'source-layer': 'road',
+                paint: {
+                    'line-width': 3,
+                    'line-color':{
+                        type: 'categorical',
+                        property: 'class',
+                        stops:[
+                            [{zoom: 0, value: 'motorway'}, '#0000FF'],
+                            [{zoom: 0, value: 'trunk'}, '#000FF0'],
+                            [{zoom: 0, value: 'primary'}, '#00FF00'],
+                            [{zoom: 0, value: 'secondary'}, '#0FF000'],
+                            [{zoom: 0, value: 'street'}, '#FF0000'],
+                            [{zoom: 17, value: 'motorway'}, '#000088'],
+                            [{zoom: 17, value: 'trunk'}, '#000880'],
+                            [{zoom: 17, value: 'primary'}, '#008800'],
+                            [{zoom: 17, value: 'secondary'}, '#088000'],
+                            [{zoom: 17, value: 'street'}, '#880000']
                         ],
-                        "default": "#444444"
+                        default: '#444444'
                     }
                 }
             },
             {
-                "id": "poi",
-                "type": "circle",
-                "source": "mapbox",
-                "source-layer": "poi_label",
-                "paint": {
-                    "circle-radius": {
-                        "base": 2,
-                        "property": "scalerank",
-                        "stops":[
-                            [{"zoom": 0, "value": 0}, 1],
-                            [{"zoom": 0, "value": 10}, 5],
-                            [{"zoom": 17, "value": 0}, 20],
-                            [{"zoom": 17, "value": 10}, 50]
+                id: 'poi',
+                type: 'circle',
+                source: 'mapbox',
+                'source-layer': 'poi_label',
+                paint: {
+                    'circle-radius': {
+                        base: 2,
+                        property: 'scalerank',
+                        stops:[
+                            [{zoom: 0, value: 0}, 1],
+                            [{zoom: 0, value: 10}, 5],
+                            [{zoom: 17, value: 0}, 20],
+                            [{zoom: 17, value: 10}, 50]
                         ]
                     },
-                    "circle-color": {
-                        "base": 1.25,
-                        "property": "localrank",
-                        "stops":[
-                            [{"zoom": 0, "value": 0}, "#002222"],
-                            [{"zoom": 0, "value": 10}, "#220022"],
-                            [{"zoom": 17, "value": 0}, "#008888"],
-                            [{"zoom": 17, "value": 10}, "#880088"]
+                    'circle-color': {
+                        base: 1.25,
+                        property: 'localrank',
+                        stops:[
+                            [{zoom: 0, value: 0}, '#002222'],
+                            [{zoom: 0, value: 10}, '#220022'],
+                            [{zoom: 17, value: 0}, '#008888'],
+                            [{zoom: 17, value: 10}, '#880088']
                         ]
                     }
                 }

--- a/bench/benchmarks/paint_states.js
+++ b/bench/benchmarks/paint_states.js
@@ -28,12 +28,12 @@ export default class PaintStates extends Benchmark {
             .then(data => {
                 this.numFeatures = data.features.length;
                 return Object.assign({}, style, {
-                    sources: {'land': {'type': 'geojson', data, 'maxzoom': 23}},
+                    sources: {land: {type: 'geojson', data, maxzoom: 23}},
                     layers: generateLayers({
-                        'id': 'layer',
-                        'type': 'fill',
-                        'source': 'land',
-                        'paint': {
+                        id: 'layer',
+                        type: 'fill',
+                        source: 'land',
+                        paint: {
                             'fill-color': [
                                 'case',
                                 ['boolean', ['feature-state', 'bench'], false],

--- a/bench/benchmarks/remove_paint_state.js
+++ b/bench/benchmarks/remove_paint_state.js
@@ -28,12 +28,12 @@ class RemovePaintState extends Benchmark {
             .then(data => {
                 this.numFeatures = data.features.length;
                 return Object.assign({}, style, {
-                    sources: {'land': {'type': 'geojson', data, 'maxzoom': 23}},
+                    sources: {land: {type: 'geojson', data, maxzoom: 23}},
                     layers: generateLayers({
-                        'id': 'layer',
-                        'type': 'fill',
-                        'source': 'land',
-                        'paint': {
+                        id: 'layer',
+                        type: 'fill',
+                        source: 'land',
+                        paint: {
                             'fill-color': [
                                 'case',
                                 ['boolean', ['feature-state', 'bench'], false],

--- a/bench/benchmarks/style_layer_create.ts
+++ b/bench/benchmarks/style_layer_create.ts
@@ -1,4 +1,4 @@
-import type { StyleSpecification } from '../../src/style-spec/types';
+import type {StyleSpecification} from '../../src/style-spec/types';
 import Benchmark from '../lib/benchmark';
 import createStyleLayer from '../../src/style/create_style_layer';
 import deref from '../../src/style-spec/deref';

--- a/bench/benchmarks/style_validate.ts
+++ b/bench/benchmarks/style_validate.ts
@@ -1,4 +1,4 @@
-import type { StyleSpecification } from '../../src/style-spec/types';
+import type {StyleSpecification} from '../../src/style-spec/types';
 import Benchmark from '../lib/benchmark';
 import validateStyle from '../../src/style-spec/validate_style.min';
 import fetchStyle from '../lib/fetch_style';

--- a/bench/benchmarks/worker_transfer.ts
+++ b/bench/benchmarks/worker_transfer.ts
@@ -1,4 +1,4 @@
-import type { StyleSpecification } from '../../src/style-spec/types';
+import type {StyleSpecification} from '../../src/style-spec/types';
 import Benchmark from '../lib/benchmark';
 import fetchStyle from '../lib/fetch_style';
 import TileParser from '../lib/tile_parser';

--- a/bench/lib/benchmark.ts
+++ b/bench/lib/benchmark.ts
@@ -5,8 +5,8 @@
 const minTimeForMeasurement = 0.005 * 1000;
 
 export type Measurement = {
-  iterations: number,
-  time: number
+  iterations: number;
+  time: number;
 };
 
 class Benchmark {

--- a/bench/lib/fetch_style.ts
+++ b/bench/lib/fetch_style.ts
@@ -1,4 +1,4 @@
-import type { StyleSpecification } from '../../src/style-spec/types';
+import type {StyleSpecification} from '../../src/style-spec/types';
 import {RequestManager} from '../../src/util/request_manager';
 
 const requestManager = new RequestManager();

--- a/bench/lib/tile_parser.ts
+++ b/bench/lib/tile_parser.ts
@@ -49,7 +49,7 @@ export default class TileParser {
     glyphs: any;
     style: Style;
     actor: {
-      send: Function
+      send: Function;
     };
 
     constructor(styleJSON: StyleSpecification, sourceID: string) {
@@ -115,8 +115,8 @@ export default class TileParser {
 
     parseTile(
       tile: {
-        tileID: OverscaledTileID,
-        buffer: ArrayBuffer
+        tileID: OverscaledTileID;
+        buffer: ArrayBuffer;
       },
       returnDependencies?: boolean
     ): Promise<WorkerTileResult | undefined | null> {


### PR DESCRIPTION
 - [x] confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] briefly describe the changes in this PR

- minor cleanup:
  - whitespace around braces in imports
  - switch quotes to single quotes
  - remove quotes for object keys with no hyphens
  - semicolons instead of commas in type definitions