### PR TITLE
Update mapbox dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,9 +10,7 @@ updates:
     schedule:
       interval: "monthly"
     ignore:
-      - dependency-name: "@types/d3"
       - dependency-name: "@types/diff"
-      - dependency-name: "d3"
       - dependency-name: "documentation"
       - dependency-name: "diff"
       - dependency-name: "@mapbox/mapbox-gl-supported"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.1.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@mapbox/geojson-rewind": "^0.5.0",
+        "@mapbox/geojson-rewind": "^0.5.1",
         "@mapbox/jsonlint-lines-primitives": "^2.0.2",
         "@mapbox/mapbox-gl-supported": "^2.0.1",
         "@mapbox/point-geometry": "^0.1.0",
@@ -32,7 +32,7 @@
       "devDependencies": {
         "@babel/core": "^7.16.0",
         "@mapbox/gazetteer": "^5.1.0",
-        "@mapbox/mapbox-gl-rtl-text": "^0.2.1",
+        "@mapbox/mapbox-gl-rtl-text": "^0.2.3",
         "@mapbox/mvt-fixtures": "^3.6.0",
         "@rollup/plugin-commonjs": "^21.0.1",
         "@rollup/plugin-json": "^4.1.0",
@@ -2652,7 +2652,8 @@
     },
     "node_modules/@mapbox/geojson-rewind": {
       "version": "0.5.1",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/@mapbox/geojson-rewind/-/geojson-rewind-0.5.1.tgz",
+      "integrity": "sha512-eL7fMmfTBKjrb+VFHXCGv9Ot0zc3C0U+CwXo1IrP+EPwDczLoXv34Tgq3y+2mPSFNVUXgU42ILWJTC7145KPTA==",
       "dependencies": {
         "get-stream": "^6.0.1",
         "minimist": "^1.2.5"
@@ -2660,6 +2661,13 @@
       "bin": {
         "geojson-rewind": "geojson-rewind"
       }
+    },
+    "node_modules/@mapbox/geojson-types": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@mapbox/geojson-types/-/geojson-types-1.0.2.tgz",
+      "integrity": "sha512-e9EBqHHv3EORHrSfbR9DqecPNn+AmuAoQxV6aL8Xu30bJMJR1o8PZLZzpk1Wq7/NfCbuhmakHTPYRhoqLsXRnw==",
+      "dev": true,
+      "peer": true
     },
     "node_modules/@mapbox/geojsonhint": {
       "version": "2.2.0",
@@ -2690,8 +2698,9 @@
     },
     "node_modules/@mapbox/mapbox-gl-rtl-text": {
       "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-rtl-text/-/mapbox-gl-rtl-text-0.2.3.tgz",
+      "integrity": "sha512-RaCYfnxULUUUxNwcUimV9C/o2295ktTyLEUzD/+VWkqXqvaVfFcZ5slytGzb2Sd/Jj4MlbxD0DCZbfa6CzcmMw==",
       "dev": true,
-      "license": "BSD-2-Clause",
       "peerDependencies": {
         "mapbox-gl": ">=0.32.1 <2.0.0"
       }
@@ -10899,6 +10908,13 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/grid-index": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/grid-index/-/grid-index-1.1.0.tgz",
+      "integrity": "sha512-HZRwumpOGUrHyxO5bqKZL0B0GlUpwtCAzZ42sgxUPniu33R1LSFH5yrIcBCHjkctCAh3mtWKcKd9J4vDDdeVHA==",
+      "dev": true,
+      "peer": true
+    },
     "node_modules/growly": {
       "version": "1.3.0",
       "dev": true,
@@ -14593,6 +14609,41 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/mapbox-gl": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-1.13.2.tgz",
+      "integrity": "sha512-CPjtWygL+f7naL+sGHoC2JQR0DG7u+9ik6WdkjjVmz2uy0kBC2l+aKfdi3ZzUR7VKSQJ6Mc/CeCN+6iVNah+ww==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@mapbox/geojson-rewind": "^0.5.0",
+        "@mapbox/geojson-types": "^1.0.2",
+        "@mapbox/jsonlint-lines-primitives": "^2.0.2",
+        "@mapbox/mapbox-gl-supported": "^1.5.0",
+        "@mapbox/point-geometry": "^0.1.0",
+        "@mapbox/tiny-sdf": "^1.1.1",
+        "@mapbox/unitbezier": "^0.0.0",
+        "@mapbox/vector-tile": "^1.3.1",
+        "@mapbox/whoots-js": "^3.1.0",
+        "csscolorparser": "~1.0.3",
+        "earcut": "^2.2.2",
+        "geojson-vt": "^3.2.1",
+        "gl-matrix": "^3.2.1",
+        "grid-index": "^1.1.0",
+        "minimist": "^1.2.5",
+        "murmurhash-js": "^1.0.0",
+        "pbf": "^3.2.1",
+        "potpack": "^1.0.1",
+        "quickselect": "^2.0.0",
+        "rw": "^1.3.3",
+        "supercluster": "^7.1.0",
+        "tinyqueue": "^2.0.3",
+        "vt-pbf": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6.4.0"
+      }
+    },
     "node_modules/mapbox-gl-styles": {
       "version": "2.0.2",
       "deprecated": "This package has moved to the @mapbox namespace. All new version are available via @mapbox/mapbox-gl-styles",
@@ -14616,6 +14667,30 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/mapbox-gl/node_modules/@mapbox/mapbox-gl-supported": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-supported/-/mapbox-gl-supported-1.5.0.tgz",
+      "integrity": "sha512-/PT1P6DNf7vjEEiPkVIRJkvibbqWtqnyGaBz3nfRdcxclNSnSdaLU5tfAgcD7I8Yt5i+L19s406YLl1koLnLbg==",
+      "dev": true,
+      "peer": true,
+      "peerDependencies": {
+        "mapbox-gl": ">=0.32.1 <2.0.0"
+      }
+    },
+    "node_modules/mapbox-gl/node_modules/@mapbox/tiny-sdf": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-1.2.5.tgz",
+      "integrity": "sha512-cD8A/zJlm6fdJOk6DqPUV8mcpyJkRz2x2R+/fYcWDYG3oWbG7/L7Yl/WqQ1VZCjnL9OTIMAn6c+BC5Eru4sQEw==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/mapbox-gl/node_modules/@mapbox/unitbezier": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-0.0.0.tgz",
+      "integrity": "sha1-FWUb1VOme4WB+zmIEMmK2Go0Uk4=",
+      "dev": true,
+      "peer": true
     },
     "node_modules/markdown-escapes": {
       "version": "1.0.4",
@@ -24597,10 +24672,19 @@
     },
     "@mapbox/geojson-rewind": {
       "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@mapbox/geojson-rewind/-/geojson-rewind-0.5.1.tgz",
+      "integrity": "sha512-eL7fMmfTBKjrb+VFHXCGv9Ot0zc3C0U+CwXo1IrP+EPwDczLoXv34Tgq3y+2mPSFNVUXgU42ILWJTC7145KPTA==",
       "requires": {
         "get-stream": "^6.0.1",
         "minimist": "^1.2.5"
       }
+    },
+    "@mapbox/geojson-types": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@mapbox/geojson-types/-/geojson-types-1.0.2.tgz",
+      "integrity": "sha512-e9EBqHHv3EORHrSfbR9DqecPNn+AmuAoQxV6aL8Xu30bJMJR1o8PZLZzpk1Wq7/NfCbuhmakHTPYRhoqLsXRnw==",
+      "dev": true,
+      "peer": true
     },
     "@mapbox/geojsonhint": {
       "version": "2.2.0",
@@ -24624,6 +24708,8 @@
     },
     "@mapbox/mapbox-gl-rtl-text": {
       "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-rtl-text/-/mapbox-gl-rtl-text-0.2.3.tgz",
+      "integrity": "sha512-RaCYfnxULUUUxNwcUimV9C/o2295ktTyLEUzD/+VWkqXqvaVfFcZ5slytGzb2Sd/Jj4MlbxD0DCZbfa6CzcmMw==",
       "dev": true,
       "requires": {}
     },
