### PR TITLE
rollup plugin-replace:  enable preventAssignment

### DIFF
--- a/bench/rollup_config_benchmarks.js
+++ b/bench/rollup_config_benchmarks.js
@@ -15,6 +15,7 @@ if (process.env.MAPLIBRE_STYLES) {
 }
 
 const replaceConfig = {
+    preventAssignment: true,
     'process.env.BENCHMARK_VERSION': JSON.stringify(process.env.BENCHMARK_VERSION),
     'process.env.MAPLIBRE_STYLES': JSON.stringify(styles),
     'process.env.NODE_ENV': JSON.stringify('production')

--- a/build/rollup_plugins.js
+++ b/build/rollup_plugins.js
@@ -19,6 +19,7 @@ export const plugins = (minified, production, watch) => [
     json(),
     // https://github.com/zaach/jison/issues/351
     replace({
+        preventAssignment: true,
         include: /\/jsonlint-lines-primitives\/lib\/jsonlint.js/,
         delimiters: ['', ''],
         values: {

--- a/rollup.config.style-spec.js
+++ b/rollup.config.style-spec.js
@@ -37,6 +37,7 @@ const config = [{
         },
         // https://github.com/zaach/jison/issues/351
         replace({
+            preventAssignment: true,
             include: /\/jsonlint-lines-primitives\/lib\/jsonlint.js/,
             delimiters: ['', ''],
             values: {


### PR DESCRIPTION
We have a lot of warnings from rollup, because the next version of rollup-plugin-replace will have the setting         preventAssignment: true - and they recommend we opt-in now.