### PR TITLE
Update files in package.json, bump to version 2.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 ### 🐞 Bug fixes
 - *...Add new stuff here...*
 
+## 2.0.4
+### 🐞 Bug fixes
+- Missing package.json file in version 2.0.3 dist in npm (#811) - this causes webpack to fail
+
 ## 2.0.3
 ### Features and improvements
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "maplibre-gl",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "maplibre-gl",
-      "version": "2.0.3",
+      "version": "2.0.4",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@mapbox/geojson-rewind": "^0.5.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "maplibre-gl",
   "description": "BSD licensed community fork of mapbox-gl, a WebGL interactive maps library",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "main": "dist/maplibre-gl.js",
   "style": "dist/maplibre-gl.css",
   "license": "BSD-3-Clause",
@@ -218,8 +218,7 @@
   },
   "files": [
     "build/",
-    "dist/maplibre-gl*",
-    "dist/style-spec/",
+    "dist/*",
     "src/"
   ]
 }


### PR DESCRIPTION
Fixes #811 by making sure everything in the dist folder is packed by npm.
This probably worked in npm 6 but was a bug that was fixed in later version if I need to guess...