### PR TITLE
fix svgo options

### DIFF
--- a/postcss.config.cjs
+++ b/postcss.config.cjs
@@ -5,10 +5,14 @@ module.exports = {
             preset: ['default', {
                 svgo: {
                     plugins: [{
-                        removeViewBox: false
-                    }, {
-                        removeDimensions: false
-                    }],
+                        name: 'preset-default',
+                        params: {
+                            overrides: {
+                                removeViewBox: false,
+                                removeDimensions: false
+                            }
+                         }
+                     }],
                 },
             }],
         }),


### PR DESCRIPTION
The old svgo options are no longer supported and we effectively disabled svgo usage with an error message.
This pull request fixes the options to the original intend. This does change the generated css though as svgo is used again.

I only checked the icons on http://localhost:9966/debug/debug.html in Safari so far and they look the same in main and this branch.

Alternatively we can generate the exact same css but without any error messages by just explicitly disabling svgo with `svgo: false`.

What should we do?