### PR TITLE
Update codemods

### DIFF
--- a/codemods.js
+++ b/codemods.js
@@ -22,13 +22,13 @@ replace.sync({
 replace.sync({
     files: args,
     from: /\(t\) =>/g,
-    to: 'done =>',
+    to: process.argv.includes('--async') ? 'done =>' : '() =>',
 });
 
 replace.sync({
     files: args,
-    from: /t.end\(\)/g,
-    to: 'done()',
+    from: /t.end\(\);\n/g,
+    to: process.argv.includes('--async') ? 'done();\n' : '',
 });
 
 replace.sync({

--- a/jest-migration.md
+++ b/jest-migration.md
@@ -32,19 +32,31 @@ jest-codemods --force src/symbol/anchor.test.ts
 > Yes, use the globals provided by Jest (recommended)
 ```
 
-Run our custom codemods script with:
+Run
 
 ```
-node codemods.js src/**/*test.ts
+git add src/symbol/anchor.test.ts
+git commit -m "Run jest-codemods"
 ```
 
-Remove `done()` in tests that do not run asynchronous by changing:
+If there are no async tests in the file you are migrating run the custom codemods script with:
 
-```diff
---test('something', done => {
-++test('something', () => {
---    done()
-})
+```
+node codemods.js src/symbol/anchor.test.ts
+```
+
+Otherwise, if there are async tests, use:
+
+```
+node codemods.js --async src/symbol/anchor.test.ts
+```
+
+Lint and commit
+
+```
+npm run lint -- --fix
+git add src/symbol/anchor.test.ts
+git commit -m "Run custom codemods"
 ```
 
 Fix remaining typescript errors by hand.


### PR DESCRIPTION
I propose to change the default behavior of `codemods.js` back to `(t) =>` is replaced with `() =>` which is what one wants for synchronous tests. If the test file has asynchronous tests, use `codemods.js` with the `--async` flag.