### PR TITLE
use {ratio} instead of {r} to be compatible with maplibre-gl-native

### DIFF
--- a/src/source/tile_id.test.ts
+++ b/src/source/tile_id.test.ts
@@ -52,11 +52,11 @@ describe('CanonicalTileID', () => {
         expect(new CanonicalTileID(1, 0, 0).url(['bbox={bbox-epsg-3857}'])).toBe('bbox=-20037508.342789244,0,0,20037508.342789244');
     });
 
-    test('.url replaces {r}', () => {
+    test('.url replaces {ratio}', () => {
         devicePixelRatio = 2;
-        expect(new CanonicalTileID(1, 0, 0).url(['r={r}'])).toBe('r=@2x');
+        expect(new CanonicalTileID(1, 0, 0).url(['r={ratio}'])).toBe('r=@2x');
         devicePixelRatio = 1;
-        expect(new CanonicalTileID(1, 0, 0).url(['r={r}'])).toBe('r=');
+        expect(new CanonicalTileID(1, 0, 0).url(['r={ratio}'])).toBe('r=');
     });
 
     //Tests that multiple values of the same placeholder are replaced.

--- a/src/source/tile_id.ts
+++ b/src/source/tile_id.ts
@@ -37,7 +37,7 @@ export class CanonicalTileID {
             .replace(/{z}/g, String(this.z))
             .replace(/{x}/g, String(this.x))
             .replace(/{y}/g, String(scheme === 'tms' ? (Math.pow(2, this.z) - this.y - 1) : this.y))
-            .replace(/{r}/g, devicePixelRatio > 1 ? '@2x' : '')
+            .replace(/{ratio}/g, devicePixelRatio > 1 ? '@2x' : '')
             .replace(/{quadkey}/g, quadkey)
             .replace(/{bbox-epsg-3857}/g, bbox);
     }


### PR DESCRIPTION
Follow up to #637 as I did not know about the equivalent feature in mapbox-gl-native at the time.
I'm not sure what to do exactly about the changelog entry as we of course don't want 2 entries for this.

## Launch Checklist

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Suggest a changelog category: bug/feature/docs/etc. or "feature".
 - [x] Add an entry inside this element for inclusion in the `maplibre-gl-js` changelog: `<changelog>replace {ratio} in tile urls</changelog>`.
