### PR TITLE
Fix benchmarks rollup config

### DIFF
--- a/bench/rollup_config_benchmarks.js
+++ b/bench/rollup_config_benchmarks.js
@@ -61,7 +61,7 @@ const viewConfig = {
         sourcemap: false
     },
     plugins: [
-        buble({transforms: {dangerousForOf: true}, objectAssign: true}),
+        buble({transforms: {generator: false, dangerousForOf: true}, objectAssign: true}),
         resolve({browser: true, preferBuiltins: false}),
         watch ? typescript() : false,
         commonjs(),


### PR DESCRIPTION
Our current benchmark build pipeline has the error:

[!] (plugin buble) CompileError: Transforming generators is not implemented. Use `transforms: { generator: false }` to skip transformation and disable this error. (1:0)

Thus this PR sets `transforms: { generator: false }` for buble.