### PR TITLE
Should we fullfill the eslint rule `jest/no-done-callback`

### DIFF
--- a/src/util/throttle.test.ts
+++ b/src/util/throttle.test.ts
@@ -8,18 +8,18 @@ describe('throttle', () => {
         expect(executionCount).toBe(0);
     });
 
-    test('executes unthrottled function once per tick when period is 0', done => {
+    test('executes unthrottled function once per tick when period is 0', async () => {
         let executionCount = 0;
         const throttledFunction = throttle(() => { executionCount++; }, 0);
         throttledFunction();
         throttledFunction();
         expect(executionCount).toBe(1);
-        setTimeout(() => {
-            throttledFunction();
-            throttledFunction();
-            expect(executionCount).toBe(2);
-            done();
-        }, 0);
+
+        await new Promise(resolve => setTimeout(resolve, 0));
+        throttledFunction();
+        throttledFunction();
+
+        expect(executionCount).toBe(2);
     });
 
     test('executes unthrottled function immediately once when period is > 0', () => {
@@ -31,15 +31,15 @@ describe('throttle', () => {
         expect(executionCount).toBe(1);
     });
 
-    test('queues exactly one execution of unthrottled function when period is > 0', done => {
+    test('queues exactly one execution of unthrottled function when period is > 0', async () => {
         let executionCount = 0;
         const throttledFunction = throttle(() => { executionCount++; }, 5);
         throttledFunction();
         throttledFunction();
         throttledFunction();
-        setTimeout(() => {
-            expect(executionCount).toBe(2);
-            done();
-        }, 10);
+
+        await new Promise(resolve => setTimeout(resolve, 10));
+
+        expect(executionCount).toBe(2);
     });
 });


### PR DESCRIPTION
While trying to understand the tests I came across this issue: https://github.com/jest-community/eslint-plugin-jest/issues/494#issuecomment-562094733 in the `eslint-plugin-jest`-Repo.
What do you think? Should we try to avoid `done()` as discussed in the issue? For one test, I made one try of an implementation in this PR.