### PR TITLE
Fix events being fired after Map#remove has been called when the WebGL context is lost and restored (#726)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
 - Fix padding-top of the popup to improve readability of popup text (#354).
 - Fix GeoJSONSource#loaded sometimes returning true while there are still pending loads (#669)
 - Fix MapDataEvent#isSourceLoaded being true in GeoJSONSource "dataloading" event handlers (#694)
+- Fix events being fired after Map#remove has been called when the WebGL context is lost and restored (#726)
 
 ## 1.15.2
 

--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -2678,6 +2678,7 @@ class Map extends Camera {
         const extension = this.painter.context.gl.getExtension('WEBGL_lose_context');
         if (extension) extension.loseContext();
         this._canvas.removeEventListener('webglcontextrestored', this._contextRestored, false);
+        this._canvas.removeEventListener('webglcontextlost', this._contextLost, false);
         DOM.remove(this._canvasContainer);
         DOM.remove(this._controlContainer);
         this._container.classList.remove('maplibregl-map', 'mapboxgl-map');

--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -2677,6 +2677,7 @@ class Map extends Camera {
 
         const extension = this.painter.context.gl.getExtension('WEBGL_lose_context');
         if (extension) extension.loseContext();
+        this._canvas.removeEventListener('webglcontextrestored', this._contextRestored, false);
         DOM.remove(this._canvasContainer);
         DOM.remove(this._controlContainer);
         this._container.classList.remove('maplibregl-map', 'mapboxgl-map');

--- a/test/unit/ui/map.test.js
+++ b/test/unit/ui/map.test.js
@@ -995,6 +995,17 @@ test('Map', (t) => {
         });
     });
 
+    t.test('does not fire "webglcontextlost" after #remove has been called', (t) => {
+        const map = createMap(t);
+        const canvas = map.getCanvas();
+        map.once('webglcontextlost', () => t.fail('"webglcontextlost" fired after #remove has been called'));
+        map.remove();
+        // Dispatch the event manually because at the time of this writing, gl does not support
+        // the WEBGL_lose_context extension.
+        canvas.dispatchEvent(new window.Event('webglcontextlost'));
+        t.end();
+    });
+
     t.test('does not fire "webglcontextrestored" after #remove has been called', (t) => {
         const map = createMap(t);
         const canvas = map.getCanvas();

--- a/test/unit/ui/map.test.js
+++ b/test/unit/ui/map.test.js
@@ -995,6 +995,22 @@ test('Map', (t) => {
         });
     });
 
+    t.test('does not fire "webglcontextrestored" after #remove has been called', (t) => {
+        const map = createMap(t);
+        const canvas = map.getCanvas();
+
+        map.once('webglcontextlost', () => {
+            map.once('webglcontextrestored', () => t.fail('"webglcontextrestored" fired after #remove has been called'));
+            map.remove();
+            canvas.dispatchEvent(new window.Event('webglcontextrestored'));
+            t.end();
+        });
+
+        // Dispatch the event manually because at the time of this writing, gl does not support
+        // the WEBGL_lose_context extension.
+        canvas.dispatchEvent(new window.Event('webglcontextlost'));
+    });
+
     t.test('#redraw', (t) => {
         const map = createMap(t);
 


### PR DESCRIPTION
<changelog>Fix events being fired after Map#remove has been called when the WebGL context is lost and restored (#726)</changelog>

## Launch Checklist

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Write tests for all new functionality.
 - [x] Manually test the debug page.
 - [x] Add an entry inside this element for inclusion in the `maplibre-gl-js` changelog: `<changelog></changelog>`.
