### PR TITLE
Use createImageBitmap when supported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 - Added `redraw` function to map (#206)
 - Improve attribution controls accessibility. See [#359](https://github.com/maplibre/maplibre-gl-js/issues/359)
 - Allow maxPitch value up to 85, use values greater than 60 at your own risk (#574)
+- `getImage` uses createImageBitmap when supported (#650)
 - *...Add new stuff here...*
 
 ### 🐞 Bug fixes

--- a/test/unit/util/ajax.test.js
+++ b/test/unit/util/ajax.test.js
@@ -172,5 +172,40 @@ test('ajax', (t) => {
         window.server.respond();
     });
 
+
+    t.test('getImage uses ImageBitmap when supported', (t) => {
+        resetImageRequestQueue();
+
+        window.server.respondWith(request => request.respond(200, {'Content-Type': 'image/png'}, ''));
+
+        // mock createImageBitmap support
+        global.createImageBitmap = () => Promise.resolve(new ImageBitmap());
+
+        getImage({url: ''}, (err, img) => {
+            if (err) t.fail();
+            t.ok(img instanceof ImageBitmap);
+            t.end();
+        });
+
+        window.server.respond();
+    });
+
+    t.test('getImage uses HTMLImageElement when ImageBitmap is not supported', (t) => {
+        resetImageRequestQueue();
+
+        window.server.respondWith(request => request.respond(200, {'Content-Type': 'image/png'}, ''));
+
+        // mock createImageBitmap not supported
+        global.createImageBitmap = undefined;
+
+        getImage({url: ''}, (err, img) => {
+            if (err) t.fail();
+            t.ok(img instanceof HTMLImageElement);
+            t.end();
+        });
+
+        window.server.respond();
+    });
+
     t.end();
 });


### PR DESCRIPTION
When converting a byte buffer to a [CanvasImageSource](https://developer.mozilla.org/en-US/docs/Web/API/CanvasImageSource), maplibre uses either an [ImageBitmap](https://developer.mozilla.org/en-US/docs/Web/API/ImageBitmap) if supported or an [HTMLImageElement](https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement) as fallback.
HTMLImageElement has many flaws, such as [the transparent pixel hack to avoid memory leaks](https://github.com/maplibre/maplibre-gl-js/blob/main/src/util/ajax.ts#L304-L308). Therefore the ImageBitmap seems more reliable and is the preferred image source.

In order to load the byte buffer to an ImageBitmap the library checks if the feature is available on the browser. Currently the function checks if the function createImageBitmap is defined **and** if the  [OffscreenCanvas](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvas) feature is available. 
However the OffscreenCanvas is not required to create an ImageBitmap and on browsers like Firefox where createImageBitmap is supported but not OffscreenCanvas (which is still experimental), the image source falls back on HTMLImageElement.

This PR simply checks for the availability of the createImageBitmap function instead of the unneeded OffscreenCanvas feature.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [x] Manually test the debug page.
 - [x] Suggest a changelog category: "feature".
 - [x] Add an entry inside this element for inclusion in the `maplibre-gl-js` changelog: `<changelog>getImage uses createImageBitmap when supported (#650)</changelog>`.
