### PR TITLE
Resurrect gl-stats.js

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -29,6 +29,8 @@ By default, the style benchmark page will run its benchmarks against `https://ap
 
 ## Generating gl statistics
 
+Build minimized production maplibre-gl-js with `npm run build-prod-min`.
+
 Gather and output gl statistics from headless chromium with `npm run gl-stats`. The results are output to the terminal and saved in data.json.gz.
 
 ## Writing a Benchmark

--- a/bench/README.md
+++ b/bench/README.md
@@ -27,6 +27,12 @@ To run a specific benchmark, add its name to the url hash, for example [`http://
 
 By default, the style benchmark page will run its benchmarks against `https://api.maptiler.com/maps/streets/style.json?key=get_your_own_OpIi9ZULNHzrESv6T2vL`. `Layout` and `Paint` styles will run one instance of the test for each tile/location in an internal list of tiles. This behavior helps visualize the ways in which a style performs given various conditions present in each tile (CJK text, dense urban areas, rural areas, etc). `QueryBox` and `QueryPoint` use the internal list of tiles but otherwise run the same as their non-style benchmark equivalents. `StyleLayerCreate` and `StyleValidate` are not tile/location dependent and run the same way as their non-style benchmark equivalents. All other benchmark tests from the non-style suite are not used when benchmarking styles.
 
+## Generating gl statistics
+
+Build minimized production maplibre-gl-js with `npm run build-prod-min`.
+
+Gather and output gl statistics from headless chromium with `node bench/gl-stats.js`. The results are output to the terminal and saved in data.json.gz.
+
 ## Writing a Benchmark
 
 Good benchmarks

