### PR TITLE
Remove global typings

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "@mapbox/geojson-rewind": "^0.5.0",
     "@mapbox/jsonlint-lines-primitives": "^2.0.2",
-    "@mapbox/mapbox-gl-supported": "^2.0.0",
+    "@mapbox/mapbox-gl-supported": "^2.0.1",
     "@mapbox/tiny-sdf": "^2.0.4",
     "@mapbox/unitbezier": "^0.0.1",
     "@mapbox/vector-tile": "^1.3.1",

--- a/src/data/bucket.ts
+++ b/src/data/bucket.ts
@@ -6,6 +6,7 @@ import type Context from '../gl/context';
 import type {FeatureStates} from '../source/source_state';
 import type {ImagePosition} from '../render/image_atlas';
 import type {CanonicalTileID} from '../source/tile_id';
+import type {VectorTileFeature, VectorTileLayer} from '@mapbox/vector-tile';
 import Point from '../util/point';
 
 export type BucketParameters<Layer extends TypedStyleLayer> = {

--- a/src/data/bucket/circle_bucket.ts
+++ b/src/data/bucket/circle_bucket.ts
@@ -26,6 +26,7 @@ import type VertexBuffer from '../../gl/vertex_buffer';
 import type Point from '../../util/point';
 import type {FeatureStates} from '../../source/source_state';
 import type {ImagePosition} from '../../render/image_atlas';
+import type {VectorTileLayer} from '@mapbox/vector-tile';
 
 function addCircleVertex(layoutVertexArray, x, y, extrudeX, extrudeY) {
     layoutVertexArray.emplaceBack(

--- a/src/data/bucket/fill_bucket.ts
+++ b/src/data/bucket/fill_bucket.ts
@@ -29,6 +29,7 @@ import type VertexBuffer from '../../gl/vertex_buffer';
 import type Point from '../../util/point';
 import type {FeatureStates} from '../../source/source_state';
 import type {ImagePosition} from '../../render/image_atlas';
+import type {VectorTileLayer} from '@mapbox/vector-tile';
 
 class FillBucket implements Bucket {
     index: number;

--- a/src/data/bucket/fill_extrusion_bucket.ts
+++ b/src/data/bucket/fill_extrusion_bucket.ts
@@ -33,6 +33,7 @@ import type VertexBuffer from '../../gl/vertex_buffer';
 import type Point from '../../util/point';
 import type {FeatureStates} from '../../source/source_state';
 import type {ImagePosition} from '../../render/image_atlas';
+import type {VectorTileLayer} from '@mapbox/vector-tile';
 
 const FACTOR = Math.pow(2, 13);
 

--- a/src/data/bucket/line_bucket.ts
+++ b/src/data/bucket/line_bucket.ts
@@ -32,6 +32,7 @@ import type IndexBuffer from '../../gl/index_buffer';
 import type VertexBuffer from '../../gl/vertex_buffer';
 import type {FeatureStates} from '../../source/source_state';
 import type {ImagePosition} from '../../render/image_atlas';
+import type {VectorTileLayer} from '@mapbox/vector-tile';
 
 // NOTE ON EXTRUDE SCALE:
 // scale the extrusion vector so that the normal length is this value.

--- a/src/data/bucket/symbol_bucket.ts
+++ b/src/data/bucket/symbol_bucket.ts
@@ -56,6 +56,7 @@ import type {SymbolQuad} from '../../symbol/quads';
 import type {SizeData} from '../../symbol/symbol_size';
 import type {FeatureStates} from '../../source/source_state';
 import type {ImagePosition} from '../../render/image_atlas';
+import type {VectorTileLayer} from '@mapbox/vector-tile';
 
 export type SingleCollisionBox = {
   x1: number;

--- a/src/data/evaluation_feature.ts
+++ b/src/data/evaluation_feature.ts
@@ -1,5 +1,6 @@
 import loadGeometry from './load_geometry';
 import type Point from '../util/point';
+import type {VectorTileFeature} from '@mapbox/vector-tile';
 
 type EvaluationFeature = {
   readonly type: 1 | 2 | 3 | 'Unknown' | 'Point' | 'MultiPoint' | 'LineString' | 'MultiLineString' | 'Polygon' | 'MultiPolygon';

--- a/src/data/feature_index.ts
+++ b/src/data/feature_index.ts
@@ -23,6 +23,7 @@ import type {FeatureFilter} from '../style-spec/feature_filter';
 import type Transform from '../geo/transform';
 import type {FilterSpecification, PromoteIdSpecification} from '../style-spec/types';
 import type {FeatureState} from '../style-spec/expression';
+import type {VectorTileFeature, VectorTileLayer} from '@mapbox/vector-tile';
 
 type QueryParameters = {
   scale: number;
@@ -291,8 +292,8 @@ class FeatureIndex {
         return false;
     }
 
-    getId(feature: VectorTileFeature, sourceLayerId: string): string | number | void {
-        let id: string | number | boolean = feature.id;
+    getId(feature: VectorTileFeature, sourceLayerId: string): string | number {
+        let id: string | number = feature.id;
         if (this.promoteId) {
             const propName = typeof this.promoteId === 'string' ? this.promoteId : this.promoteId[sourceLayerId];
             id = feature.properties[propName];

--- a/src/data/load_geometry.ts
+++ b/src/data/load_geometry.ts
@@ -3,6 +3,7 @@ import {warnOnce, clamp} from '../util/util';
 import EXTENT from './extent';
 
 import type Point from '../util/point';
+import type {VectorTileFeature} from '@mapbox/vector-tile';
 
 // These bounds define the minimum and maximum supported coordinate values.
 // While visible coordinates are within [0, EXTENT], tiles may theoretically

--- a/src/data/program_configuration.ts
+++ b/src/data/program_configuration.ts
@@ -28,6 +28,7 @@ import type {
 } from '../style-spec/expression';
 import type {FeatureStates} from '../source/source_state';
 import type {FormattedSection} from '../style-spec/expression/types/formatted';
+import type {VectorTileLayer} from '@mapbox/vector-tile';
 
 export type BinderUniform = {
   name: string;

--- a/src/source/geojson_wrapper.ts
+++ b/src/source/geojson_wrapper.ts
@@ -1,6 +1,7 @@
 import Point from '../util/point';
 
 import mvt from '@mapbox/vector-tile';
+import type {VectorTileFeature, VectorTileLayer, VectorTile} from '@mapbox/vector-tile';
 const toGeoJSON = mvt.VectorTileFeature.prototype.toGeoJSON;
 import EXTENT from '../data/extent';
 

--- a/src/source/tile.ts
+++ b/src/source/tile.ts
@@ -32,6 +32,7 @@ import type {Cancelable} from '../types/cancelable';
 import type {FilterSpecification} from '../style-spec/types';
 import type Point from '../util/point';
 import {mat4} from 'gl-matrix';
+import type {VectorTileLayer} from '@mapbox/vector-tile';
 
 export type TileState = // Tile data is in the process of loading.
 'loading' | // Tile data has been loaded. Tile can be rendered.

--- a/src/source/vector_tile_worker_source.ts
+++ b/src/source/vector_tile_worker_source.ts
@@ -16,6 +16,7 @@ import type {
 import type Actor from '../util/actor';
 import type StyleLayerIndex from '../style/style_layer_index';
 import type {Callback} from '../types/callback';
+import type {VectorTile} from '@mapbox/vector-tile';
 
 export type LoadVectorTileResult = {
   vectorTile: VectorTile;

--- a/src/source/worker_tile.ts
+++ b/src/source/worker_tile.ts
@@ -25,6 +25,7 @@ import type {
     WorkerTileCallback,
 } from '../source/worker_source';
 import type {PromoteIdSpecification} from '../style-spec/types';
+import type {VectorTile} from '@mapbox/vector-tile';
 
 class WorkerTile {
     tileID: OverscaledTileID;

--- a/src/style/style_layer.ts
+++ b/src/style/style_layer.ts
@@ -28,6 +28,7 @@ import type {CustomLayerInterface} from './style_layer/custom_style_layer';
 import type Map from '../ui/map';
 import type {StyleSetterOptions} from './style';
 import {mat4} from 'gl-matrix';
+import type {VectorTileFeature} from '@mapbox/vector-tile';
 
 const TRANSITION_SUFFIX = '-transition';
 

--- a/src/style/style_layer/circle_style_layer.ts
+++ b/src/style/style_layer/circle_style_layer.ts
@@ -12,6 +12,7 @@ import type Transform from '../../geo/transform';
 import type {Bucket, BucketParameters} from '../../data/bucket';
 import type {LayoutProps, PaintProps} from './circle_style_layer_properties';
 import type {LayerSpecification} from '../../style-spec/types';
+import type {VectorTileFeature} from '@mapbox/vector-tile';
 
 class CircleStyleLayer extends StyleLayer {
     _unevaluatedLayout: Layout<LayoutProps>;

--- a/src/style/style_layer/fill_extrusion_style_layer.ts
+++ b/src/style/style_layer/fill_extrusion_style_layer.ts
@@ -12,6 +12,7 @@ import type {BucketParameters} from '../../data/bucket';
 import type {PaintProps} from './fill_extrusion_style_layer_properties';
 import type Transform from '../../geo/transform';
 import type {LayerSpecification} from '../../style-spec/types';
+import type {VectorTileFeature} from '@mapbox/vector-tile';
 
 export class Point3D extends Point {
     z: number

--- a/src/style/style_layer/fill_style_layer.ts
+++ b/src/style/style_layer/fill_style_layer.ts
@@ -13,6 +13,7 @@ import type {LayoutProps, PaintProps} from './fill_style_layer_properties';
 import type EvaluationParameters from '../evaluation_parameters';
 import type Transform from '../../geo/transform';
 import type {LayerSpecification} from '../../style-spec/types';
+import type {VectorTileFeature} from '@mapbox/vector-tile';
 
 class FillStyleLayer extends StyleLayer {
     _unevaluatedLayout: Layout<LayoutProps>;

--- a/src/style/style_layer/line_style_layer.ts
+++ b/src/style/style_layer/line_style_layer.ts
@@ -15,6 +15,7 @@ import type {Bucket, BucketParameters} from '../../data/bucket';
 import type {LayoutProps, PaintProps} from './line_style_layer_properties';
 import type Transform from '../../geo/transform';
 import type {LayerSpecification} from '../../style-spec/types';
+import type {VectorTileFeature} from '@mapbox/vector-tile';
 
 class LineFloorwidthProperty extends DataDrivenProperty<number> {
     useIntegerZoom: true;

--- a/src/types/non-typed-modules.d.ts
+++ b/src/types/non-typed-modules.d.ts
@@ -1,25 +1,7 @@
 import type Pbf from 'pbf';
 
-declare module '@mapbox/mapbox-gl-supported' {
-    type isSupported = {
-        webGLContextAttributes: WebGLContextAttributes;
-        (
-            options?: {
-                failIfMajorPerformanceCaveat: boolean;
-            }
-        ): boolean;
-    };
-
-    let __exports: {
-        supported: isSupported;
-    };
-    export = __exports
-}
-
-declare global {
-    declare interface VectorTile {
-        layers: {[_: string]: VectorTileLayer};
-    }
+declare module '@mapbox/vector-tile' {
+    import '@mapbox/vector-tile';
 
     declare interface VectorTileLayer {
         version?: number;
@@ -29,7 +11,13 @@ declare global {
         feature(i: number): VectorTileFeature;
     }
 
-    declare interface VectorTileFeature {
+    class VectorTile {
+        constructor(pbf: Pbf);
+        layers: {[_: string]: VectorTileLayer};
+    }
+
+    class VectorTileFeature {
+        static types: ['Unknown', 'Point', 'LineString', 'Polygon'];
         extent: number;
         type: 1 | 2 | 3;
         id: number;
@@ -37,22 +25,10 @@ declare global {
         loadGeometry(): Array<Array<Point>>;
         toGeoJSON(x: number, y: number, z: number): GeoJSON.Feature;
     }
-}
-
-declare module '@mapbox/vector-tile' {
-    import '@mapbox/vector-tile';
-    class VectorTileImpl {
-        constructor(pbf: Pbf);
-    }
-
-    class VectorTileFeatureImpl {
-        static types: ['Unknown', 'Point', 'LineString', 'Polygon'];
-        toGeoJSON(x: number, y: number, z: number): GeoJSON.Feature;
-    }
 
     let __exports: {
-        VectorTile: typeof VectorTileImpl;
-        VectorTileFeature: typeof VectorTileFeatureImpl;
+        VectorTile: typeof VectorTile;
+        VectorTileFeature: typeof VectorTileFeature;
     };
 
     export = __exports

--- a/src/util/vectortile_to_geojson.ts
+++ b/src/util/vectortile_to_geojson.ts
@@ -1,3 +1,5 @@
+import type {VectorTileFeature} from '@mapbox/vector-tile';
+
 class Feature {
     type: 'Feature';
     _geometry: GeoJSON.Geometry;


### PR DESCRIPTION
## Launch Checklist

I wanted to iron out all the non-typed modules and leave it so that the only change needed is to update the package once the vector-tile typings get merged.
Currently this is not the case as the vector tile types are defined globally, which I don't see a good reason to keep.
This PR irons things out.

Relevant PR in vector-tile-js repo is the following for future reference:
https://github.com/mapbox/vector-tile-js/pull/78

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.