### PR TITLE
Upgrade tiny sdf with latest typings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1872,9 +1872,9 @@
       "dev": true
     },
     "@mapbox/tiny-sdf": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-2.0.2.tgz",
-      "integrity": "sha512-XBQG3wvIaya9t2OHcWLFYv8cdg48roqOj8XhKzKSvAIg5D1scC+a+tlq0wGjPZkL+k6dL8TyOBR7RKDGh3kefQ=="
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-2.0.4.tgz",
+      "integrity": "sha512-CBtL2rhZiYmdIryksp0zh4Mmx54iClYfNb0mpYeHrZnq4z84lVjre7LBWGPEjWspEn6AiF0lxC1HaZDye89m3g=="
     },
     "@mapbox/unitbezier": {
       "version": "0.0.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@mapbox/geojson-rewind": "^0.5.0",
     "@mapbox/jsonlint-lines-primitives": "^2.0.2",
     "@mapbox/mapbox-gl-supported": "^2.0.0",
-    "@mapbox/tiny-sdf": "^2.0.2",
+    "@mapbox/tiny-sdf": "^2.0.4",
     "@mapbox/unitbezier": "^0.0.0",
     "@mapbox/vector-tile": "^1.3.1",
     "@mapbox/whoots-js": "^3.1.0",

--- a/src/render/glyph_manager.ts
+++ b/src/render/glyph_manager.ts
@@ -197,7 +197,7 @@ export default class GlyphManager {
 
         return {
             id,
-            bitmap: new AlphaImage({width: 30, height: 30}, tinySDF.draw(String.fromCharCode(id))),
+            bitmap: new AlphaImage({width: 30, height: 30}, tinySDF.draw(String.fromCharCode(id)).data),
             metrics: {
                 width: 24,
                 height: 24,


### PR DESCRIPTION
## Launch Checklist

Seems like the tiny sdf upgrade was not done entirely correctly, I have submitted a PR to add typings and after I used it here it seems that the return value was changed too, but the code was not updated here.
I'm not sure how to test this unfortunately... :-(

See: https://github.com/mapbox/tiny-sdf/pull/39

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
