### PR TITLE
Add cache for coveringTiles

### DIFF
--- a/src/geo/transform.test.ts
+++ b/src/geo/transform.test.ts
@@ -203,13 +203,16 @@ describe('transform', () => {
         });
 
         test('general cached', () => {
+            const spy = jest.spyOn(transform, 'coveringZoomLevel');
 
             // make slightly off center so that sort order is not subject to precision issues
             transform.center = new LngLat(-0.01, 0.01);
 
             transform.zoom = 0;
             expect(transform.coveringTiles(options)).toEqual([]);
+            expect(spy).toHaveBeenCalledTimes(1);
             expect(transform.coveringTiles(options)).toEqual([]);
+            expect(spy).toHaveBeenCalledTimes(1);
 
             transform.zoom = 1;
             expect(transform.coveringTiles(options)).toEqual([
@@ -217,11 +220,13 @@ describe('transform', () => {
                 new OverscaledTileID(1, 0, 1, 1, 0),
                 new OverscaledTileID(1, 0, 1, 0, 1),
                 new OverscaledTileID(1, 0, 1, 1, 1)]);
+            expect(spy).toHaveBeenCalledTimes(2);
             expect(transform.coveringTiles(options)).toEqual([
                 new OverscaledTileID(1, 0, 1, 0, 0),
                 new OverscaledTileID(1, 0, 1, 1, 0),
                 new OverscaledTileID(1, 0, 1, 0, 1),
                 new OverscaledTileID(1, 0, 1, 1, 1)]);
+            expect(spy).toHaveBeenCalledTimes(2);
 
             transform.zoom = 2.4;
             expect(transform.coveringTiles(options)).toEqual([
@@ -229,11 +234,13 @@ describe('transform', () => {
                 new OverscaledTileID(2, 0, 2, 2, 1),
                 new OverscaledTileID(2, 0, 2, 1, 2),
                 new OverscaledTileID(2, 0, 2, 2, 2)]);
+            expect(spy).toHaveBeenCalledTimes(3);
             expect(transform.coveringTiles(options)).toEqual([
                 new OverscaledTileID(2, 0, 2, 1, 1),
                 new OverscaledTileID(2, 0, 2, 2, 1),
                 new OverscaledTileID(2, 0, 2, 1, 2),
                 new OverscaledTileID(2, 0, 2, 2, 2)]);
+            expect(spy).toHaveBeenCalledTimes(3);
 
             transform.zoom = 10;
             expect(transform.coveringTiles(options)).toEqual([
@@ -241,11 +248,13 @@ describe('transform', () => {
                 new OverscaledTileID(10, 0, 10, 512, 511),
                 new OverscaledTileID(10, 0, 10, 511, 512),
                 new OverscaledTileID(10, 0, 10, 512, 512)]);
+            expect(spy).toHaveBeenCalledTimes(4);
             expect(transform.coveringTiles(options)).toEqual([
                 new OverscaledTileID(10, 0, 10, 511, 511),
                 new OverscaledTileID(10, 0, 10, 512, 511),
                 new OverscaledTileID(10, 0, 10, 511, 512),
                 new OverscaledTileID(10, 0, 10, 512, 512)]);
+            expect(spy).toHaveBeenCalledTimes(4);
 
             transform.zoom = 11;
             expect(transform.coveringTiles(options)).toEqual([
@@ -253,11 +262,13 @@ describe('transform', () => {
                 new OverscaledTileID(10, 0, 10, 512, 511),
                 new OverscaledTileID(10, 0, 10, 511, 512),
                 new OverscaledTileID(10, 0, 10, 512, 512)]);
+            expect(spy).toHaveBeenCalledTimes(5);
             expect(transform.coveringTiles(options)).toEqual([
                 new OverscaledTileID(10, 0, 10, 511, 511),
                 new OverscaledTileID(10, 0, 10, 512, 511),
                 new OverscaledTileID(10, 0, 10, 511, 512),
                 new OverscaledTileID(10, 0, 10, 512, 512)]);
+            expect(spy).toHaveBeenCalledTimes(5);
 
             transform.zoom = 5.1;
             transform.pitch = 60.0;
@@ -287,6 +298,7 @@ describe('transform', () => {
                 new OverscaledTileID(5, 0, 5, 24, 9),
                 new OverscaledTileID(5, 0, 5, 22, 7)
             ]);
+            expect(spy).toHaveBeenCalledTimes(6);
             expect(transform.coveringTiles(options)).toEqual([
                 new OverscaledTileID(5, 0, 5, 21, 11),
                 new OverscaledTileID(5, 0, 5, 20, 11),
@@ -310,6 +322,7 @@ describe('transform', () => {
                 new OverscaledTileID(5, 0, 5, 24, 9),
                 new OverscaledTileID(5, 0, 5, 22, 7)
             ]);
+            expect(spy).toHaveBeenCalledTimes(6);
 
             transform.zoom = 8;
             transform.pitch = 60;
@@ -321,11 +334,13 @@ describe('transform', () => {
                 new OverscaledTileID(8, 0, 8, 145, 73),
                 new OverscaledTileID(8, 0, 8, 146, 74)
             ]);
+            expect(spy).toHaveBeenCalledTimes(7);
             expect(transform.coveringTiles(options)).toEqual([
                 new OverscaledTileID(8, 0, 8, 145, 74),
                 new OverscaledTileID(8, 0, 8, 145, 73),
                 new OverscaledTileID(8, 0, 8, 146, 74)
             ]);
+            expect(spy).toHaveBeenCalledTimes(7);
 
             transform.resize(50, 300);
             expect(transform.coveringTiles(options)).toEqual([
@@ -334,12 +349,14 @@ describe('transform', () => {
                 new OverscaledTileID(8, 0, 8, 146, 74),
                 new OverscaledTileID(8, 0, 8, 146, 73)
             ]);
+            expect(spy).toHaveBeenCalledTimes(8);
             expect(transform.coveringTiles(options)).toEqual([
                 new OverscaledTileID(8, 0, 8, 145, 74),
                 new OverscaledTileID(8, 0, 8, 145, 73),
                 new OverscaledTileID(8, 0, 8, 146, 74),
                 new OverscaledTileID(8, 0, 8, 146, 73)
             ]);
+            expect(spy).toHaveBeenCalledTimes(8);
 
             transform.zoom = 2;
             transform.pitch = 0;

--- a/src/geo/transform.test.ts
+++ b/src/geo/transform.test.ts
@@ -112,7 +112,7 @@ describe('transform', () => {
         const transform = new Transform(0, 22, 0, 60, true);
         transform.resize(200, 200);
 
-        test('generell', () => {
+        test('general', () => {
 
             // make slightly off center so that sort order is not subject to precision issues
             transform.center = new LngLat(-0.01, 0.01);
@@ -189,6 +189,151 @@ describe('transform', () => {
             ]);
 
             transform.resize(50, 300);
+            expect(transform.coveringTiles(options)).toEqual([
+                new OverscaledTileID(8, 0, 8, 145, 74),
+                new OverscaledTileID(8, 0, 8, 145, 73),
+                new OverscaledTileID(8, 0, 8, 146, 74),
+                new OverscaledTileID(8, 0, 8, 146, 73)
+            ]);
+
+            transform.zoom = 2;
+            transform.pitch = 0;
+            transform.bearing = 0;
+            transform.resize(300, 300);
+        });
+
+        test('general cached', () => {
+
+            // make slightly off center so that sort order is not subject to precision issues
+            transform.center = new LngLat(-0.01, 0.01);
+
+            transform.zoom = 0;
+            expect(transform.coveringTiles(options)).toEqual([]);
+            expect(transform.coveringTiles(options)).toEqual([]);
+
+            transform.zoom = 1;
+            expect(transform.coveringTiles(options)).toEqual([
+                new OverscaledTileID(1, 0, 1, 0, 0),
+                new OverscaledTileID(1, 0, 1, 1, 0),
+                new OverscaledTileID(1, 0, 1, 0, 1),
+                new OverscaledTileID(1, 0, 1, 1, 1)]);
+            expect(transform.coveringTiles(options)).toEqual([
+                new OverscaledTileID(1, 0, 1, 0, 0),
+                new OverscaledTileID(1, 0, 1, 1, 0),
+                new OverscaledTileID(1, 0, 1, 0, 1),
+                new OverscaledTileID(1, 0, 1, 1, 1)]);
+
+            transform.zoom = 2.4;
+            expect(transform.coveringTiles(options)).toEqual([
+                new OverscaledTileID(2, 0, 2, 1, 1),
+                new OverscaledTileID(2, 0, 2, 2, 1),
+                new OverscaledTileID(2, 0, 2, 1, 2),
+                new OverscaledTileID(2, 0, 2, 2, 2)]);
+            expect(transform.coveringTiles(options)).toEqual([
+                new OverscaledTileID(2, 0, 2, 1, 1),
+                new OverscaledTileID(2, 0, 2, 2, 1),
+                new OverscaledTileID(2, 0, 2, 1, 2),
+                new OverscaledTileID(2, 0, 2, 2, 2)]);
+
+            transform.zoom = 10;
+            expect(transform.coveringTiles(options)).toEqual([
+                new OverscaledTileID(10, 0, 10, 511, 511),
+                new OverscaledTileID(10, 0, 10, 512, 511),
+                new OverscaledTileID(10, 0, 10, 511, 512),
+                new OverscaledTileID(10, 0, 10, 512, 512)]);
+            expect(transform.coveringTiles(options)).toEqual([
+                new OverscaledTileID(10, 0, 10, 511, 511),
+                new OverscaledTileID(10, 0, 10, 512, 511),
+                new OverscaledTileID(10, 0, 10, 511, 512),
+                new OverscaledTileID(10, 0, 10, 512, 512)]);
+
+            transform.zoom = 11;
+            expect(transform.coveringTiles(options)).toEqual([
+                new OverscaledTileID(10, 0, 10, 511, 511),
+                new OverscaledTileID(10, 0, 10, 512, 511),
+                new OverscaledTileID(10, 0, 10, 511, 512),
+                new OverscaledTileID(10, 0, 10, 512, 512)]);
+            expect(transform.coveringTiles(options)).toEqual([
+                new OverscaledTileID(10, 0, 10, 511, 511),
+                new OverscaledTileID(10, 0, 10, 512, 511),
+                new OverscaledTileID(10, 0, 10, 511, 512),
+                new OverscaledTileID(10, 0, 10, 512, 512)]);
+
+            transform.zoom = 5.1;
+            transform.pitch = 60.0;
+            transform.bearing = 32.0;
+            transform.center = new LngLat(56.90, 48.20);
+            transform.resize(1024, 768);
+            expect(transform.coveringTiles(options)).toEqual([
+                new OverscaledTileID(5, 0, 5, 21, 11),
+                new OverscaledTileID(5, 0, 5, 20, 11),
+                new OverscaledTileID(5, 0, 5, 21, 10),
+                new OverscaledTileID(5, 0, 5, 20, 10),
+                new OverscaledTileID(5, 0, 5, 21, 12),
+                new OverscaledTileID(5, 0, 5, 22, 11),
+                new OverscaledTileID(5, 0, 5, 20, 12),
+                new OverscaledTileID(5, 0, 5, 22, 10),
+                new OverscaledTileID(5, 0, 5, 21, 9),
+                new OverscaledTileID(5, 0, 5, 20, 9),
+                new OverscaledTileID(5, 0, 5, 22, 9),
+                new OverscaledTileID(5, 0, 5, 23, 10),
+                new OverscaledTileID(5, 0, 5, 21, 8),
+                new OverscaledTileID(5, 0, 5, 20, 8),
+                new OverscaledTileID(5, 0, 5, 23, 9),
+                new OverscaledTileID(5, 0, 5, 22, 8),
+                new OverscaledTileID(5, 0, 5, 23, 8),
+                new OverscaledTileID(5, 0, 5, 21, 7),
+                new OverscaledTileID(5, 0, 5, 20, 7),
+                new OverscaledTileID(5, 0, 5, 24, 9),
+                new OverscaledTileID(5, 0, 5, 22, 7)
+            ]);
+            expect(transform.coveringTiles(options)).toEqual([
+                new OverscaledTileID(5, 0, 5, 21, 11),
+                new OverscaledTileID(5, 0, 5, 20, 11),
+                new OverscaledTileID(5, 0, 5, 21, 10),
+                new OverscaledTileID(5, 0, 5, 20, 10),
+                new OverscaledTileID(5, 0, 5, 21, 12),
+                new OverscaledTileID(5, 0, 5, 22, 11),
+                new OverscaledTileID(5, 0, 5, 20, 12),
+                new OverscaledTileID(5, 0, 5, 22, 10),
+                new OverscaledTileID(5, 0, 5, 21, 9),
+                new OverscaledTileID(5, 0, 5, 20, 9),
+                new OverscaledTileID(5, 0, 5, 22, 9),
+                new OverscaledTileID(5, 0, 5, 23, 10),
+                new OverscaledTileID(5, 0, 5, 21, 8),
+                new OverscaledTileID(5, 0, 5, 20, 8),
+                new OverscaledTileID(5, 0, 5, 23, 9),
+                new OverscaledTileID(5, 0, 5, 22, 8),
+                new OverscaledTileID(5, 0, 5, 23, 8),
+                new OverscaledTileID(5, 0, 5, 21, 7),
+                new OverscaledTileID(5, 0, 5, 20, 7),
+                new OverscaledTileID(5, 0, 5, 24, 9),
+                new OverscaledTileID(5, 0, 5, 22, 7)
+            ]);
+
+            transform.zoom = 8;
+            transform.pitch = 60;
+            transform.bearing = 45.0;
+            transform.center = new LngLat(25.02, 60.15);
+            transform.resize(300, 50);
+            expect(transform.coveringTiles(options)).toEqual([
+                new OverscaledTileID(8, 0, 8, 145, 74),
+                new OverscaledTileID(8, 0, 8, 145, 73),
+                new OverscaledTileID(8, 0, 8, 146, 74)
+            ]);
+            expect(transform.coveringTiles(options)).toEqual([
+                new OverscaledTileID(8, 0, 8, 145, 74),
+                new OverscaledTileID(8, 0, 8, 145, 73),
+                new OverscaledTileID(8, 0, 8, 146, 74)
+            ]);
+
+            transform.resize(50, 300);
+            expect(transform.coveringTiles(options)).toEqual([
+                new OverscaledTileID(8, 0, 8, 145, 74),
+                new OverscaledTileID(8, 0, 8, 145, 73),
+                new OverscaledTileID(8, 0, 8, 146, 74),
+                new OverscaledTileID(8, 0, 8, 146, 73)
+            ]);
             expect(transform.coveringTiles(options)).toEqual([
                 new OverscaledTileID(8, 0, 8, 145, 74),
                 new OverscaledTileID(8, 0, 8, 145, 73),

--- a/src/geo/transform.ts
+++ b/src/geo/transform.ts
@@ -347,7 +347,10 @@ class Transform {
         let z = this.coveringZoomLevel(options);
         const actualZ = z;
 
-        if (options.minzoom !== undefined && z < options.minzoom) return [];
+        if (options.minzoom !== undefined && z < options.minzoom) {
+            this._coveringTilesCache[optionsKey] = [];
+            return [];
+        }
         if (options.maxzoom !== undefined && z > options.maxzoom) z = options.maxzoom;
 
         const centerCoord = MercatorCoordinate.fromLngLat(this.center);

--- a/src/geo/transform.ts
+++ b/src/geo/transform.ts
@@ -53,6 +53,7 @@ class Transform {
     _constraining: boolean;
     _posMatrixCache: {[_: string]: mat4};
     _alignedPosMatrixCache: {[_: string]: mat4};
+    _coveringTilesCache: {[_: string]: Array<any>};
 
     constructor(minZoom?: number, maxZoom?: number, minPitch?: number, maxPitch?: number, renderWorldCopies?: boolean) {
         this.tileSize = 512; // constant
@@ -78,6 +79,7 @@ class Transform {
         this._edgeInsets = new EdgeInsets();
         this._posMatrixCache = {};
         this._alignedPosMatrixCache = {};
+        this._coveringTilesCache = {};
     }
 
     clone(): Transform {
@@ -321,9 +323,17 @@ class Transform {
         maxzoom?: number;
         roundZoom?: boolean;
         reparseOverscaled?: boolean;
-        renderWorldCopies?: boolean;
       }
     ): Array<OverscaledTileID> {
+        const loadCacheEntry = (cacheEntry): Array<OverscaledTileID> => {
+            return cacheEntry.map(it => new OverscaledTileID(it.overscaledZ, it.wrap, it.zoom, it.x, it.y));
+        };
+
+        const optionsKey = JSON.stringify([options, this._renderWorldCopies]);
+        if (this._coveringTilesCache[optionsKey]) {
+            return loadCacheEntry(this._coveringTilesCache[optionsKey]);
+        }
+
         let z = this.coveringZoomLevel(options);
         const actualZ = z;
 
@@ -358,7 +368,7 @@ class Transform {
 
         // Do a depth-first traversal to find visible tiles and proper levels of detail
         const stack = [];
-        const result = [];
+        const cacheEntry = [];
         const maxZoom = z;
         const overscaledZ = options.reparseOverscaled ? actualZ : z;
 
@@ -401,8 +411,13 @@ class Transform {
 
             // Have we reached the target depth or is the tile too far away to be any split further?
             if (it.zoom === maxZoom || (longestDim > distToSplit && it.zoom >= minZoom)) {
-                result.push({
-                    tileID: new OverscaledTileID(it.zoom === maxZoom ? overscaledZ : it.zoom, it.wrap, it.zoom, x, y),
+                cacheEntry.push({
+                    tileParameters: {
+                        overscaledZ: it.zoom === maxZoom ? overscaledZ : it.zoom,
+                        wrap: it.wrap,
+                        zoom: it.zoom,
+                        x, y
+                    },
                     distanceSq: vec2.sqrLen([centerPoint[0] - 0.5 - x, centerPoint[1] - 0.5 - y])
                 });
                 continue;
@@ -416,7 +431,10 @@ class Transform {
             }
         }
 
-        return result.sort((a, b) => a.distanceSq - b.distanceSq).map(a => a.tileID);
+        const sortedCacheEntry = cacheEntry.sort((a, b) => a.distanceSq - b.distanceSq).map(a => a.tileParameters);
+        this._coveringTilesCache[optionsKey] = sortedCacheEntry;
+
+        return loadCacheEntry(sortedCacheEntry);
     }
 
     resize(width: number, height: number) {
@@ -767,6 +785,7 @@ class Transform {
 
         this._posMatrixCache = {};
         this._alignedPosMatrixCache = {};
+        this._coveringTilesCache = {};
     }
 
     maxPitchScaleFactor() {


### PR DESCRIPTION
This is a follow-up on @JannikGM's pull request for caching covering tiles. I copy-pasted the code from his original pull request #105. Looks like benchmarks are not affected except for `LayerBackground`, which runs roughly 2x faster with the caching. Is this the behavior you expected, Jannik?

![image](https://user-images.githubusercontent.com/53421382/143720472-48f01175-10c5-4036-bff7-3a99ba56464d.png)


 - [ ?] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask! - I'm not sure, @JannikGM please comment about the origin of this code.
 - [:whale:  ] Briefly describe the changes in this PR. -> see #105 
 - [ :skier: ] Post benchmark scores.
 - [? ] Suggest a changelog category: bug/feature/docs/etc. or "skip changelog". @JannikGM, what would you say?
