### PR TITLE
Export GeoJSONSource

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ import LngLat from './geo/lng_lat';
 import LngLatBounds from './geo/lng_lat_bounds';
 import Point from './util/point';
 import MercatorCoordinate from './geo/mercator_coordinate';
+import GeoJSONSource from './source/geojson_source';
 import {Evented} from './util/evented';
 import config from './util/config';
 import {Debug} from './util/debug';
@@ -43,6 +44,7 @@ const exported = {
     LngLatBounds,
     Point,
     MercatorCoordinate,
+    GeoJSONSource,
     Evented,
     config,
     /**


### PR DESCRIPTION
This small change would give developers a more convenient way to subclass from 'GeoJSONSource'. Using 3rd party libraries that implement some kind of "xxx2geojson" it will become easy to create custom sources.
Issue: https://github.com/maplibre/maplibre-gl-js/issues/468#issuecomment-956181469
Example: https://mapsrc.js.org/

I think this could be handled like the "addSourceType" methode of 'map' and 'style'; as a undocumented feature (https://github.com/mapbox/mapbox-gl-js/issues/2920#issue-168275144)

Therefor I would suggest the "skip changelog" category.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [ ] Manually test the debug page.
 - [x] Suggest a changelog category: "skip changelog".
 - [ ] Add an entry inside this element for inclusion in the `maplibre-gl-js` changelog: `<changelog></changelog>`.
