### PR TITLE
Add `.mockImplementation(() => { })` to console-spy to not see warnings while running the tests

### DIFF
--- a/src/data/bucket/symbol_bucket.test.ts
+++ b/src/data/bucket/symbol_bucket.test.ts
@@ -104,7 +104,7 @@ describe('SymbolBucket', () => {
     });
 
     test('SymbolBucket integer overflow', () => {
-        const spy = jest.spyOn(console, 'warn');
+        const spy = jest.spyOn(console, 'warn').mockImplementation(() => { });
         SymbolBucket.MAX_GLYPHS = 5;
 
         const bucket = bucketSetup() as any as SymbolBucket;


### PR DESCRIPTION
if I run `run test-jest` I see next message. I addes `.mockImplementation(() => { })` to console-spy to not see warnings while running the tests.

```
$ npm run test-jest src/data/bucket/symbol_bucket.test.ts 

> maplibre-gl@2.0.0-pre.5 test-jest /home/astrid/git/maplibre/maplibre-gl-js
> jest "src/data/bucket/symbol_bucket.test.ts"

  console.warn
    Too many glyphs being rendered in a tile. See https://github.com/mapbox/mapbox-gl-js/issues/2907

      298 |     if (!warnOnceHistory[message]) {
      299 |         // console isn't defined in some WebWorkers, see #2558
    > 300 |         if (typeof console !== 'undefined') console.warn(message);
          |                                                     ^
      301 |         warnOnceHistory[message] = true;
      302 |     }
      303 | }

      at console.<anonymous> (node_modules/jest-mock/build/index.js:850:25)
      at warnOnce (src/util/util.ts:300:53)
      at addSymbol (src/symbol/symbol_layout.ts:757:76)
      at addSymbolAtAnchor (src/symbol/symbol_layout.ts:417:9)

 PASS  src/data/bucket/symbol_bucket.test.ts (9.191 s)
  SymbolBucket
    ✓ SymbolBucket (28 ms)
    ✓ SymbolBucket integer overflow (139 ms)
    ✓ SymbolBucket image undefined sdf (7 ms)
    ✓ SymbolBucket image mismatched sdf (3 ms)
    ✓ SymbolBucket detects rtl text (2 ms)
    ✓ SymbolBucket with rtl text is NOT empty even though no symbol instances are created (4 ms)
    ✓ SymbolBucket detects rtl text mixed with ltr text (1 ms)

Test Suites: 1 passed, 1 total
Tests:       7 passed, 7 total
Snapshots:   0 total
Time:        10.58 s

```
