### PR TITLE
[Jest Lint] Add rule prefer-to-be 

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -98,7 +98,8 @@
     "jest/no-disabled-tests": "warn",
     "jest/no-focused-tests": "error",
     "jest/prefer-to-have-length": "warn",
-    "jest/valid-expect": "error"    
+    "jest/valid-expect": "error",
+    "jest/prefer-to-be": "warn"   
   },
   "settings": {
     "jsdoc":{

--- a/src/geo/lng_lat_bounds.test.ts
+++ b/src/geo/lng_lat_bounds.test.ts
@@ -146,7 +146,7 @@ describe('LngLatBounds', () => {
         const sw = new LngLat(0, 0);
         const ne = new LngLat(-10, 10);
         const bounds = new LngLatBounds(sw, ne);
-        expect(LngLatBounds.convert(undefined)).toBe(undefined);
+        expect(LngLatBounds.convert(undefined)).toBeUndefined();
         expect(LngLatBounds.convert(bounds)).toEqual(bounds);
         expect(LngLatBounds.convert([sw, ne])).toEqual(bounds);
         expect(
@@ -161,7 +161,7 @@ describe('LngLatBounds', () => {
 
     test('#toString', () => {
         const llb = new LngLatBounds([-73.9876, 40.7661], [-73.9397, 40.8002]);
-        expect(llb.toString()).toEqual('LngLatBounds(LngLat(-73.9876, 40.7661), LngLat(-73.9397, 40.8002))');
+        expect(llb.toString()).toBe('LngLatBounds(LngLat(-73.9876, 40.7661), LngLat(-73.9397, 40.8002))');
     });
 
     test('#isEmpty', () => {

--- a/src/geo/transform.test.ts
+++ b/src/geo/transform.test.ts
@@ -256,52 +256,52 @@ describe('transform', () => {
         const transform = new Transform(0, 22, 0, 60, true);
 
         transform.zoom = 0;
-        expect(transform.coveringZoomLevel(options)).toEqual(0);
+        expect(transform.coveringZoomLevel(options)).toBe(0);
 
         transform.zoom = 0.1;
-        expect(transform.coveringZoomLevel(options)).toEqual(0);
+        expect(transform.coveringZoomLevel(options)).toBe(0);
 
         transform.zoom = 1;
-        expect(transform.coveringZoomLevel(options)).toEqual(1);
+        expect(transform.coveringZoomLevel(options)).toBe(1);
 
         transform.zoom = 2.4;
-        expect(transform.coveringZoomLevel(options)).toEqual(2);
+        expect(transform.coveringZoomLevel(options)).toBe(2);
 
         transform.zoom = 10;
-        expect(transform.coveringZoomLevel(options)).toEqual(10);
+        expect(transform.coveringZoomLevel(options)).toBe(10);
 
         transform.zoom = 11;
-        expect(transform.coveringZoomLevel(options)).toEqual(11);
+        expect(transform.coveringZoomLevel(options)).toBe(11);
 
         transform.zoom = 11.5;
-        expect(transform.coveringZoomLevel(options)).toEqual(11);
+        expect(transform.coveringZoomLevel(options)).toBe(11);
 
         options.tileSize = 256;
 
         transform.zoom = 0;
-        expect(transform.coveringZoomLevel(options)).toEqual(1);
+        expect(transform.coveringZoomLevel(options)).toBe(1);
 
         transform.zoom = 0.1;
-        expect(transform.coveringZoomLevel(options)).toEqual(1);
+        expect(transform.coveringZoomLevel(options)).toBe(1);
 
         transform.zoom = 1;
-        expect(transform.coveringZoomLevel(options)).toEqual(2);
+        expect(transform.coveringZoomLevel(options)).toBe(2);
 
         transform.zoom = 2.4;
-        expect(transform.coveringZoomLevel(options)).toEqual(3);
+        expect(transform.coveringZoomLevel(options)).toBe(3);
 
         transform.zoom = 10;
-        expect(transform.coveringZoomLevel(options)).toEqual(11);
+        expect(transform.coveringZoomLevel(options)).toBe(11);
 
         transform.zoom = 11;
-        expect(transform.coveringZoomLevel(options)).toEqual(12);
+        expect(transform.coveringZoomLevel(options)).toBe(12);
 
         transform.zoom = 11.5;
-        expect(transform.coveringZoomLevel(options)).toEqual(12);
+        expect(transform.coveringZoomLevel(options)).toBe(12);
 
         options.roundZoom = true;
 
-        expect(transform.coveringZoomLevel(options)).toEqual(13);
+        expect(transform.coveringZoomLevel(options)).toBe(13);
     });
 
     test('clamps latitude', () => {

--- a/src/gl/vertex_buffer.test.ts
+++ b/src/gl/vertex_buffer.test.ts
@@ -24,7 +24,7 @@ describe('VertexBuffer', () => {
             {name: 'map', components: 1, type: 'Int16', offset: 0},
             {name: 'box', components: 2, type: 'Int16', offset: 4}
         ]);
-        expect(buffer.itemSize).toEqual(6);
+        expect(buffer.itemSize).toBe(6);
         expect(buffer).toHaveLength(3);
     });
 

--- a/src/render/glyph_manager.test.ts
+++ b/src/render/glyph_manager.test.ts
@@ -79,7 +79,7 @@ describe('GlyphManager', () => {
 
         manager.getGlyphs({'Arial Unicode MS': [0x5e73]}, (err, glyphs) => {
             expect(err).toBeFalsy();
-            expect(glyphs['Arial Unicode MS'][0x5e73]).toBe(null); // The fixture returns a PBF without the glyph we requested
+            expect(glyphs['Arial Unicode MS'][0x5e73]).toBeNull(); // The fixture returns a PBF without the glyph we requested
             done();
         });
     });
@@ -100,7 +100,7 @@ describe('GlyphManager', () => {
         //Request char that overlaps Katakana range
         manager.getGlyphs({'Arial Unicode MS': [0x3005]}, (err, glyphs) => {
             expect(err).toBeFalsy();
-            expect(glyphs['Arial Unicode MS'][0x3005]).not.toBe(null);
+            expect(glyphs['Arial Unicode MS'][0x3005]).not.toBeNull();
             //Request char from Katakana range (te)
             manager.getGlyphs({'Arial Unicode MS': [0x30C6]}, (err, glyphs) => {
                 expect(err).toBeFalsy();

--- a/src/source/tile_cache.test.ts
+++ b/src/source/tile_cache.test.ts
@@ -20,12 +20,12 @@ describe('TileCache', () => {
         const cache = new TileCache(10, (removed) => {
             expect(removed).toBe('dc');
         });
-        expect(cache.getAndRemove(idC)).toBe(null);
+        expect(cache.getAndRemove(idC)).toBeNull();
         expect(cache.add(idA, tileA)).toBe(cache);
         keysExpected(cache, [idA]);
         expect(cache.has(idA)).toBe(true);
         expect(cache.getAndRemove(idA)).toBe(tileA);
-        expect(cache.getAndRemove(idA)).toBe(null);
+        expect(cache.getAndRemove(idA)).toBeNull();
         expect(cache.has(idA)).toBe(false);
         keysExpected(cache, []);
     });

--- a/src/source/tile_id.test.ts
+++ b/src/source/tile_id.test.ts
@@ -21,10 +21,10 @@ describe('CanonicalTileID', () => {
     });
 
     test('.key', () => {
-        expect(new CanonicalTileID(0, 0, 0).key).toEqual('000');
-        expect(new CanonicalTileID(1, 0, 0).key).toEqual('011');
-        expect(new CanonicalTileID(1, 1, 0).key).toEqual('111');
-        expect(new CanonicalTileID(1, 1, 1).key).toEqual('311');
+        expect(new CanonicalTileID(0, 0, 0).key).toBe('000');
+        expect(new CanonicalTileID(1, 0, 0).key).toBe('011');
+        expect(new CanonicalTileID(1, 1, 0).key).toBe('111');
+        expect(new CanonicalTileID(1, 1, 1).key).toBe('311');
     });
 
     test('.equals', () => {
@@ -69,15 +69,15 @@ describe('OverscaledTileID', () => {
     });
 
     test('.key', () => {
-        expect(new OverscaledTileID(0, 0, 0, 0, 0).key).toEqual('000');
-        expect(new OverscaledTileID(1, 0, 1, 0, 0).key).toEqual('011');
-        expect(new OverscaledTileID(1, 0, 1, 1, 0).key).toEqual('111');
-        expect(new OverscaledTileID(1, 0, 1, 1, 1).key).toEqual('311');
-        expect(new OverscaledTileID(1, -1, 1, 1, 1).key).toEqual('711');
+        expect(new OverscaledTileID(0, 0, 0, 0, 0).key).toBe('000');
+        expect(new OverscaledTileID(1, 0, 1, 0, 0).key).toBe('011');
+        expect(new OverscaledTileID(1, 0, 1, 1, 0).key).toBe('111');
+        expect(new OverscaledTileID(1, 0, 1, 1, 1).key).toBe('311');
+        expect(new OverscaledTileID(1, -1, 1, 1, 1).key).toBe('711');
     });
 
     test('.toString', () => {
-        expect(new OverscaledTileID(1, 0, 1, 1, 1).toString()).toEqual('1/1/1');
+        expect(new OverscaledTileID(1, 0, 1, 1, 1).toString()).toBe('1/1/1');
     });
 
     test('.children', () => {

--- a/src/source/vector_tile_source.test.ts
+++ b/src/source/vector_tile_source.test.ts
@@ -59,9 +59,9 @@ describe('VectorTileSource', () => {
         source.on('data', (e) => {
             if (e.sourceDataType === 'metadata') {
                 expect(source.tiles).toEqual(['http://example.com/{z}/{x}/{y}.png']);
-                expect(source.minzoom).toEqual(1);
-                expect(source.maxzoom).toEqual(10);
-                expect((source as Source).attribution).toEqual('Maplibre');
+                expect(source.minzoom).toBe(1);
+                expect(source.maxzoom).toBe(10);
+                expect((source as Source).attribution).toBe('Maplibre');
                 done();
             }
         });
@@ -75,9 +75,9 @@ describe('VectorTileSource', () => {
         source.on('data', (e) => {
             if (e.sourceDataType === 'metadata') {
                 expect(source.tiles).toEqual(['http://example.com/{z}/{x}/{y}.png']);
-                expect(source.minzoom).toEqual(1);
-                expect(source.maxzoom).toEqual(10);
-                expect((source as Source).attribution).toEqual('Maplibre');
+                expect(source.minzoom).toBe(1);
+                expect(source.maxzoom).toBe(10);
+                expect((source as Source).attribution).toBe('Maplibre');
                 done();
             }
         });

--- a/src/source/worker.test.ts
+++ b/src/source/worker.test.ts
@@ -145,7 +145,7 @@ describe('load worker source', () => {
 describe('set images', () => {
     test('set images', () => {
         const worker = new Worker(_self);
-        expect(worker.availableImages['0']).toEqual(undefined);
+        expect(worker.availableImages['0']).toBeUndefined();
         worker.setImages('0', ['availableImages'], () => {});
         expect(worker.availableImages['0']).toEqual(['availableImages']);
     });

--- a/src/style-spec/function/index.test.ts
+++ b/src/style-spec/function/index.test.ts
@@ -430,9 +430,9 @@ describe('exponential function', () => {
             type: 'color'
         }).evaluate;
 
-        expect(f({zoom: 0}, {properties: {}})).toBe(undefined);
-        expect(f({zoom: 0.5}, {properties: {}})).toBe(undefined);
-        expect(f({zoom: 1}, {properties: {}})).toBe(undefined);
+        expect(f({zoom: 0}, {properties: {}})).toBeUndefined();
+        expect(f({zoom: 0.5}, {properties: {}})).toBeUndefined();
+        expect(f({zoom: 1}, {properties: {}})).toBeUndefined();
 
     });
 

--- a/src/style-spec/util/color.test.ts
+++ b/src/style-spec/util/color.test.ts
@@ -4,9 +4,9 @@ describe('Color', () => {
     test('Color.parse', () => {
         expect(Color.parse('red')).toEqual(new Color(1, 0, 0, 1));
         expect(Color.parse('#ff00ff')).toEqual(new Color(1, 0, 1, 1));
-        expect(Color.parse('invalid')).toEqual(undefined);
-        expect(Color.parse(null)).toEqual(undefined);
-        expect(Color.parse(undefined)).toEqual(undefined);
+        expect(Color.parse('invalid')).toBeUndefined();
+        expect(Color.parse(null)).toBeUndefined();
+        expect(Color.parse(undefined)).toBeUndefined();
     });
 
     test('Color#toString', () => {

--- a/src/style/light.test.ts
+++ b/src/style/light.test.ts
@@ -26,9 +26,9 @@ test('Light with options', () => {
     });
     light.recalculate({zoom: 0, zoomHistory: {}} as EvaluationParameters);
 
-    expect(light.properties.get('anchor')).toEqual('map');
+    expect(light.properties.get('anchor')).toBe('map');
     expect(light.properties.get('position')).toEqual(sphericalToCartesian([2, 30, 30]));
-    expect(light.properties.get('intensity')).toEqual(1);
+    expect(light.properties.get('intensity')).toBe(1);
     expect(light.properties.get('color')).toEqual(Color.parse(spec.color.default));
 });
 
@@ -40,7 +40,7 @@ test('Light with stops function', () => {
     } as LightSpecification);
     light.recalculate({zoom: 16.5, zoomHistory: {}} as EvaluationParameters);
 
-    expect(light.properties.get('intensity')).toEqual(0.5);
+    expect(light.properties.get('intensity')).toBe(0.5);
 });
 
 test('Light#getLight', () => {

--- a/src/style/style_layer.test.ts
+++ b/src/style/style_layer.test.ts
@@ -25,7 +25,7 @@ describe('StyleLayer#setPaintProperty', () => {
 
         layer.setPaintProperty('background-color', 'blue');
 
-        expect(layer.getPaintProperty('background-color')).toEqual('blue');
+        expect(layer.getPaintProperty('background-color')).toBe('blue');
     });
 
     test('updates property value', () => {
@@ -39,7 +39,7 @@ describe('StyleLayer#setPaintProperty', () => {
 
         layer.setPaintProperty('background-color', 'blue');
 
-        expect(layer.getPaintProperty('background-color')).toEqual('blue');
+        expect(layer.getPaintProperty('background-color')).toBe('blue');
     });
 
     test('unsets value', () => {
@@ -57,7 +57,7 @@ describe('StyleLayer#setPaintProperty', () => {
         layer.recalculate({zoom: 0, zoomHistory: {}} as EvaluationParameters, undefined);
 
         expect(layer.paint.get('background-color')).toEqual(new Color(0, 0, 0, 1));
-        expect(layer.getPaintProperty('background-color')).toBe(undefined);
+        expect(layer.getPaintProperty('background-color')).toBeUndefined();
         expect(layer.paint.get('background-opacity')).toBe(1);
         expect(layer.getPaintProperty('background-opacity')).toBe(1);
     });
@@ -100,7 +100,7 @@ describe('StyleLayer#setPaintProperty', () => {
         });
 
         layer.on('error', () => {
-            expect(layer.getPaintProperty('background-opacity')).toBe(undefined);
+            expect(layer.getPaintProperty('background-opacity')).toBeUndefined();
             done();
         });
 
@@ -182,7 +182,7 @@ describe('StyleLayer#setPaintProperty', () => {
 
         layer.setPaintProperty('background-color-transition', null);
 
-        expect(layer.getPaintProperty('background-color-transition')).toEqual(undefined);
+        expect(layer.getPaintProperty('background-color-transition')).toBeUndefined();
     });
 
 });
@@ -196,7 +196,7 @@ describe('StyleLayer#setLayoutProperty', () => {
 
         layer.setLayoutProperty('text-transform', 'lowercase');
 
-        expect(layer.getLayoutProperty('text-transform')).toEqual('lowercase');
+        expect(layer.getLayoutProperty('text-transform')).toBe('lowercase');
     });
 
     test('emits on an invalid property value', done => {
@@ -223,7 +223,7 @@ describe('StyleLayer#setLayoutProperty', () => {
 
         layer.setLayoutProperty('text-transform', 'lowercase');
 
-        expect(layer.getLayoutProperty('text-transform')).toEqual('lowercase');
+        expect(layer.getLayoutProperty('text-transform')).toBe('lowercase');
     });
 
     test('unsets property value', () => {
@@ -239,7 +239,7 @@ describe('StyleLayer#setLayoutProperty', () => {
         layer.recalculate({zoom: 0, zoomHistory: {}} as EvaluationParameters, undefined);
 
         expect(layer.layout.get('text-transform').value).toEqual({kind: 'constant', value: 'none'});
-        expect(layer.getLayoutProperty('text-transform')).toBe(undefined);
+        expect(layer.getLayoutProperty('text-transform')).toBeUndefined();
     });
 });
 
@@ -311,7 +311,7 @@ describe('StyleLayer#serialize', () => {
         const layer = createStyleLayer(createSymbolLayer());
         layer.setLayoutProperty('visibility', undefined);
 
-        expect(layer.serialize().layout['visibility']).toBe(undefined);
+        expect(layer.serialize().layout['visibility']).toBeUndefined();
 
     });
 

--- a/src/util/evented.test.ts
+++ b/src/util/evented.test.ts
@@ -43,7 +43,7 @@ describe('Evented', () => {
     test('passes "type" to listeners', () => {
         const evented = new Evented();
         evented.on('a', (data) => {
-            expect(data.type).toEqual('a');
+            expect(data.type).toBe('a');
         });
         evented.fire(new Event('a'));
 
@@ -110,7 +110,7 @@ describe('Evented', () => {
         evented.on('a', listener);
         evented.fire('a' as any as Event, {foo: 'bar'});
         expect(listener).toHaveBeenCalledTimes(1);
-        expect(listener.mock.calls[0][0].foo).toEqual('bar');
+        expect(listener.mock.calls[0][0].foo).toBe('bar');
 
     });
 


### PR DESCRIPTION
Do we like to use the rule https://github.com/jest-community/eslint-plugin-jest/blob/HEAD/docs/rules/prefer-to-be.md ?

I have added it here and checked the tests via` npm run lint -- --fix`.