--- a/bench/README.md
+++ b/bench/README.md
@@ -29,9 +29,7 @@ By default, the style benchmark page will run its benchmarks against `https://ap
 
 ## Generating gl statistics
 
-Build minimized production maplibre-gl-js with `npm run build-prod-min`.
-
-Gather and output gl statistics from headless chromium with `node bench/gl-stats.js`. The results are output to the terminal and saved in data.json.gz.
+Gather and output gl statistics from headless chromium with `npm run gl-stats`. The results are output to the terminal and saved in data.json.gz.
 
 ## Writing a Benchmark
 

--- a/bench/gl-stats.html
+++ b/bench/gl-stats.html
@@ -5,7 +5,7 @@
 <script>
 // stub performance.now for deterministic rendering per-frame;
 // we'll later increment the value by 16 on every frame (16ms per frame for 60fps)
-let now = performance.now();
+let now = performance.now(); //eslint-disable-line prefer-const
 window.performance.now = () => now;
 </script>
 <script src="../dist/maplibre-gl.js"></script>

--- a/bench/gl-stats.html
+++ b/bench/gl-stats.html
@@ -5,7 +5,7 @@
 <script>
 // stub performance.now for deterministic rendering per-frame;
 // we'll later increment the value by 16 on every frame (16ms per frame for 60fps)
-const now = performance.now();
+let now = performance.now();
 window.performance.now = () => now;
 </script>
 <script src="../dist/maplibre-gl.js"></script>
@@ -16,7 +16,7 @@ maplibregl.workerCount = 1;
 
 const map = new maplibregl.Map({
     container: document.getElementById('map'),
-    style: 'mapbox://styles/mapbox/streets-v11',
+    style: 'https://api.maptiler.com/maps/streets/style.json?key=get_your_own_OpIi9ZULNHzrESv6T2vL',
     center: [-77.07842066675323, 38.890315130853566],
     zoom: 11
 });

--- a/bench/gl-stats.js
+++ b/bench/gl-stats.js
@@ -1,11 +1,11 @@
 import puppeteer from 'puppeteer';
 import fs from 'fs';
 import zlib from 'zlib';
+import {execSync} from 'child_process';
 
 const maplibreGLJSSrc = fs.readFileSync('dist/maplibre-gl.js', 'utf8');
 const maplibreGLCSSSrc = fs.readFileSync('dist/maplibre-gl.css', 'utf8');
 const benchSrc = fs.readFileSync('bench/gl-stats.html', 'utf8');
-import {execSync} from 'child_process';
 
 const benchHTML = benchSrc
     .replace(/<script src="..\/dist\/maplibre-gl.js"><\/script>/, `<script>${maplibreGLJSSrc}</script>`);

--- a/bench/gl-stats.js
+++ b/bench/gl-stats.js
@@ -1,5 +1,3 @@
-/* eslint-disable import/no-commonjs */
-
 import puppeteer from 'puppeteer';
 import fs from 'fs';
 import zlib from 'zlib';

--- a/bench/gl-stats.js
+++ b/bench/gl-stats.js
@@ -1,12 +1,13 @@
 /* eslint-disable import/no-commonjs */
 
-const puppeteer = require('puppeteer');
-const fs = require('fs');
-const zlib = require('zlib');
+import puppeteer from 'puppeteer';
+import fs from 'fs';
+import zlib from 'zlib';
+
 const maplibreGLJSSrc = fs.readFileSync('dist/maplibre-gl.js', 'utf8');
 const maplibreGLCSSSrc = fs.readFileSync('dist/maplibre-gl.css', 'utf8');
 const benchSrc = fs.readFileSync('bench/gl-stats.html', 'utf8');
-const {execSync} = require('child_process');
+import {execSync} from 'child_process';
 
 const benchHTML = benchSrc
     .replace(/<script src="..\/dist\/maplibre-gl.js"><\/script>/, `<script>${maplibreGLJSSrc}</script>`);

--- a/bench/gl-stats.js
+++ b/bench/gl-stats.js
@@ -22,10 +22,10 @@ function waitForConsole(page) {
     });
 }
 
-(async () => {
-    const browser = await puppeteer.launch({
-        args: ['--no-sandbox', '--disable-setuid-sandbox']
-    });
+const browser = await puppeteer.launch({
+    args: ['--no-sandbox', '--disable-setuid-sandbox']
+});
+try {
     const page = await browser.newPage();
 
     console.log('collecting stats...');
@@ -43,5 +43,6 @@ function waitForConsole(page) {
     fs.writeFileSync('data.json.gz', zlib.gzipSync(JSON.stringify(stats)));
 
     await page.close();
+} finally {
     await browser.close();
-})();
+}

--- a/package.json
+++ b/package.json
@@ -213,7 +213,7 @@
     "test-cov": "nyc --reporter=text-summary --reporter=lcov --cache run-s test-unit test-expressions test-query test-render",
     "test-jest": "jest",
     "codegen": "node --loader ts-node/esm --experimental-specifier-resolution=node build/generate-style-code.ts && node --loader ts-node/esm --experimental-specifier-resolution=node build/generate-struct-arrays.ts && node --loader ts-node/esm --experimental-specifier-resolution=node build/generate-style-spec.ts",
-    "gl-stats": "npm run build-prod-min && node bench/gl-stats.js"
+    "gl-stats": "node bench/gl-stats.js"
   },
   "files": [
     "build/",

--- a/package.json
+++ b/package.json
@@ -212,7 +212,8 @@
     "test-expressions": "node --experimental-specifier-resolution=node test/expression.test.js",
     "test-cov": "nyc --reporter=text-summary --reporter=lcov --cache run-s test-unit test-expressions test-query test-render",
     "test-jest": "jest",
-    "codegen": "node --loader ts-node/esm --experimental-specifier-resolution=node build/generate-style-code.ts && node --loader ts-node/esm --experimental-specifier-resolution=node build/generate-struct-arrays.ts && node --loader ts-node/esm --experimental-specifier-resolution=node build/generate-style-spec.ts"
+    "codegen": "node --loader ts-node/esm --experimental-specifier-resolution=node build/generate-style-code.ts && node --loader ts-node/esm --experimental-specifier-resolution=node build/generate-struct-arrays.ts && node --loader ts-node/esm --experimental-specifier-resolution=node build/generate-style-spec.ts",
+    "gl-stats": "npm run build-prod-min && node bench/gl-stats.js"
   },
   "files": [
     "build/",


### PR DESCRIPTION
## Launch Checklist

This fixes and refactors bench/gl-stats.js, a script to run a short zoom animation and gather some gl statistics.
I also added some minimal documentation so people can find it and know how to run it.

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.