### PR TITLE
Fix timediff test

### DIFF
--- a/src/ui/camera.test.ts
+++ b/src/ui/camera.test.ts
@@ -1545,7 +1545,7 @@ describe('#flyTo', () => {
             .on('moveend', () => {
                 endTime = new Date();
                 timeDiff = endTime - startTime;
-                expect(timeDiff / 10).toBeCloseTo(0, 1);
+                expect(timeDiff / 100).toBeCloseTo(0, 1);
                 done();
             });
 

--- a/src/ui/camera.test.ts
+++ b/src/ui/camera.test.ts
@@ -1545,7 +1545,7 @@ describe('#flyTo', () => {
             .on('moveend', () => {
                 endTime = new Date();
                 timeDiff = endTime - startTime;
-                expect(timeDiff / 100).toBeCloseTo(0, 1);
+                expect(timeDiff).toBeLessThan(10);
                 done();
             });
 


### PR DESCRIPTION
`camera.test.ts` has a test which fails sometimes since we migrated it from tap to jest. The original code of this test looked like this:

https://github.com/maplibre/maplibre-gl-js/blob/cb3a4200bfbc113969e9dcbedae2aa7655f9aa98/test/unit/ui/camera.test.js#L1624-L1627

which looks like a strange use of comparing a limited number of digits. Basically this means if `abs(timeDiff) < 10`, the test passes. If we divide `timeDiff` by 100 and check to to first digit after the decimal point, we should get the same result.