### PR TITLE
handle {r} in tile urls for hidpi raster tiles (fix #141)

### DIFF
--- a/src/source/tile_id.test.ts
+++ b/src/source/tile_id.test.ts
@@ -52,6 +52,13 @@ describe('CanonicalTileID', () => {
         expect(new CanonicalTileID(1, 0, 0).url(['bbox={bbox-epsg-3857}'])).toBe('bbox=-20037508.342789244,0,0,20037508.342789244');
     });
 
+    test('.url replaces {r}', () => {
+        devicePixelRatio = 2;
+        expect(new CanonicalTileID(1, 0, 0).url(['r={r}'])).toBe('r=@2x');
+        devicePixelRatio = 1;
+        expect(new CanonicalTileID(1, 0, 0).url(['r={r}'])).toBe('r=');
+    });
+
     //Tests that multiple values of the same placeholder are replaced.
     test('.url replaces {z}/{x}/{y}/{z}/{x}/{y}', () => {
         expect(new CanonicalTileID(2, 1, 0).url(['{z}/{x}/{y}/{z}/{x}/{y}.json'])).toBe('2/1/0/2/1/0.json');

--- a/src/source/tile_id.ts
+++ b/src/source/tile_id.ts
@@ -37,6 +37,7 @@ export class CanonicalTileID {
             .replace(/{z}/g, String(this.z))
             .replace(/{x}/g, String(this.x))
             .replace(/{y}/g, String(scheme === 'tms' ? (Math.pow(2, this.z) - this.y - 1) : this.y))
+            .replace(/{r}/g, devicePixelRatio > 1 ? '@2x' : '')
             .replace(/{quadkey}/g, quadkey)
             .replace(/{bbox-epsg-3857}/g, bbox);
     }


### PR DESCRIPTION
Replace {r} in tile urls with @2x for devices with a pixelratio > 1.

This feature is compatible with leafletjs and useful to fetch hidpi tiles for
layers that support it.

## Launch Checklist

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Write tests for all new functionality.
 - [x] Suggest a changelog category: "feature".
 - [x] Add an entry inside this element for inclusion in the `maplibre-gl-js` changelog: `<changelog>replace {r} in tile urls</changelog>`.
