### PR TITLE
[Jest Lint] Add rule `no-commented-out-tests`

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -95,6 +95,7 @@
     "jsdoc/require-returns-description": "warn",
     
     // Jest https://www.npmjs.com/package/eslint-plugin-jest
+    "jest/no-commented-out-tests": "error",
     "jest/no-disabled-tests": "warn",
     "jest/no-focused-tests": "error",
     "jest/prefer-to-have-length": "warn",


### PR DESCRIPTION
Do we like to use the rule https://github.com/jest-community/eslint-plugin-jest/blob/HEAD/docs/rules/no-commented-out-tests.md ?

I have added it here and checked the tests via` npm run lint -- --fix`. There is no commented out test currently. But I would like it to get a message in case.