### PR TITLE
Disable strict list of supported node versions package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,9 +9,6 @@
     "type": "git",
     "url": "git://github.com/maplibre/maplibre-gl-js.git"
   },
-  "engines": {
-    "node": ">=16.0.0"
-  },
   "types": "dist/maplibre-gl.d.ts",
   "type": "module",
   "dependencies": {


### PR DESCRIPTION
Our CI/CD currently test Node 16, but maplibre can run on many more versions. Having node >=16 (#797) in package.json break all these build systems, but adding i.e. node 14 put us in the position of claiming node 14 support without testing it.

I therefore suggest we simply removed the engines list, to let any build system install and try to run the maplibre code.