### PR TITLE
Fix entry point paths

### DIFF
--- a/.github/workflows/publish-style-spec.yml
+++ b/.github/workflows/publish-style-spec.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Build style spec
         run: |
           npm run build-style-spec
-          cp -r dist/style-spec/ src/style-spec/dist
+          cp -r dist/style-spec/* src/style-spec/dist
       
       - name: Check version and publish
         run: |

--- a/src/style-spec/CHANGELOG.md
+++ b/src/style-spec/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 14.0.2
+
+### ✨ Features and improvements
+* Fix node entry points [#400](https://github.com/maplibre/maplibre-gl-js/issues/400)
+
 ## 14.0.1
 
 ### ✨ Features and improvements

--- a/src/style-spec/package.json
+++ b/src/style-spec/package.json
@@ -12,8 +12,8 @@
     "maplibre-gl-js"
   ],
   "license": "ISC",
-  "main": "./dist/style-spec/index.js",
-  "module": "./dist/style-spec/index.es.js",
+  "main": "./dist/index.js",
+  "module": "./dist/index.es.js",
   "scripts": {
   },
   "repository": {

--- a/src/style-spec/package.json
+++ b/src/style-spec/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@maplibre/maplibre-gl-style-spec",
   "description": "a specification for maplibre gl styles",
-  "version": "14.0.1",
+  "version": "14.0.2",
   "author": "MapLibre",
   "keywords": [
     "mapbox",
@@ -12,8 +12,8 @@
     "maplibre-gl-js"
   ],
   "license": "ISC",
-  "main": "./dist/index.js",
-  "module": "./dist/index.es.js",
+  "main": "./dist/style-spec/index.js",
+  "module": "./dist/style-spec/index.es.js",
   "scripts": {
   },
   "repository": {


### PR DESCRIPTION
As reported in https://github.com/maplibre/maplibre-gl-js/issues/400, currently our style spec CLI scripts are broken. I think this is related to rollup and typescript putting files not in `dist`, but rather `dist/style-spec`.

 - [🐳  ] confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [ 🍏 ] briefly describe the changes in this PR