### PR TITLE
Bugfix/fix pattern

### DIFF
--- a/src/shaders/fill_pattern.fragment.glsl
+++ b/src/shaders/fill_pattern.fragment.glsl
@@ -1,3 +1,6 @@
+#ifdef GL_ES
+    precision highp float;
+#endif
 uniform vec2 u_texsize;
 uniform float u_fade;
 

--- a/src/shaders/line_pattern.fragment.glsl
+++ b/src/shaders/line_pattern.fragment.glsl
@@ -1,3 +1,6 @@
+#ifdef GL_ES
+    precision highp float;
+#endif
 uniform lowp float u_device_pixel_ratio;
 uniform vec2 u_texsize;
 uniform float u_fade;


### PR DESCRIPTION
My changes do not include backports from Mapbox projects.

Summary
At high zoom levels there are a ton of pixels between the current pixel and the edge of the pattern polygon.
To guarantee that the drawing is correct, it was needed to increase the float precision to highp.

I found another issue that is caused by the same code:
mapbox/mapbox-gl-native#14321

No change to public APIs

[BUG] Fixed a precision problem in patterns shadeds.