### PR TITLE
Add Chrome 66+ notice to v2 breaking changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Migrated the production code to typescript
 - ** Breaking Change ** removed `version` from the public API
 - ** Breaking Change ** stopped supporting IE (internet explorer)
+- ** Breaking Change ** stopped supporting Chrome 49-65. Chrome 66+ required. For Chrome 49-65 support use version 1.15.2.
 - ** Breaking Change ** removed all code related to `accessToken` and Mapbox specific urls starting with `mapbox://`. Telemetry and tracking code was removed.
 - ** Breaking Change ** removed `baseApiUrl` as it was used only for Mapbox related urls
 - ** Breaking Change ** typescript typings have changed:


### PR DESCRIPTION
Related to #783.

- v1.15.2 works with Chrome 49+.
- v2.0.0 require Chrome 66+.

It is breaking change for some cases when Chrome 49-65 support needed.
So, it may be useful to specify that Chrome 66+ is required for v2 in the Release notes.