### PR TITLE
add attribut open to html details element, if no compact is used

### DIFF
--- a/src/ui/control/attribution_control.ts
+++ b/src/ui/control/attribution_control.ts
@@ -59,6 +59,8 @@ class AttributionControl implements IControl {
 
         if (compact) {
             this._container.classList.add('maplibregl-compact', 'mapboxgl-compact');
+        } else {
+            this._container.setAttribute('open', '');
         }
 
         this._updateAttributions();


### PR DESCRIPTION
In https://github.com/maplibre/maplibre-gl-js/pull/557 I forgot to set the `open `attribute in the `details `element when details is not displayed as **compact** but as open by default. This is automatically set with the **compact** option when the `summary `element is clicked (https://www.w3.org/TR/2011/WD-html5-author-20110809/the-details-element.html).

This error was reported in the issue https://github.com/maplibre/maplibre-gl-js/issues/640.