### PR TITLE
Fix camera tests on mac runners

### DIFF
--- a/src/ui/camera.test.ts
+++ b/src/ui/camera.test.ts
@@ -1545,7 +1545,7 @@ describe('#flyTo', () => {
             .on('moveend', () => {
                 endTime = new Date();
                 timeDiff = endTime - startTime;
-                expect(timeDiff).toBeLessThan(10);
+                expect(timeDiff).toBeLessThan(20);
                 done();
             });
 


### PR DESCRIPTION
fix #908 . Change timeDiff from being <10 sec to <20, so slower runners can pass test.