### PR TITLE
Revert "Bump potpack from 1.0.1 to 1.0.2 (#594)"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17512,9 +17512,9 @@
       "dev": true
     },
     "potpack": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/potpack/-/potpack-1.0.2.tgz",
-      "integrity": "sha512-choctRBIV9EMT9WGAZHn3V7t0Z2pMQyl0EZE6pFc/6ml3ssw7Dlf/oAOvFwjm1HVsqfQN8GfeFyJ+d8tRzqueQ=="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/potpack/-/potpack-1.0.1.tgz",
+      "integrity": "sha512-15vItUAbViaYrmaB/Pbw7z6qX2xENbFSTA7Ii4tgbPtasxm5v6ryKhKtL91tpWovDJzTiZqdwzhcFBCwiMVdVw=="
     },
     "prebuild-install": {
       "version": "5.3.6",


### PR DESCRIPTION
This reverts commit 54a8a7775599312e0211c701187356a07c91df80.

## Launch Checklist

Because I see this error message while running jest-tests

`src/render/image_manager.ts:13:14 - error TS2614: Module '"potpack"' has no exported member 'Bin'. Did you mean to use 'import Bin from "potpack"' instead?`