### PR TITLE
Remove link to broken codepen

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ And replace ```mapboxgl``` with ```maplibregl``` in your JavaScript and optional
 +    <button class="maplibregl-ctrl">
 ```
 
-Want an example? [Try out MapLibre GL on CodePen](https://codepen.io/klokan/pen/WNoZRyx) and have a look at ones in the official [MapLibre GL JS Documentation](https://maplibre.org/maplibre-gl-js-docs/example/).
+Want an example?  Have a look at the official [MapLibre GL JS Documentation](https://maplibre.org/maplibre-gl-js-docs/example/).
 
 Use MapLibre GL JS bindings for React (https://visgl.github.io/react-map-gl/docs/get-started/get-started#using-with-a-mapbox-gl-fork) and Angular (https://github.com/maplibre/ngx-maplibre-gl). Find more at [awesome-maplibre](https://github.com/maplibre/awesome-maplibre).
 


### PR DESCRIPTION
I think the examples from the documentation are better and enough and it is also easy enough to get to a working codepen from there. Alternatively we could somehow use the same codepen link as on https://maplibre.org/maplibre-gl-js-docs/example/simple-map/ for a direct link, but I would not know how to do that.