### PR TITLE
No more `console.log` outputs in the Jest test output

### DIFF
--- a/src/data/bucket/line_bucket.test.ts
+++ b/src/data/bucket/line_bucket.test.ts
@@ -100,7 +100,7 @@ describe('LineBucket', () => {
     });
 
     test('LineBucket segmentation', () => {
-        jest.spyOn(console, 'warn');
+        jest.spyOn(console, 'warn').mockImplementation(() => { });
 
         // Stub MAX_VERTEX_ARRAY_LENGTH so we can test features
         // breaking across array groups without tests taking a _long_ time.

--- a/src/style-spec/expression/expression.test.ts
+++ b/src/style-spec/expression/expression.test.ts
@@ -51,7 +51,7 @@ describe('evaluate expression', () => {
             }
         } as any as StylePropertySpecification) as {value: StylePropertyExpression};
 
-        jest.spyOn(console, 'warn');
+        jest.spyOn(console, 'warn').mockImplementation(() => { });
 
         expect(value.kind).toBe('source');
 

--- a/src/style/light.test.ts
+++ b/src/style/light.test.ts
@@ -64,7 +64,7 @@ describe('Light#setLight', () => {
     test('validates by default', () => {
         const light = new Light({});
         const lightSpy = jest.spyOn(light, '_validate');
-        jest.spyOn(console, 'error');
+        jest.spyOn(console, 'error').mockImplementation(() => { });
         light.setLight({color: 'notacolor'});
         light.updateTransitions({transition: false} as any as TransitionParameters);
         light.recalculate({zoom: 16, zoomHistory: {}, now: 10} as EvaluationParameters);

--- a/src/util/worker_pool.test.ts
+++ b/src/util/worker_pool.test.ts
@@ -28,11 +28,12 @@ describe('WorkerPool', () => {
         });
 
         pool.release('map-2');
-        console.log('keeps workers if a dispatcher is still active');
+
+        // keeps workers if a dispatcher is still active
         expect(workersTerminated).toBe(0);
         expect(pool.workers.length > 0).toBeTruthy();
 
-        console.log('terminates workers if no dispatchers are active');
+        // terminates workers if no dispatchers are active
         pool.release('map-1');
         expect(workersTerminated).toBe(4);
         expect(pool.workers).toBeFalsy();


### PR DESCRIPTION
See title