### PR TITLE
Remove duplicates for code generated types

### DIFF
--- a/build/generate-style-code.ts
+++ b/build/generate-style-code.ts
@@ -4,10 +4,15 @@ import * as fs from 'fs';
 
 import spec from '../src/style-spec/reference/v8.json';
 
-function camelizeWithLeadingLowercase(str) {
+function camelCase(str: string): string {
     return str.replace(/-(.)/g, function (_, x) {
       return x.toUpperCase();
     });
+}
+
+function pascalCase(str: string): string {
+    let almostCamelized = camelCase(str);
+    return almostCamelized[0].toUpperCase() + almostCamelized.slice(1);
 }
 
 function nativeType(property) {
@@ -97,7 +102,7 @@ function runtimeType(property) {
 }
 
 function overrides(property) {
-    return `{ runtimeType: ${runtimeType(property)}, getOverride: (o) => o.${camelizeWithLeadingLowercase(property.name)}, hasOverride: (o) => !!o.${camelizeWithLeadingLowercase(property.name)} }`;
+    return `{ runtimeType: ${runtimeType(property)}, getOverride: (o) => o.${camelCase(property.name)}, hasOverride: (o) => !!o.${camelCase(property.name)} }`;
 }
 
 function propertyValue(property, type) {
@@ -146,7 +151,7 @@ const layers = Object.keys(spec.layer.type.values).map((type) => {
 
 function emitlayerProperties(locals) {
     const output = [];
-
+    const layerType = pascalCase(locals.type);
     const {
         layoutProperties,
         paintProperties
@@ -188,7 +193,7 @@ import {StylePropertySpecification} from '../../style-spec/style-spec';
 
     if (layoutProperties.length) {
         output.push(
-            'export type LayoutProps = {');
+            `export type ${layerType}LayoutProps = {`);
 
         for (const property of layoutProperties) {
             output.push(
@@ -198,7 +203,7 @@ import {StylePropertySpecification} from '../../style-spec/style-spec';
         output.push(
             `};
 
-export type LayoutPropsPossiblyEvaluated = {`);
+export type ${layerType}LayoutPropsPossiblyEvaluated = {`);
 
         for (const property of layoutProperties) {
             output.push(
@@ -208,7 +213,7 @@ export type LayoutPropsPossiblyEvaluated = {`);
         output.push(
             `};
 
-const layout: Properties<LayoutProps> = new Properties({`);
+const layout: Properties<${layerType}LayoutProps> = new Properties({`);
 
         for (const property of layoutProperties) {
             output.push(
@@ -222,7 +227,7 @@ const layout: Properties<LayoutProps> = new Properties({`);
     if (paintProperties.length) {
         output.push(
             `
-export type PaintProps = {`);
+export type ${layerType}PaintProps = {`);
 
         for (const property of paintProperties) {
             output.push(
@@ -232,7 +237,7 @@ export type PaintProps = {`);
         output.push(
             `};
 
-export type PaintPropsPossiblyEvaluated = {`);
+export type ${layerType}PaintPropsPossiblyEvaluated = {`);
 
         for (const property of paintProperties) {
             output.push(
@@ -243,12 +248,12 @@ export type PaintPropsPossiblyEvaluated = {`);
             '};');
     } else {
         output.push(
-            'export type PaintProps = {};');
+            `export type ${layerType}PaintProps = {};`);
     }
 
     output.push(
         `
-const paint: Properties<PaintProps> = new Properties({`);
+const paint: Properties<${layerType}PaintProps> = new Properties({`);
 
     for (const property of paintProperties) {
         output.push(
@@ -259,7 +264,7 @@ const paint: Properties<PaintProps> = new Properties({`);
         `});
 
 export default ({ paint${layoutProperties.length ? ', layout' : ''} } as {
-    paint: Properties<PaintProps>${layoutProperties.length ? ',\n    layout: Properties<LayoutProps>' : ''}
+    paint: Properties<${layerType}PaintProps>${layoutProperties.length ? ',\n    layout: Properties<' + layerType + 'LayoutProps>' : ''}
 });`);
 
     return output.join('\n');

--- a/build/generate-style-spec.ts
+++ b/build/generate-style-spec.ts
@@ -47,7 +47,7 @@ function propertyType(property) {
     } else if (properties.supportsZoomExpression(property)) {
         return `PropertyValueSpecification<${baseType}>`;
     } else if (property.expression) {
-        return 'ExpressionSpecification';
+        return 'Array<unknown>';
     } else {
         return baseType;
     }
@@ -158,19 +158,17 @@ export type CompositeFunctionSpecification<T> =
     | { type: 'interval',    stops: Array<[{zoom: number, value: number}, T]>, property: string, default?: T }
     | { type: 'categorical', stops: Array<[{zoom: number, value: string | number | boolean}, T]>, property: string, default?: T };
 
-export type ExpressionSpecification = Array<unknown>;
-
 export type PropertyValueSpecification<T> =
       T
     | CameraFunctionSpecification<T>
-    | ExpressionSpecification;
+    | Array<unknown>;
 
 export type DataDrivenPropertyValueSpecification<T> =
       T
     | CameraFunctionSpecification<T>
     | SourceFunctionSpecification<T>
     | CompositeFunctionSpecification<T>
-    | ExpressionSpecification;
+    | Array<unknown>;
 
 ${objectDeclaration('StyleSpecification', spec.$root)}
 

--- a/build/generate-style-spec.ts
+++ b/build/generate-style-spec.ts
@@ -47,7 +47,7 @@ function propertyType(property) {
     } else if (properties.supportsZoomExpression(property)) {
         return `PropertyValueSpecification<${baseType}>`;
     } else if (property.expression) {
-        return 'Array<unknown>';
+        return 'ExpressionSpecificationArray';
     } else {
         return baseType;
     }
@@ -158,17 +158,19 @@ export type CompositeFunctionSpecification<T> =
     | { type: 'interval',    stops: Array<[{zoom: number, value: number}, T]>, property: string, default?: T }
     | { type: 'categorical', stops: Array<[{zoom: number, value: string | number | boolean}, T]>, property: string, default?: T };
 
+export type ExpressionSpecificationArray = Array<unknown>;
+
 export type PropertyValueSpecification<T> =
       T
     | CameraFunctionSpecification<T>
-    | Array<unknown>;
+    | ExpressionSpecificationArray;
 
 export type DataDrivenPropertyValueSpecification<T> =
       T
     | CameraFunctionSpecification<T>
     | SourceFunctionSpecification<T>
     | CompositeFunctionSpecification<T>
-    | Array<unknown>;
+    | ExpressionSpecificationArray;
 
 ${objectDeclaration('StyleSpecification', spec.$root)}
 

--- a/src/gl/context.ts
+++ b/src/gl/context.ts
@@ -7,7 +7,7 @@ import StencilMode from './stencil_mode';
 import ColorMode from './color_mode';
 import CullFaceMode from './cull_face_mode';
 import {deepEqual} from '../util/util';
-import {ClearColor, ClearDepth, ClearStencil, ColorMask, DepthMask, StencilMask, StencilFunc, StencilOp, StencilTest, DepthRange, DepthTest, DepthFunc, Blend, BlendFunc, BlendColor, BlendEquation, CullFace, CullFaceSide, FrontFace, Program, ActiveTextureUnit, Viewport, BindFramebuffer, BindRenderbuffer, BindTexture, BindVertexBuffer, BindElementBuffer, BindVertexArrayOES, PixelStoreUnpack, PixelStoreUnpackPremultiplyAlpha, PixelStoreUnpackFlipY} from './value';
+import {ClearColor, ClearDepth, ClearStencil, ColorMask, DepthMask, StencilMask, StencilFunc, StencilOp, StencilTest, DepthRange, DepthTest, DepthFunc, Blend, BlendFunc, BlendColor, BlendEquation, CullFace, CullFaceSide, FrontFace, ProgramValue, ActiveTextureUnit, Viewport, BindFramebuffer, BindRenderbuffer, BindTexture, BindVertexBuffer, BindElementBuffer, BindVertexArrayOES, PixelStoreUnpack, PixelStoreUnpackPremultiplyAlpha, PixelStoreUnpackFlipY} from './value';
 
 import type {TriangleIndexArray, LineIndexArray, LineStripIndexArray} from '../data/index_array_type';
 import type {
@@ -47,7 +47,7 @@ class Context {
     cullFace: CullFace;
     cullFaceSide: CullFaceSide;
     frontFace: FrontFace;
-    program: Program;
+    program: ProgramValue;
     activeTexture: ActiveTextureUnit;
     viewport: Viewport;
     bindFramebuffer: BindFramebuffer;
@@ -89,7 +89,7 @@ class Context {
         this.cullFace = new CullFace(this);
         this.cullFaceSide = new CullFaceSide(this);
         this.frontFace = new FrontFace(this);
-        this.program = new Program(this);
+        this.program = new ProgramValue(this);
         this.activeTexture = new ActiveTextureUnit(this);
         this.viewport = new Viewport(this);
         this.bindFramebuffer = new BindFramebuffer(this);

--- a/src/gl/state.test.ts
+++ b/src/gl/state.test.ts
@@ -1,4 +1,4 @@
-import {ClearColor, ClearDepth, ClearStencil, ColorMask, DepthMask, StencilMask, StencilFunc, StencilOp, StencilTest, DepthRange, DepthTest, DepthFunc, Blend, BlendFunc, BlendColor, Program, ActiveTextureUnit, Viewport, BindFramebuffer, BindRenderbuffer, BindTexture, BindVertexBuffer, BindElementBuffer, BindVertexArrayOES, PixelStoreUnpack, PixelStoreUnpackPremultiplyAlpha} from './value';
+import {ClearColor, ClearDepth, ClearStencil, ColorMask, DepthMask, StencilMask, StencilFunc, StencilOp, StencilTest, DepthRange, DepthTest, DepthFunc, Blend, BlendFunc, BlendColor, ProgramValue, ActiveTextureUnit, Viewport, BindFramebuffer, BindRenderbuffer, BindTexture, BindVertexBuffer, BindElementBuffer, BindVertexArrayOES, PixelStoreUnpack, PixelStoreUnpackPremultiplyAlpha} from './value';
 import Context from './context';
 import Color from '../style-spec/util/color';
 import {deepEqual} from '../util/util';
@@ -118,7 +118,7 @@ describe('BlendColor', () => {
 });
 
 describe('Program', () => {
-    valueTest(Program, {
+    valueTest(ProgramValue, {
         equality: (a, b) => a === b,
         setValue: context.gl.createProgram()
     });

--- a/src/gl/stencil_mode.ts
+++ b/src/gl/stencil_mode.ts
@@ -1,17 +1,17 @@
-import type {StencilOpConstant, StencilTest} from './types';
+import type {StencilOpConstant, StencilTestGL} from './types';
 
 const ALWAYS = 0x0207;
 const KEEP = 0x1E00;
 
 class StencilMode {
-    test: StencilTest;
+    test: StencilTestGL;
     ref: number;
     mask: number;
     fail: StencilOpConstant;
     depthFail: StencilOpConstant;
     pass: StencilOpConstant;
 
-    constructor(test: StencilTest, ref: number, mask: number, fail: StencilOpConstant,
+    constructor(test: StencilTestGL, ref: number, mask: number, fail: StencilOpConstant,
         depthFail: StencilOpConstant, pass: StencilOpConstant) {
         this.test = test;
         this.ref = ref;

--- a/src/gl/types.ts
+++ b/src/gl/types.ts
@@ -28,7 +28,7 @@ export type TextureUnitType = number;
 
 export type ViewportType = [number, number, number, number];
 
-export type StencilTest = {
+export type StencilTestGL = {
   func: WebGLRenderingContext['NEVER'];
   mask: 0;
 } | {

--- a/src/gl/value.ts
+++ b/src/gl/value.ts
@@ -16,7 +16,7 @@ import type {
     FrontFaceType,
 } from './types';
 
-export interface Value<T> {
+export interface IValue<T> {
   current: T;
   default: T;
   dirty: boolean;
@@ -25,7 +25,7 @@ export interface Value<T> {
   set(value: T): void;
 }
 
-class BaseValue<T> implements Value<T> {
+class BaseValue<T> implements IValue<T> {
     gl: WebGLRenderingContext;
     current: T;
     default: T;
@@ -314,7 +314,7 @@ export class FrontFace extends BaseValue<FrontFaceType> {
     }
 }
 
-export class Program extends BaseValue<WebGLProgram> {
+export class ProgramValue extends BaseValue<WebGLProgram> {
     getDefault(): WebGLProgram {
         return null;
     }

--- a/src/render/image_atlas.ts
+++ b/src/render/image_atlas.ts
@@ -5,16 +5,10 @@ import potpack from 'potpack';
 import type {StyleImage} from '../style/style_image';
 import type ImageManager from './image_manager';
 import type Texture from './texture';
+import type {Rect} from './glyph_atlas';
 
 const IMAGE_PADDING: number = 1;
 export {IMAGE_PADDING};
-
-type Rect = {
-  x: number;
-  y: number;
-  w: number;
-  h: number;
-};
 
 export class ImagePosition {
     paddedRect: Rect;

--- a/src/style-spec/types.ts
+++ b/src/style-spec/types.ts
@@ -42,19 +42,17 @@ export type CompositeFunctionSpecification<T> =
     | { type: 'interval',    stops: Array<[{zoom: number, value: number}, T]>, property: string, default?: T }
     | { type: 'categorical', stops: Array<[{zoom: number, value: string | number | boolean}, T]>, property: string, default?: T };
 
-export type ExpressionSpecification = Array<unknown>;
-
 export type PropertyValueSpecification<T> =
       T
     | CameraFunctionSpecification<T>
-    | ExpressionSpecification;
+    | Array<unknown>;
 
 export type DataDrivenPropertyValueSpecification<T> =
       T
     | CameraFunctionSpecification<T>
     | SourceFunctionSpecification<T>
     | CompositeFunctionSpecification<T>
-    | ExpressionSpecification;
+    | Array<unknown>;
 
 export type StyleSpecification = {
     "version": 8,
@@ -208,7 +206,7 @@ export type LineLayerSpecification = {
         "line-blur"?: DataDrivenPropertyValueSpecification<number>,
         "line-dasharray"?: PropertyValueSpecification<Array<number>>,
         "line-pattern"?: DataDrivenPropertyValueSpecification<ResolvedImageSpecification>,
-        "line-gradient"?: ExpressionSpecification
+        "line-gradient"?: Array<unknown>
     }
 };
 
@@ -327,7 +325,7 @@ export type HeatmapLayerSpecification = {
         "heatmap-radius"?: DataDrivenPropertyValueSpecification<number>,
         "heatmap-weight"?: DataDrivenPropertyValueSpecification<number>,
         "heatmap-intensity"?: PropertyValueSpecification<number>,
-        "heatmap-color"?: ExpressionSpecification,
+        "heatmap-color"?: Array<unknown>,
         "heatmap-opacity"?: PropertyValueSpecification<number>
     }
 };

--- a/src/style-spec/types.ts
+++ b/src/style-spec/types.ts
@@ -42,17 +42,19 @@ export type CompositeFunctionSpecification<T> =
     | { type: 'interval',    stops: Array<[{zoom: number, value: number}, T]>, property: string, default?: T }
     | { type: 'categorical', stops: Array<[{zoom: number, value: string | number | boolean}, T]>, property: string, default?: T };
 
+export type ExpressionSpecificationArray = Array<unknown>;
+
 export type PropertyValueSpecification<T> =
       T
     | CameraFunctionSpecification<T>
-    | Array<unknown>;
+    | ExpressionSpecificationArray;
 
 export type DataDrivenPropertyValueSpecification<T> =
       T
     | CameraFunctionSpecification<T>
     | SourceFunctionSpecification<T>
     | CompositeFunctionSpecification<T>
-    | Array<unknown>;
+    | ExpressionSpecificationArray;
 
 export type StyleSpecification = {
     "version": 8,
@@ -206,7 +208,7 @@ export type LineLayerSpecification = {
         "line-blur"?: DataDrivenPropertyValueSpecification<number>,
         "line-dasharray"?: PropertyValueSpecification<Array<number>>,
         "line-pattern"?: DataDrivenPropertyValueSpecification<ResolvedImageSpecification>,
-        "line-gradient"?: Array<unknown>
+        "line-gradient"?: ExpressionSpecificationArray
     }
 };
 
@@ -325,7 +327,7 @@ export type HeatmapLayerSpecification = {
         "heatmap-radius"?: DataDrivenPropertyValueSpecification<number>,
         "heatmap-weight"?: DataDrivenPropertyValueSpecification<number>,
         "heatmap-intensity"?: PropertyValueSpecification<number>,
-        "heatmap-color"?: Array<unknown>,
+        "heatmap-color"?: ExpressionSpecificationArray,
         "heatmap-opacity"?: PropertyValueSpecification<number>
     }
 };

--- a/src/style/load_glyph_range.ts
+++ b/src/style/load_glyph_range.ts
@@ -6,7 +6,7 @@ import type {StyleGlyph} from './style_glyph';
 import type {RequestManager} from '../util/request_manager';
 import type {Callback} from '../types/callback';
 
-export default function (fontstack: string,
+export default function loadGlyphRange(fontstack: string,
                            range: number,
                            urlTemplate: string,
                            requestManager: RequestManager,

--- a/src/style/style_layer/background_style_layer.ts
+++ b/src/style/style_layer/background_style_layer.ts
@@ -1,15 +1,15 @@
 import StyleLayer from '../style_layer';
 
-import properties, {PaintPropsPossiblyEvaluated} from './background_style_layer_properties';
+import properties, {BackgroundPaintPropsPossiblyEvaluated} from './background_style_layer_properties';
 import {Transitionable, Transitioning, PossiblyEvaluated} from '../properties';
 
-import type {PaintProps} from './background_style_layer_properties';
+import type {BackgroundPaintProps} from './background_style_layer_properties';
 import type {LayerSpecification} from '../../style-spec/types';
 
 class BackgroundStyleLayer extends StyleLayer {
-    _transitionablePaint: Transitionable<PaintProps>;
-    _transitioningPaint: Transitioning<PaintProps>;
-    paint: PossiblyEvaluated<PaintProps, PaintPropsPossiblyEvaluated>;
+    _transitionablePaint: Transitionable<BackgroundPaintProps>;
+    _transitioningPaint: Transitioning<BackgroundPaintProps>;
+    paint: PossiblyEvaluated<BackgroundPaintProps, BackgroundPaintPropsPossiblyEvaluated>;
 
     constructor(layer: LayerSpecification) {
         super(layer, properties);

--- a/src/style/style_layer/background_style_layer_properties.ts
+++ b/src/style/style_layer/background_style_layer_properties.ts
@@ -22,24 +22,24 @@ import type ResolvedImage from '../../style-spec/expression/types/resolved_image
 import {StylePropertySpecification} from '../../style-spec/style-spec';
 
 
-export type PaintProps = {
+export type BackgroundPaintProps = {
     "background-color": DataConstantProperty<Color>,
     "background-pattern": CrossFadedProperty<ResolvedImage>,
     "background-opacity": DataConstantProperty<number>,
 };
 
-export type PaintPropsPossiblyEvaluated = {
+export type BackgroundPaintPropsPossiblyEvaluated = {
     "background-color": Color,
     "background-pattern": CrossFaded<ResolvedImage>,
     "background-opacity": number,
 };
 
-const paint: Properties<PaintProps> = new Properties({
+const paint: Properties<BackgroundPaintProps> = new Properties({
     "background-color": new DataConstantProperty(styleSpec["paint_background"]["background-color"] as any as StylePropertySpecification),
     "background-pattern": new CrossFadedProperty(styleSpec["paint_background"]["background-pattern"] as any as StylePropertySpecification),
     "background-opacity": new DataConstantProperty(styleSpec["paint_background"]["background-opacity"] as any as StylePropertySpecification),
 });
 
 export default ({ paint } as {
-    paint: Properties<PaintProps>
+    paint: Properties<BackgroundPaintProps>
 });

--- a/src/style/style_layer/circle_style_layer.ts
+++ b/src/style/style_layer/circle_style_layer.ts
@@ -3,24 +3,24 @@ import StyleLayer from '../style_layer';
 import CircleBucket from '../../data/bucket/circle_bucket';
 import {polygonIntersectsBufferedPoint} from '../../util/intersection_tests';
 import {getMaximumPaintValue, translateDistance, translate} from '../query_utils';
-import properties, {LayoutPropsPossiblyEvaluated, PaintPropsPossiblyEvaluated} from './circle_style_layer_properties';
+import properties, {CircleLayoutPropsPossiblyEvaluated, CirclePaintPropsPossiblyEvaluated} from './circle_style_layer_properties';
 import {Transitionable, Transitioning, Layout, PossiblyEvaluated} from '../properties';
 import {mat4, vec4} from 'gl-matrix';
 import Point from '../../util/point';
 import type {FeatureState} from '../../style-spec/expression';
 import type Transform from '../../geo/transform';
 import type {Bucket, BucketParameters} from '../../data/bucket';
-import type {LayoutProps, PaintProps} from './circle_style_layer_properties';
+import type {CircleLayoutProps, CirclePaintProps} from './circle_style_layer_properties';
 import type {LayerSpecification} from '../../style-spec/types';
 import type {VectorTileFeature} from '@mapbox/vector-tile';
 
 class CircleStyleLayer extends StyleLayer {
-    _unevaluatedLayout: Layout<LayoutProps>;
-    layout: PossiblyEvaluated<LayoutProps, LayoutPropsPossiblyEvaluated>;
+    _unevaluatedLayout: Layout<CircleLayoutProps>;
+    layout: PossiblyEvaluated<CircleLayoutProps, CircleLayoutPropsPossiblyEvaluated>;
 
-    _transitionablePaint: Transitionable<PaintProps>;
-    _transitioningPaint: Transitioning<PaintProps>;
-    paint: PossiblyEvaluated<PaintProps, PaintPropsPossiblyEvaluated>;
+    _transitionablePaint: Transitionable<CirclePaintProps>;
+    _transitioningPaint: Transitioning<CirclePaintProps>;
+    paint: PossiblyEvaluated<CirclePaintProps, CirclePaintPropsPossiblyEvaluated>;
 
     constructor(layer: LayerSpecification) {
         super(layer, properties);

--- a/src/style/style_layer/circle_style_layer_properties.ts
+++ b/src/style/style_layer/circle_style_layer_properties.ts
@@ -21,19 +21,19 @@ import type Formatted from '../../style-spec/expression/types/formatted';
 import type ResolvedImage from '../../style-spec/expression/types/resolved_image';
 import {StylePropertySpecification} from '../../style-spec/style-spec';
 
-export type LayoutProps = {
+export type CircleLayoutProps = {
     "circle-sort-key": DataDrivenProperty<number>,
 };
 
-export type LayoutPropsPossiblyEvaluated = {
+export type CircleLayoutPropsPossiblyEvaluated = {
     "circle-sort-key": PossiblyEvaluatedPropertyValue<number>,
 };
 
-const layout: Properties<LayoutProps> = new Properties({
+const layout: Properties<CircleLayoutProps> = new Properties({
     "circle-sort-key": new DataDrivenProperty(styleSpec["layout_circle"]["circle-sort-key"] as any as StylePropertySpecification),
 });
 
-export type PaintProps = {
+export type CirclePaintProps = {
     "circle-radius": DataDrivenProperty<number>,
     "circle-color": DataDrivenProperty<Color>,
     "circle-blur": DataDrivenProperty<number>,
@@ -47,7 +47,7 @@ export type PaintProps = {
     "circle-stroke-opacity": DataDrivenProperty<number>,
 };
 
-export type PaintPropsPossiblyEvaluated = {
+export type CirclePaintPropsPossiblyEvaluated = {
     "circle-radius": PossiblyEvaluatedPropertyValue<number>,
     "circle-color": PossiblyEvaluatedPropertyValue<Color>,
     "circle-blur": PossiblyEvaluatedPropertyValue<number>,
@@ -61,7 +61,7 @@ export type PaintPropsPossiblyEvaluated = {
     "circle-stroke-opacity": PossiblyEvaluatedPropertyValue<number>,
 };
 
-const paint: Properties<PaintProps> = new Properties({
+const paint: Properties<CirclePaintProps> = new Properties({
     "circle-radius": new DataDrivenProperty(styleSpec["paint_circle"]["circle-radius"] as any as StylePropertySpecification),
     "circle-color": new DataDrivenProperty(styleSpec["paint_circle"]["circle-color"] as any as StylePropertySpecification),
     "circle-blur": new DataDrivenProperty(styleSpec["paint_circle"]["circle-blur"] as any as StylePropertySpecification),
@@ -76,6 +76,6 @@ const paint: Properties<PaintProps> = new Properties({
 });
 
 export default ({ paint, layout } as {
-    paint: Properties<PaintProps>,
-    layout: Properties<LayoutProps>
+    paint: Properties<CirclePaintProps>,
+    layout: Properties<CircleLayoutProps>
 });

--- a/src/style/style_layer/fill_extrusion_style_layer.ts
+++ b/src/style/style_layer/fill_extrusion_style_layer.ts
@@ -3,13 +3,13 @@ import StyleLayer from '../style_layer';
 import FillExtrusionBucket from '../../data/bucket/fill_extrusion_bucket';
 import {polygonIntersectsPolygon, polygonIntersectsMultiPolygon} from '../../util/intersection_tests';
 import {translateDistance, translate} from '../query_utils';
-import properties, {PaintPropsPossiblyEvaluated} from './fill_extrusion_style_layer_properties';
+import properties, {FillExtrusionPaintPropsPossiblyEvaluated} from './fill_extrusion_style_layer_properties';
 import {Transitionable, Transitioning, PossiblyEvaluated} from '../properties';
 import {mat4, vec4} from 'gl-matrix';
 import Point from '../../util/point';
 import type {FeatureState} from '../../style-spec/expression';
 import type {BucketParameters} from '../../data/bucket';
-import type {PaintProps} from './fill_extrusion_style_layer_properties';
+import type {FillExtrusionPaintProps} from './fill_extrusion_style_layer_properties';
 import type Transform from '../../geo/transform';
 import type {LayerSpecification} from '../../style-spec/types';
 import type {VectorTileFeature} from '@mapbox/vector-tile';
@@ -19,9 +19,9 @@ export class Point3D extends Point {
 }
 
 class FillExtrusionStyleLayer extends StyleLayer {
-    _transitionablePaint: Transitionable<PaintProps>;
-    _transitioningPaint: Transitioning<PaintProps>;
-    paint: PossiblyEvaluated<PaintProps, PaintPropsPossiblyEvaluated>;
+    _transitionablePaint: Transitionable<FillExtrusionPaintProps>;
+    _transitioningPaint: Transitioning<FillExtrusionPaintProps>;
+    paint: PossiblyEvaluated<FillExtrusionPaintProps, FillExtrusionPaintPropsPossiblyEvaluated>;
 
     constructor(layer: LayerSpecification) {
         super(layer, properties);

--- a/src/style/style_layer/fill_extrusion_style_layer_properties.ts
+++ b/src/style/style_layer/fill_extrusion_style_layer_properties.ts
@@ -22,7 +22,7 @@ import type ResolvedImage from '../../style-spec/expression/types/resolved_image
 import {StylePropertySpecification} from '../../style-spec/style-spec';
 
 
-export type PaintProps = {
+export type FillExtrusionPaintProps = {
     "fill-extrusion-opacity": DataConstantProperty<number>,
     "fill-extrusion-color": DataDrivenProperty<Color>,
     "fill-extrusion-translate": DataConstantProperty<[number, number]>,
@@ -33,7 +33,7 @@ export type PaintProps = {
     "fill-extrusion-vertical-gradient": DataConstantProperty<boolean>,
 };
 
-export type PaintPropsPossiblyEvaluated = {
+export type FillExtrusionPaintPropsPossiblyEvaluated = {
     "fill-extrusion-opacity": number,
     "fill-extrusion-color": PossiblyEvaluatedPropertyValue<Color>,
     "fill-extrusion-translate": [number, number],
@@ -44,7 +44,7 @@ export type PaintPropsPossiblyEvaluated = {
     "fill-extrusion-vertical-gradient": boolean,
 };
 
-const paint: Properties<PaintProps> = new Properties({
+const paint: Properties<FillExtrusionPaintProps> = new Properties({
     "fill-extrusion-opacity": new DataConstantProperty(styleSpec["paint_fill-extrusion"]["fill-extrusion-opacity"] as any as StylePropertySpecification),
     "fill-extrusion-color": new DataDrivenProperty(styleSpec["paint_fill-extrusion"]["fill-extrusion-color"] as any as StylePropertySpecification),
     "fill-extrusion-translate": new DataConstantProperty(styleSpec["paint_fill-extrusion"]["fill-extrusion-translate"] as any as StylePropertySpecification),
@@ -56,5 +56,5 @@ const paint: Properties<PaintProps> = new Properties({
 });
 
 export default ({ paint } as {
-    paint: Properties<PaintProps>
+    paint: Properties<FillExtrusionPaintProps>
 });

--- a/src/style/style_layer/fill_style_layer.ts
+++ b/src/style/style_layer/fill_style_layer.ts
@@ -3,25 +3,25 @@ import StyleLayer from '../style_layer';
 import FillBucket from '../../data/bucket/fill_bucket';
 import {polygonIntersectsMultiPolygon} from '../../util/intersection_tests';
 import {translateDistance, translate} from '../query_utils';
-import properties, {LayoutPropsPossiblyEvaluated, PaintPropsPossiblyEvaluated} from './fill_style_layer_properties';
+import properties, {FillLayoutPropsPossiblyEvaluated, FillPaintPropsPossiblyEvaluated} from './fill_style_layer_properties';
 import {Transitionable, Transitioning, Layout, PossiblyEvaluated} from '../properties';
 
 import type {FeatureState} from '../../style-spec/expression';
 import type {BucketParameters} from '../../data/bucket';
 import type Point from '../../util/point';
-import type {LayoutProps, PaintProps} from './fill_style_layer_properties';
+import type {FillLayoutProps, FillPaintProps} from './fill_style_layer_properties';
 import type EvaluationParameters from '../evaluation_parameters';
 import type Transform from '../../geo/transform';
 import type {LayerSpecification} from '../../style-spec/types';
 import type {VectorTileFeature} from '@mapbox/vector-tile';
 
 class FillStyleLayer extends StyleLayer {
-    _unevaluatedLayout: Layout<LayoutProps>;
-    layout: PossiblyEvaluated<LayoutProps, LayoutPropsPossiblyEvaluated>;
+    _unevaluatedLayout: Layout<FillLayoutProps>;
+    layout: PossiblyEvaluated<FillLayoutProps, FillLayoutPropsPossiblyEvaluated>;
 
-    _transitionablePaint: Transitionable<PaintProps>;
-    _transitioningPaint: Transitioning<PaintProps>;
-    paint: PossiblyEvaluated<PaintProps, PaintPropsPossiblyEvaluated>;
+    _transitionablePaint: Transitionable<FillPaintProps>;
+    _transitioningPaint: Transitioning<FillPaintProps>;
+    paint: PossiblyEvaluated<FillPaintProps, FillPaintPropsPossiblyEvaluated>;
 
     constructor(layer: LayerSpecification) {
         super(layer, properties);

--- a/src/style/style_layer/fill_style_layer_properties.ts
+++ b/src/style/style_layer/fill_style_layer_properties.ts
@@ -21,19 +21,19 @@ import type Formatted from '../../style-spec/expression/types/formatted';
 import type ResolvedImage from '../../style-spec/expression/types/resolved_image';
 import {StylePropertySpecification} from '../../style-spec/style-spec';
 
-export type LayoutProps = {
+export type FillLayoutProps = {
     "fill-sort-key": DataDrivenProperty<number>,
 };
 
-export type LayoutPropsPossiblyEvaluated = {
+export type FillLayoutPropsPossiblyEvaluated = {
     "fill-sort-key": PossiblyEvaluatedPropertyValue<number>,
 };
 
-const layout: Properties<LayoutProps> = new Properties({
+const layout: Properties<FillLayoutProps> = new Properties({
     "fill-sort-key": new DataDrivenProperty(styleSpec["layout_fill"]["fill-sort-key"] as any as StylePropertySpecification),
 });
 
-export type PaintProps = {
+export type FillPaintProps = {
     "fill-antialias": DataConstantProperty<boolean>,
     "fill-opacity": DataDrivenProperty<number>,
     "fill-color": DataDrivenProperty<Color>,
@@ -43,7 +43,7 @@ export type PaintProps = {
     "fill-pattern": CrossFadedDataDrivenProperty<ResolvedImage>,
 };
 
-export type PaintPropsPossiblyEvaluated = {
+export type FillPaintPropsPossiblyEvaluated = {
     "fill-antialias": boolean,
     "fill-opacity": PossiblyEvaluatedPropertyValue<number>,
     "fill-color": PossiblyEvaluatedPropertyValue<Color>,
@@ -53,7 +53,7 @@ export type PaintPropsPossiblyEvaluated = {
     "fill-pattern": PossiblyEvaluatedPropertyValue<CrossFaded<ResolvedImage>>,
 };
 
-const paint: Properties<PaintProps> = new Properties({
+const paint: Properties<FillPaintProps> = new Properties({
     "fill-antialias": new DataConstantProperty(styleSpec["paint_fill"]["fill-antialias"] as any as StylePropertySpecification),
     "fill-opacity": new DataDrivenProperty(styleSpec["paint_fill"]["fill-opacity"] as any as StylePropertySpecification),
     "fill-color": new DataDrivenProperty(styleSpec["paint_fill"]["fill-color"] as any as StylePropertySpecification),
@@ -64,6 +64,6 @@ const paint: Properties<PaintProps> = new Properties({
 });
 
 export default ({ paint, layout } as {
-    paint: Properties<PaintProps>,
-    layout: Properties<LayoutProps>
+    paint: Properties<FillPaintProps>,
+    layout: Properties<FillLayoutProps>
 });

--- a/src/style/style_layer/heatmap_style_layer.ts
+++ b/src/style/style_layer/heatmap_style_layer.ts
@@ -2,13 +2,13 @@ import StyleLayer from '../style_layer';
 
 import HeatmapBucket from '../../data/bucket/heatmap_bucket';
 import {RGBAImage} from '../../util/image';
-import properties, {PaintPropsPossiblyEvaluated} from './heatmap_style_layer_properties';
+import properties, {HeatmapPaintPropsPossiblyEvaluated} from './heatmap_style_layer_properties';
 import {renderColorRamp} from '../../util/color_ramp';
 import {Transitionable, Transitioning, PossiblyEvaluated} from '../properties';
 
 import type Texture from '../../render/texture';
 import type Framebuffer from '../../gl/framebuffer';
-import type {PaintProps} from './heatmap_style_layer_properties';
+import type {HeatmapPaintProps} from './heatmap_style_layer_properties';
 import type {LayerSpecification} from '../../style-spec/types';
 
 class HeatmapStyleLayer extends StyleLayer {
@@ -17,9 +17,9 @@ class HeatmapStyleLayer extends StyleLayer {
     colorRamp: RGBAImage;
     colorRampTexture: Texture;
 
-    _transitionablePaint: Transitionable<PaintProps>;
-    _transitioningPaint: Transitioning<PaintProps>;
-    paint: PossiblyEvaluated<PaintProps, PaintPropsPossiblyEvaluated>;
+    _transitionablePaint: Transitionable<HeatmapPaintProps>;
+    _transitioningPaint: Transitioning<HeatmapPaintProps>;
+    paint: PossiblyEvaluated<HeatmapPaintProps, HeatmapPaintPropsPossiblyEvaluated>;
 
     createBucket(options: any) {
         return new HeatmapBucket(options);

--- a/src/style/style_layer/heatmap_style_layer_properties.ts
+++ b/src/style/style_layer/heatmap_style_layer_properties.ts
@@ -22,7 +22,7 @@ import type ResolvedImage from '../../style-spec/expression/types/resolved_image
 import {StylePropertySpecification} from '../../style-spec/style-spec';
 
 
-export type PaintProps = {
+export type HeatmapPaintProps = {
     "heatmap-radius": DataDrivenProperty<number>,
     "heatmap-weight": DataDrivenProperty<number>,
     "heatmap-intensity": DataConstantProperty<number>,
@@ -30,7 +30,7 @@ export type PaintProps = {
     "heatmap-opacity": DataConstantProperty<number>,
 };
 
-export type PaintPropsPossiblyEvaluated = {
+export type HeatmapPaintPropsPossiblyEvaluated = {
     "heatmap-radius": PossiblyEvaluatedPropertyValue<number>,
     "heatmap-weight": PossiblyEvaluatedPropertyValue<number>,
     "heatmap-intensity": number,
@@ -38,7 +38,7 @@ export type PaintPropsPossiblyEvaluated = {
     "heatmap-opacity": number,
 };
 
-const paint: Properties<PaintProps> = new Properties({
+const paint: Properties<HeatmapPaintProps> = new Properties({
     "heatmap-radius": new DataDrivenProperty(styleSpec["paint_heatmap"]["heatmap-radius"] as any as StylePropertySpecification),
     "heatmap-weight": new DataDrivenProperty(styleSpec["paint_heatmap"]["heatmap-weight"] as any as StylePropertySpecification),
     "heatmap-intensity": new DataConstantProperty(styleSpec["paint_heatmap"]["heatmap-intensity"] as any as StylePropertySpecification),
@@ -47,5 +47,5 @@ const paint: Properties<PaintProps> = new Properties({
 });
 
 export default ({ paint } as {
-    paint: Properties<PaintProps>
+    paint: Properties<HeatmapPaintProps>
 });

--- a/src/style/style_layer/hillshade_style_layer.ts
+++ b/src/style/style_layer/hillshade_style_layer.ts
@@ -1,15 +1,15 @@
 import StyleLayer from '../style_layer';
 
-import properties, {PaintPropsPossiblyEvaluated} from './hillshade_style_layer_properties';
+import properties, {HillshadePaintPropsPossiblyEvaluated} from './hillshade_style_layer_properties';
 import {Transitionable, Transitioning, PossiblyEvaluated} from '../properties';
 
-import type {PaintProps} from './hillshade_style_layer_properties';
+import type {HillshadePaintProps} from './hillshade_style_layer_properties';
 import type {LayerSpecification} from '../../style-spec/types';
 
 class HillshadeStyleLayer extends StyleLayer {
-    _transitionablePaint: Transitionable<PaintProps>;
-    _transitioningPaint: Transitioning<PaintProps>;
-    paint: PossiblyEvaluated<PaintProps, PaintPropsPossiblyEvaluated>;
+    _transitionablePaint: Transitionable<HillshadePaintProps>;
+    _transitioningPaint: Transitioning<HillshadePaintProps>;
+    paint: PossiblyEvaluated<HillshadePaintProps, HillshadePaintPropsPossiblyEvaluated>;
 
     constructor(layer: LayerSpecification) {
         super(layer, properties);

--- a/src/style/style_layer/hillshade_style_layer_properties.ts
+++ b/src/style/style_layer/hillshade_style_layer_properties.ts
@@ -22,7 +22,7 @@ import type ResolvedImage from '../../style-spec/expression/types/resolved_image
 import {StylePropertySpecification} from '../../style-spec/style-spec';
 
 
-export type PaintProps = {
+export type HillshadePaintProps = {
     "hillshade-illumination-direction": DataConstantProperty<number>,
     "hillshade-illumination-anchor": DataConstantProperty<"map" | "viewport">,
     "hillshade-exaggeration": DataConstantProperty<number>,
@@ -31,7 +31,7 @@ export type PaintProps = {
     "hillshade-accent-color": DataConstantProperty<Color>,
 };
 
-export type PaintPropsPossiblyEvaluated = {
+export type HillshadePaintPropsPossiblyEvaluated = {
     "hillshade-illumination-direction": number,
     "hillshade-illumination-anchor": "map" | "viewport",
     "hillshade-exaggeration": number,
@@ -40,7 +40,7 @@ export type PaintPropsPossiblyEvaluated = {
     "hillshade-accent-color": Color,
 };
 
-const paint: Properties<PaintProps> = new Properties({
+const paint: Properties<HillshadePaintProps> = new Properties({
     "hillshade-illumination-direction": new DataConstantProperty(styleSpec["paint_hillshade"]["hillshade-illumination-direction"] as any as StylePropertySpecification),
     "hillshade-illumination-anchor": new DataConstantProperty(styleSpec["paint_hillshade"]["hillshade-illumination-anchor"] as any as StylePropertySpecification),
     "hillshade-exaggeration": new DataConstantProperty(styleSpec["paint_hillshade"]["hillshade-exaggeration"] as any as StylePropertySpecification),
@@ -50,5 +50,5 @@ const paint: Properties<PaintProps> = new Properties({
 });
 
 export default ({ paint } as {
-    paint: Properties<PaintProps>
+    paint: Properties<HillshadePaintProps>
 });

--- a/src/style/style_layer/line_style_layer.ts
+++ b/src/style/style_layer/line_style_layer.ts
@@ -4,7 +4,7 @@ import StyleLayer from '../style_layer';
 import LineBucket from '../../data/bucket/line_bucket';
 import {polygonIntersectsBufferedMultiLine} from '../../util/intersection_tests';
 import {getMaximumPaintValue, translateDistance, translate} from '../query_utils';
-import properties, {LayoutPropsPossiblyEvaluated, PaintPropsPossiblyEvaluated} from './line_style_layer_properties';
+import properties, {LineLayoutPropsPossiblyEvaluated, LinePaintPropsPossiblyEvaluated} from './line_style_layer_properties';
 import {extend} from '../../util/util';
 import EvaluationParameters from '../evaluation_parameters';
 import {Transitionable, Transitioning, Layout, PossiblyEvaluated, DataDrivenProperty} from '../properties';
@@ -12,7 +12,7 @@ import {Transitionable, Transitioning, Layout, PossiblyEvaluated, DataDrivenProp
 import Step from '../../style-spec/expression/definitions/step';
 import type {FeatureState, ZoomConstantExpression} from '../../style-spec/expression';
 import type {Bucket, BucketParameters} from '../../data/bucket';
-import type {LayoutProps, PaintProps} from './line_style_layer_properties';
+import type {LineLayoutProps, LinePaintProps} from './line_style_layer_properties';
 import type Transform from '../../geo/transform';
 import type {LayerSpecification} from '../../style-spec/types';
 import type {VectorTileFeature} from '@mapbox/vector-tile';
@@ -40,15 +40,15 @@ const lineFloorwidthProperty = new LineFloorwidthProperty(properties.paint.prope
 lineFloorwidthProperty.useIntegerZoom = true;
 
 class LineStyleLayer extends StyleLayer {
-    _unevaluatedLayout: Layout<LayoutProps>;
-    layout: PossiblyEvaluated<LayoutProps, LayoutPropsPossiblyEvaluated>;
+    _unevaluatedLayout: Layout<LineLayoutProps>;
+    layout: PossiblyEvaluated<LineLayoutProps, LineLayoutPropsPossiblyEvaluated>;
 
     gradientVersion: number;
     stepInterpolant: boolean;
 
-    _transitionablePaint: Transitionable<PaintProps>;
-    _transitioningPaint: Transitioning<PaintProps>;
-    paint: PossiblyEvaluated<PaintProps, PaintPropsPossiblyEvaluated>;
+    _transitionablePaint: Transitionable<LinePaintProps>;
+    _transitioningPaint: Transitioning<LinePaintProps>;
+    paint: PossiblyEvaluated<LinePaintProps, LinePaintPropsPossiblyEvaluated>;
 
     constructor(layer: LayerSpecification) {
         super(layer, properties);

--- a/src/style/style_layer/line_style_layer_properties.ts
+++ b/src/style/style_layer/line_style_layer_properties.ts
@@ -21,7 +21,7 @@ import type Formatted from '../../style-spec/expression/types/formatted';
 import type ResolvedImage from '../../style-spec/expression/types/resolved_image';
 import {StylePropertySpecification} from '../../style-spec/style-spec';
 
-export type LayoutProps = {
+export type LineLayoutProps = {
     "line-cap": DataConstantProperty<"butt" | "round" | "square">,
     "line-join": DataDrivenProperty<"bevel" | "round" | "miter">,
     "line-miter-limit": DataConstantProperty<number>,
@@ -29,7 +29,7 @@ export type LayoutProps = {
     "line-sort-key": DataDrivenProperty<number>,
 };
 
-export type LayoutPropsPossiblyEvaluated = {
+export type LineLayoutPropsPossiblyEvaluated = {
     "line-cap": "butt" | "round" | "square",
     "line-join": PossiblyEvaluatedPropertyValue<"bevel" | "round" | "miter">,
     "line-miter-limit": number,
@@ -37,7 +37,7 @@ export type LayoutPropsPossiblyEvaluated = {
     "line-sort-key": PossiblyEvaluatedPropertyValue<number>,
 };
 
-const layout: Properties<LayoutProps> = new Properties({
+const layout: Properties<LineLayoutProps> = new Properties({
     "line-cap": new DataConstantProperty(styleSpec["layout_line"]["line-cap"] as any as StylePropertySpecification),
     "line-join": new DataDrivenProperty(styleSpec["layout_line"]["line-join"] as any as StylePropertySpecification),
     "line-miter-limit": new DataConstantProperty(styleSpec["layout_line"]["line-miter-limit"] as any as StylePropertySpecification),
@@ -45,7 +45,7 @@ const layout: Properties<LayoutProps> = new Properties({
     "line-sort-key": new DataDrivenProperty(styleSpec["layout_line"]["line-sort-key"] as any as StylePropertySpecification),
 });
 
-export type PaintProps = {
+export type LinePaintProps = {
     "line-opacity": DataDrivenProperty<number>,
     "line-color": DataDrivenProperty<Color>,
     "line-translate": DataConstantProperty<[number, number]>,
@@ -59,7 +59,7 @@ export type PaintProps = {
     "line-gradient": ColorRampProperty,
 };
 
-export type PaintPropsPossiblyEvaluated = {
+export type LinePaintPropsPossiblyEvaluated = {
     "line-opacity": PossiblyEvaluatedPropertyValue<number>,
     "line-color": PossiblyEvaluatedPropertyValue<Color>,
     "line-translate": [number, number],
@@ -73,7 +73,7 @@ export type PaintPropsPossiblyEvaluated = {
     "line-gradient": ColorRampProperty,
 };
 
-const paint: Properties<PaintProps> = new Properties({
+const paint: Properties<LinePaintProps> = new Properties({
     "line-opacity": new DataDrivenProperty(styleSpec["paint_line"]["line-opacity"] as any as StylePropertySpecification),
     "line-color": new DataDrivenProperty(styleSpec["paint_line"]["line-color"] as any as StylePropertySpecification),
     "line-translate": new DataConstantProperty(styleSpec["paint_line"]["line-translate"] as any as StylePropertySpecification),
@@ -88,6 +88,6 @@ const paint: Properties<PaintProps> = new Properties({
 });
 
 export default ({ paint, layout } as {
-    paint: Properties<PaintProps>,
-    layout: Properties<LayoutProps>
+    paint: Properties<LinePaintProps>,
+    layout: Properties<LineLayoutProps>
 });

--- a/src/style/style_layer/raster_style_layer.ts
+++ b/src/style/style_layer/raster_style_layer.ts
@@ -1,15 +1,15 @@
 import StyleLayer from '../style_layer';
 
-import properties, {PaintPropsPossiblyEvaluated} from './raster_style_layer_properties';
+import properties, {RasterPaintPropsPossiblyEvaluated} from './raster_style_layer_properties';
 import {Transitionable, Transitioning, PossiblyEvaluated} from '../properties';
 
-import type {PaintProps} from './raster_style_layer_properties';
+import type {RasterPaintProps} from './raster_style_layer_properties';
 import type {LayerSpecification} from '../../style-spec/types';
 
 class RasterStyleLayer extends StyleLayer {
-    _transitionablePaint: Transitionable<PaintProps>;
-    _transitioningPaint: Transitioning<PaintProps>;
-    paint: PossiblyEvaluated<PaintProps, PaintPropsPossiblyEvaluated>;
+    _transitionablePaint: Transitionable<RasterPaintProps>;
+    _transitioningPaint: Transitioning<RasterPaintProps>;
+    paint: PossiblyEvaluated<RasterPaintProps, RasterPaintPropsPossiblyEvaluated>;
 
     constructor(layer: LayerSpecification) {
         super(layer, properties);

--- a/src/style/style_layer/raster_style_layer_properties.ts
+++ b/src/style/style_layer/raster_style_layer_properties.ts
@@ -22,7 +22,7 @@ import type ResolvedImage from '../../style-spec/expression/types/resolved_image
 import {StylePropertySpecification} from '../../style-spec/style-spec';
 
 
-export type PaintProps = {
+export type RasterPaintProps = {
     "raster-opacity": DataConstantProperty<number>,
     "raster-hue-rotate": DataConstantProperty<number>,
     "raster-brightness-min": DataConstantProperty<number>,
@@ -33,7 +33,7 @@ export type PaintProps = {
     "raster-fade-duration": DataConstantProperty<number>,
 };
 
-export type PaintPropsPossiblyEvaluated = {
+export type RasterPaintPropsPossiblyEvaluated = {
     "raster-opacity": number,
     "raster-hue-rotate": number,
     "raster-brightness-min": number,
@@ -44,7 +44,7 @@ export type PaintPropsPossiblyEvaluated = {
     "raster-fade-duration": number,
 };
 
-const paint: Properties<PaintProps> = new Properties({
+const paint: Properties<RasterPaintProps> = new Properties({
     "raster-opacity": new DataConstantProperty(styleSpec["paint_raster"]["raster-opacity"] as any as StylePropertySpecification),
     "raster-hue-rotate": new DataConstantProperty(styleSpec["paint_raster"]["raster-hue-rotate"] as any as StylePropertySpecification),
     "raster-brightness-min": new DataConstantProperty(styleSpec["paint_raster"]["raster-brightness-min"] as any as StylePropertySpecification),
@@ -56,5 +56,5 @@ const paint: Properties<PaintProps> = new Properties({
 });
 
 export default ({ paint } as {
-    paint: Properties<PaintProps>
+    paint: Properties<RasterPaintProps>
 });

--- a/src/style/style_layer/symbol_style_layer.ts
+++ b/src/style/style_layer/symbol_style_layer.ts
@@ -3,7 +3,7 @@ import StyleLayer from '../style_layer';
 import assert from 'assert';
 import SymbolBucket from '../../data/bucket/symbol_bucket';
 import resolveTokens from '../../util/resolve_tokens';
-import properties, {LayoutPropsPossiblyEvaluated, PaintPropsPossiblyEvaluated} from './symbol_style_layer_properties';
+import properties, {SymbolLayoutPropsPossiblyEvaluated, SymbolPaintPropsPossiblyEvaluated} from './symbol_style_layer_properties';
 
 import {
     Transitionable,
@@ -22,7 +22,7 @@ import {
 } from '../../style-spec/expression';
 
 import type {BucketParameters} from '../../data/bucket';
-import type {LayoutProps, PaintProps} from './symbol_style_layer_properties';
+import type {SymbolLayoutProps, SymbolPaintProps} from './symbol_style_layer_properties';
 import type EvaluationParameters from '../evaluation_parameters';
 import type {LayerSpecification} from '../../style-spec/types';
 import type {Feature, SourceExpression, CompositeExpression} from '../../style-spec/expression';
@@ -36,12 +36,12 @@ import FormatExpression from '../../style-spec/expression/definitions/format';
 import Literal from '../../style-spec/expression/definitions/literal';
 
 class SymbolStyleLayer extends StyleLayer {
-    _unevaluatedLayout: Layout<LayoutProps>;
-    layout: PossiblyEvaluated<LayoutProps, LayoutPropsPossiblyEvaluated>;
+    _unevaluatedLayout: Layout<SymbolLayoutProps>;
+    layout: PossiblyEvaluated<SymbolLayoutProps, SymbolLayoutPropsPossiblyEvaluated>;
 
-    _transitionablePaint: Transitionable<PaintProps>;
-    _transitioningPaint: Transitioning<PaintProps>;
-    paint: PossiblyEvaluated<PaintProps, PaintPropsPossiblyEvaluated>;
+    _transitionablePaint: Transitionable<SymbolPaintProps>;
+    _transitioningPaint: Transitioning<SymbolPaintProps>;
+    paint: PossiblyEvaluated<SymbolPaintProps, SymbolPaintPropsPossiblyEvaluated>;
 
     constructor(layer: LayerSpecification) {
         super(layer, properties);
@@ -119,7 +119,7 @@ class SymbolStyleLayer extends StyleLayer {
             if (!SymbolStyleLayer.hasPaintOverride(this.layout, overridable)) {
                 continue;
             }
-            const overriden = this.paint.get(overridable as keyof PaintPropsPossiblyEvaluated) as PossiblyEvaluatedPropertyValue<number>;
+            const overriden = this.paint.get(overridable as keyof SymbolPaintPropsPossiblyEvaluated) as PossiblyEvaluatedPropertyValue<number>;
             const override = new FormatSectionOverride(overriden);
             const styleExpression = new StyleExpression(override, overriden.property.specification);
             let expression = null;
@@ -144,7 +144,7 @@ class SymbolStyleLayer extends StyleLayer {
         return SymbolStyleLayer.hasPaintOverride(this.layout, name);
     }
 
-    static hasPaintOverride(layout: PossiblyEvaluated<LayoutProps, LayoutPropsPossiblyEvaluated>, propertyName: string): boolean {
+    static hasPaintOverride(layout: PossiblyEvaluated<SymbolLayoutProps, SymbolLayoutPropsPossiblyEvaluated>, propertyName: string): boolean {
         const textField = layout.get('text-field');
         const property = properties.paint.properties[propertyName];
         let hasOverrides = false;

--- a/src/style/style_layer/symbol_style_layer_properties.ts
+++ b/src/style/style_layer/symbol_style_layer_properties.ts
@@ -25,7 +25,7 @@ import {
     ColorType
 } from '../../style-spec/expression/types';
 
-export type LayoutProps = {
+export type SymbolLayoutProps = {
     "symbol-placement": DataConstantProperty<"point" | "line" | "line-center">,
     "symbol-spacing": DataConstantProperty<number>,
     "symbol-avoid-edges": DataConstantProperty<boolean>,
@@ -69,7 +69,7 @@ export type LayoutProps = {
     "text-optional": DataConstantProperty<boolean>,
 };
 
-export type LayoutPropsPossiblyEvaluated = {
+export type SymbolLayoutPropsPossiblyEvaluated = {
     "symbol-placement": "point" | "line" | "line-center",
     "symbol-spacing": number,
     "symbol-avoid-edges": boolean,
@@ -113,7 +113,7 @@ export type LayoutPropsPossiblyEvaluated = {
     "text-optional": boolean,
 };
 
-const layout: Properties<LayoutProps> = new Properties({
+const layout: Properties<SymbolLayoutProps> = new Properties({
     "symbol-placement": new DataConstantProperty(styleSpec["layout_symbol"]["symbol-placement"] as any as StylePropertySpecification),
     "symbol-spacing": new DataConstantProperty(styleSpec["layout_symbol"]["symbol-spacing"] as any as StylePropertySpecification),
     "symbol-avoid-edges": new DataConstantProperty(styleSpec["layout_symbol"]["symbol-avoid-edges"] as any as StylePropertySpecification),
@@ -157,7 +157,7 @@ const layout: Properties<LayoutProps> = new Properties({
     "text-optional": new DataConstantProperty(styleSpec["layout_symbol"]["text-optional"] as any as StylePropertySpecification),
 });
 
-export type PaintProps = {
+export type SymbolPaintProps = {
     "icon-opacity": DataDrivenProperty<number>,
     "icon-color": DataDrivenProperty<Color>,
     "icon-halo-color": DataDrivenProperty<Color>,
@@ -174,7 +174,7 @@ export type PaintProps = {
     "text-translate-anchor": DataConstantProperty<"map" | "viewport">,
 };
 
-export type PaintPropsPossiblyEvaluated = {
+export type SymbolPaintPropsPossiblyEvaluated = {
     "icon-opacity": PossiblyEvaluatedPropertyValue<number>,
     "icon-color": PossiblyEvaluatedPropertyValue<Color>,
     "icon-halo-color": PossiblyEvaluatedPropertyValue<Color>,
@@ -191,7 +191,7 @@ export type PaintPropsPossiblyEvaluated = {
     "text-translate-anchor": "map" | "viewport",
 };
 
-const paint: Properties<PaintProps> = new Properties({
+const paint: Properties<SymbolPaintProps> = new Properties({
     "icon-opacity": new DataDrivenProperty(styleSpec["paint_symbol"]["icon-opacity"] as any as StylePropertySpecification),
     "icon-color": new DataDrivenProperty(styleSpec["paint_symbol"]["icon-color"] as any as StylePropertySpecification),
     "icon-halo-color": new DataDrivenProperty(styleSpec["paint_symbol"]["icon-halo-color"] as any as StylePropertySpecification),
@@ -209,6 +209,6 @@ const paint: Properties<PaintProps> = new Properties({
 });
 
 export default ({ paint, layout } as {
-    paint: Properties<PaintProps>,
-    layout: Properties<LayoutProps>
+    paint: Properties<SymbolPaintProps>,
+    layout: Properties<SymbolLayoutProps>
 });

--- a/src/symbol/collision_index.ts
+++ b/src/symbol/collision_index.ts
@@ -3,7 +3,7 @@ import clipLine from './clip_line';
 import PathInterpolator from './path_interpolator';
 
 import * as intersectionTests from '../util/intersection_tests';
-import Grid from './grid_index';
+import GridIndex from './grid_index';
 import {mat4, vec4} from 'gl-matrix';
 import ONE_EM from '../symbol/one_em';
 import assert from 'assert';
@@ -38,8 +38,8 @@ const viewportPadding = 100;
  * @private
  */
 class CollisionIndex {
-    grid: Grid;
-    ignoredGrid: Grid;
+    grid: GridIndex;
+    ignoredGrid: GridIndex;
     transform: Transform;
     pitchfactor: number;
     screenRightBoundary: number;
@@ -49,8 +49,8 @@ class CollisionIndex {
 
     constructor(
         transform: Transform,
-        grid: Grid = new Grid(transform.width + 2 * viewportPadding, transform.height + 2 * viewportPadding, 25),
-        ignoredGrid: Grid = new Grid(transform.width + 2 * viewportPadding, transform.height + 2 * viewportPadding, 25)
+        grid = new GridIndex(transform.width + 2 * viewportPadding, transform.height + 2 * viewportPadding, 25),
+        ignoredGrid = new GridIndex(transform.width + 2 * viewportPadding, transform.height + 2 * viewportPadding, 25)
     ) {
         this.transform = transform;
 

--- a/src/symbol/symbol_style_layer.test.ts
+++ b/src/symbol/symbol_style_layer.test.ts
@@ -1,6 +1,6 @@
 import SymbolStyleLayer from '../style/style_layer/symbol_style_layer';
 import FormatSectionOverride from '../style/format_section_override';
-import properties, {PaintPropsPossiblyEvaluated} from '../style/style_layer/symbol_style_layer_properties';
+import properties, {SymbolPaintPropsPossiblyEvaluated} from '../style/style_layer/symbol_style_layer_properties';
 import ZoomHistory from '../style/zoom_history';
 import EvaluationParameters from '../style/evaluation_parameters';
 
@@ -22,7 +22,7 @@ describe('setPaintOverrides', () => {
         const layer = createSymbolLayer({});
         layer._setPaintOverrides();
         for (const overridable of properties.paint.overridableProperties) {
-            expect(isOverriden(layer.paint.get(overridable as keyof PaintPropsPossiblyEvaluated))).toBe(false);
+            expect(isOverriden(layer.paint.get(overridable as keyof SymbolPaintPropsPossiblyEvaluated))).toBe(false);
         }
 
     });

--- a/src/types/non-typed-modules.d.ts
+++ b/src/types/non-typed-modules.d.ts
@@ -4,7 +4,7 @@ import type Point from '../util/point';
 declare module '@mapbox/vector-tile' {
     import '@mapbox/vector-tile';
 
-    declare interface VectorTileLayer {
+    interface VectorTileLayer {
         version?: number;
         name: string;
         extent: number;

--- a/src/types/non-typed-modules.d.ts
+++ b/src/types/non-typed-modules.d.ts
@@ -1,4 +1,5 @@
 import type Pbf from 'pbf';
+import type Point from '../util/point';
 
 declare module '@mapbox/vector-tile' {
     import '@mapbox/vector-tile';

--- a/src/ui/anchor.ts
+++ b/src/ui/anchor.ts
@@ -1,7 +1,7 @@
-export type Anchor = 'center' | 'top' | 'bottom' | 'left' | 'right' | 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right';
+export type PositionAnchor = 'center' | 'top' | 'bottom' | 'left' | 'right' | 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right';
 
 export const anchorTranslate: {
-  [_ in Anchor]: string;
+  [_ in PositionAnchor]: string;
 } = {
     'center': 'translate(-50%,-50%)',
     'top': 'translate(-50%,0)',
@@ -14,7 +14,7 @@ export const anchorTranslate: {
     'right': 'translate(-100%,-50%)'
 };
 
-export function applyAnchorClass(element: HTMLElement, anchor: Anchor, prefix: string) {
+export function applyAnchorClass(element: HTMLElement, anchor: PositionAnchor, prefix: string) {
     const classList = element.classList;
     for (const key in anchorTranslate) {
         classList.remove(`maplibregl-${prefix}-anchor-${key}`, `mapboxgl-${prefix}-anchor-${key}`);

--- a/src/ui/control/attribution_control.ts
+++ b/src/ui/control/attribution_control.ts
@@ -4,7 +4,7 @@ import {bindAll} from '../../util/util';
 import type Map from '../map';
 import type {ControlPosition, IControl} from './control';
 
-type Options = {
+type AttributionOptions = {
   compact?: boolean;
   customAttribution?: string | Array<string>;
 };
@@ -23,7 +23,7 @@ type Options = {
  *     }));
  */
 class AttributionControl implements IControl {
-    options: Options;
+    options: AttributionOptions;
     _map: Map;
     _container: HTMLElement;
     _innerContainer: HTMLElement;
@@ -33,7 +33,7 @@ class AttributionControl implements IControl {
     styleId: string;
     styleOwner: string;
 
-    constructor(options: Options = {}) {
+    constructor(options: AttributionOptions = {}) {
         this.options = options;
 
         bindAll([

--- a/src/ui/control/control.d.ts
+++ b/src/ui/control/control.d.ts
@@ -1,5 +1,5 @@
 export type ControlPosition = 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right';
-
+import type Map from '../map';
 /**
  * Interface for interactive controls added to the map. This is a
  * specification for implementers to model: it is not

--- a/src/ui/control/fullscreen_control.ts
+++ b/src/ui/control/fullscreen_control.ts
@@ -5,7 +5,7 @@ import {bindAll, warnOnce} from '../../util/util';
 import type Map from '../map';
 import type {IControl} from './control';
 
-type Options = {
+type FullscreenOptions = {
   container?: HTMLElement;
 };
 
@@ -29,7 +29,7 @@ class FullscreenControl implements IControl {
     _fullscreenButton: HTMLButtonElement;
     _container: HTMLElement;
 
-    constructor(options: Options) {
+    constructor(options: FullscreenOptions) {
         this._fullscreen = false;
         if (options && options.container) {
             if (options.container instanceof HTMLElement) {

--- a/src/ui/control/geolocate_control.ts
+++ b/src/ui/control/geolocate_control.ts
@@ -9,7 +9,7 @@ import type Map from '../map';
 import type {AnimationOptions, CameraOptions} from '../camera';
 import type {IControl} from './control';
 
-type Options = {
+type GeolocateOptions = {
   positionOptions?: PositionOptions;
   fitBoundsOptions?: AnimationOptions & CameraOptions;
   trackUserLocation?: boolean;
@@ -17,7 +17,7 @@ type Options = {
   showUserLocation?: boolean;
 };
 
-const defaultOptions: Options = {
+const defaultOptions: GeolocateOptions = {
     positionOptions: {
         enableHighAccuracy: false,
         maximumAge: 0,
@@ -94,7 +94,7 @@ let noTimeout = false;
  */
 class GeolocateControl extends Evented implements IControl {
     _map: Map;
-    options: Options;
+    options: GeolocateOptions;
     _container: HTMLElement;
     _dotElement: HTMLElement;
     _circleElement: HTMLElement;
@@ -108,7 +108,7 @@ class GeolocateControl extends Evented implements IControl {
     _accuracy: number;
     _setup: boolean; // set to true once the control has been setup
 
-    constructor(options: Options) {
+    constructor(options: GeolocateOptions) {
         super();
         this.options = extend({}, defaultOptions, options);
 

--- a/src/ui/control/navigation_control.ts
+++ b/src/ui/control/navigation_control.ts
@@ -7,13 +7,13 @@ import {MouseRotateHandler, MousePitchHandler} from '../handler/mouse';
 import type Map from '../map';
 import type {IControl} from './control';
 
-type Options = {
+type NavigationOptions = {
   showCompass?: boolean;
   showZoom?: boolean;
   visualizePitch?: boolean;
 };
 
-const defaultOptions: Options = {
+const defaultOptions: NavigationOptions = {
     showCompass: true,
     showZoom: true,
     visualizePitch: false
@@ -35,7 +35,7 @@ const defaultOptions: Options = {
  */
 class NavigationControl implements IControl {
     _map: Map;
-    options: Options;
+    options: NavigationOptions;
     _container: HTMLElement;
     _zoomInButton: HTMLButtonElement;
     _zoomOutButton: HTMLButtonElement;
@@ -43,7 +43,7 @@ class NavigationControl implements IControl {
     _compassIcon: HTMLElement;
     _handler: MouseRotateWrapper;
 
-    constructor(options: Options) {
+    constructor(options: NavigationOptions) {
         this.options = extend({}, defaultOptions, options);
 
         this._container = DOM.create('div', 'maplibregl-ctrl maplibregl-ctrl-group mapboxgl-ctrl mapboxgl-ctrl-group');

--- a/src/ui/control/scale_control.ts
+++ b/src/ui/control/scale_control.ts
@@ -6,12 +6,12 @@ import type {ControlPosition, IControl} from './control';
 
 type Unit = 'imperial' | 'metric' | 'nautical';
 
-type Options = {
+type ScaleOptions = {
   maxWidth?: number;
   unit?: Unit;
 };
 
-const defaultOptions: Options = {
+const defaultOptions: ScaleOptions = {
     maxWidth: 100,
     unit: 'metric'
 };
@@ -35,9 +35,9 @@ const defaultOptions: Options = {
 class ScaleControl implements IControl {
     _map: Map;
     _container: HTMLElement;
-    options: Options;
+    options: ScaleOptions;
 
-    constructor(options: Options) {
+    constructor(options: ScaleOptions) {
         this.options = extend({}, defaultOptions, options);
 
         bindAll([

--- a/src/ui/marker.ts
+++ b/src/ui/marker.ts
@@ -4,17 +4,17 @@ import Point, {PointLike} from '../util/point';
 import smartWrap from '../util/smart_wrap';
 import {bindAll, extend} from '../util/util';
 import {anchorTranslate, applyAnchorClass} from './anchor';
-import type {Anchor} from './anchor';
+import type {PositionAnchor} from './anchor';
 import {Event, Evented} from '../util/evented';
 import type Map from './map';
 import Popup, {Offset} from './popup';
 import type {LngLatLike} from '../geo/lng_lat';
 import type {MapMouseEvent, MapTouchEvent} from './events';
 
-type Options = {
+type MarkerOptions = {
   element?: HTMLElement;
   offset?: PointLike;
-  anchor?: Anchor;
+  anchor?: PositionAnchor;
   color?: string;
   scale?: number;
   draggable?: boolean;
@@ -54,7 +54,7 @@ type Options = {
  */
 export default class Marker extends Evented {
     _map: Map;
-    _anchor: Anchor;
+    _anchor: PositionAnchor;
     _offset: Point;
     _element: HTMLElement;
     _popup: Popup;
@@ -74,7 +74,7 @@ export default class Marker extends Evented {
     _rotationAlignment: string;
     _originalTabIndex: string; // original tabindex of _element
 
-    constructor(options?: Options, legacyOptions?: Options) {
+    constructor(options?: MarkerOptions, legacyOptions?: MarkerOptions) {
         super();
         // For backward compatibility -- the constructor used to accept the element as a
         // required first argument, before it was made optional.

--- a/src/ui/popup.ts
+++ b/src/ui/popup.ts
@@ -7,7 +7,7 @@ import Point, {PointLike} from '../util/point';
 import smartWrap from '../util/smart_wrap';
 import {anchorTranslate, applyAnchorClass} from './anchor';
 
-import type {Anchor} from './anchor';
+import type {PositionAnchor} from './anchor';
 
 import type Map from './map';
 import type {LngLatLike} from '../geo/lng_lat';
@@ -21,7 +21,7 @@ const defaultOptions = {
 };
 
 export type Offset = number | PointLike | {
-  [_ in Anchor]: PointLike;
+  [_ in PositionAnchor]: PointLike;
 };
 
 export type PopupOptions = {
@@ -29,7 +29,7 @@ export type PopupOptions = {
   closeOnClick?: boolean;
   closeOnMove?: boolean;
   focusAfterOpen?: boolean;
-  anchor?: Anchor;
+  anchor?: PositionAnchor;
   offset?: Offset;
   className?: string;
   maxWidth?: string;
@@ -542,7 +542,7 @@ export default class Popup extends Evented {
 
         const pos = this._pos = this._trackPointer && cursor ? cursor : this._map.project(this._lngLat);
 
-        let anchor: Anchor = this.options.anchor;
+        let anchor = this.options.anchor;
         const offset = normalizeOffset(this.options.offset);
 
         if (!anchor) {

--- a/src/util/image.ts
+++ b/src/util/image.ts
@@ -7,7 +7,7 @@ export type Size = {
   height: number;
 };
 
-type Point = {
+type XyPoint = {
   x: number;
   y: number;
 };
@@ -49,7 +49,7 @@ function resizeImage(image: any, {
     image.data = newImage.data;
 }
 
-function copyImage(srcImg: any, dstImg: any, srcPt: Point, dstPt: Point, size: Size, channels: number) {
+function copyImage(srcImg: any, dstImg: any, srcPt: XyPoint, dstPt: XyPoint, size: Size, channels: number) {
     if (size.width === 0 || size.height === 0) {
         return dstImg;
     }
@@ -100,7 +100,7 @@ export class AlphaImage {
         return new AlphaImage({width: this.width, height: this.height}, new Uint8Array(this.data));
     }
 
-    static copy(srcImg: AlphaImage, dstImg: AlphaImage, srcPt: Point, dstPt: Point, size: Size) {
+    static copy(srcImg: AlphaImage, dstImg: AlphaImage, srcPt: XyPoint, dstPt: XyPoint, size: Size) {
         copyImage(srcImg, dstImg, srcPt, dstPt, size, 1);
     }
 }
@@ -137,7 +137,7 @@ export class RGBAImage {
         return new RGBAImage({width: this.width, height: this.height}, new Uint8Array(this.data));
     }
 
-    static copy(srcImg: RGBAImage | ImageData, dstImg: RGBAImage, srcPt: Point, dstPt: Point, size: Size) {
+    static copy(srcImg: RGBAImage | ImageData, dstImg: RGBAImage, srcPt: XyPoint, dstPt: XyPoint, size: Size) {
         copyImage(srcImg, dstImg, srcPt, dstPt, size, 4);
     }
 }

--- a/src/util/image.ts
+++ b/src/util/image.ts
@@ -7,7 +7,7 @@ export type Size = {
   height: number;
 };
 
-type XyPoint = {
+type Point2D = {
   x: number;
   y: number;
 };
@@ -49,7 +49,7 @@ function resizeImage(image: any, {
     image.data = newImage.data;
 }
 
-function copyImage(srcImg: any, dstImg: any, srcPt: XyPoint, dstPt: XyPoint, size: Size, channels: number) {
+function copyImage(srcImg: any, dstImg: any, srcPt: Point2D, dstPt: Point2D, size: Size, channels: number) {
     if (size.width === 0 || size.height === 0) {
         return dstImg;
     }
@@ -100,7 +100,7 @@ export class AlphaImage {
         return new AlphaImage({width: this.width, height: this.height}, new Uint8Array(this.data));
     }
 
-    static copy(srcImg: AlphaImage, dstImg: AlphaImage, srcPt: XyPoint, dstPt: XyPoint, size: Size) {
+    static copy(srcImg: AlphaImage, dstImg: AlphaImage, srcPt: Point2D, dstPt: Point2D, size: Size) {
         copyImage(srcImg, dstImg, srcPt, dstPt, size, 1);
     }
 }
@@ -137,7 +137,7 @@ export class RGBAImage {
         return new RGBAImage({width: this.width, height: this.height}, new Uint8Array(this.data));
     }
 
-    static copy(srcImg: RGBAImage | ImageData, dstImg: RGBAImage, srcPt: XyPoint, dstPt: XyPoint, size: Size) {
+    static copy(srcImg: RGBAImage | ImageData, dstImg: RGBAImage, srcPt: Point2D, dstPt: Point2D, size: Size) {
         copyImage(srcImg, dstImg, srcPt, dstPt, size, 4);
     }
 }

--- a/src/util/vectortile_to_geojson.ts
+++ b/src/util/vectortile_to_geojson.ts
@@ -1,6 +1,6 @@
 import type {VectorTileFeature} from '@mapbox/vector-tile';
 
-class Feature {
+class GeoJSONFeature {
     type: 'Feature';
     _geometry: GeoJSON.Geometry;
     properties: {};
@@ -42,4 +42,4 @@ class Feature {
     }
 }
 
-export default Feature;
+export default GeoJSONFeature;


### PR DESCRIPTION
## Launch Checklist

In order to export some part of the generated code in the near future (version 2.0 hopefully) to allow proper typing the types that are exported that are related to layout and paint properties need have a different names.

I changed the code generation code to allow this and also fixed the import to support this change.
There's not much here besides renaming of types...