### PR TITLE
[Jest] Correction  of geolocate_control_test

### DIFF
--- a/src/ui/control/geolocate_control.test.ts
+++ b/src/ui/control/geolocate_control.test.ts
@@ -25,13 +25,6 @@ afterEach(() => {
 });
 
 describe('GeolocateControl with no options', () => {
-    test('with no options', () => {
-        expect(() => {
-            const geolocate = new GeolocateControl(undefined);
-            map.addControl(geolocate);
-        }).not.toThrow();
-    });
-
     test('error event', done => {
         const geolocate = new GeolocateControl(undefined);
         map.addControl(geolocate);


### PR DESCRIPTION
I'm sorry, but I think I misinterpreted[ this messages](https://github.com/maplibre/maplibre-gl-js/pull/565#issuecomment-950351107). 
I was initially of the opinion that a test with `done `always causes following tests to `fail `if `done `is not reached due to an error in a test.

Because I didn't fully understand this, I took a closer look. 

I found out that `tests with done` have no effect on following tests. Not even if they are within` try/catch`. 
Inside` try/catch` only the error message is nicer. But the code is bloated.

In the case of the _geolocate control test_, a failed test where `done `is not reached does not end correctly. That is normal. But not normal is,that this effects other tests. Reason ist the following: We initialise the map element in every test newly. But because of the failing test, the map element remains and cannot be initialised in the next test. So we start each following test with a map element from the previous tests that is in an error state.

I have now hopefully fixed this correctly by creating the map element in `beforeEach `before each test and always removing it in `afterEache `at the end.


