### PR TITLE
Define return type of getSource as possibly undefined

### DIFF
--- a/src/style/style.ts
+++ b/src/style/style.ts
@@ -629,9 +629,9 @@ class Style extends Evented {
     /**
      * Get a source by id.
      * @param {string} id id of the desired source
-     * @returns {Object} source
+     * @returns {Source | undefined} source
      */
-    getSource(id: string): Source {
+    getSource(id: string): Source | undefined {
         return this.sourceCaches[id] && this.sourceCaches[id].getSource();
     }
 

--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -1607,7 +1607,7 @@ class Map extends Camera {
      * of an image source.
      *
      * @param {string} id The ID of the source to get.
-     * @returns {Source} The style source with the specified ID or `undefined` if the ID
+     * @returns {Source | undefined} The style source with the specified ID or `undefined` if the ID
      * corresponds to no existing sources.
      * The shape of the object varies by source type.
      * A list of options for each source type is available on the Mapbox Style Specification's
@@ -1618,7 +1618,7 @@ class Map extends Camera {
      * @see [Animate a point](https://maplibre.org/maplibre-gl-js-docs/example/animate-point-along-line/)
      * @see [Add live realtime data](https://maplibre.org/maplibre-gl-js-docs/example/live-geojson/)
      */
-    getSource(id: string): Source {
+    getSource(id: string): Source | undefined {
         return this.style.getSource(id);
     }
 


### PR DESCRIPTION
## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

Defines the return type of `getSource` as possibly `undefined` as described in JSDoc.

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [ ] Manually test the debug page.
 - [ ] Suggest a changelog category: bug/feature/docs/etc. or "skip changelog".
 - [ ] Add an entry inside this element for inclusion in the `maplibre-gl-js` changelog: `<changelog></changelog>`.
