### PR TITLE
Run dependabot weekly, avoiding monthly crunch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,4 @@ updates:
   - package-ecosystem: "npm" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
-      interval: "daily"
-    ignore:
-      - dependency-name: "documentation"
+      interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,6 @@ updates:
   - package-ecosystem: "npm" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
-      interval: "monthly"
+      interval: "daily"
     ignore:
       - dependency-name: "documentation"


### PR DESCRIPTION
The monthly dependabot took up an entire workday to resolve last time, and that would be great to spread out going forward.