### PR TITLE
[Jest-Lint] Add rule `no-deprecated-functions`

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -102,7 +102,8 @@
     "jest/prefer-to-have-length": "warn",
     "jest/valid-expect": "error",
     "jest/prefer-to-be": "warn",
-    "jest/no-alias-methods": "warn"
+    "jest/no-alias-methods": "warn",
+    "jest/no-deprecated-functions": "warn"
   },
   "settings": {
     "jsdoc":{


### PR DESCRIPTION
I think this rule is fine too:
https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-deprecated-functions.md
What do you mean