### PR TITLE
Fire dataabort event when a tile request is aborted (#794)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### 🐞 Bug fixes
 
 - Fix error mismatched image size for CJK characters (#718)
+- Fire `dataabort` event when a tile request is aborted (#794)
 - *...Add new stuff here...*
 
 ## 2.1.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 ### 🐞 Bug fixes
 
 - Fix error mismatched image size for CJK characters (#718)
-- Fire `dataabort` event when a tile request is aborted (#794)
+- Fire `dataabort` and `sourcedataabort` events when a tile request is aborted (#794)
 - *...Add new stuff here...*
 
 ## 2.1.1

--- a/src/source/source_cache.ts
+++ b/src/source/source_cache.ts
@@ -160,7 +160,9 @@ class SourceCache extends Evented {
 
     _abortTile(tile: Tile) {
         if (this._source.abortTile)
-            return this._source.abortTile(tile, () => {});
+            this._source.abortTile(tile, () => {});
+
+        this._source.fire(new Event('dataabort', {tile, coord: tile.tileID, dataType: 'source'}));
     }
 
     serialize() {
@@ -775,7 +777,6 @@ class SourceCache extends Evented {
             tile.aborted = true;
             this._abortTile(tile);
             this._unloadTile(tile);
-            this._source.fire(new Event('dataabort', {tile, coord: tile.tileID, dataType: 'source'}));
         }
     }
 

--- a/src/source/source_cache.ts
+++ b/src/source/source_cache.ts
@@ -775,6 +775,7 @@ class SourceCache extends Evented {
             tile.aborted = true;
             this._abortTile(tile);
             this._unloadTile(tile);
+            this._source.fire(new Event('dataabort', {tile, coord: tile.tileID, dataType: 'source'}));
         }
     }
 

--- a/src/ui/events.ts
+++ b/src/ui/events.ts
@@ -344,6 +344,8 @@ export type MapEventType = {
      sourcedata: MapSourceDataEvent;
      styledata: MapStyleDataEvent;
      styleimagemissing: MapStyleImageMissingEvent;
+     dataabort: MapDataEvent;
+     sourcedataabort: MapSourceDataEvent;
 
      boxzoomcancel: MapLibreZoomEvent;
      boxzoomstart: MapLibreZoomEvent;
@@ -1258,8 +1260,8 @@ export type MapEvent = /**
 
 /**
      * Fired when any map data (style, source, tile, etc) begins loading or
-     * changing asyncronously. All `dataloading` events are followed by a `data`
-     * or `error` event. See {@link MapDataEvent} for more information.
+     * changing asyncronously. All `dataloading` events are followed by a `data`,
+     * `dataabort` or `error` event. See {@link MapDataEvent} for more information.
      *
      * @event dataloading
      * @memberof Map
@@ -1298,7 +1300,7 @@ export type MapEvent = /**
 
 /**
      * Fired when one of the map's sources begins loading or changing asyncronously.
-     * All `sourcedataloading` events are followed by a `sourcedata` or `error` event.
+     * All `sourcedataloading` events are followed by a `sourcedata`, `sourcedataabort` or `error` event.
      * See {@link MapDataEvent} for more information.
      *
      * @event sourcedataloading
@@ -1341,4 +1343,40 @@ export type MapEvent = /**
      * @memberof Map
      * @instance
      * @private
-     */ | 'style.load';
+     */ | 'style.load'
+
+/**
+     * Fired when a request for one of the map's sources' tiles is aborted.
+     * See {@link MapDataEvent} for more information.
+     *
+     * @event dataabort
+     * @memberof Map
+     * @instance
+     * @property {MapDataEvent} data
+     * @example
+     * // Initialize the map
+     * var map = new maplibregl.Map({ // map options });
+     * // Set an event listener that fires
+     * // when a request for one of the map's sources' tiles is aborted.
+     * map.on('dataabort', function() {
+     *   console.log('A dataabort event occurred.');
+     * });
+     */ | 'dataabort'
+
+/**
+     * Fired when a request for one of the map's sources' tiles is aborted.
+     * See {@link MapDataEvent} for more information.
+     *
+     * @event sourcedataabort
+     * @memberof Map
+     * @instance
+     * @property {MapDataEvent} data
+     * @example
+     * // Initialize the map
+     * var map = new maplibregl.Map({ // map options });
+     * // Set an event listener that fires
+     * // when a request for one of the map's sources' tiles is aborted.
+     * map.on('sourcedataabort', function() {
+     *   console.log('A sourcedataabort event occurred.');
+     * });
+     */ | 'sourcedataabort';

--- a/src/ui/map.test.ts
+++ b/src/ui/map.test.ts
@@ -2115,6 +2115,12 @@ describe('Map', () => {
         expect(map.painter.height).toBe(1024);
     });
 
+    test('fires sourcedataabort event on dataabort event with dataType of "source"', done => {
+        const map = createMap();
+        map.once('sourcedataabort', () => done());
+        map.fire(new Event('dataabort', {dataType: 'source'}));
+    });
+
 });
 
 function createStyle() {

--- a/src/ui/map.test.ts
+++ b/src/ui/map.test.ts
@@ -2115,10 +2115,10 @@ describe('Map', () => {
         expect(map.painter.height).toBe(1024);
     });
 
-    test('fires sourcedataabort event on dataabort event with dataType of "source"', done => {
+    test('fires sourcedataabort event on dataabort event', done => {
         const map = createMap();
         map.once('sourcedataabort', () => done());
-        map.fire(new Event('dataabort', {dataType: 'source'}));
+        map.fire(new Event('dataabort'));
     });
 
 });

--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -476,6 +476,9 @@ class Map extends Camera {
         this.on('dataloading', (event: MapDataEvent) => {
             this.fire(new Event(`${event.dataType}dataloading`, event));
         });
+        this.on('dataabort', (event: MapDataEvent) => {
+            this.fire(new Event(`${event.dataType}dataabort`, event));
+        });
     }
 
     /*
@@ -1018,6 +1021,8 @@ class Map extends Camera {
      * | [`styledataloading`](#map.event:styledataloading)         |                           |
      * | [`sourcedataloading`](#map.event:sourcedataloading)       |                           |
      * | [`styleimagemissing`](#map.event:styleimagemissing)       |                           |
+     * | [`dataabort`](#map.event:dataabort)                       |                           |
+     * | [`sourcedataabort`](#map.event:sourcedataabort)           |                           |
      *
      * @param {string | Listener} layerIdOrListener The ID of a style layer or a listener if no ID is provided. Event will only be triggered if its location
      * is within a visible feature in this layer. The event will have a `features` property containing

--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -477,7 +477,7 @@ class Map extends Camera {
             this.fire(new Event(`${event.dataType}dataloading`, event));
         });
         this.on('dataabort', (event: MapDataEvent) => {
-            this.fire(new Event(`${event.dataType}dataabort`, event));
+            this.fire(new Event('sourcedataabort', event));
         });
     }
 


### PR DESCRIPTION
<changelog>Fire dataabort event when a tile request is aborted (#794)</changelog>

## Launch Checklist

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Write tests for all new functionality.
 - [x] Document any changes to public APIs.
 - [x] Manually test the debug page.
 - [x] Add an entry inside this element for inclusion in the `maplibre-gl-js` changelog: `<changelog></changelog>`.