@@ -30650,6 +30736,13 @@
       "version": "4.2.8",
       "dev": true
     },
+    "grid-index": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/grid-index/-/grid-index-1.1.0.tgz",
+      "integrity": "sha512-HZRwumpOGUrHyxO5bqKZL0B0GlUpwtCAzZ42sgxUPniu33R1LSFH5yrIcBCHjkctCAh3mtWKcKd9J4vDDdeVHA==",
+      "dev": true,
+      "peer": true
+    },
     "growly": {
       "version": "1.3.0",
       "dev": true
@@ -33205,6 +33298,62 @@
       "dev": true,
       "requires": {
         "object-visit": "^1.0.0"
+      }
+    },
+    "mapbox-gl": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-1.13.2.tgz",
+      "integrity": "sha512-CPjtWygL+f7naL+sGHoC2JQR0DG7u+9ik6WdkjjVmz2uy0kBC2l+aKfdi3ZzUR7VKSQJ6Mc/CeCN+6iVNah+ww==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "@mapbox/geojson-rewind": "^0.5.0",
+        "@mapbox/geojson-types": "^1.0.2",
+        "@mapbox/jsonlint-lines-primitives": "^2.0.2",
+        "@mapbox/mapbox-gl-supported": "^1.5.0",
+        "@mapbox/point-geometry": "^0.1.0",
+        "@mapbox/tiny-sdf": "^1.1.1",
+        "@mapbox/unitbezier": "^0.0.0",
+        "@mapbox/vector-tile": "^1.3.1",
+        "@mapbox/whoots-js": "^3.1.0",
+        "csscolorparser": "~1.0.3",
+        "earcut": "^2.2.2",
+        "geojson-vt": "^3.2.1",
+        "gl-matrix": "^3.2.1",
+        "grid-index": "^1.1.0",
+        "minimist": "^1.2.5",
+        "murmurhash-js": "^1.0.0",
+        "pbf": "^3.2.1",
+        "potpack": "^1.0.1",
+        "quickselect": "^2.0.0",
+        "rw": "^1.3.3",
+        "supercluster": "^7.1.0",
+        "tinyqueue": "^2.0.3",
+        "vt-pbf": "^3.1.1"
+      },
+      "dependencies": {
+        "@mapbox/mapbox-gl-supported": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-supported/-/mapbox-gl-supported-1.5.0.tgz",
+          "integrity": "sha512-/PT1P6DNf7vjEEiPkVIRJkvibbqWtqnyGaBz3nfRdcxclNSnSdaLU5tfAgcD7I8Yt5i+L19s406YLl1koLnLbg==",
+          "dev": true,
+          "peer": true,
+          "requires": {}
+        },
+        "@mapbox/tiny-sdf": {
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-1.2.5.tgz",
+          "integrity": "sha512-cD8A/zJlm6fdJOk6DqPUV8mcpyJkRz2x2R+/fYcWDYG3oWbG7/L7Yl/WqQ1VZCjnL9OTIMAn6c+BC5Eru4sQEw==",
+          "dev": true,
+          "peer": true
+        },
+        "@mapbox/unitbezier": {
+          "version": "0.0.0",
+          "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-0.0.0.tgz",
+          "integrity": "sha1-FWUb1VOme4WB+zmIEMmK2Go0Uk4=",
+          "dev": true,
+          "peer": true
+        }
       }
     },
     "mapbox-gl-styles": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "types": "dist/maplibre-gl.d.ts",
   "type": "module",
   "dependencies": {
-    "@mapbox/geojson-rewind": "^0.5.0",
+    "@mapbox/geojson-rewind": "^0.5.1",
     "@mapbox/jsonlint-lines-primitives": "^2.0.2",
     "@mapbox/mapbox-gl-supported": "^2.0.1",
     "@mapbox/point-geometry": "^0.1.0",
@@ -35,7 +35,7 @@
   "devDependencies": {
     "@babel/core": "^7.16.0",
     "@mapbox/gazetteer": "^5.1.0",
-    "@mapbox/mapbox-gl-rtl-text": "^0.2.1",
+    "@mapbox/mapbox-gl-rtl-text": "^0.2.3",
     "@mapbox/mvt-fixtures": "^3.6.0",
     "@rollup/plugin-commonjs": "^21.0.1",
     "@rollup/plugin-json": "^4.1.0",


### PR DESCRIPTION
This updates a few packages not covered by dependabot to their latest versions.

I noticed our devDeps for right-to-left text `@mapbox/mapbox-gl-rtl-text` adds a mapbox-gl peer dependency  v0.2.2 - back in 2019 when the library last wass updated

```
"peerDependencies": {
    "mapbox-gl": ">=0.32.1 <2.0.0"
 }
```

https://github.com/mapbox/mapbox-gl-rtl-text/commit/046c611e38efb7a1335d7126662a6803c564f3f1

Any opinions on that? It's the BSD version, but we also have the option to make a fork and cut it out.