### PR TITLE
Improve guidance in issue template Bug_report.md about using the non-minified version.

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -7,10 +7,16 @@ about: Report a bug
 <!--
 Hello! Thanks for contributing.  For the fastest response and resolution, please:
 
- - Make the issue title a succinct but specific description of the unexpected behavior. Bad: "Map rotation is broken". Good: "map.setBearing(...) throws a TypeError for negative values"
- - Include a link to a minimal demonstration of the bug. We recommend using https://jsbin.com.
+ - Make the issue title a succinct but specific description of the unexpected behavior.
+   Bad: "Map rotation is broken". 
+   Good: "map.setBearing(...) throws a TypeError for negative values"
+
+ - Include a link to a minimal demonstration of the bug – more below …
+
  - Ensure you can reproduce the bug using the latest release.
+
  - Check the console for relevant errors and warnings
+
  - Only post to report a bug. For feature requests, please use https://github.com/maplibre/maplibre-gl-js/issues/new?template=Feature_request.md instead.  Direct all other questions to https://stackoverflow.com/questions/tagged/maplibre-gl-js
 
 -->
@@ -28,10 +34,15 @@ Hello! Thanks for contributing.  For the fastest response and resolution, please
 ### Link to Demonstration
 
 <!--
-Providing a minimal, complete, verifiable demonstration *dramatically* improves maintainers' and other community members' ability to understand and address the problem you're reporting. (See https://stackoverflow.com/help/mcve for guidelines on creating an effective example.)
--->
+Providing a minimal, complete, verifiable demonstration *dramatically* improves maintainers' and other community members' ability to understand and address the problem you're reporting. 
 
-https://jsbin.com/
+We recommend using https://jsbin.com.
+
+Consider using the non-minified version for this demo to create better error messages. 
+E.g. `<script src='https://unpkg.com/maplibre-gl@1.15.2/dist/maplibre-gl-dev.js'></script><link href='https://unpkg.com/maplibre-gl@1.15.2/dist/maplibre-gl.css' rel='stylesheet' />`
+
+See https://stackoverflow.com/help/mcve for guidelines on creating an effective example.
+-->
 
 ### Expected Behavior
 


### PR DESCRIPTION
Based on the great feedback in https://github.com/maplibre/maplibre-gl-js/issues/575#issuecomment-952247469, I think this change will help creating besser MCVE-demos.

- Some spaces for easier readability/scanabiity
- Consolidate help about the demo in one section (reference it from the top)
- Add suggestion about the non-minified version.
