### PR TITLE
Fix stale tiles being shown when calling VectorTileSource#setTiles while the map is moving

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### 🐞 Bug fixes
 
+- Fix stale tiles being shown when calling VectorTileSource#setTiles while the map is moving.
 - *...Add new stuff here...*
 
 ## 2.1.0

--- a/src/source/vector_tile_source.ts
+++ b/src/source/vector_tile_source.ts
@@ -97,10 +97,10 @@ class VectorTileSource extends Evented implements Source {
         this._tileJSONRequest = loadTileJSON(this._options, this.map._requestManager, (err, tileJSON) => {
             this._tileJSONRequest = null;
             this._loaded = true;
+            this.map.style.sourceCaches[this.id].clearTiles();
             if (err) {
                 this.fire(new ErrorEvent(err));
             } else if (tileJSON) {
-                this.map.style.sourceCaches[this.id].clearTiles();
                 extend(this, tileJSON);
                 if (tileJSON.bounds) this.tileBounds = new TileBounds(tileJSON.bounds, this.minzoom, this.maxzoom);
 

--- a/src/source/vector_tile_source.ts
+++ b/src/source/vector_tile_source.ts
@@ -100,6 +100,7 @@ class VectorTileSource extends Evented implements Source {
             if (err) {
                 this.fire(new ErrorEvent(err));
             } else if (tileJSON) {
+                this.map.style.sourceCaches[this.id].clearTiles();
                 extend(this, tileJSON);
                 if (tileJSON.bounds) this.tileBounds = new TileBounds(tileJSON.bounds, this.minzoom, this.maxzoom);
 
@@ -132,8 +133,6 @@ class VectorTileSource extends Evented implements Source {
 
         callback();
 
-        const sourceCache = this.map.style.sourceCaches[this.id];
-        sourceCache.clearTiles();
         this.load();
     }
 

--- a/src/style/style.test.ts
+++ b/src/style/style.test.ts
@@ -48,6 +48,7 @@ function createGeoJSONSource() {
 }
 
 class StubMap extends Evented {
+    style: Style;
     transform: Transform;
     private _requestManager: RequestManager;
 
@@ -67,6 +68,12 @@ class StubMap extends Evented {
 }
 
 const getStubMap = () => new StubMap() as any;
+
+function createStyle(map = getStubMap()) {
+    const style = new Style(map);
+    map.style = style;
+    return style;
+}
 
 let sinonFakeXMLServer;
 let sinonFakeServer;
@@ -258,7 +265,7 @@ describe('Style#loadJSON', () => {
     });
 
     test('creates sources', done => {
-        const style = new Style(getStubMap());
+        const style = createStyle();
 
         style.on('style.load', () => {
             expect(style.sourceCaches['mapLibre'] instanceof SourceCache).toBeTruthy();
@@ -276,7 +283,7 @@ describe('Style#loadJSON', () => {
     });
 
     test('creates layers', done => {
-        const style = new Style(getStubMap());
+        const style = createStyle();
 
         style.on('style.load', () => {
             expect(style.getLayer('fill') instanceof StyleLayer).toBeTruthy();
@@ -302,7 +309,7 @@ describe('Style#loadJSON', () => {
     test('transforms sprite json and image URLs before request', done => {
         const map = getStubMap();
         const transformSpy = jest.spyOn(map._requestManager, 'transformRequest');
-        const style = new Style(map);
+        const style = createStyle(map);
 
         style.on('style.load', () => {
             expect(transformSpy).toHaveBeenCalledTimes(2);
@@ -319,7 +326,7 @@ describe('Style#loadJSON', () => {
     });
 
     test('emits an error on non-existant vector source layer', done => {
-        const style = new Style(getStubMap());
+        const style = createStyle();
         style.loadJSON(createStyleJSON({
             sources: {
                 '-source-id-': {type: 'vector', tiles: []}
@@ -407,7 +414,7 @@ describe('Style#_remove', () => {
 
 describe('Style#update', () => {
     test('on error', done => {
-        const style = new Style(getStubMap());
+        const style = createStyle();
         style.loadJSON({
             'version': 8,
             'sources': {
@@ -449,7 +456,7 @@ describe('Style#setState', () => {
     });
 
     test('do nothing if there are no changes', done => {
-        const style = new Style(getStubMap());
+        const style = createStyle();
         style.loadJSON(createStyleJSON());
         jest.spyOn(style, 'addLayer').mockImplementation(() => done('test failed'));
         jest.spyOn(style, 'removeLayer').mockImplementation(() => done('test failed'));
@@ -574,7 +581,7 @@ describe('Style#addSource', () => {
     });
 
     test('fires "data" event', done => {
-        const style = new Style(getStubMap());
+        const style = createStyle();
         style.loadJSON(createStyleJSON());
         const source = createSource();
         style.once('data', () => { done(); });
@@ -585,7 +592,7 @@ describe('Style#addSource', () => {
     });
 
     test('throws on duplicates', done => {
-        const style = new Style(getStubMap());
+        const style = createStyle();
         style.loadJSON(createStyleJSON());
         const source = createSource();
         style.on('style.load', () => {
@@ -607,7 +614,7 @@ describe('Style#addSource', () => {
                 done();
             }
         };
-        const style = new Style(getStubMap());
+        const style = createStyle();
         style.loadJSON(createStyleJSON({
             layers: [{
                 id: 'background',
@@ -795,7 +802,7 @@ describe('Style#addLayer', () => {
     });
 
     test('throws on non-existant vector source layer', done => {
-        const style = new Style(getStubMap());
+        const style = createStyle();
         style.loadJSON(createStyleJSON({
             sources: {
                 // At least one source must be added to trigger the load event
@@ -864,7 +871,7 @@ describe('Style#addLayer', () => {
     });
 
     test('reloads source', done => {
-        const style = new Style(getStubMap());
+        const style = createStyle();
         style.loadJSON(extend(createStyleJSON(), {
             'sources': {
                 'mapLibre': {
@@ -891,7 +898,7 @@ describe('Style#addLayer', () => {
     });
 
     test('#3895 reloads source (instead of clearing) if adding this layer with the same type, immediately after removing it', done => {
-        const style = new Style(getStubMap());
+        const style = createStyle();
         style.loadJSON(extend(createStyleJSON(), {
             'sources': {
                 'mapLibre': {
@@ -928,7 +935,7 @@ describe('Style#addLayer', () => {
     });
 
     test('clears source (instead of reloading) if adding this layer with a different type, immediately after removing it', done => {
-        const style = new Style(getStubMap());
+        const style = createStyle();
         style.loadJSON(extend(createStyleJSON(), {
             'sources': {
                 'mapLibre': {

--- a/src/ui/control/logo_control.test.ts
+++ b/src/ui/control/logo_control.test.ts
@@ -34,6 +34,7 @@ function createSource(options, logoRequired) {
             _skuToken: '1234567890123',
             canonicalizeTileset: tileJSON => tileJSON.tiles
         },
+        style: {sourceCaches: {id: {clearTiles() {}}}},
         transform: {angle: 0, pitch: 0, showCollisionBoxes: false},
         _getMapId: () => 1
     }as any as Map);


### PR DESCRIPTION
<changelog>Fix stale tiles being shown when calling VectorTileSource#setTiles while the map is moving</changelog>

Before this PR, when calling `VectorTileSource#setTiles`, the source cache was cleared before the TileJSON was reloaded asynchronously. If the map was moving while `VectorTileSource#setTiles` was called, it was possible for the cache to be repopulated with the old tiles if `VectorTileSource#loadTile` happened to be called before the TileJSON had been reloaded. This was due to the `VectorTileSource#tiles` property, which is used by `VectorTileSource#loadTile`, only being updated asynchronously after the TileJSON had reloaded.

## Launch Checklist

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Write tests for all new functionality.
 - [x] Manually test the debug page.
 - [x] Add an entry inside this element for inclusion in the `maplibre-gl-js` changelog: `<changelog></changelog>`.
