### PR TITLE
[Jest Lint] Add rule `prefer-to-contain`

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -97,6 +97,7 @@
     // Jest https://www.npmjs.com/package/eslint-plugin-jest
     "jest/no-disabled-tests": "warn",
     "jest/no-focused-tests": "error",
+    "jest/prefer-to-contain": "warn",
     "jest/prefer-to-have-length": "warn",
     "jest/valid-expect": "error",
     "jest/prefer-to-be": "warn"   


### PR DESCRIPTION
Do we like to use the rule https://github.com/jest-community/eslint-plugin-jest/blob/HEAD/docs/rules/prefer-to-contain.md ?

I have added it here and checked the tests via` npm run lint -- --fix`. All test files are fine currently. But I think it good to get a message, in future.

