### PR TITLE
fix #334 umd export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - Fix tile placeholder replacement to allow for placeholders to be in a URL more than once. (#348)
 - Fix type check for non dom environment. (#334)
 - Fix precision problem in patterns when overzoomed in OpenGL ES devices.
+- Fix UMD export (#334)
 
 ## 1.15.2
 

--- a/build/check-bundle-size.js
+++ b/build/check-bundle-size.js
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 
-import fs from "fs";
-import zlib from "zlib";
-import prettyBytes from "pretty-bytes";
+const fs = require("fs");
+const zlib = require("zlib");
+const prettyBytes = require("pretty-bytes");
 const beforeSourcemap = JSON.parse(fs.readFileSync('./before.json').toString());
 const afterSourcemap = JSON.parse(fs.readFileSync('./after.json').toString());
 

--- a/build/copy-glsl-files.js
+++ b/build/copy-glsl-files.js
@@ -1,5 +1,5 @@
-import fs from 'fs';
-import glob from 'glob';
+const fs = require('fs');
+const glob = require('glob');
 
 let args = process.argv.slice(2);
 let outputBaseDir = args[0];

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "node": ">=14.0.0"
   },
   "types": "types/index.d.ts",
-  "type": "module",
   "dependencies": {
     "@mapbox/geojson-rewind": "^0.5.0",
     "@mapbox/jsonlint-lines-primitives": "^2.0.2",
@@ -197,7 +196,7 @@
     "lint-css": "stylelint \"src/css/maplibre-gl.css\"",
     "test": "run-s lint lint-css lint-docs test-unit",
     "test-suite": "run-s test-render test-query test-expressions",
-    "test-suite-clean": "find test/integration/{render,query, expressions}-tests -mindepth 2 -type d -exec test -e \"{}/actual.png\" \\; -not \\( -exec test -e \"{}/style.json\" \\; \\) -print | xargs -t rm -r",
+    "test-suite-clean": "find test/integration/{render,query,expressions}-tests -mindepth 2 -type d -exec test -e \"{}/actual.png\" \\; -not \\( -exec test -e \"{}/style.json\" \\; \\) -print | xargs -t rm -r",
     "test-unit": "tap --node-arg --no-warnings --node-arg --experimental-specifier-resolution=node --node-arg --experimental-json-modules --reporter classic --no-coverage test/unit",
     "test-unit-file": "tap --node-arg --no-warnings --node-arg --experimental-specifier-resolution=node --node-arg --experimental-json-modules --reporter classic --no-coverage ",
     "test-build": "tap --node-arg --no-warnings --node-arg --experimental-specifier-resolution=node --node-arg --experimental-json-modules --reporter classic --no-coverage test/build/**/*.test.js",


### PR DESCRIPTION
After trying to propose a ESM export with #368. I propose a simpler alternative.
Because the export is an umd package I remove the `"type": "module"` option. Therefore, I've replaced the `import` in the nodejs code with `require`. 
Another solution would be to rename `XXXX.js` to `XXXX.mjs`.

With this PR, we find an umd package well defined by the package.json file as in the 1.xx versions of maplibre.

it is therefore possible to find a default export and named exports.

## Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [X] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [X] Briefly describe the changes in this PR.
 - [X] Add an entry inside this element for inclusion in the `maplibre-gl-js` changelog: `<changelog></changelog>`.
