### PR TITLE
[Jest Lint] Add rule `no-alias-methods`

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -99,7 +99,8 @@
     "jest/no-focused-tests": "error",
     "jest/prefer-to-have-length": "warn",
     "jest/valid-expect": "error",
-    "jest/prefer-to-be": "warn"   
+    "jest/prefer-to-be": "warn",
+    "jest/no-alias-methods": "warn"
   },
   "settings": {
     "jsdoc":{

--- a/src/style-spec/composite.test.ts
+++ b/src/style-spec/composite.test.ts
@@ -100,7 +100,7 @@ describe('composite', () => {
                     'source': 'mapbox-b'
                 }]
             });
-        }).toThrowError(/Conflicting source layer names/);
+        }).toThrow(/Conflicting source layer names/);
 
     });
 });

--- a/src/style-spec/function/index.test.ts
+++ b/src/style-spec/function/index.test.ts
@@ -949,7 +949,7 @@ describe('unknown function', () => {
         type: 'nonesuch', stops: [[]]
     }, {
         type: 'string'
-    })).toThrowError(/Unknown function type "nonesuch"/);
+    })).toThrow(/Unknown function type "nonesuch"/);
 });
 
 describe('kind', () => {


### PR DESCRIPTION
Do we like to use the rule https://github.com/jest-community/eslint-plugin-jest/blob/HEAD/docs/rules/no-alias-methods.md ?

I have added it here and checked the tests via` npm run lint -- --fix`.

