### PR TITLE
run-benchmarks.js: handle --compare parameters

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -12,7 +12,7 @@ To run a specific benchmark, add its name to the url hash, for example [`http://
 
 By default, the benchmark page will compare the local branch against `main` and the latest release. To change this, include one or more `compare` query parameters in the URL: E.g., [localhost:9966/bench/versions?compare=main](http://localhost:9966/bench/versions?compare=main) or [localhost:9966/bench/versions?compare=main#Layout](http://localhost:9966/bench/versions?compare=main#Layout) to compare only to main, or [localhost:9966/bench/versions?compare=v1.13.1](http://localhost:9966/bench/versions?compare=v1.13.1) to compare to `v1.13.1` (but not `main`).  Versions available for comparison are the ones stored in the `gh-pages` branch, see [here](https://github.com/maplibre/maplibre-gl-js/tree/gh-pages/benchmarks).
 
-To run all benchmarks in headless chromium use `npm run benchmark`.
+To run all benchmarks in headless chromium use `npm run benchmark`. As with the browser you can include one or more `--compare` arguments to change the default comparison, e.g. `npm run benchmark -- --compare main`. You can also run only specific benchmarks by passing their names as positional arguments, e.g. `npm run benchmark -- Layout Paint`.
 
 ## Running Style Benchmarks
 

--- a/bench/run-benchmarks.js
+++ b/bench/run-benchmarks.js
@@ -3,7 +3,7 @@ import puppeteer from 'puppeteer';
 import PDFMerger from 'pdf-merger-js';
 import minimist from 'minimist';
 
-let argv = minimist(process.argv.slice(2));
+const argv = minimist(process.argv.slice(2));
 
 const formatTime = (v) => `${v.toFixed(4)} ms`;
 const formatRegression = (v) => v.correlation < 0.9 ? '\u2620\uFE0F' : v.correlation < 0.99 ? '\u26A0\uFE0F' : ' ';
@@ -15,7 +15,7 @@ if (!fs.existsSync(dir)) {
 
 const url = new URL('http://localhost:9966/bench/versions/');
 
-for (let compare of [].concat(argv.compare).filter(Boolean))
+for (const compare of [].concat(argv.compare).filter(Boolean))
     url.searchParams.append('compare', compare);
 
 const browser = await puppeteer.launch({
@@ -37,7 +37,7 @@ try {
     const namewidth = Math.max(...torun.map(v => v.length)) + 1;
     const timewidth = Math.max(...versions.map(v => v.length), 16);
 
-    console.log(''.padStart(namewidth), ...versions.map(v =>  v.padStart(timewidth) + ' '));
+    console.log(''.padStart(namewidth), ...versions.map(v =>  `${v.padStart(timewidth)} `));
 
     const merger = new PDFMerger();
     for (const name of torun) {
@@ -56,8 +56,8 @@ try {
         );
 
         const results = await webPage.evaluate((name) => window.maplibreglBenchmarkResults[name], name);
-        let output = versions.map((v) => formatTime(results[v].summary.trimmedMean).padStart(timewidth) + formatRegression(results[v].regression));
-        if (versions.length == 2) {
+        const output = versions.map((v) => formatTime(results[v].summary.trimmedMean).padStart(timewidth) + formatRegression(results[v].regression));
+        if (versions.length === 2) {
             const [main, current] = versions;
             const delta = results[current].summary.trimmedMean - results[main].summary.trimmedMean;
             output.push(((delta > 0 ? '+' : '') + formatTime(delta)).padStart(15));

--- a/bench/run-benchmarks.js
+++ b/bench/run-benchmarks.js
@@ -1,6 +1,9 @@
 import fs from 'fs';
 import puppeteer from 'puppeteer';
 import PDFMerger from 'pdf-merger-js';
+import minimist from 'minimist';
+
+let argv = minimist(process.argv.slice(2));
 
 const formatTime = (v) => `${v.toFixed(4)} ms`;
 const formatRegression = (v) => v.correlation < 0.9 ? '\u2620\uFE0F' : v.correlation < 0.99 ? '\u26A0\uFE0F' : ' ';
@@ -10,6 +13,11 @@ if (!fs.existsSync(dir)) {
     fs.mkdirSync(dir);
 }
 
+const url = new URL('http://localhost:9966/bench/versions/');
+
+for (let compare of [].concat(argv.compare).filter(Boolean))
+    url.searchParams.append('compare', compare);
+
 const browser = await puppeteer.launch({
     headless: true,
     args: ['--use-gl=angle', '--no-sandbox', '--disable-setuid-sandbox']
@@ -18,23 +26,24 @@ const browser = await puppeteer.launch({
 try {
     const webPage = await browser.newPage();
 
-    await webPage.goto('http://localhost:9966/bench/versions?compare=main#NONE');
+    url.hash = 'NONE';
+    await webPage.goto(url);
+    await webPage.waitForFunction(() => window.maplibreglBenchmarkFinished);
     const allnames = await webPage.evaluate(() => Object.keys(window.maplibreglBenchmarks));
-    const [main, current] = await webPage.evaluate((name) => Object.keys(window.maplibreglBenchmarks[name]), allnames[0]);
+    const versions = await webPage.evaluate((name) => Object.keys(window.maplibreglBenchmarks[name]), allnames[0]);
 
-    const torun = process.argv.length > 2 ? process.argv.slice(2) : allnames;
+    const torun = argv._.length > 0 ? argv._ : allnames;
 
     const namewidth = Math.max(...torun.map(v => v.length)) + 1;
-    const timewidth = Math.max(main.length, current.length, 16);
+    const timewidth = Math.max(...versions.map(v => v.length), 16);
 
-    console.log(''.padStart(namewidth), main.padStart(timewidth), ' ', current.padStart(timewidth), ' ');
+    console.log(''.padStart(namewidth), ...versions.map(v =>  v.padStart(timewidth) + ' '));
 
     const merger = new PDFMerger();
     for (const name of torun) {
-        const url = `http://localhost:9966/bench/versions?compare=main#${name}`;
-
         process.stdout.write(name.padStart(namewidth));
 
+        url.hash = name;
         await webPage.goto(url);
         await webPage.reload();
 
@@ -47,13 +56,13 @@ try {
         );
 
         const results = await webPage.evaluate((name) => window.maplibreglBenchmarkResults[name], name);
-        const [main, current] = Object.values(results);
-        const delta = current.summary.trimmedMean - main.summary.trimmedMean;
-        console.log(
-            formatTime(main.summary.trimmedMean).padStart(timewidth), formatRegression(main.regression),
-            formatTime(current.summary.trimmedMean).padStart(timewidth), formatRegression(current.regression),
-            ((delta > 0 ? '+' : '') + formatTime(delta)).padStart(15),
-        );
+        let output = versions.map((v) => formatTime(results[v].summary.trimmedMean).padStart(timewidth) + formatRegression(results[v].regression));
+        if (versions.length == 2) {
+            const [main, current] = versions;
+            const delta = results[current].summary.trimmedMean - results[main].summary.trimmedMean;
+            output.push(((delta > 0 ? '+' : '') + formatTime(delta)).padStart(15));
+        }
+        console.log(...output);
 
         merger.add(await webPage.pdf({
             format: 'A4',

--- a/bench/run-benchmarks.js
+++ b/bench/run-benchmarks.js
@@ -29,19 +29,19 @@ try {
     url.hash = 'NONE';
     await webPage.goto(url);
     await webPage.waitForFunction(() => window.maplibreglBenchmarkFinished);
-    const allnames = await webPage.evaluate(() => Object.keys(window.maplibreglBenchmarks));
-    const versions = await webPage.evaluate((name) => Object.keys(window.maplibreglBenchmarks[name]), allnames[0]);
+    const allNames = await webPage.evaluate(() => Object.keys(window.maplibreglBenchmarks));
+    const versions = await webPage.evaluate((name) => Object.keys(window.maplibreglBenchmarks[name]), allNames[0]);
 
-    const torun = argv._.length > 0 ? argv._ : allnames;
+    const toRun = argv._.length > 0 ? argv._ : allNames;
 
-    const namewidth = Math.max(...torun.map(v => v.length)) + 1;
-    const timewidth = Math.max(...versions.map(v => v.length), 16);
+    const nameWidth = Math.max(...toRun.map(v => v.length)) + 1;
+    const timeWidth = Math.max(...versions.map(v => v.length), 16);
 
-    console.log(''.padStart(namewidth), ...versions.map(v =>  `${v.padStart(timewidth)} `));
+    console.log(''.padStart(nameWidth), ...versions.map(v =>  `${v.padStart(timeWidth)} `));
 
     const merger = new PDFMerger();
-    for (const name of torun) {
-        process.stdout.write(name.padStart(namewidth));
+    for (const name of toRun) {
+        process.stdout.write(name.padStart(nameWidth));
 
         url.hash = name;
         await webPage.goto(url);
@@ -56,7 +56,7 @@ try {
         );
 
         const results = await webPage.evaluate((name) => window.maplibreglBenchmarkResults[name], name);
-        const output = versions.map((v) => formatTime(results[v].summary.trimmedMean).padStart(timewidth) + formatRegression(results[v].regression));
+        const output = versions.map((v) => formatTime(results[v].summary.trimmedMean).padStart(timeWidth) + formatRegression(results[v].regression));
         if (versions.length === 2) {
             const [main, current] = versions;
             const delta = results[current].summary.trimmedMean - results[main].summary.trimmedMean;


### PR DESCRIPTION
## Launch Checklist

run-bechmarks.js now handles different --compare parameters and also passes them on as url parameters. That way the script default output more closely follows the default output in the browser and supports the same parameters.

This also fixes an error when executing run-benchmarks.js on a clean checkout of main as the old script always expected two versions to benchmark but only got one in that case.

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.