### PR TITLE
[Benchmarks] add then() back to fetch(url) in fetch_style (fixing benchmarks)

### DIFF
--- a/bench/benchmarks/style_layer_create.ts
+++ b/bench/benchmarks/style_layer_create.ts
@@ -1,4 +1,4 @@
-import type { StyleSpecification } from '../../src/style-spec/types';
+import type {StyleSpecification} from '../../src/style-spec/types';
 import Benchmark from '../lib/benchmark';
 import createStyleLayer from '../../src/style/create_style_layer';
 import deref from '../../src/style-spec/deref';

--- a/bench/lib/fetch_style.ts
+++ b/bench/lib/fetch_style.ts
@@ -1,10 +1,7 @@
-import type { StyleSpecification } from '../../src/style-spec/types';
-import {RequestManager} from '../../src/util/request_manager';
-
-const requestManager = new RequestManager();
+import type {StyleSpecification} from '../../src/style-spec/types';
 
 export default function fetchStyle(value: string | StyleSpecification): Promise<StyleSpecification> {
     return typeof value === 'string' ?
-        fetch(value) as any :
+        fetch(value).then(response => response.json()) :
         Promise.resolve(value);
 }


### PR DESCRIPTION
 - [x] confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] briefly describe the changes in this PR

tiny fix that breaks a lot of tests.. after this they all run for me