### PR TITLE
[Stylelint] alpha-value-notation

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -10,8 +10,6 @@
       "ignoreAtRules": ["svg-load"]
     }],
 
-
-    "alpha-value-notation": null,
     "at-rule-no-vendor-prefix": null,
     "color-function-notation": null,
     "function-url-quotes": null,

--- a/src/css/maplibre-gl.css
+++ b/src/css/maplibre-gl.css
@@ -3,7 +3,7 @@
     font: 12px/20px "Helvetica Neue", Arial, Helvetica, sans-serif;
     overflow: hidden;
     position: relative;
-    -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
+    -webkit-tap-highlight-color: rgba(0, 0, 0, 0%);
 }
 
 .maplibregl-canvas,
@@ -117,9 +117,9 @@
 
 .maplibregl-ctrl-group:not(:empty),
 .mapboxgl-ctrl-group:not(:empty) {
-    -moz-box-shadow: 0 0 2px rgba(0, 0, 0, 0.1);
-    -webkit-box-shadow: 0 0 2px rgba(0, 0, 0, 0.1);
-    box-shadow: 0 0 0 2px rgba(0, 0, 0, 0.1);
+    -moz-box-shadow: 0 0 2px rgba(0, 0, 0, 10%);
+    -webkit-box-shadow: 0 0 2px rgba(0, 0, 0, 10%);
+    box-shadow: 0 0 0 2px rgba(0, 0, 0, 10%);
 }
 
 @media (-ms-high-contrast: active) {
@@ -179,7 +179,7 @@
 .maplibregl-ctrl-group button:focus,
 .mapboxgl-ctrl-attrib-button:focus,
 .mapboxgl-ctrl-group button:focus {
-    box-shadow: 0 0 2px 2px rgba(0, 150, 255, 1);
+    box-shadow: 0 0 2px 2px rgba(0, 150, 255, 100%);
 }
 
 .maplibregl-ctrl button:disabled,
@@ -194,12 +194,12 @@
 
 .maplibregl-ctrl button:not(:disabled):hover,
 .mapboxgl-ctrl button:not(:disabled):hover {
-    background-color: rgba(0, 0, 0, 0.05);
+    background-color: rgba(0, 0, 0, 5%);
 }
 
 .maplibregl-ctrl-group button:focus:focus-visible,
 .mapboxgl-ctrl-group button:focus:focus-visible {
-    box-shadow: 0 0 2px 2px rgba(0, 150, 255, 1);
+    box-shadow: 0 0 2px 2px rgba(0, 150, 255, 100%);
 }
 
 .maplibregl-ctrl-group button:focus:not(:focus-visible),
@@ -519,7 +519,7 @@ a.mapboxgl-ctrl-logo.mapboxgl-compact {
 .maplibregl-ctrl.maplibregl-ctrl-attrib,
 .mapboxgl-ctrl.mapboxgl-ctrl-attrib {
     padding: 0 5px;
-    background-color: rgba(255, 255, 255, 0.5);
+    background-color: rgba(255, 255, 255, 50%);
     margin: 0;
 }
 
@@ -559,7 +559,7 @@ a.mapboxgl-ctrl-logo.mapboxgl-compact {
         cursor: pointer;
         position: absolute;
         background-image: svg-load("svg/maplibregl-ctrl-attrib.svg");
-        background-color: rgba(255, 255, 255, 0.5);
+        background-color: rgba(255, 255, 255, 50%);
         width: 24px;
         height: 24px;
         box-sizing: border-box;
@@ -586,7 +586,7 @@ a.mapboxgl-ctrl-logo.mapboxgl-compact {
 
     .maplibregl-ctrl-attrib.maplibregl-compact-show .maplibregl-ctrl-attrib-button,
     .mapboxgl-ctrl-attrib.mapboxgl-compact-show .mapboxgl-ctrl-attrib-button {
-        background-color: rgba(0, 0, 0, 0.05);
+        background-color: rgba(0, 0, 0, 5%);
     }
 
     .maplibregl-ctrl-bottom-right > .maplibregl-ctrl-attrib.maplibregl-compact::after,
@@ -630,7 +630,7 @@ a.mapboxgl-ctrl-logo.mapboxgl-compact {
 
 .maplibregl-ctrl-attrib a,
 .mapboxgl-ctrl-attrib a {
-    color: rgba(0, 0, 0, 0.75);
+    color: rgba(0, 0, 0, 75%);
     text-decoration: none;
 }
 
@@ -647,7 +647,7 @@ a.mapboxgl-ctrl-logo.mapboxgl-compact {
 
 .maplibregl-ctrl-scale,
 .mapboxgl-ctrl-scale {
-    background-color: rgba(255, 255, 255, 0.75);
+    background-color: rgba(255, 255, 255, 75%);
     font-size: 10px;
     border-width: medium 2px 2px;
     border-style: none solid solid;
@@ -789,7 +789,7 @@ a.mapboxgl-ctrl-logo.mapboxgl-compact {
 
 .maplibregl-popup-close-button:hover,
 .mapboxgl-popup-close-button:hover {
-    background-color: rgba(0, 0, 0, 0.05);
+    background-color: rgba(0, 0, 0, 5%);
 }
 
 .maplibregl-popup-content,
@@ -797,7 +797,7 @@ a.mapboxgl-ctrl-logo.mapboxgl-compact {
     position: relative;
     background: #fff;
     border-radius: 3px;
-    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 10%);
     padding: 15px 10px;
     pointer-events: auto;
 }
@@ -884,7 +884,7 @@ a.mapboxgl-ctrl-logo.mapboxgl-compact {
     top: -2px;
     width: 19px;
     box-sizing: border-box;
-    box-shadow: 0 0 3px rgba(0, 0, 0, 0.35);
+    box-shadow: 0 0 3px rgba(0, 0, 0, 35%);
 }
 
 @-webkit-keyframes maplibregl-user-location-dot-pulse {


### PR DESCRIPTION
Another stylelint rule [ alpha-value-notation](https://stylelint.io/user-guide/rules/list/alpha-value-notation/). 

I'm not fully convinced about this one, because not even [w3c](https://drafts.csswg.org/css-color-3/#alphavalue-def) uses it on their website. But since it is a standard rule in stylelint and I think it is good to handle everything consistently, I suggest using it anyway.