### PR TITLE
Allow relative URL paths in styles

### DIFF
--- a/src/render/glyph_manager.test.ts
+++ b/src/render/glyph_manager.test.ts
@@ -11,10 +11,11 @@ for (const glyph of parseGlyphPBF(fs.readFileSync('./test/fixtures/0-255.pbf')))
 const identityTransform = ((url) => ({url})) as any as RequestManager;
 
 const createLoadGlyphRangeStub = () => {
-    return jest.spyOn(GlyphManager, 'loadGlyphRange').mockImplementation((stack, range, urlTemplate, transform, callback) => {
+    return jest.spyOn(GlyphManager, 'loadGlyphRange').mockImplementation((stack, range, baseUrl, urlTemplate, transform, callback) => {
         expect(stack).toBe('Arial Unicode MS');
         expect(range).toBe(0);
-        expect(urlTemplate).toBe('https://localhost/fonts/v1/{fontstack}/{range}.pbf');
+        expect(baseUrl).toBe('https://localhost/');
+        expect(urlTemplate).toBe('/fonts/v1/{fontstack}/{range}.pbf');
         expect(transform).toBe(identityTransform);
         setTimeout(() => callback(null, glyphs), 0);
     });
@@ -28,7 +29,7 @@ const createGlyphManager = (font?) => {
         }
     };
     const manager = new GlyphManager(identityTransform, font);
-    manager.setURL('https://localhost/fonts/v1/{fontstack}/{range}.pbf');
+    manager.setURL('/fonts/v1/{fontstack}/{range}.pbf', 'https://localhost/');
     return manager;
 };
 
@@ -71,7 +72,7 @@ describe('GlyphManager', () => {
     });
 
     test('GlyphManager requests remote CJK PBF', done => {
-        jest.spyOn(GlyphManager, 'loadGlyphRange').mockImplementation((stack, range, urlTemplate, transform, callback) => {
+        jest.spyOn(GlyphManager, 'loadGlyphRange').mockImplementation((stack, range, baseUrl, urlTemplate, transform, callback) => {
             setTimeout(() => callback(null, glyphs), 0);
         });
 
@@ -85,7 +86,7 @@ describe('GlyphManager', () => {
     });
 
     test('GlyphManager does not cache CJK chars that should be rendered locally', done => {
-        jest.spyOn(GlyphManager, 'loadGlyphRange').mockImplementation((stack, range, urlTemplate, transform, callback) => {
+        jest.spyOn(GlyphManager, 'loadGlyphRange').mockImplementation((stack, range, baseUrl, urlTemplate, transform, callback) => {
             const overlappingGlyphs = {};
             const start = range * 256;
             const end = start + 256;

--- a/src/render/glyph_manager.ts
+++ b/src/render/glyph_manager.ts
@@ -32,6 +32,7 @@ export default class GlyphManager {
       [_: string]: Entry;
     };
     url: string;
+    baseUrl: string;
 
     // exposed as statics to enable stubbing in unit tests
     static loadGlyphRange = loadGlyphRange;
@@ -43,8 +44,9 @@ export default class GlyphManager {
         this.entries = {};
     }
 
-    setURL(url?: string | null) {
+    setURL(url?: string | null, baseUrl?: string | null) {
         this.url = url;
+        this.baseUrl = baseUrl;
     }
 
     getGlyphs(glyphs: {
@@ -103,7 +105,7 @@ export default class GlyphManager {
             let requests = entry.requests[range];
             if (!requests) {
                 requests = entry.requests[range] = [];
-                GlyphManager.loadGlyphRange(stack, range, ((this.url as any)), this.requestManager,
+                GlyphManager.loadGlyphRange(stack, range, this.baseUrl, ((this.url as any)), this.requestManager,
                     (err, response?: {
                       [_: number]: StyleGlyph | null;
                     } | null) => {

--- a/src/source/load_tilejson.ts
+++ b/src/source/load_tilejson.ts
@@ -11,7 +11,7 @@ import type {Cancelable} from '../types/cancelable';
 export default function(options: any, requestManager: RequestManager, callback: Callback<TileJSON>): Cancelable {
     let tileBaseUrl;
     if (options.url && options.baseUrl)
-        tileBaseUrl = requestManager.absoluteURL(options.url, options.baseUrl)
+        tileBaseUrl = requestManager.absoluteURL(options.url, options.baseUrl);
     else
         tileBaseUrl = requestManager.absoluteURL(options.url || options.baseUrl, getReferrer());
     const loaded = function(err: Error, tileJSON: any) {

--- a/src/source/vector_tile_source.ts
+++ b/src/source/vector_tile_source.ts
@@ -51,6 +51,8 @@ class VectorTileSource extends Evented implements Source {
     tileSize: number;
     promoteId: PromoteIdSpecification;
 
+    baseUrl: string;
+    tileBaseUrl: string;
     _options: VectorSourceSpecification;
     _collectResourceTiming: boolean;
     dispatcher: Dispatcher;
@@ -65,6 +67,7 @@ class VectorTileSource extends Evented implements Source {
 
     constructor(id: string, options: VectorSourceSpecification & {
       collectResourceTiming: boolean;
+      baseUrl: string;
     }, dispatcher: Dispatcher, eventedParent: Evented) {
         super();
         this.id = id;
@@ -79,7 +82,7 @@ class VectorTileSource extends Evented implements Source {
         this.isTileClipped = true;
         this._loaded = false;
 
-        extend(this, pick(options, ['url', 'scheme', 'tileSize', 'promoteId']));
+        extend(this, pick(options, ['url', 'scheme', 'tileSize', 'promoteId', 'baseUrl']));
         this._options = extend({type: 'vector'}, options);
 
         this._collectResourceTiming = options.collectResourceTiming;
@@ -178,7 +181,7 @@ class VectorTileSource extends Evented implements Source {
     }
 
     loadTile(tile: Tile, callback: Callback<void>) {
-        const url = tile.tileID.canonical.url(this.tiles, this.scheme);
+        const url = this.map._requestManager.absoluteURL(tile.tileID.canonical.url(this.tiles, this.scheme), this.tileBaseUrl);
         const params = {
             request: this.map._requestManager.transformRequest(url, ResourceType.Tile),
             uid: tile.uid,

--- a/src/style/load_glyph_range.ts
+++ b/src/style/load_glyph_range.ts
@@ -8,6 +8,7 @@ import type {Callback} from '../types/callback';
 
 export default function loadGlyphRange(fontstack: string,
                            range: number,
+                           baseUrl: string,
                            urlTemplate: string,
                            requestManager: RequestManager,
                            callback: Callback<{
@@ -17,7 +18,7 @@ export default function loadGlyphRange(fontstack: string,
     const end = begin + 255;
 
     const request = requestManager.transformRequest(
-        urlTemplate.replace('{fontstack}', fontstack).replace('{range}', `${begin}-${end}`),
+        requestManager.absoluteURL(urlTemplate.replace('{fontstack}', fontstack).replace('{range}', `${begin}-${end}`), baseUrl),
         ResourceType.Glyphs
     );
 

--- a/src/style/style.ts
+++ b/src/style/style.ts
@@ -253,7 +253,7 @@ class Style extends Evented {
             this.imageManager.setLoaded(true);
         }
 
-        this.glyphManager.setURL(json.glyphs);
+        this.glyphManager.setURL(json.glyphs, baseUrl);
 
         const layers = deref(this.stylesheet.layers);
 

--- a/src/style/style.ts
+++ b/src/style/style.ts
@@ -249,7 +249,7 @@ class Style extends Evented {
         }
 
         if (json.sprite) {
-            this._loadSprite(json.sprite);
+            this._loadSprite(this.map._requestManager.absoluteURL(json.sprite, baseUrl));
         } else {
             this.imageManager.setLoaded(true);
         }

--- a/src/style/style.ts
+++ b/src/style/style.ts
@@ -216,7 +216,7 @@ class Style extends Evented {
             if (error) {
                 this.fire(new ErrorEvent(error));
             } else if (json) {
-                this._load(json, validate);
+                this._load(json, validate, url);
             }
         });
     }
@@ -226,16 +226,16 @@ class Style extends Evented {
 
         this._request = browser.frame(() => {
             this._request = null;
-            this._load(json, options.validate !== false);
+            this._load(json, options.validate !== false, getReferrer());
         });
     }
 
     loadEmpty() {
         this.fire(new Event('dataloading', {dataType: 'style'}));
-        this._load(empty, false);
+        this._load(empty, false, getReferrer());
     }
 
-    _load(json: StyleSpecification, validate: boolean) {
+    _load(json: StyleSpecification, validate: boolean, baseUrl: string) {
         if (validate && emitValidationErrors(this, validateStyle(json))) {
             return;
         }

--- a/src/style/style.ts
+++ b/src/style/style.ts
@@ -94,6 +94,7 @@ export type StyleOptions = {
 
 export type StyleSetterOptions = {
   validate?: boolean;
+  baseUrl?: string;
 };
 /**
  * @private
@@ -244,7 +245,7 @@ class Style extends Evented {
         this.stylesheet = json;
 
         for (const id in json.sources) {
-            this.addSource(id, json.sources[id], {validate: false});
+            this.addSource(id, json.sources[id], {validate: false, baseUrl});
         }
 
         if (json.sprite) {
@@ -569,6 +570,7 @@ class Style extends Evented {
         if (shouldValidate && this._validate(validateStyle.source, `sources.${id}`, source, null, options)) return;
 
         if (this.map && this.map._collectResourceTiming) (source as any).collectResourceTiming = true;
+        if (options.baseUrl) (source as any).baseUrl = options.baseUrl;
         const sourceCache = this.sourceCaches[id] = new SourceCache(id, source, this.dispatcher);
         sourceCache.style = this;
         sourceCache.setEventedParent(this, () => ({

--- a/src/ui/control/logo_control.test.ts
+++ b/src/ui/control/logo_control.test.ts
@@ -31,8 +31,7 @@ function createSource(options, logoRequired) {
     const source = new VectorTileSource('id', options, mockDispatcher, undefined);
     source.onAdd({
         _requestManager: {
-            _skuToken: '1234567890123',
-            canonicalizeTileset: tileJSON => tileJSON.tiles
+            absoluteURL: url => url
         },
         transform: {angle: 0, pitch: 0, showCollisionBoxes: false},
         _getMapId: () => 1

--- a/src/util/request_manager.ts
+++ b/src/util/request_manager.ts
@@ -27,6 +27,13 @@ export class RequestManager {
         return {url};
     }
 
+    absoluteURL(url: string, base: string): string {
+        if (!/^\w+:/.test(url) && /^\w+:\/\//.test(base)) {
+            return (new URL(url, base)).toString();
+        }
+        return url;
+    }
+
     normalizeSpriteURL(url: string, format: string, extension: string): string {
         const urlObject = parseUrl(url);
         urlObject.path += `${format}${extension}`;

--- a/test/unit/style/load_glyph_range.test.js
+++ b/test/unit/style/load_glyph_range.test.js
@@ -20,7 +20,7 @@ test('loadGlyphRange', (t) => {
     let request;
     XMLHttpRequest.onCreate = (req) => { request = req; };
 
-    loadGlyphRange('Arial Unicode MS', 0, 'https://localhost/fonts/v1/{fontstack}/{range}.pbf', manager, (err, result) => {
+    loadGlyphRange('Arial Unicode MS', 0, null, 'https://localhost/fonts/v1/{fontstack}/{range}.pbf', manager, (err, result) => {
         t.ifError(err);
         t.ok(transform.calledOnce);
         t.deepEqual(transform.getCall(0).args, ['https://localhost/fonts/v1/Arial Unicode MS/0-255.pbf', 'Glyphs']);


### PR DESCRIPTION
This uses the url of the style (or of the tilejson) as base url for relative urls. Before the referrer was used everywhere (that is the the url of the map application itself).

With this patches you can for example directly use `https://basemaps.arcgis.com/arcgis/rest/services/World_Basemap_v2/VectorTileServer/resources/styles/` as style url and everything works.

This fixes #182.

## Todo
- [ ] Adapt all other sources to use tileBaseUrl for tiles.
- [ ] How should the style baseUrl be passed around? Is expanding options correct?
- [ ] Should the baseUrl be included in serialize or not?
- [ ] Depending on the answers of the above questions, fix the two failing tests.
- [ ] Can wie use URL (https://developer.mozilla.org/en-US/docs/Web/API/URL/URL)?

## Launch Checklist
 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [ ] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [x] Manually test the debug page.
 - [x] Suggest a changelog category: "feature".
 - [x] Add an entry inside this element for inclusion in the `maplibre-gl-js` changelog: `<changelog>Intepret urls in json files relative to the location of the json itself.</changelog>`.
