### PR TITLE
Raise limit for camera test further

### DIFF
--- a/src/ui/camera.test.ts
+++ b/src/ui/camera.test.ts
@@ -1545,7 +1545,7 @@ describe('#flyTo', () => {
             .on('moveend', () => {
                 endTime = new Date();
                 timeDiff = endTime - startTime;
-                expect(timeDiff).toBeLessThan(20);
+                expect(timeDiff).toBeLessThan(30);
                 done();
             });
 


### PR DESCRIPTION
The can apparently takes longer than the limit set in #910, so this raises the limit a bit further from 20 to 30, so the even the mac runner, which has a timeDiff of 22 sometimes, can pass every time.