### PR TITLE
Fix broken path in benchmark build

### DIFF
--- a/bench/rollup_config_benchmarks.js
+++ b/bench/rollup_config_benchmarks.js
@@ -51,7 +51,7 @@ const splitConfig = (name) => [{
 }];
 
 const viewConfig = {
-    input: `${srcDir}bench/benchmarks_view.${inputExt}x`,
+    input: `${srcDir}bench/benchmarks_view.${inputExt}${watch ? 'x' : ''}`,
     output: {
         name: 'Benchmarks',
         file: 'bench/benchmarks_view_generated.js',


### PR DESCRIPTION
bench/benchmarks_view.tsx transpiles to .js and not .jsx. 

This PR fixes the broken path in benchmark rollup config.