### PR TITLE
use glyph-metrics from tinySDF.draw call

### DIFF
--- a/src/render/glyph_manager.ts
+++ b/src/render/glyph_manager.ts
@@ -198,13 +198,13 @@ export default class GlyphManager {
         const char = tinySDF.draw(String.fromCharCode(id));
         return {
             id,
-            bitmap: new AlphaImage({width: char.width, height: char.height}, char.data),
+            bitmap: new AlphaImage({width: char.width || 30, height: char.height || 30}, char.data),
             metrics: {
-                width: char.glyphWidth,
-                height: char.glyphHeight,
-                left: char.glyphLeft,
-                top: char.glyphTop,
-                advance: char.glyphAdvance
+                width: char.glyphWidth || 24,
+                height: char.glyphHeight || 24,
+                left: char.glyphLeft || 0,
+                top: char.glyphTop || -8,
+                advance: char.glyphAdvance || 24
             }
         };
     }

--- a/src/render/glyph_manager.ts
+++ b/src/render/glyph_manager.ts
@@ -195,15 +195,16 @@ export default class GlyphManager {
             });
         }
 
+        const char = tinySDF.draw(String.fromCharCode(id));
         return {
             id,
-            bitmap: new AlphaImage({width: 30, height: 30}, tinySDF.draw(String.fromCharCode(id)).data),
+            bitmap: new AlphaImage({width: char.width, height: char.height}, char.data),
             metrics: {
-                width: 24,
-                height: 24,
-                left: 0,
-                top: -8,
-                advance: 24
+                width: char.glyphWidth,
+                height: char.glyphHeight,
+                left: char.glyphLeft,
+                top: char.glyphTop,
+                advance: char.glyphAdvance
             }
         };
     }


### PR DESCRIPTION
In some of our stylesheets we get "mismatched image size" errors. This is because tinySDF glyphs has hardcoded width & height properties, which do not match with the generated width & height generated by TinySDF.draw calls.

I do not know anything about tinySDF and what it is used for in detail, but the below lines fixes the issue in our case.

## Launch Checklist

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [ ] Write tests for all new functionality.
