### PR TITLE
Use `@typescript-eslint/indent`

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -72,18 +72,9 @@
     "space-before-function-paren": "off",
     "template-curly-spacing": "error",
     "no-useless-escape": "off",
-    "indent": ["error", 4, {
-      "flatTernaryExpressions": true,
-      "CallExpression": {
-        "arguments": "off"
-      },
-      "FunctionDeclaration": {
-        "parameters": "off"
-      },
-      "FunctionExpression": {
-        "parameters": "off"
-      }
-    }],
+    // @typescript-eslint/indent requires standard indent rule to be turned off
+    "indent": "off",
+    "@typescript-eslint/indent": ["error"],
     "no-multiple-empty-lines": [ "error", {
         "max": 1
     }],

--- a/bench/benchmarks/layout.ts
+++ b/bench/benchmarks/layout.ts
@@ -6,8 +6,8 @@ import {OverscaledTileID} from '../../src/source/tile_id';
 
 export default class Layout extends Benchmark {
     tiles: Array<{
-      tileID: OverscaledTileID;
-      buffer: ArrayBuffer;
+        tileID: OverscaledTileID;
+        buffer: ArrayBuffer;
     }>;
     parser: TileParser;
     style: string | StyleSpecification;

--- a/bench/benchmarks/symbol_layout.ts
+++ b/bench/benchmarks/symbol_layout.ts
@@ -31,12 +31,12 @@ export default class SymbolLayout extends Layout {
                 for (const bucket of tileResult.buckets) {
                     if (bucket instanceof SymbolBucket) {
                         performSymbolLayout(bucket,
-                                            tileResult.glyphMap,
-                                            tileResult.glyphPositions,
-                                            tileResult.iconMap,
-                                            tileResult.imageAtlas.iconPositions,
-                                            false,
-                                            tileResult.featureIndex.tileID.canonical);
+                            tileResult.glyphMap,
+                            tileResult.glyphPositions,
+                            tileResult.iconMap,
+                            tileResult.imageAtlas.iconPositions,
+                            false,
+                            tileResult.featureIndex.tileID.canonical);
                     }
                 }
             });

--- a/bench/components/util.ts
+++ b/bench/components/util.ts
@@ -2,13 +2,13 @@ import * as d3 from 'd3';
 import {RegressionResults, Summary} from '../lib/statistics';
 
 export type Version = {
-  name: string;
-  status: string;
-  samples: number[];
-  density: [number, number][];
-  summary: Summary;
-  regression: RegressionResults;
-  error: Error;
+    name: string;
+    status: string;
+    samples: number[];
+    density: [number, number][];
+    summary: Summary;
+    regression: RegressionResults;
+    error: Error;
 }
 
 export const versionColor = d3.scaleOrdinal(['#1b9e77', '#7570b3', '#d95f02']);

--- a/bench/lib/benchmark.ts
+++ b/bench/lib/benchmark.ts
@@ -5,8 +5,8 @@
 const minTimeForMeasurement = 0.005 * 1000;
 
 export type Measurement = {
-  iterations: number;
-  time: number;
+    iterations: number;
+    time: number;
 };
 
 class Benchmark {

--- a/bench/lib/statistics.ts
+++ b/bench/lib/statistics.ts
@@ -63,8 +63,8 @@ export function summaryStatistics(data): Summary {
     const trimmedMean = d3.mean(data.filter(d => d >= lowerQuintile && d <= upperQuintile));
     const windsorizedDeviation = d3.deviation(data.map(d =>
         d < lowerQuintile ? lowerQuintile :
-        d > upperQuintile ? upperQuintile :
-        d
+            d > upperQuintile ? upperQuintile :
+                d
     ));
 
     return {

--- a/bench/lib/tile_parser.ts
+++ b/bench/lib/tile_parser.ts
@@ -49,7 +49,7 @@ export default class TileParser {
     glyphs: any;
     style: Style;
     actor: {
-      send: Function;
+        send: Function;
     };
 
     constructor(styleJSON: StyleSpecification, sourceID: string) {
@@ -114,11 +114,11 @@ export default class TileParser {
     }
 
     parseTile(
-      tile: {
-        tileID: OverscaledTileID;
-        buffer: ArrayBuffer;
-      },
-      returnDependencies?: boolean
+        tile: {
+            tileID: OverscaledTileID;
+            buffer: ArrayBuffer;
+        },
+        returnDependencies?: boolean
     ): Promise<WorkerTileResult> {
         const workerTile = new WorkerTile({
             tileID: tile.tileID,

--- a/build/generate-style-code.ts
+++ b/build/generate-style-code.ts
@@ -17,27 +17,27 @@ function pascalCase(str: string): string {
 
 function nativeType(property) {
     switch (property.type) {
-    case 'boolean':
-        return 'boolean';
-    case 'number':
-        return 'number';
-    case 'string':
-        return 'string';
-    case 'enum':
-        return Object.keys(property.values).map(v => JSON.stringify(v)).join(' | ');
-    case 'color':
-        return 'Color';
-    case 'formatted':
-        return 'Formatted';
-    case 'resolvedImage':
-        return 'ResolvedImage';
-    case 'array':
-        if (property.length) {
-            return `[${new Array(property.length).fill(nativeType({type: property.value})).join(', ')}]`;
-        } else {
-            return `Array<${nativeType({type: property.value, values: property.values})}>`;
-        }
-    default: throw new Error(`unknown type for ${property.name}`);
+        case 'boolean':
+            return 'boolean';
+        case 'number':
+            return 'number';
+        case 'string':
+            return 'string';
+        case 'enum':
+            return Object.keys(property.values).map(v => JSON.stringify(v)).join(' | ');
+        case 'color':
+            return 'Color';
+        case 'formatted':
+            return 'Formatted';
+        case 'resolvedImage':
+            return 'ResolvedImage';
+        case 'array':
+            if (property.length) {
+                return `[${new Array(property.length).fill(nativeType({type: property.value})).join(', ')}]`;
+            } else {
+                return `Array<${nativeType({type: property.value, values: property.values})}>`;
+            }
+        default: throw new Error(`unknown type for ${property.name}`);
     }
 }
 
@@ -45,14 +45,14 @@ function possiblyEvaluatedType(property)  {
     const propType = nativeType(property);
 
     switch (property['property-type']) {
-    case 'color-ramp':
-        return 'ColorRampProperty';
-    case 'cross-faded':
-        return `CrossFaded<${propType}>`;
-    case 'cross-faded-data-driven':
-        return `PossiblyEvaluatedPropertyValue<CrossFaded<${propType}>>`;
-    case 'data-driven':
-        return `PossiblyEvaluatedPropertyValue<${propType}>`;
+        case 'color-ramp':
+            return 'ColorRampProperty';
+        case 'cross-faded':
+            return `CrossFaded<${propType}>`;
+        case 'cross-faded-data-driven':
+            return `PossiblyEvaluatedPropertyValue<CrossFaded<${propType}>>`;
+        case 'data-driven':
+            return `PossiblyEvaluatedPropertyValue<${propType}>`;
     }
 
     return propType;
@@ -60,44 +60,44 @@ function possiblyEvaluatedType(property)  {
 
 function propertyType(property) {
     switch (property['property-type']) {
-    case 'data-driven':
-        return `DataDrivenProperty<${nativeType(property)}>`;
-    case 'cross-faded':
-        return `CrossFadedProperty<${nativeType(property)}>`;
-    case 'cross-faded-data-driven':
-        return `CrossFadedDataDrivenProperty<${nativeType(property)}>`;
-    case 'color-ramp':
-        return 'ColorRampProperty';
-    case 'data-constant':
-    case 'constant':
-        return `DataConstantProperty<${nativeType(property)}>`;
-    default:
-        throw new Error(`unknown property-type "${property['property-type']}" for ${property.name}`);
+        case 'data-driven':
+            return `DataDrivenProperty<${nativeType(property)}>`;
+        case 'cross-faded':
+            return `CrossFadedProperty<${nativeType(property)}>`;
+        case 'cross-faded-data-driven':
+            return `CrossFadedDataDrivenProperty<${nativeType(property)}>`;
+        case 'color-ramp':
+            return 'ColorRampProperty';
+        case 'data-constant':
+        case 'constant':
+            return `DataConstantProperty<${nativeType(property)}>`;
+        default:
+            throw new Error(`unknown property-type "${property['property-type']}" for ${property.name}`);
     }
 }
 
 function runtimeType(property) {
     switch (property.type) {
-    case 'boolean':
-        return 'BooleanType';
-    case 'number':
-        return 'NumberType';
-    case 'string':
-    case 'enum':
-        return 'StringType';
-    case 'color':
-        return 'ColorType';
-    case 'formatted':
-        return 'FormattedType';
-    case 'Image':
-        return 'ImageType';
-    case 'array':
-        if (property.length) {
-            return `array(${runtimeType({type: property.value})}, ${property.length})`;
-        } else {
-            return `array(${runtimeType({type: property.value})})`;
-        }
-    default: throw new Error(`unknown type for ${property.name}`);
+        case 'boolean':
+            return 'BooleanType';
+        case 'number':
+            return 'NumberType';
+        case 'string':
+        case 'enum':
+            return 'StringType';
+        case 'color':
+            return 'ColorType';
+        case 'formatted':
+            return 'FormattedType';
+        case 'Image':
+            return 'ImageType';
+        case 'array':
+            if (property.length) {
+                return `array(${runtimeType({type: property.value})}, ${property.length})`;
+            } else {
+                return `array(${runtimeType({type: property.value})})`;
+            }
+        default: throw new Error(`unknown type for ${property.name}`);
     }
 }
 
@@ -109,23 +109,23 @@ function propertyValue(property, type) {
     const propertyAsSpec = `styleSpec["${type}_${property.layerType}"]["${property.name}"] as any as StylePropertySpecification`;
 
     switch (property['property-type']) {
-    case 'data-driven':
-        if (property.overridable) {
-            return `new DataDrivenProperty(${propertyAsSpec}, ${overrides(property)})`;
-        } else {
-            return `new DataDrivenProperty(${propertyAsSpec})`;
-        }
-    case 'cross-faded':
-        return `new CrossFadedProperty(${propertyAsSpec})`;
-    case 'cross-faded-data-driven':
-        return `new CrossFadedDataDrivenProperty(${propertyAsSpec})`;
-    case 'color-ramp':
-        return `new ColorRampProperty(${propertyAsSpec})`;
-    case 'data-constant':
-    case 'constant':
-        return `new DataConstantProperty(${propertyAsSpec})`;
-    default:
-        throw new Error(`unknown property-type "${property['property-type']}" for ${property.name}`);
+        case 'data-driven':
+            if (property.overridable) {
+                return `new DataDrivenProperty(${propertyAsSpec}, ${overrides(property)})`;
+            } else {
+                return `new DataDrivenProperty(${propertyAsSpec})`;
+            }
+        case 'cross-faded':
+            return `new CrossFadedProperty(${propertyAsSpec})`;
+        case 'cross-faded-data-driven':
+            return `new CrossFadedDataDrivenProperty(${propertyAsSpec})`;
+        case 'color-ramp':
+            return `new ColorRampProperty(${propertyAsSpec})`;
+        case 'data-constant':
+        case 'constant':
+            return `new DataConstantProperty(${propertyAsSpec})`;
+        default:
+            throw new Error(`unknown property-type "${property['property-type']}" for ${property.name}`);
     }
 }
 

--- a/build/generate-style-spec.ts
+++ b/build/generate-style-spec.ts
@@ -18,28 +18,28 @@ function propertyType(property) {
 
     const baseType = (() => {
         switch (property.type) {
-        case 'string':
-        case 'number':
-        case 'boolean':
-            return property.type;
-        case 'enum':
-            return unionType(property.values);
-        case 'array': {
-            const elementType = propertyType(typeof property.value === 'string' ? {type: property.value, values: property.values} : property.value);
-            if (property.length) {
-                return `[${Array(property.length).fill(elementType).join(', ')}]`;
-            } else {
-                return `Array<${elementType}>`;
+            case 'string':
+            case 'number':
+            case 'boolean':
+                return property.type;
+            case 'enum':
+                return unionType(property.values);
+            case 'array': {
+                const elementType = propertyType(typeof property.value === 'string' ? {type: property.value, values: property.values} : property.value);
+                if (property.length) {
+                    return `[${Array(property.length).fill(elementType).join(', ')}]`;
+                } else {
+                    return `Array<${elementType}>`;
+                }
             }
-        }
-        case 'light':
-            return 'LightSpecification';
-        case 'sources':
-            return '{[_: string]: SourceSpecification}';
-        case '*':
-            return 'unknown';
-        default:
-            return `${property.type.slice(0, 1).toUpperCase()}${property.type.slice(1)}Specification`;
+            case 'light':
+                return 'LightSpecification';
+            case 'sources':
+                return '{[_: string]: SourceSpecification}';
+            case '*':
+                return 'unknown';
+            default:
+                return `${property.type.slice(0, 1).toUpperCase()}${property.type.slice(1)}Specification`;
         }
     })();
 
@@ -115,7 +115,7 @@ function layerType(key) {
 const layerTypes = Object.keys(spec.layer.type.values);
 
 fs.writeFileSync('src/style-spec/types.ts',
-`// Generated code; do not edit. Edit build/generate-style-spec.ts instead.
+    `// Generated code; do not edit. Edit build/generate-style-spec.ts instead.
 /* eslint-disable */
 
 export type ColorSpecification = string;

--- a/src/data/bucket.ts
+++ b/src/data/bucket.ts
@@ -10,46 +10,46 @@ import type {VectorTileFeature, VectorTileLayer} from '@mapbox/vector-tile';
 import Point from '@mapbox/point-geometry';
 
 export type BucketParameters<Layer extends TypedStyleLayer> = {
-  index: number;
-  layers: Array<Layer>;
-  zoom: number;
-  pixelRatio: number;
-  overscaling: number;
-  collisionBoxArray: CollisionBoxArray;
-  sourceLayerIndex: number;
-  sourceID: string;
+    index: number;
+    layers: Array<Layer>;
+    zoom: number;
+    pixelRatio: number;
+    overscaling: number;
+    collisionBoxArray: CollisionBoxArray;
+    sourceLayerIndex: number;
+    sourceID: string;
 };
 
 export type PopulateParameters = {
-  featureIndex: FeatureIndex;
-  iconDependencies: {};
-  patternDependencies: {};
-  glyphDependencies: {};
-  availableImages: Array<string>;
+    featureIndex: FeatureIndex;
+    iconDependencies: {};
+    patternDependencies: {};
+    glyphDependencies: {};
+    availableImages: Array<string>;
 };
 
 export type IndexedFeature = {
-  feature: VectorTileFeature;
-  id: number | string;
-  index: number;
-  sourceLayerIndex: number;
+    feature: VectorTileFeature;
+    id: number | string;
+    index: number;
+    sourceLayerIndex: number;
 };
 
 export type BucketFeature = {
-  index: number;
-  sourceLayerIndex: number;
-  geometry: Array<Array<Point>>;
-  properties: any;
-  type: 1 | 2 | 3;
-  id?: any;
-  readonly patterns: {
-    [_: string]: {
-      'min': string;
-      'mid': string;
-      'max': string;
+    index: number;
+    sourceLayerIndex: number;
+    geometry: Array<Array<Point>>;
+    properties: any;
+    type: 1 | 2 | 3;
+    id?: any;
+    readonly patterns: {
+        [_: string]: {
+            'min': string;
+            'mid': string;
+            'max': string;
+        };
     };
-  };
-  sortKey?: number;
+    sortKey?: number;
 };
 
 /**
@@ -76,24 +76,24 @@ export type BucketFeature = {
  * @private
  */
 export interface Bucket {
-  layerIds: Array<string>;
-  hasPattern: boolean;
-  readonly layers: Array<any>;
-  readonly stateDependentLayers: Array<any>;
-  readonly stateDependentLayerIds: Array<string>;
-  populate(features: Array<IndexedFeature>, options: PopulateParameters, canonical: CanonicalTileID): void;
-  update(states: FeatureStates, vtLayer: VectorTileLayer, imagePositions: {[_: string]: ImagePosition}): void;
-  isEmpty(): boolean;
-  upload(context: Context): void;
-  uploadPending(): boolean;
-  /**
+    layerIds: Array<string>;
+    hasPattern: boolean;
+    readonly layers: Array<any>;
+    readonly stateDependentLayers: Array<any>;
+    readonly stateDependentLayerIds: Array<string>;
+    populate(features: Array<IndexedFeature>, options: PopulateParameters, canonical: CanonicalTileID): void;
+    update(states: FeatureStates, vtLayer: VectorTileLayer, imagePositions: {[_: string]: ImagePosition}): void;
+    isEmpty(): boolean;
+    upload(context: Context): void;
+    uploadPending(): boolean;
+    /**
      * Release the WebGL resources associated with the buffers. Note that because
      * buckets are shared between layers having the same layout properties, they
      * must be destroyed in groups (all buckets for a tile, or all symbol buckets).
      *
      * @private
      */
-  destroy(): void;
+    destroy(): void;
 }
 
 export function deserialize(input: Array<Bucket>, style: Style): {[_: string]: Bucket} {

--- a/src/data/bucket/fill_bucket.ts
+++ b/src/data/bucket/fill_bucket.ts
@@ -126,14 +126,14 @@ class FillBucket implements Bucket {
     }
 
     update(states: FeatureStates, vtLayer: VectorTileLayer, imagePositions: {
-      [_: string]: ImagePosition;
+        [_: string]: ImagePosition;
     }) {
         if (!this.stateDependentLayers.length) return;
         this.programConfigurations.updatePaintArrays(states, vtLayer, this.stateDependentLayers, imagePositions);
     }
 
     addFeatures(options: PopulateParameters, canonical: CanonicalTileID, imagePositions: {
-      [_: string]: ImagePosition;
+        [_: string]: ImagePosition;
     }) {
         for (const feature of this.patternFeatures) {
             this.addFeature(feature, feature.geometry, feature.index, canonical, imagePositions);
@@ -168,7 +168,7 @@ class FillBucket implements Bucket {
     }
 
     addFeature(feature: BucketFeature, geometry: Array<Array<Point>>, index: number, canonical: CanonicalTileID, imagePositions: {
-      [_: string]: ImagePosition;
+        [_: string]: ImagePosition;
     }) {
         for (const polygon of classifyRings(geometry, EARCUT_MAX_RINGS)) {
             let numVertices = 0;

--- a/src/data/bucket/line_bucket.ts
+++ b/src/data/bucket/line_bucket.ts
@@ -71,14 +71,14 @@ const LINE_DISTANCE_SCALE = 1 / 2;
 const MAX_LINE_DISTANCE = Math.pow(2, LINE_DISTANCE_BUFFER_BITS - 1) / LINE_DISTANCE_SCALE;
 
 type LineClips = {
-  start: number;
-  end: number;
+    start: number;
+    end: number;
 };
 
 type GradientTexture = {
-  texture?: Texture;
-  gradient?: RGBAImage;
-  version?: number;
+    texture?: Texture;
+    gradient?: RGBAImage;
+    version?: number;
 };
 
 /**

--- a/src/data/bucket/symbol_bucket.test.ts
+++ b/src/data/bucket/symbol_bucket.test.ts
@@ -139,12 +139,12 @@ describe('SymbolBucket', () => {
         const options = {iconDependencies: {}, glyphDependencies: {}} as PopulateParameters;
 
         bucket.populate(
-        [
-            createIndexedFeature(0, 0, 'a'),
-            createIndexedFeature(1, 1, 'b'),
-            createIndexedFeature(2, 2, 'a')
-        ] as any as IndexedFeature[],
-        options, undefined
+            [
+                createIndexedFeature(0, 0, 'a'),
+                createIndexedFeature(1, 1, 'b'),
+                createIndexedFeature(2, 2, 'a')
+            ] as any as IndexedFeature[],
+            options, undefined
         );
 
         const icons = options.iconDependencies as any;
@@ -179,12 +179,12 @@ describe('SymbolBucket', () => {
         const options = {iconDependencies: {}, glyphDependencies: {}} as PopulateParameters;
 
         bucket.populate(
-        [
-            createIndexedFeature(0, 0, 'a'),
-            createIndexedFeature(1, 1, 'b'),
-            createIndexedFeature(2, 2, 'a')
-        ] as any as IndexedFeature[],
-        options, undefined
+            [
+                createIndexedFeature(0, 0, 'a'),
+                createIndexedFeature(1, 1, 'b'),
+                createIndexedFeature(2, 2, 'a')
+            ] as any as IndexedFeature[],
+            options, undefined
         );
 
         const icons = options.iconDependencies as any;

--- a/src/data/bucket/symbol_bucket.ts
+++ b/src/data/bucket/symbol_bucket.ts
@@ -59,41 +59,41 @@ import type {ImagePosition} from '../../render/image_atlas';
 import type {VectorTileLayer} from '@mapbox/vector-tile';
 
 export type SingleCollisionBox = {
-  x1: number;
-  y1: number;
-  x2: number;
-  y2: number;
-  anchorPointX: number;
-  anchorPointY: number;
+    x1: number;
+    y1: number;
+    x2: number;
+    y2: number;
+    anchorPointX: number;
+    anchorPointY: number;
 };
 
 export type CollisionArrays = {
-  textBox?: SingleCollisionBox;
-  verticalTextBox?: SingleCollisionBox;
-  iconBox?: SingleCollisionBox;
-  verticalIconBox?: SingleCollisionBox;
-  textFeatureIndex?: number;
-  verticalTextFeatureIndex?: number;
-  iconFeatureIndex?: number;
-  verticalIconFeatureIndex?: number;
+    textBox?: SingleCollisionBox;
+    verticalTextBox?: SingleCollisionBox;
+    iconBox?: SingleCollisionBox;
+    verticalIconBox?: SingleCollisionBox;
+    textFeatureIndex?: number;
+    verticalTextFeatureIndex?: number;
+    iconFeatureIndex?: number;
+    verticalIconFeatureIndex?: number;
 };
 
 export type SymbolFeature = {
-  sortKey: number | void;
-  text: Formatted | void;
-  icon: ResolvedImage;
-  index: number;
-  sourceLayerIndex: number;
-  geometry: Array<Array<Point>>;
-  properties: any;
-  type: 'Point' | 'LineString' | 'Polygon';
-  id?: any;
+    sortKey: number | void;
+    text: Formatted | void;
+    icon: ResolvedImage;
+    index: number;
+    sourceLayerIndex: number;
+    geometry: Array<Array<Point>>;
+    properties: any;
+    type: 'Point' | 'LineString' | 'Polygon';
+    id?: any;
 };
 
 export type SortKeyRange = {
-  sortKey: number;
-  symbolInstanceStart: number;
-  symbolInstanceEnd: number;
+    sortKey: number;
+    symbolInstanceStart: number;
+    symbolInstanceEnd: number;
 };
 
 // Opacity arrays are frequently updated but don't contain a lot of information, so we pack them
@@ -244,12 +244,12 @@ class CollisionBuffers {
     collisionVertexBuffer: VertexBuffer;
 
     constructor(LayoutArray: {
-      new (...args: any): StructArray;
+        new (...args: any): StructArray;
     },
-                layoutAttributes: Array<StructArrayMember>,
-                IndexArray: {
-                  new (...args: any): TriangleIndexArray | LineIndexArray;
-                }) {
+    layoutAttributes: Array<StructArrayMember>,
+    IndexArray: {
+        new (...args: any): TriangleIndexArray | LineIndexArray;
+    }) {
         this.layoutVertexArray = new LayoutArray();
         this.layoutAttributes = layoutAttributes;
         this.indexArray = new IndexArray();
@@ -624,17 +624,17 @@ class SymbolBucket implements Bucket {
     }
 
     addSymbols(arrays: SymbolBuffers,
-               quads: Array<SymbolQuad>,
-               sizeVertex: any,
-               lineOffset: [number, number],
-               alongLine: boolean,
-               feature: SymbolFeature,
-               writingMode: WritingMode,
-               labelAnchor: Anchor,
-               lineStartIndex: number,
-               lineLength: number,
-               associatedIconIndex: number,
-               canonical: CanonicalTileID) {
+        quads: Array<SymbolQuad>,
+        sizeVertex: any,
+        lineOffset: [number, number],
+        alongLine: boolean,
+        feature: SymbolFeature,
+        writingMode: WritingMode,
+        labelAnchor: Anchor,
+        lineStartIndex: number,
+        lineLength: number,
+        associatedIconIndex: number,
+        canonical: CanonicalTileID) {
         const indexArray = arrays.indexArray;
         const layoutVertexArray = arrays.layoutVertexArray;
 
@@ -766,15 +766,15 @@ class SymbolBucket implements Bucket {
     // These flat arrays are meant to be quicker to iterate over than the source
     // CollisionBoxArray
     _deserializeCollisionBoxesForSymbol(
-      collisionBoxArray: CollisionBoxArray,
-      textStartIndex: number,
-      textEndIndex: number,
-      verticalTextStartIndex: number,
-      verticalTextEndIndex: number,
-      iconStartIndex: number,
-      iconEndIndex: number,
-      verticalIconStartIndex: number,
-      verticalIconEndIndex: number
+        collisionBoxArray: CollisionBoxArray,
+        textStartIndex: number,
+        textEndIndex: number,
+        verticalTextStartIndex: number,
+        verticalTextEndIndex: number,
+        iconStartIndex: number,
+        iconEndIndex: number,
+        verticalIconStartIndex: number,
+        verticalIconEndIndex: number
     ): CollisionArrays {
 
         const collisionArrays = {} as CollisionArrays;

--- a/src/data/dem_data.ts
+++ b/src/data/dem_data.ts
@@ -95,21 +95,21 @@ export default class DEMData {
             yMax = dy * this.dim + this.dim;
 
         switch (dx) {
-        case -1:
-            xMin = xMax - 1;
-            break;
-        case 1:
-            xMax = xMin + 1;
-            break;
+            case -1:
+                xMin = xMax - 1;
+                break;
+            case 1:
+                xMax = xMin + 1;
+                break;
         }
 
         switch (dy) {
-        case -1:
-            yMin = yMax - 1;
-            break;
-        case 1:
-            yMax = yMin + 1;
-            break;
+            case -1:
+                yMin = yMax - 1;
+                break;
+            case 1:
+                yMax = yMin + 1;
+                break;
         }
 
         const ox = -dx * this.dim;

--- a/src/data/evaluation_feature.ts
+++ b/src/data/evaluation_feature.ts
@@ -3,17 +3,17 @@ import type Point from '@mapbox/point-geometry';
 import type {VectorTileFeature} from '@mapbox/vector-tile';
 
 type EvaluationFeature = {
-  readonly type: 1 | 2 | 3 | 'Unknown' | 'Point' | 'MultiPoint' | 'LineString' | 'MultiLineString' | 'Polygon' | 'MultiPolygon';
-  readonly id?: any;
-  readonly properties: {[_: string]: any};
-  readonly patterns?: {
-    [_: string]: {
-      'min': string;
-      'mid': string;
-      'max': string;
+    readonly type: 1 | 2 | 3 | 'Unknown' | 'Point' | 'MultiPoint' | 'LineString' | 'MultiLineString' | 'Polygon' | 'MultiPolygon';
+    readonly id?: any;
+    readonly properties: {[_: string]: any};
+    readonly patterns?: {
+        [_: string]: {
+            'min': string;
+            'mid': string;
+            'max': string;
+        };
     };
-  };
-  geometry: Array<Array<Point>>;
+    geometry: Array<Array<Point>>;
 };
 
 /**

--- a/src/data/feature_index.ts
+++ b/src/data/feature_index.ts
@@ -26,18 +26,18 @@ import type {FeatureState} from '../style-spec/expression';
 import type {VectorTileFeature, VectorTileLayer} from '@mapbox/vector-tile';
 
 type QueryParameters = {
-  scale: number;
-  pixelPosMatrix: mat4;
-  transform: Transform;
-  tileSize: number;
-  queryGeometry: Array<Point>;
-  cameraQueryGeometry: Array<Point>;
-  queryPadding: number;
-  params: {
-    filter: FilterSpecification;
-    layers: Array<string>;
-    availableImages: Array<string>;
-  };
+    scale: number;
+    pixelPosMatrix: mat4;
+    transform: Transform;
+    tileSize: number;
+    queryGeometry: Array<Point>;
+    cameraQueryGeometry: Array<Point>;
+    queryPadding: number;
+    params: {
+        filter: FilterSpecification;
+        layers: Array<string>;
+        availableImages: Array<string>;
+    };
 };
 
 class FeatureIndex {
@@ -104,10 +104,10 @@ class FeatureIndex {
 
     // Finds non-symbol features in this tile at a particular position.
     query(
-      args: QueryParameters,
-      styleLayers: {[_: string]: StyleLayer},
-      serializedLayers: {[_: string]: any},
-      sourceFeatureState: SourceFeatureState
+        args: QueryParameters,
+        styleLayers: {[_: string]: StyleLayer},
+        serializedLayers: {[_: string]: any},
+        sourceFeatureState: SourceFeatureState
     ): {[_: string]: Array<{featureIndex: number; feature: GeoJSONFeature}>} {
         this.loadVTLayers();
 
@@ -123,10 +123,10 @@ class FeatureIndex {
 
         const cameraBounds = getBounds(args.cameraQueryGeometry);
         const matching3D = this.grid3D.query(
-                cameraBounds.minX - queryPadding, cameraBounds.minY - queryPadding, cameraBounds.maxX + queryPadding, cameraBounds.maxY + queryPadding,
-                (bx1, by1, bx2, by2) => {
-                    return polygonIntersectsBox(args.cameraQueryGeometry, bx1 - queryPadding, by1 - queryPadding, bx2 + queryPadding, by2 + queryPadding);
-                });
+            cameraBounds.minX - queryPadding, cameraBounds.minY - queryPadding, cameraBounds.maxX + queryPadding, cameraBounds.maxY + queryPadding,
+            (bx1, by1, bx2, by2) => {
+                return polygonIntersectsBox(args.cameraQueryGeometry, bx1 - queryPadding, by1 - queryPadding, bx2 + queryPadding, by2 + queryPadding);
+            });
 
         for (const key of matching3D) {
             matching.push(key);
@@ -171,11 +171,11 @@ class FeatureIndex {
 
     loadMatchingFeature(
         result: {
-          [_: string]: Array<{
-            featureIndex: number;
-            feature: GeoJSONFeature;
-            intersectionZ?: boolean | number;
-          }>;
+            [_: string]: Array<{
+                featureIndex: number;
+                feature: GeoJSONFeature;
+                intersectionZ?: boolean | number;
+            }>;
         },
         bucketIndex: number,
         sourceLayerIndex: number,
@@ -187,10 +187,10 @@ class FeatureIndex {
         serializedLayers: {[_: string]: any},
         sourceFeatureState?: SourceFeatureState,
         intersectionTest?: (
-          feature: VectorTileFeature,
-          styleLayer: StyleLayer,
-          featureState: any,
-          id: string | number | void
+            feature: VectorTileFeature,
+            styleLayer: StyleLayer,
+            featureState: any,
+            id: string | number | void
         ) => boolean | number) {
 
         const layerIDs = this.bucketLayerIDs[bucketIndex];
@@ -253,13 +253,13 @@ class FeatureIndex {
     // Given a set of symbol indexes that have already been looked up,
     // return a matching set of GeoJSONFeatures
     lookupSymbolFeatures(symbolFeatureIndexes: Array<number>,
-                         serializedLayers: {[_: string]: StyleLayer},
-                         bucketIndex: number,
-                         sourceLayerIndex: number,
-                         filterSpec: FilterSpecification,
-                         filterLayerIDs: Array<string>,
-                         availableImages: Array<string>,
-                         styleLayers: {[_: string]: StyleLayer}) {
+        serializedLayers: {[_: string]: StyleLayer},
+        bucketIndex: number,
+        sourceLayerIndex: number,
+        filterSpec: FilterSpecification,
+        filterLayerIDs: Array<string>,
+        availableImages: Array<string>,
+        styleLayers: {[_: string]: StyleLayer}) {
         const result = {};
         this.loadVTLayers();
 

--- a/src/data/feature_position_map.ts
+++ b/src/data/feature_position_map.ts
@@ -3,14 +3,14 @@ import {register} from '../util/web_worker_transfer';
 import assert from 'assert';
 
 type SerializedFeaturePositionMap = {
-  ids: Float64Array;
-  positions: Uint32Array;
+    ids: Float64Array;
+    positions: Uint32Array;
 };
 
 type FeaturePosition = {
-  index: number;
-  start: number;
-  end: number;
+    index: number;
+    start: number;
+    end: number;
 };
 
 // A transferable data structure that maps feature ids to their indices and buffer offsets

--- a/src/data/program_configuration.ts
+++ b/src/data/program_configuration.ts
@@ -31,9 +31,9 @@ import type {FormattedSection} from '../style-spec/expression/types/formatted';
 import type {VectorTileLayer} from '@mapbox/vector-tile';
 
 export type BinderUniform = {
-  name: string;
-  property: string;
-  binding: Uniform<any>;
+    name: string;
+    property: string;
+    binding: Uniform<any>;
 };
 
 function packColor(color: Color): [number, number] {
@@ -72,33 +72,33 @@ function packColor(color: Color): [number, number] {
  */
 
 interface AttributeBinder {
-  populatePaintArray(
-    length: number,
-    feature: Feature,
-    imagePositions: {[_: string]: ImagePosition},
-    canonical?: CanonicalTileID,
-    formattedSection?: FormattedSection
-  ): void;
-  updatePaintArray(
-    start: number,
-    length: number,
-    feature: Feature,
-    featureState: FeatureState,
-    imagePositions: {[_: string]: ImagePosition}
-  ): void;
-  upload(a: Context): void;
-  destroy(): void;
+    populatePaintArray(
+        length: number,
+        feature: Feature,
+        imagePositions: {[_: string]: ImagePosition},
+        canonical?: CanonicalTileID,
+        formattedSection?: FormattedSection
+    ): void;
+    updatePaintArray(
+        start: number,
+        length: number,
+        feature: Feature,
+        featureState: FeatureState,
+        imagePositions: {[_: string]: ImagePosition}
+    ): void;
+    upload(a: Context): void;
+    destroy(): void;
 }
 
 interface UniformBinder {
-  uniformNames: Array<string>;
-  setUniform(
-    uniform: Uniform<any>,
-    globals: GlobalProperties,
-    currentValue: PossiblyEvaluatedPropertyValue<any>,
-    uniformName: string
-  ): void;
-  getBinding(context: Context, location: WebGLUniformLocation, name: string): Partial<Uniform<any>>;
+    uniformNames: Array<string>;
+    setUniform(
+        uniform: Uniform<any>,
+        globals: GlobalProperties,
+        currentValue: PossiblyEvaluatedPropertyValue<any>,
+        uniformName: string
+    ): void;
+    getBinding(context: Context, location: WebGLUniformLocation, name: string): Partial<Uniform<any>>;
 }
 
 class ConstantBinder implements UniformBinder {
@@ -113,9 +113,9 @@ class ConstantBinder implements UniformBinder {
     }
 
     setUniform(
-      uniform: Uniform<any>,
-      globals: GlobalProperties,
-      currentValue: PossiblyEvaluatedPropertyValue<unknown>
+        uniform: Uniform<any>,
+        globals: GlobalProperties,
+        currentValue: PossiblyEvaluatedPropertyValue<unknown>
     ): void {
         uniform.set(currentValue.constantOr(this.value));
     }
@@ -152,9 +152,9 @@ class CrossFadedConstantBinder implements UniformBinder {
     setUniform(uniform: Uniform<any>, globals: GlobalProperties, currentValue: PossiblyEvaluatedPropertyValue<unknown>, uniformName: string) {
         const pos =
             uniformName === 'u_pattern_to' ? this.patternTo :
-            uniformName === 'u_pattern_from' ? this.patternFrom :
-            uniformName === 'u_pixel_ratio_to' ? this.pixelRatioTo :
-            uniformName === 'u_pixel_ratio_from' ? this.pixelRatioFrom : null;
+                uniformName === 'u_pattern_from' ? this.patternFrom :
+                    uniformName === 'u_pixel_ratio_to' ? this.pixelRatioTo :
+                        uniformName === 'u_pixel_ratio_from' ? this.pixelRatioFrom : null;
         if (pos) uniform.set(pos);
     }
 
@@ -175,7 +175,7 @@ class SourceExpressionBinder implements AttributeBinder {
     paintVertexBuffer: VertexBuffer;
 
     constructor(expression: SourceExpression, names: Array<string>, type: string, PaintVertexArray: {
-      new (...args: any): StructArray;
+        new (...args: any): StructArray;
     }) {
         this.expression = expression;
         this.type = type;
@@ -245,7 +245,7 @@ class CompositeExpressionBinder implements AttributeBinder, UniformBinder {
     paintVertexBuffer: VertexBuffer;
 
     constructor(expression: CompositeExpression, names: Array<string>, type: string, useIntegerZoom: boolean, zoom: number, PaintVertexArray: {
-      new (...args: any): StructArray;
+        new (...args: any): StructArray;
     }) {
         this.expression = expression;
         this.uniformNames = names.map(name => `u_${name}_t`);
@@ -332,7 +332,7 @@ class CrossFadedCompositeBinder implements AttributeBinder {
     paintVertexAttributes: Array<StructArrayMember>;
 
     constructor(expression: CompositeExpression, type: string, useIntegerZoom: boolean, zoom: number, PaintVertexArray: {
-      new (...args: any): StructArray;
+        new (...args: any): StructArray;
     }, layerId: string) {
         this.expression = expression;
         this.type = type;
@@ -485,11 +485,11 @@ export default class ProgramConfiguration {
     }
 
     updatePaintArrays(
-      featureStates: FeatureStates,
-      featureMap: FeaturePositionMap,
-      vtLayer: VectorTileLayer,
-      layer: TypedStyleLayer,
-      imagePositions: {[_: string]: ImagePosition}
+        featureStates: FeatureStates,
+        featureMap: FeaturePositionMap,
+        vtLayer: VectorTileLayer,
+        layer: TypedStyleLayer,
+        imagePositions: {[_: string]: ImagePosition}
     ): boolean {
         let dirty: boolean = false;
         for (const id in featureStates) {
@@ -576,10 +576,10 @@ export default class ProgramConfiguration {
     }
 
     setUniforms(
-      context: Context,
-      binderUniforms: Array<BinderUniform>,
-      properties: any,
-      globals: GlobalProperties
+        context: Context,
+        binderUniforms: Array<BinderUniform>,
+        properties: any,
+        globals: GlobalProperties
     ) {
         // Uniform state bindings are owned by the Program, but we set them
         // from within the ProgramConfiguraton's binder members.

--- a/src/data/segment.ts
+++ b/src/data/segment.ts
@@ -6,12 +6,12 @@ import type VertexArrayObject from '../render/vertex_array_object';
 import type {StructArray} from '../util/struct_array';
 
 export type Segment = {
-  sortKey?: number;
-  vertexOffset: number;
-  primitiveOffset: number;
-  vertexLength: number;
-  primitiveLength: number;
-  vaos: {[_: string]: VertexArrayObject};
+    sortKey?: number;
+    vertexOffset: number;
+    primitiveOffset: number;
+    vertexLength: number;
+    primitiveLength: number;
+    vaos: {[_: string]: VertexArrayObject};
 };
 
 class SegmentVector {
@@ -23,10 +23,10 @@ class SegmentVector {
     }
 
     prepareSegment(
-      numVertices: number,
-      layoutVertexArray: StructArray,
-      indexArray: StructArray,
-      sortKey?: number
+        numVertices: number,
+        layoutVertexArray: StructArray,
+        indexArray: StructArray,
+        sortKey?: number
     ): Segment {
         let segment: Segment = this.segments[this.segments.length - 1];
         if (numVertices > SegmentVector.MAX_VERTEX_ARRAY_LENGTH) warnOnce(`Max vertices per segment is ${SegmentVector.MAX_VERTEX_ARRAY_LENGTH}: bucket requested ${numVertices}`);
@@ -56,10 +56,10 @@ class SegmentVector {
     }
 
     static simpleSegment(
-      vertexOffset: number,
-      primitiveOffset: number,
-      vertexLength: number,
-      primitiveLength: number
+        vertexOffset: number,
+        primitiveOffset: number,
+        vertexLength: number,
+        primitiveLength: number
     ): SegmentVector {
         return new SegmentVector([{
             vertexOffset,

--- a/src/geo/lng_lat.ts
+++ b/src/geo/lng_lat.ts
@@ -161,11 +161,11 @@ class LngLat {
  * var v3 = {lon: -122.420679, lat: 37.772537};
  */
 export type LngLatLike = LngLat | {
-  lng: number;
-  lat: number;
+    lng: number;
+    lat: number;
 } | {
-  lon: number;
-  lat: number;
+    lon: number;
+    lat: number;
 } | [number, number];
 
 export default LngLat;

--- a/src/geo/mercator_coordinate.ts
+++ b/src/geo/mercator_coordinate.ts
@@ -99,9 +99,9 @@ class MercatorCoordinate {
         const lngLat = LngLat.convert(lngLatLike);
 
         return new MercatorCoordinate(
-                mercatorXfromLng(lngLat.lng),
-                mercatorYfromLat(lngLat.lat),
-                mercatorZfromAltitude(altitude, lngLat.lat));
+            mercatorXfromLng(lngLat.lng),
+            mercatorYfromLat(lngLat.lat),
+            mercatorZfromAltitude(altitude, lngLat.lat));
     }
 
     /**
@@ -114,8 +114,8 @@ class MercatorCoordinate {
      */
     toLngLat() {
         return new LngLat(
-                lngFromMercatorX(this.x),
-                latFromMercatorY(this.y));
+            lngFromMercatorX(this.x),
+            latFromMercatorY(this.y));
     }
 
     /**

--- a/src/geo/transform.ts
+++ b/src/geo/transform.ts
@@ -262,8 +262,8 @@ class Transform {
      * @returns {number} zoom level An integer zoom level at which all tiles will be visible.
      */
     coveringZoomLevel(options: {
-      roundZoom?: boolean;
-      tileSize: number;
+        roundZoom?: boolean;
+        tileSize: number;
     }) {
         const z = (options.roundZoom ? Math.round : Math.floor)(
             this.zoom + this.scaleZoom(this.tileSize / options.tileSize)
@@ -315,14 +315,14 @@ class Transform {
      * @private
      */
     coveringTiles(
-      options: {
-        tileSize: number;
-        minzoom?: number;
-        maxzoom?: number;
-        roundZoom?: boolean;
-        reparseOverscaled?: boolean;
-        renderWorldCopies?: boolean;
-      }
+        options: {
+            tileSize: number;
+            minzoom?: number;
+            maxzoom?: number;
+            roundZoom?: boolean;
+            reparseOverscaled?: boolean;
+            renderWorldCopies?: boolean;
+        }
     ): Array<OverscaledTileID> {
         let z = this.coveringZoomLevel(options);
         const actualZ = z;
@@ -436,8 +436,8 @@ class Transform {
     project(lnglat: LngLat) {
         const lat = clamp(lnglat.lat, -this.maxValidLatitude, this.maxValidLatitude);
         return new Point(
-                mercatorXfromLng(lnglat.lng) * this.worldSize,
-                mercatorYfromLat(lat) * this.worldSize);
+            mercatorXfromLng(lnglat.lng) * this.worldSize,
+            mercatorYfromLat(lat) * this.worldSize);
     }
 
     unproject(point: Point): LngLat {
@@ -451,8 +451,8 @@ class Transform {
         const b = this.pointCoordinate(this.centerPoint);
         const loc = this.locationCoordinate(lnglat);
         const newCenter = new MercatorCoordinate(
-                loc.x - (a.x - b.x),
-                loc.y - (a.y - b.y));
+            loc.x - (a.x - b.x),
+            loc.y - (a.y - b.y));
         this.center = this.coordinateLocation(newCenter);
         if (this._renderWorldCopies) {
             this.center = this.center.wrap();

--- a/src/gl/context.ts
+++ b/src/gl/context.ts
@@ -17,9 +17,9 @@ import type {
 import type Color from '../style-spec/util/color';
 
 type ClearArgs = {
-  color?: Color;
-  depth?: number;
-  stencil?: number;
+    color?: Color;
+    depth?: number;
+    stencil?: number;
 };
 
 class Context {

--- a/src/gl/types.ts
+++ b/src/gl/types.ts
@@ -15,9 +15,9 @@ export type DepthRangeType = [number, number];
 export type DepthFuncType = CompareFuncType;
 
 export type StencilFuncType = {
-  func: CompareFuncType;
-  ref: number;
-  mask: number;
+    func: CompareFuncType;
+    ref: number;
+    mask: number;
 };
 
 export type StencilOpConstant = WebGLRenderingContext['KEEP'] | WebGLRenderingContext['ZERO'] | WebGLRenderingContext['REPLACE'] | WebGLRenderingContext['INCR'] | WebGLRenderingContext['INCR_WRAP'] | WebGLRenderingContext['DECR'] | WebGLRenderingContext['DECR_WRAP'] | WebGLRenderingContext['INVERT'];
@@ -29,29 +29,29 @@ export type TextureUnitType = number;
 export type ViewportType = [number, number, number, number];
 
 export type StencilTestGL = {
-  func: WebGLRenderingContext['NEVER'];
-  mask: 0;
+    func: WebGLRenderingContext['NEVER'];
+    mask: 0;
 } | {
-  func: WebGLRenderingContext['LESS'];
-  mask: number;
+    func: WebGLRenderingContext['LESS'];
+    mask: number;
 } | {
-  func: WebGLRenderingContext['EQUAL'];
-  mask: number;
+    func: WebGLRenderingContext['EQUAL'];
+    mask: number;
 } | {
-  func: WebGLRenderingContext['LEQUAL'];
-  mask: number;
+    func: WebGLRenderingContext['LEQUAL'];
+    mask: number;
 } | {
-  func: WebGLRenderingContext['GREATER'];
-  mask: number;
+    func: WebGLRenderingContext['GREATER'];
+    mask: number;
 } | {
-  func: WebGLRenderingContext['NOTEQUAL'];
-  mask: number;
+    func: WebGLRenderingContext['NOTEQUAL'];
+    mask: number;
 } | {
-  func: WebGLRenderingContext['GEQUAL'];
-  mask: number;
+    func: WebGLRenderingContext['GEQUAL'];
+    mask: number;
 } | {
-  func: WebGLRenderingContext['ALWAYS'];
-  mask: 0;
+    func: WebGLRenderingContext['ALWAYS'];
+    mask: 0;
 };
 
 export type CullFaceModeType = WebGLRenderingContext['FRONT'] | WebGLRenderingContext['BACK'] | WebGLRenderingContext['FRONT_AND_BACK'];

--- a/src/gl/value.ts
+++ b/src/gl/value.ts
@@ -17,12 +17,12 @@ import type {
 } from './types';
 
 export interface IValue<T> {
-  current: T;
-  default: T;
-  dirty: boolean;
-  get(): T;
-  setDefault(): void;
-  set(value: T): void;
+    current: T;
+    default: T;
+    dirty: boolean;
+    get(): T;
+    setDefault(): void;
+    set(value: T): void;
 }
 
 class BaseValue<T> implements IValue<T> {

--- a/src/render/draw_circle.ts
+++ b/src/render/draw_circle.ts
@@ -19,17 +19,17 @@ import type {CircleUniformsType} from './program/circle_program';
 export default drawCircles;
 
 type TileRenderState = {
-  programConfiguration: ProgramConfiguration;
-  program: Program<any>;
-  layoutVertexBuffer: VertexBuffer;
-  indexBuffer: IndexBuffer;
-  uniformValues: UniformValues<CircleUniformsType>;
+    programConfiguration: ProgramConfiguration;
+    program: Program<any>;
+    layoutVertexBuffer: VertexBuffer;
+    indexBuffer: IndexBuffer;
+    uniformValues: UniformValues<CircleUniformsType>;
 };
 
 type SegmentsTileRenderState = {
-  segments: SegmentVector;
-  sortKey: number;
-  state: TileRenderState;
+    segments: SegmentVector;
+    sortKey: number;
+    state: TileRenderState;
 };
 
 function drawCircles(painter: Painter, sourceCache: SourceCache, layer: CircleStyleLayer, coords: Array<OverscaledTileID>) {

--- a/src/render/draw_collision_debug.ts
+++ b/src/render/draw_collision_debug.ts
@@ -18,10 +18,10 @@ import IndexBuffer from '../gl/index_buffer';
 export default drawCollisionDebug;
 
 type TileBatch = {
-  circleArray: Array<number>;
-  circleOffset: number;
-  transform: mat4;
-  invTransform: mat4;
+    circleArray: Array<number>;
+    circleOffset: number;
+    transform: mat4;
+    invTransform: mat4;
 };
 
 let quadTriangles: QuadTriangleArray;

--- a/src/render/draw_line.ts
+++ b/src/render/draw_line.ts
@@ -36,8 +36,8 @@ export default function drawLine(painter: Painter, sourceCache: SourceCache, lay
 
     const programId =
         image ? 'linePattern' :
-        dasharray ? 'lineSDF' :
-        gradient ? 'lineGradient' : 'line';
+            dasharray ? 'lineSDF' :
+                gradient ? 'lineGradient' : 'line';
 
     const context = painter.context;
     const gl = context.gl;
@@ -67,8 +67,8 @@ export default function drawLine(painter: Painter, sourceCache: SourceCache, lay
 
         const uniformValues = image ? linePatternUniformValues(painter, tile, layer, crossfade) :
             dasharray ? lineSDFUniformValues(painter, tile, layer, dasharray, crossfade) :
-            gradient ? lineGradientUniformValues(painter, tile, layer, bucket.lineClipsArray.length) :
-            lineUniformValues(painter, tile, layer);
+                gradient ? lineGradientUniformValues(painter, tile, layer, bucket.lineClipsArray.length) :
+                    lineUniformValues(painter, tile, layer);
 
         if (image) {
             context.activeTexture.set(gl.TEXTURE0);

--- a/src/render/draw_symbol.ts
+++ b/src/render/draw_symbol.ts
@@ -34,25 +34,25 @@ import type {CrossTileID, VariableOffset} from '../symbol/placement';
 export default drawSymbols;
 
 type SymbolTileRenderState = {
-  segments: SegmentVector;
-  sortKey: number;
-  state: {
-    program: any;
-    buffers: SymbolBuffers;
-    uniformValues: any;
-    atlasTexture: Texture;
-    atlasTextureIcon: Texture | null;
-    atlasInterpolation: any;
-    atlasInterpolationIcon: any;
-    isSDF: boolean;
-    hasHalo: boolean;
-  };
+    segments: SegmentVector;
+    sortKey: number;
+    state: {
+        program: any;
+        buffers: SymbolBuffers;
+        uniformValues: any;
+        atlasTexture: Texture;
+        atlasTextureIcon: Texture | null;
+        atlasInterpolation: any;
+        atlasInterpolationIcon: any;
+        isSDF: boolean;
+        hasHalo: boolean;
+    };
 };
 
 const identityMat4 = mat4.identity(new Float32Array(16));
 
 function drawSymbols(painter: Painter, sourceCache: SourceCache, layer: SymbolStyleLayer, coords: Array<OverscaledTileID>, variableOffsets: {
-  [_ in CrossTileID]: VariableOffset;
+    [_ in CrossTileID]: VariableOffset;
 }) {
     if (painter.renderPass !== 'translucent') return;
 
@@ -132,13 +132,13 @@ function updateVariableAnchors(coords, painter, layer, sourceCache, rotationAlig
         if (size) {
             const tileScale = Math.pow(2, tr.zoom - tile.tileID.overscaledZ);
             updateVariableAnchorsForBucket(bucket, rotateWithMap, pitchWithMap, variableOffsets, symbolSize,
-                                  tr, labelPlaneMatrix, coord.posMatrix, tileScale, size, updateTextFitIcon);
+                tr, labelPlaneMatrix, coord.posMatrix, tileScale, size, updateTextFitIcon);
         }
     }
 }
 
 function updateVariableAnchorsForBucket(bucket, rotateWithMap, pitchWithMap, variableOffsets, symbolSize,
-                               transform, labelPlaneMatrix, posMatrix, tileScale, size, updateTextFitIcon) {
+    transform, labelPlaneMatrix, posMatrix, tileScale, size, updateTextFitIcon) {
     const placedSymbols = bucket.text.placedSymbolArray;
     const dynamicTextLayoutVertexArray = bucket.text.dynamicLayoutVertexArray;
     const dynamicIconLayoutVertexArray = bucket.icon.dynamicLayoutVertexArray;
@@ -223,7 +223,7 @@ function getSymbolProgramName(isSDF: boolean, isText: boolean, bucket: SymbolBuc
 }
 
 function drawLayerSymbols(painter, sourceCache, layer, coords, isText, translate, translateAnchor,
-                          rotationAlignment, pitchAlignment, keepUpright, stencilMode, colorMode) {
+    rotationAlignment, pitchAlignment, keepUpright, stencilMode, colorMode) {
 
     const context = painter.context;
     const gl = context.gl;
@@ -310,12 +310,12 @@ function drawLayerSymbols(painter, sourceCache, layer, coords, isText, translate
         if (isSDF) {
             if (!bucket.iconsInText) {
                 uniformValues = symbolSDFUniformValues(sizeData.kind,
-                size, rotateInShader, pitchWithMap, painter, matrix,
-                uLabelPlaneMatrix, uglCoordMatrix, isText, texSize, true);
+                    size, rotateInShader, pitchWithMap, painter, matrix,
+                    uLabelPlaneMatrix, uglCoordMatrix, isText, texSize, true);
             } else {
                 uniformValues = symbolTextAndIconUniformValues(sizeData.kind,
-                size, rotateInShader, pitchWithMap, painter, matrix,
-                uLabelPlaneMatrix, uglCoordMatrix, texSize, texSizeIcon);
+                    size, rotateInShader, pitchWithMap, painter, matrix,
+                    uLabelPlaneMatrix, uglCoordMatrix, texSize, texSizeIcon);
             }
         } else {
             uniformValues = symbolIconUniformValues(sizeData.kind,

--- a/src/render/glyph_atlas.ts
+++ b/src/render/glyph_atlas.ts
@@ -7,21 +7,21 @@ import type {GlyphMetrics, StyleGlyph} from '../style/style_glyph';
 const padding = 1;
 
 export type Rect = {
-  x: number;
-  y: number;
-  w: number;
-  h: number;
+    x: number;
+    y: number;
+    w: number;
+    h: number;
 };
 
 export type GlyphPosition = {
-  rect: Rect;
-  metrics: GlyphMetrics;
+    rect: Rect;
+    metrics: GlyphMetrics;
 };
 
 export type GlyphPositions = {
-  [_: string]: {
-    [_: number]: GlyphPosition;
-  };
+    [_: string]: {
+        [_: number]: GlyphPosition;
+    };
 };
 
 export default class GlyphAtlas {
@@ -29,9 +29,9 @@ export default class GlyphAtlas {
     positions: GlyphPositions;
 
     constructor(stacks: {
-      [_: string]: {
-        [_: number]: StyleGlyph;
-      };
+        [_: string]: {
+            [_: number]: StyleGlyph;
+        };
     }) {
         const positions = {};
         const bins = [];

--- a/src/render/glyph_manager.ts
+++ b/src/render/glyph_manager.ts
@@ -10,26 +10,26 @@ import type {RequestManager} from '../util/request_manager';
 import type {Callback} from '../types/callback';
 
 type Entry = {
-  // null means we've requested the range, but the glyph wasn't included in the result.
-  glyphs: {
-    [id: number]: StyleGlyph | null;
-  };
-  requests: {
-    [range: number]: Array<Callback<{
-      [_: number]: StyleGlyph | null;
-    }>>;
-  };
-  ranges: {
-    [range: number]: boolean | null;
-  };
-  tinySDF?: TinySDF;
+    // null means we've requested the range, but the glyph wasn't included in the result.
+    glyphs: {
+        [id: number]: StyleGlyph | null;
+    };
+    requests: {
+        [range: number]: Array<Callback<{
+            [_: number]: StyleGlyph | null;
+        }>>;
+    };
+    ranges: {
+        [range: number]: boolean | null;
+    };
+    tinySDF?: TinySDF;
 };
 
 export default class GlyphManager {
     requestManager: RequestManager;
     localIdeographFontFamily: string;
     entries: {
-      [_: string]: Entry;
+        [_: string]: Entry;
     };
     url: string;
 
@@ -48,11 +48,11 @@ export default class GlyphManager {
     }
 
     getGlyphs(glyphs: {
-      [stack: string]: Array<number>;
+        [stack: string]: Array<number>;
     }, callback: Callback<{
-      [stack: string]: {
-        [id: number]: StyleGlyph;
-      };
+        [stack: string]: {
+            [id: number]: StyleGlyph;
+        };
     }>) {
         const all = [];
 
@@ -63,9 +63,9 @@ export default class GlyphManager {
         }
 
         asyncAll(all, ({stack, id}, callback: Callback<{
-          stack: string;
-          id: number;
-          glyph: StyleGlyph;
+            stack: string;
+            id: number;
+            glyph: StyleGlyph;
         }>) => {
             let entry = this.entries[stack];
             if (!entry) {
@@ -105,7 +105,7 @@ export default class GlyphManager {
                 requests = entry.requests[range] = [];
                 GlyphManager.loadGlyphRange(stack, range, this.url, this.requestManager,
                     (err, response?: {
-                      [_: number]: StyleGlyph | null;
+                        [_: number]: StyleGlyph | null;
                     } | null) => {
                         if (response) {
                             for (const id in response) {
@@ -123,7 +123,7 @@ export default class GlyphManager {
             }
 
             requests.push((err, result?: {
-              [_: number]: StyleGlyph | null;
+                [_: number]: StyleGlyph | null;
             } | null) => {
                 if (err) {
                     callback(err);
@@ -132,9 +132,9 @@ export default class GlyphManager {
                 }
             });
         }, (err, glyphs?: Array<{
-          stack: string;
-          id: number;
-          glyph: StyleGlyph;
+            stack: string;
+            id: number;
+            glyph: StyleGlyph;
         }> | null) => {
             if (err) {
                 callback(err);

--- a/src/render/image_manager.ts
+++ b/src/render/image_manager.ts
@@ -14,8 +14,8 @@ import type {PotpackBox} from 'potpack';
 import type {Callback} from '../types/callback';
 
 type Pattern = {
-  bin: PotpackBox;
-  position: ImagePosition;
+    bin: PotpackBox;
+    position: ImagePosition;
 };
 
 // When copied into the atlas texture, image data is padded by one pixel on each side. Icon
@@ -41,8 +41,8 @@ class ImageManager extends Evented {
     callbackDispatchedThisFrame: {[_: string]: boolean};
     loaded: boolean;
     requestors: Array<{
-      ids: Array<string>;
-      callback: Callback<{[_: string]: StyleImage}>;
+        ids: Array<string>;
+        callback: Callback<{[_: string]: StyleImage}>;
     }>;
 
     patterns: {[_: string]: Pattern};

--- a/src/render/painter.ts
+++ b/src/render/painter.ts
@@ -65,14 +65,14 @@ import type {RGBAImage} from '../util/image';
 export type RenderPass = 'offscreen' | 'opaque' | 'translucent';
 
 type PainterOptions = {
-  showOverdrawInspector: boolean;
-  showTileBoundaries: boolean;
-  showPadding: boolean;
-  rotating: boolean;
-  zooming: boolean;
-  moving: boolean;
-  gpuTiming: boolean;
-  fadeDuration: number;
+    showOverdrawInspector: boolean;
+    showTileBoundaries: boolean;
+    showPadding: boolean;
+    rotating: boolean;
+    zooming: boolean;
+    moving: boolean;
+    gpuTiming: boolean;
+    fadeDuration: number;
 };
 
 /**
@@ -85,7 +85,7 @@ class Painter {
     context: Context;
     transform: Transform;
     _tileTextures: {
-      [_: number]: Array<Texture>;
+        [_: number]: Array<Texture>;
     };
     numSublayers: number;
     depthEpsilon: number;
@@ -305,7 +305,7 @@ class Painter {
      * Returns [StencilMode for tile overscaleZ map, sortedCoords].
      */
     stencilConfigForOverlap(tileIDs: Array<OverscaledTileID>): [{
-      [_: number]: Readonly<StencilMode>;
+        [_: number]: Readonly<StencilMode>;
     }, Array<OverscaledTileID>] {
         const gl = this.context.gl;
         const coords = tileIDs.sort((a, b) => b.overscaledZ - a.overscaledZ);

--- a/src/render/program.ts
+++ b/src/render/program.ts
@@ -35,16 +35,16 @@ class Program<Us extends UniformBindings> {
     failedToCreate: boolean;
 
     constructor(context: Context,
-            name: string,
-            source: {
-              fragmentSource: string;
-              vertexSource: string;
-              staticAttributes: Array<string>;
-              staticUniforms: Array<string>;
-            },
-            configuration: ProgramConfiguration,
-            fixedUniforms: (b: Context, a: UniformLocations) => Us,
-            showOverdrawInspector: boolean) {
+        name: string,
+        source: {
+            fragmentSource: string;
+            vertexSource: string;
+            staticAttributes: Array<string>;
+            staticUniforms: Array<string>;
+        },
+        configuration: ProgramConfiguration,
+        fixedUniforms: (b: Context, a: UniformLocations) => Us,
+        showOverdrawInspector: boolean) {
         const gl = context.gl;
         this.program = gl.createProgram();
 
@@ -121,21 +121,21 @@ class Program<Us extends UniformBindings> {
     }
 
     draw(context: Context,
-         drawMode: DrawMode,
-         depthMode: Readonly<DepthMode>,
-         stencilMode: Readonly<StencilMode>,
-         colorMode: Readonly<ColorMode>,
-         cullFaceMode: Readonly<CullFaceMode>,
-         uniformValues: UniformValues<Us>,
-         layerID: string,
-         layoutVertexBuffer: VertexBuffer,
-         indexBuffer: IndexBuffer,
-         segments: SegmentVector,
-         currentProperties?: any,
-         zoom?: number | null,
-         configuration?: ProgramConfiguration | null,
-         dynamicLayoutBuffer?: VertexBuffer | null,
-         dynamicLayoutBuffer2?: VertexBuffer | null) {
+        drawMode: DrawMode,
+        depthMode: Readonly<DepthMode>,
+        stencilMode: Readonly<StencilMode>,
+        colorMode: Readonly<ColorMode>,
+        cullFaceMode: Readonly<CullFaceMode>,
+        uniformValues: UniformValues<Us>,
+        layerID: string,
+        layoutVertexBuffer: VertexBuffer,
+        indexBuffer: IndexBuffer,
+        segments: SegmentVector,
+        currentProperties?: any,
+        zoom?: number | null,
+        configuration?: ProgramConfiguration | null,
+        dynamicLayoutBuffer?: VertexBuffer | null,
+        dynamicLayoutBuffer2?: VertexBuffer | null) {
 
         const gl = context.gl;
 

--- a/src/render/program/background_program.ts
+++ b/src/render/program/background_program.ts
@@ -19,29 +19,29 @@ import type ResolvedImage from '../../style-spec/expression/types/resolved_image
 import {mat4} from 'gl-matrix';
 
 export type BackgroundUniformsType = {
-  'u_matrix': UniformMatrix4f;
-  'u_opacity': Uniform1f;
-  'u_color': UniformColor;
+    'u_matrix': UniformMatrix4f;
+    'u_opacity': Uniform1f;
+    'u_color': UniformColor;
 };
 
 export type BackgroundPatternUniformsType = {
-  'u_matrix': UniformMatrix4f;
-  'u_opacity': Uniform1f;
-  // pattern uniforms:
-  'u_image': Uniform1i;
-  'u_pattern_tl_a': Uniform2f;
-  'u_pattern_br_a': Uniform2f;
-  'u_pattern_tl_b': Uniform2f;
-  'u_pattern_br_b': Uniform2f;
-  'u_texsize': Uniform2f;
-  'u_mix': Uniform1f;
-  'u_pattern_size_a': Uniform2f;
-  'u_pattern_size_b': Uniform2f;
-  'u_scale_a': Uniform1f;
-  'u_scale_b': Uniform1f;
-  'u_pixel_coord_upper': Uniform2f;
-  'u_pixel_coord_lower': Uniform2f;
-  'u_tile_units_to_pixels': Uniform1f;
+    'u_matrix': UniformMatrix4f;
+    'u_opacity': Uniform1f;
+    // pattern uniforms:
+    'u_image': Uniform1i;
+    'u_pattern_tl_a': Uniform2f;
+    'u_pattern_br_a': Uniform2f;
+    'u_pattern_tl_b': Uniform2f;
+    'u_pattern_br_b': Uniform2f;
+    'u_texsize': Uniform2f;
+    'u_mix': Uniform1f;
+    'u_pattern_size_a': Uniform2f;
+    'u_pattern_size_b': Uniform2f;
+    'u_scale_a': Uniform1f;
+    'u_scale_b': Uniform1f;
+    'u_pixel_coord_upper': Uniform2f;
+    'u_pixel_coord_lower': Uniform2f;
+    'u_tile_units_to_pixels': Uniform1f;
 };
 
 const backgroundUniforms = (context: Context, locations: UniformLocations): BackgroundUniformsType => ({
@@ -76,15 +76,15 @@ const backgroundUniformValues = (matrix: mat4, opacity: number, color: Color): U
 });
 
 const backgroundPatternUniformValues = (
-  matrix: mat4,
-  opacity: number,
-  painter: Painter,
-  image: CrossFaded<ResolvedImage>,
-  tile: {
-    tileID: OverscaledTileID;
-    tileSize: number;
-  },
-  crossfade: CrossfadeParameters
+    matrix: mat4,
+    opacity: number,
+    painter: Painter,
+    image: CrossFaded<ResolvedImage>,
+    tile: {
+        tileID: OverscaledTileID;
+        tileSize: number;
+    },
+    crossfade: CrossfadeParameters
 ): UniformValues<BackgroundPatternUniformsType> => extend(
     bgPatternUniformValues(image, crossfade, painter, tile),
     {

--- a/src/render/program/circle_program.ts
+++ b/src/render/program/circle_program.ts
@@ -9,12 +9,12 @@ import type CircleStyleLayer from '../../style/style_layer/circle_style_layer';
 import type Painter from '../painter';
 
 export type CircleUniformsType = {
-  'u_camera_to_center_distance': Uniform1f;
-  'u_scale_with_map': Uniform1i;
-  'u_pitch_with_map': Uniform1i;
-  'u_extrude_scale': Uniform2f;
-  'u_device_pixel_ratio': Uniform1f;
-  'u_matrix': UniformMatrix4f;
+    'u_camera_to_center_distance': Uniform1f;
+    'u_scale_with_map': Uniform1i;
+    'u_pitch_with_map': Uniform1i;
+    'u_extrude_scale': Uniform2f;
+    'u_device_pixel_ratio': Uniform1f;
+    'u_matrix': UniformMatrix4f;
 };
 
 const circleUniforms = (context: Context, locations: UniformLocations): CircleUniformsType => ({
@@ -27,10 +27,10 @@ const circleUniforms = (context: Context, locations: UniformLocations): CircleUn
 });
 
 const circleUniformValues = (
-  painter: Painter,
-  coord: OverscaledTileID,
-  tile: Tile,
-  layer: CircleStyleLayer
+    painter: Painter,
+    coord: OverscaledTileID,
+    tile: Tile,
+    layer: CircleStyleLayer
 ): UniformValues<CircleUniformsType> => {
     const transform = painter.transform;
 

--- a/src/render/program/clipping_mask_program.ts
+++ b/src/render/program/clipping_mask_program.ts
@@ -5,7 +5,7 @@ import type {UniformValues, UniformLocations} from '../uniform_binding';
 import {mat4} from 'gl-matrix';
 
 export type ClippingMaskUniformsType = {
-  'u_matrix': UniformMatrix4f;
+    'u_matrix': UniformMatrix4f;
 };
 
 const clippingMaskUniforms = (context: Context, locations: UniformLocations): ClippingMaskUniformsType => ({

--- a/src/render/program/collision_program.ts
+++ b/src/render/program/collision_program.ts
@@ -8,18 +8,18 @@ import type Tile from '../../source/tile';
 import {mat4} from 'gl-matrix';
 
 export type CollisionUniformsType = {
-  'u_matrix': UniformMatrix4f;
-  'u_camera_to_center_distance': Uniform1f;
-  'u_pixels_to_tile_units': Uniform1f;
-  'u_extrude_scale': Uniform2f;
-  'u_overscale_factor': Uniform1f;
+    'u_matrix': UniformMatrix4f;
+    'u_camera_to_center_distance': Uniform1f;
+    'u_pixels_to_tile_units': Uniform1f;
+    'u_extrude_scale': Uniform2f;
+    'u_overscale_factor': Uniform1f;
 };
 
 export type CollisionCircleUniformsType = {
-  'u_matrix': UniformMatrix4f;
-  'u_inv_matrix': UniformMatrix4f;
-  'u_camera_to_center_distance': Uniform1f;
-  'u_viewport_size': Uniform2f;
+    'u_matrix': UniformMatrix4f;
+    'u_inv_matrix': UniformMatrix4f;
+    'u_camera_to_center_distance': Uniform1f;
+    'u_viewport_size': Uniform2f;
 };
 
 const collisionUniforms = (context: Context, locations: UniformLocations): CollisionUniformsType => ({

--- a/src/render/program/debug_program.ts
+++ b/src/render/program/debug_program.ts
@@ -6,10 +6,10 @@ import type Color from '../../style-spec/util/color';
 import {mat4} from 'gl-matrix';
 
 export type DebugUniformsType = {
-  'u_color': UniformColor;
-  'u_matrix': UniformMatrix4f;
-  'u_overlay': Uniform1i;
-  'u_overlay_scale': Uniform1f;
+    'u_color': UniformColor;
+    'u_matrix': UniformMatrix4f;
+    'u_overlay': Uniform1i;
+    'u_overlay_scale': Uniform1f;
 };
 
 const debugUniforms = (context: Context, locations: UniformLocations): DebugUniformsType => ({

--- a/src/render/program/fill_extrusion_program.ts
+++ b/src/render/program/fill_extrusion_program.ts
@@ -18,29 +18,29 @@ import type {CrossfadeParameters} from '../../style/evaluation_parameters';
 import type Tile from '../../source/tile';
 
 export type FillExtrusionUniformsType = {
-  'u_matrix': UniformMatrix4f;
-  'u_lightpos': Uniform3f;
-  'u_lightintensity': Uniform1f;
-  'u_lightcolor': Uniform3f;
-  'u_vertical_gradient': Uniform1f;
-  'u_opacity': Uniform1f;
+    'u_matrix': UniformMatrix4f;
+    'u_lightpos': Uniform3f;
+    'u_lightintensity': Uniform1f;
+    'u_lightcolor': Uniform3f;
+    'u_vertical_gradient': Uniform1f;
+    'u_opacity': Uniform1f;
 };
 
 export type FillExtrusionPatternUniformsType = {
-  'u_matrix': UniformMatrix4f;
-  'u_lightpos': Uniform3f;
-  'u_lightintensity': Uniform1f;
-  'u_lightcolor': Uniform3f;
-  'u_height_factor': Uniform1f;
-  'u_vertical_gradient': Uniform1f;
-  // pattern uniforms:
-  'u_texsize': Uniform2f;
-  'u_image': Uniform1i;
-  'u_pixel_coord_upper': Uniform2f;
-  'u_pixel_coord_lower': Uniform2f;
-  'u_scale': Uniform3f;
-  'u_fade': Uniform1f;
-  'u_opacity': Uniform1f;
+    'u_matrix': UniformMatrix4f;
+    'u_lightpos': Uniform3f;
+    'u_lightintensity': Uniform1f;
+    'u_lightcolor': Uniform3f;
+    'u_height_factor': Uniform1f;
+    'u_vertical_gradient': Uniform1f;
+    // pattern uniforms:
+    'u_texsize': Uniform2f;
+    'u_image': Uniform1i;
+    'u_pixel_coord_upper': Uniform2f;
+    'u_pixel_coord_lower': Uniform2f;
+    'u_scale': Uniform3f;
+    'u_fade': Uniform1f;
+    'u_opacity': Uniform1f;
 };
 
 const fillExtrusionUniforms = (context: Context, locations: UniformLocations): FillExtrusionUniformsType => ({
@@ -70,10 +70,10 @@ const fillExtrusionPatternUniforms = (context: Context, locations: UniformLocati
 });
 
 const fillExtrusionUniformValues = (
-  matrix: mat4,
-  painter: Painter,
-  shouldUseVerticalGradient: boolean,
-  opacity: number
+    matrix: mat4,
+    painter: Painter,
+    shouldUseVerticalGradient: boolean,
+    opacity: number
 ): UniformValues<FillExtrusionUniformsType> => {
     const light = painter.style.light;
     const _lp = light.properties.get('position');
@@ -97,13 +97,13 @@ const fillExtrusionUniformValues = (
 };
 
 const fillExtrusionPatternUniformValues = (
-  matrix: mat4,
-  painter: Painter,
-  shouldUseVerticalGradient: boolean,
-  opacity: number,
-  coord: OverscaledTileID,
-  crossfade: CrossfadeParameters,
-  tile: Tile
+    matrix: mat4,
+    painter: Painter,
+    shouldUseVerticalGradient: boolean,
+    opacity: number,
+    coord: OverscaledTileID,
+    crossfade: CrossfadeParameters,
+    tile: Tile
 ): UniformValues<FillExtrusionPatternUniformsType> => {
     return extend(fillExtrusionUniformValues(matrix, painter, shouldUseVerticalGradient, opacity),
         patternUniformValues(crossfade, painter, tile),

--- a/src/render/program/fill_program.ts
+++ b/src/render/program/fill_program.ts
@@ -16,35 +16,35 @@ import type Tile from '../../source/tile';
 import {mat4} from 'gl-matrix';
 
 export type FillUniformsType = {
-  'u_matrix': UniformMatrix4f;
+    'u_matrix': UniformMatrix4f;
 };
 
 export type FillOutlineUniformsType = {
-  'u_matrix': UniformMatrix4f;
-  'u_world': Uniform2f;
+    'u_matrix': UniformMatrix4f;
+    'u_world': Uniform2f;
 };
 
 export type FillPatternUniformsType = {
-  'u_matrix': UniformMatrix4f;
-  // pattern uniforms:
-  'u_texsize': Uniform2f;
-  'u_image': Uniform1i;
-  'u_pixel_coord_upper': Uniform2f;
-  'u_pixel_coord_lower': Uniform2f;
-  'u_scale': Uniform3f;
-  'u_fade': Uniform1f;
+    'u_matrix': UniformMatrix4f;
+    // pattern uniforms:
+    'u_texsize': Uniform2f;
+    'u_image': Uniform1i;
+    'u_pixel_coord_upper': Uniform2f;
+    'u_pixel_coord_lower': Uniform2f;
+    'u_scale': Uniform3f;
+    'u_fade': Uniform1f;
 };
 
 export type FillOutlinePatternUniformsType = {
-  'u_matrix': UniformMatrix4f;
-  'u_world': Uniform2f;
-  // pattern uniforms:
-  'u_texsize': Uniform2f;
-  'u_image': Uniform1i;
-  'u_pixel_coord_upper': Uniform2f;
-  'u_pixel_coord_lower': Uniform2f;
-  'u_scale': Uniform3f;
-  'u_fade': Uniform1f;
+    'u_matrix': UniformMatrix4f;
+    'u_world': Uniform2f;
+    // pattern uniforms:
+    'u_texsize': Uniform2f;
+    'u_image': Uniform1i;
+    'u_pixel_coord_upper': Uniform2f;
+    'u_pixel_coord_lower': Uniform2f;
+    'u_scale': Uniform3f;
+    'u_fade': Uniform1f;
 };
 
 const fillUniforms = (context: Context, locations: UniformLocations): FillUniformsType => ({
@@ -82,10 +82,10 @@ const fillUniformValues = (matrix: mat4): UniformValues<FillUniformsType> => ({
 });
 
 const fillPatternUniformValues = (
-  matrix: mat4,
-  painter: Painter,
-  crossfade: CrossfadeParameters,
-  tile: Tile
+    matrix: mat4,
+    painter: Painter,
+    crossfade: CrossfadeParameters,
+    tile: Tile
 ): UniformValues<FillPatternUniformsType> => extend(
     fillUniformValues(matrix),
     patternUniformValues(crossfade, painter, tile)
@@ -97,11 +97,11 @@ const fillOutlineUniformValues = (matrix: mat4, drawingBufferSize: [number, numb
 });
 
 const fillOutlinePatternUniformValues = (
-  matrix: mat4,
-  painter: Painter,
-  crossfade: CrossfadeParameters,
-  tile: Tile,
-  drawingBufferSize: [number, number]
+    matrix: mat4,
+    painter: Painter,
+    crossfade: CrossfadeParameters,
+    tile: Tile,
+    drawingBufferSize: [number, number]
 ): UniformValues<FillOutlinePatternUniformsType> => extend(
     fillPatternUniformValues(matrix, painter, crossfade, tile),
     {

--- a/src/render/program/heatmap_program.ts
+++ b/src/render/program/heatmap_program.ts
@@ -15,17 +15,17 @@ import type Painter from '../painter';
 import type HeatmapStyleLayer from '../../style/style_layer/heatmap_style_layer';
 
 export type HeatmapUniformsType = {
-  'u_extrude_scale': Uniform1f;
-  'u_intensity': Uniform1f;
-  'u_matrix': UniformMatrix4f;
+    'u_extrude_scale': Uniform1f;
+    'u_intensity': Uniform1f;
+    'u_matrix': UniformMatrix4f;
 };
 
 export type HeatmapTextureUniformsType = {
-  'u_matrix': UniformMatrix4f;
-  'u_world': Uniform2f;
-  'u_image': Uniform1i;
-  'u_color_ramp': Uniform1i;
-  'u_opacity': Uniform1f;
+    'u_matrix': UniformMatrix4f;
+    'u_world': Uniform2f;
+    'u_image': Uniform1i;
+    'u_color_ramp': Uniform1i;
+    'u_opacity': Uniform1f;
 };
 
 const heatmapUniforms = (context: Context, locations: UniformLocations): HeatmapUniformsType => ({
@@ -49,10 +49,10 @@ const heatmapUniformValues = (matrix: mat4, tile: Tile, zoom: number, intensity:
 });
 
 const heatmapTextureUniformValues = (
-  painter: Painter,
-  layer: HeatmapStyleLayer,
-  textureUnit: number,
-  colorRampUnit: number
+    painter: Painter,
+    layer: HeatmapStyleLayer,
+    textureUnit: number,
+    colorRampUnit: number
 ): UniformValues<HeatmapTextureUniformsType> => {
     const matrix = mat4.create();
     mat4.ortho(matrix, 0, painter.width, painter.height, 0, 0, 1);

--- a/src/render/program/hillshade_program.ts
+++ b/src/render/program/hillshade_program.ts
@@ -20,21 +20,21 @@ import type DEMData from '../../data/dem_data';
 import type {OverscaledTileID} from '../../source/tile_id';
 
 export type HillshadeUniformsType = {
-  'u_matrix': UniformMatrix4f;
-  'u_image': Uniform1i;
-  'u_latrange': Uniform2f;
-  'u_light': Uniform2f;
-  'u_shadow': UniformColor;
-  'u_highlight': UniformColor;
-  'u_accent': UniformColor;
+    'u_matrix': UniformMatrix4f;
+    'u_image': Uniform1i;
+    'u_latrange': Uniform2f;
+    'u_light': Uniform2f;
+    'u_shadow': UniformColor;
+    'u_highlight': UniformColor;
+    'u_accent': UniformColor;
 };
 
 export type HillshadePrepareUniformsType = {
-  'u_matrix': UniformMatrix4f;
-  'u_image': Uniform1i;
-  'u_dimension': Uniform2f;
-  'u_zoom': Uniform1f;
-  'u_unpack': Uniform4f;
+    'u_matrix': UniformMatrix4f;
+    'u_image': Uniform1i;
+    'u_dimension': Uniform2f;
+    'u_zoom': Uniform1f;
+    'u_unpack': Uniform4f;
 };
 
 const hillshadeUniforms = (context: Context, locations: UniformLocations): HillshadeUniformsType => ({

--- a/src/render/program/line_program.ts
+++ b/src/render/program/line_program.ts
@@ -12,44 +12,44 @@ import type Painter from '../painter';
 import type {CrossfadeParameters} from '../../style/evaluation_parameters';
 
 export type LineUniformsType = {
-  'u_matrix': UniformMatrix4f;
-  'u_ratio': Uniform1f;
-  'u_device_pixel_ratio': Uniform1f;
-  'u_units_to_pixels': Uniform2f;
+    'u_matrix': UniformMatrix4f;
+    'u_ratio': Uniform1f;
+    'u_device_pixel_ratio': Uniform1f;
+    'u_units_to_pixels': Uniform2f;
 };
 
 export type LineGradientUniformsType = {
-  'u_matrix': UniformMatrix4f;
-  'u_ratio': Uniform1f;
-  'u_device_pixel_ratio': Uniform1f;
-  'u_units_to_pixels': Uniform2f;
-  'u_image': Uniform1i;
-  'u_image_height': Uniform1f;
+    'u_matrix': UniformMatrix4f;
+    'u_ratio': Uniform1f;
+    'u_device_pixel_ratio': Uniform1f;
+    'u_units_to_pixels': Uniform2f;
+    'u_image': Uniform1i;
+    'u_image_height': Uniform1f;
 };
 
 export type LinePatternUniformsType = {
-  'u_matrix': UniformMatrix4f;
-  'u_texsize': Uniform2f;
-  'u_ratio': Uniform1f;
-  'u_device_pixel_ratio': Uniform1f;
-  'u_units_to_pixels': Uniform2f;
-  'u_image': Uniform1i;
-  'u_scale': Uniform3f;
-  'u_fade': Uniform1f;
+    'u_matrix': UniformMatrix4f;
+    'u_texsize': Uniform2f;
+    'u_ratio': Uniform1f;
+    'u_device_pixel_ratio': Uniform1f;
+    'u_units_to_pixels': Uniform2f;
+    'u_image': Uniform1i;
+    'u_scale': Uniform3f;
+    'u_fade': Uniform1f;
 };
 
 export type LineSDFUniformsType = {
-  'u_matrix': UniformMatrix4f;
-  'u_ratio': Uniform1f;
-  'u_device_pixel_ratio': Uniform1f;
-  'u_units_to_pixels': Uniform2f;
-  'u_patternscale_a': Uniform2f;
-  'u_patternscale_b': Uniform2f;
-  'u_sdfgamma': Uniform1f;
-  'u_image': Uniform1i;
-  'u_tex_y_a': Uniform1f;
-  'u_tex_y_b': Uniform1f;
-  'u_mix': Uniform1f;
+    'u_matrix': UniformMatrix4f;
+    'u_ratio': Uniform1f;
+    'u_device_pixel_ratio': Uniform1f;
+    'u_units_to_pixels': Uniform2f;
+    'u_patternscale_a': Uniform2f;
+    'u_patternscale_b': Uniform2f;
+    'u_sdfgamma': Uniform1f;
+    'u_image': Uniform1i;
+    'u_tex_y_a': Uniform1f;
+    'u_tex_y_b': Uniform1f;
+    'u_mix': Uniform1f;
 };
 
 const lineUniforms = (context: Context, locations: UniformLocations): LineUniformsType => ({
@@ -115,10 +115,10 @@ const lineGradientUniformValues = (painter: Painter, tile: Tile, layer: LineStyl
 };
 
 const linePatternUniformValues = (
-  painter: Painter,
-  tile: Tile,
-  layer: LineStyleLayer,
-  crossfade: CrossfadeParameters
+    painter: Painter,
+    tile: Tile,
+    layer: LineStyleLayer,
+    crossfade: CrossfadeParameters
 ): UniformValues<LinePatternUniformsType> => {
     const transform = painter.transform;
     const tileZoomRatio = calculateTileRatio(tile, transform);
@@ -139,11 +139,11 @@ const linePatternUniformValues = (
 };
 
 const lineSDFUniformValues = (
-  painter: Painter,
-  tile: Tile,
-  layer: LineStyleLayer,
-  dasharray: CrossFaded<Array<number>>,
-  crossfade: CrossfadeParameters
+    painter: Painter,
+    tile: Tile,
+    layer: LineStyleLayer,
+    dasharray: CrossFaded<Array<number>>,
+    crossfade: CrossfadeParameters
 ): UniformValues<LineSDFUniformsType> => {
     const transform = painter.transform;
     const lineAtlas = painter.lineAtlas;

--- a/src/render/program/pattern.ts
+++ b/src/render/program/pattern.ts
@@ -16,30 +16,30 @@ import type Tile from '../../source/tile';
 import type ResolvedImage from '../../style-spec/expression/types/resolved_image';
 
 type BackgroundPatternUniformsType = {
-  'u_image': Uniform1i;
-  'u_pattern_tl_a': Uniform2f;
-  'u_pattern_br_a': Uniform2f;
-  'u_pattern_tl_b': Uniform2f;
-  'u_pattern_br_b': Uniform2f;
-  'u_texsize': Uniform2f;
-  'u_mix': Uniform1f;
-  'u_pattern_size_a': Uniform2f;
-  'u_pattern_size_b': Uniform2f;
-  'u_scale_a': Uniform1f;
-  'u_scale_b': Uniform1f;
-  'u_pixel_coord_upper': Uniform2f;
-  'u_pixel_coord_lower': Uniform2f;
-  'u_tile_units_to_pixels': Uniform1f;
+    'u_image': Uniform1i;
+    'u_pattern_tl_a': Uniform2f;
+    'u_pattern_br_a': Uniform2f;
+    'u_pattern_tl_b': Uniform2f;
+    'u_pattern_br_b': Uniform2f;
+    'u_texsize': Uniform2f;
+    'u_mix': Uniform1f;
+    'u_pattern_size_a': Uniform2f;
+    'u_pattern_size_b': Uniform2f;
+    'u_scale_a': Uniform1f;
+    'u_scale_b': Uniform1f;
+    'u_pixel_coord_upper': Uniform2f;
+    'u_pixel_coord_lower': Uniform2f;
+    'u_tile_units_to_pixels': Uniform1f;
 };
 
 export type PatternUniformsType = {
-  // pattern uniforms:
-  'u_image': Uniform1i;
-  'u_texsize': Uniform2f;
-  'u_scale': Uniform3f;
-  'u_fade': Uniform1f;
-  'u_pixel_coord_upper': Uniform2f;
-  'u_pixel_coord_lower': Uniform2f;
+    // pattern uniforms:
+    'u_image': Uniform1i;
+    'u_texsize': Uniform2f;
+    'u_scale': Uniform3f;
+    'u_fade': Uniform1f;
+    'u_pixel_coord_upper': Uniform2f;
+    'u_pixel_coord_lower': Uniform2f;
 };
 
 function patternUniformValues(crossfade: CrossfadeParameters, painter: Painter, tile: Tile): UniformValues<PatternUniformsType> {
@@ -64,13 +64,13 @@ function patternUniformValues(crossfade: CrossfadeParameters, painter: Painter, 
 }
 
 function bgPatternUniformValues(
-  image: CrossFaded<ResolvedImage>,
-  crossfade: CrossfadeParameters,
-  painter: Painter,
-  tile: {
-    tileID: OverscaledTileID;
-    tileSize: number;
-  }
+    image: CrossFaded<ResolvedImage>,
+    crossfade: CrossfadeParameters,
+    painter: Painter,
+    tile: {
+        tileID: OverscaledTileID;
+        tileSize: number;
+    }
 ): UniformValues<BackgroundPatternUniformsType> {
     const imagePosA = painter.imageManager.getPattern(image.from.toString());
     const imagePosB = painter.imageManager.getPattern(image.to.toString());

--- a/src/render/program/raster_program.ts
+++ b/src/render/program/raster_program.ts
@@ -6,19 +6,19 @@ import type RasterStyleLayer from '../../style/style_layer/raster_style_layer';
 import {mat4} from 'gl-matrix';
 
 export type RasterUniformsType = {
-  'u_matrix': UniformMatrix4f;
-  'u_tl_parent': Uniform2f;
-  'u_scale_parent': Uniform1f;
-  'u_buffer_scale': Uniform1f;
-  'u_fade_t': Uniform1f;
-  'u_opacity': Uniform1f;
-  'u_image0': Uniform1i;
-  'u_image1': Uniform1i;
-  'u_brightness_low': Uniform1f;
-  'u_brightness_high': Uniform1f;
-  'u_saturation_factor': Uniform1f;
-  'u_contrast_factor': Uniform1f;
-  'u_spin_weights': Uniform3f;
+    'u_matrix': UniformMatrix4f;
+    'u_tl_parent': Uniform2f;
+    'u_scale_parent': Uniform1f;
+    'u_buffer_scale': Uniform1f;
+    'u_fade_t': Uniform1f;
+    'u_opacity': Uniform1f;
+    'u_image0': Uniform1i;
+    'u_image1': Uniform1i;
+    'u_brightness_low': Uniform1f;
+    'u_brightness_high': Uniform1f;
+    'u_saturation_factor': Uniform1f;
+    'u_contrast_factor': Uniform1f;
+    'u_spin_weights': Uniform3f;
 };
 
 const rasterUniforms = (context: Context, locations: UniformLocations): RasterUniformsType => ({
@@ -38,14 +38,14 @@ const rasterUniforms = (context: Context, locations: UniformLocations): RasterUn
 });
 
 const rasterUniformValues = (
-  matrix: mat4,
-  parentTL: [number, number],
-  parentScaleBy: number,
-  fade: {
-    mix: number;
-    opacity: number;
-  },
-  layer: RasterStyleLayer
+    matrix: mat4,
+    parentTL: [number, number],
+    parentScaleBy: number,
+    fade: {
+        mix: number;
+        opacity: number;
+    },
+    layer: RasterStyleLayer
 ): UniformValues<RasterUniformsType> => ({
     'u_matrix': matrix,
     'u_tl_parent': parentTL,

--- a/src/render/program/symbol_program.ts
+++ b/src/render/program/symbol_program.ts
@@ -7,68 +7,68 @@ import type {UniformValues, UniformLocations} from '../uniform_binding';
 import {mat4} from 'gl-matrix';
 
 export type SymbolIconUniformsType = {
-  'u_is_size_zoom_constant': Uniform1i;
-  'u_is_size_feature_constant': Uniform1i;
-  'u_size_t': Uniform1f;
-  'u_size': Uniform1f;
-  'u_camera_to_center_distance': Uniform1f;
-  'u_pitch': Uniform1f;
-  'u_rotate_symbol': Uniform1i;
-  'u_aspect_ratio': Uniform1f;
-  'u_fade_change': Uniform1f;
-  'u_matrix': UniformMatrix4f;
-  'u_label_plane_matrix': UniformMatrix4f;
-  'u_coord_matrix': UniformMatrix4f;
-  'u_is_text': Uniform1i;
-  'u_pitch_with_map': Uniform1i;
-  'u_texsize': Uniform2f;
-  'u_texture': Uniform1i;
+    'u_is_size_zoom_constant': Uniform1i;
+    'u_is_size_feature_constant': Uniform1i;
+    'u_size_t': Uniform1f;
+    'u_size': Uniform1f;
+    'u_camera_to_center_distance': Uniform1f;
+    'u_pitch': Uniform1f;
+    'u_rotate_symbol': Uniform1i;
+    'u_aspect_ratio': Uniform1f;
+    'u_fade_change': Uniform1f;
+    'u_matrix': UniformMatrix4f;
+    'u_label_plane_matrix': UniformMatrix4f;
+    'u_coord_matrix': UniformMatrix4f;
+    'u_is_text': Uniform1i;
+    'u_pitch_with_map': Uniform1i;
+    'u_texsize': Uniform2f;
+    'u_texture': Uniform1i;
 };
 
 export type SymbolSDFUniformsType = {
-  'u_is_size_zoom_constant': Uniform1i;
-  'u_is_size_feature_constant': Uniform1i;
-  'u_size_t': Uniform1f;
-  'u_size': Uniform1f;
-  'u_camera_to_center_distance': Uniform1f;
-  'u_pitch': Uniform1f;
-  'u_rotate_symbol': Uniform1i;
-  'u_aspect_ratio': Uniform1f;
-  'u_fade_change': Uniform1f;
-  'u_matrix': UniformMatrix4f;
-  'u_label_plane_matrix': UniformMatrix4f;
-  'u_coord_matrix': UniformMatrix4f;
-  'u_is_text': Uniform1i;
-  'u_pitch_with_map': Uniform1i;
-  'u_texsize': Uniform2f;
-  'u_texture': Uniform1i;
-  'u_gamma_scale': Uniform1f;
-  'u_device_pixel_ratio': Uniform1f;
-  'u_is_halo': Uniform1i;
+    'u_is_size_zoom_constant': Uniform1i;
+    'u_is_size_feature_constant': Uniform1i;
+    'u_size_t': Uniform1f;
+    'u_size': Uniform1f;
+    'u_camera_to_center_distance': Uniform1f;
+    'u_pitch': Uniform1f;
+    'u_rotate_symbol': Uniform1i;
+    'u_aspect_ratio': Uniform1f;
+    'u_fade_change': Uniform1f;
+    'u_matrix': UniformMatrix4f;
+    'u_label_plane_matrix': UniformMatrix4f;
+    'u_coord_matrix': UniformMatrix4f;
+    'u_is_text': Uniform1i;
+    'u_pitch_with_map': Uniform1i;
+    'u_texsize': Uniform2f;
+    'u_texture': Uniform1i;
+    'u_gamma_scale': Uniform1f;
+    'u_device_pixel_ratio': Uniform1f;
+    'u_is_halo': Uniform1i;
 };
 
 export type symbolTextAndIconUniformsType = {
-  'u_is_size_zoom_constant': Uniform1i;
-  'u_is_size_feature_constant': Uniform1i;
-  'u_size_t': Uniform1f;
-  'u_size': Uniform1f;
-  'u_camera_to_center_distance': Uniform1f;
-  'u_pitch': Uniform1f;
-  'u_rotate_symbol': Uniform1i;
-  'u_aspect_ratio': Uniform1f;
-  'u_fade_change': Uniform1f;
-  'u_matrix': UniformMatrix4f;
-  'u_label_plane_matrix': UniformMatrix4f;
-  'u_coord_matrix': UniformMatrix4f;
-  'u_is_text': Uniform1i;
-  'u_pitch_with_map': Uniform1i;
-  'u_texsize': Uniform2f;
-  'u_texsize_icon': Uniform2f;
-  'u_texture': Uniform1i;
-  'u_texture_icon': Uniform1i;
-  'u_gamma_scale': Uniform1f;
-  'u_device_pixel_ratio': Uniform1f;
-  'u_is_halo': Uniform1i;
+    'u_is_size_zoom_constant': Uniform1i;
+    'u_is_size_feature_constant': Uniform1i;
+    'u_size_t': Uniform1f;
+    'u_size': Uniform1f;
+    'u_camera_to_center_distance': Uniform1f;
+    'u_pitch': Uniform1f;
+    'u_rotate_symbol': Uniform1i;
+    'u_aspect_ratio': Uniform1f;
+    'u_fade_change': Uniform1f;
+    'u_matrix': UniformMatrix4f;
+    'u_label_plane_matrix': UniformMatrix4f;
+    'u_coord_matrix': UniformMatrix4f;
+    'u_is_text': Uniform1i;
+    'u_pitch_with_map': Uniform1i;
+    'u_texsize': Uniform2f;
+    'u_texsize_icon': Uniform2f;
+    'u_texture': Uniform1i;
+    'u_texture_icon': Uniform1i;
+    'u_gamma_scale': Uniform1f;
+    'u_device_pixel_ratio': Uniform1f;
+    'u_is_halo': Uniform1i;
 };
 
 const symbolIconUniforms = (context: Context, locations: UniformLocations): SymbolIconUniformsType => ({
@@ -137,19 +137,19 @@ const symbolTextAndIconUniforms = (context: Context, locations: UniformLocations
 });
 
 const symbolIconUniformValues = (
-  functionType: string,
-  size: {
-    uSizeT: number;
-    uSize: number;
-  },
-  rotateInShader: boolean,
-  pitchWithMap: boolean,
-  painter: Painter,
-  matrix: mat4,
-  labelPlaneMatrix: mat4,
-  glCoordMatrix: mat4,
-  isText: boolean,
-  texSize: [number, number]
+    functionType: string,
+    size: {
+        uSizeT: number;
+        uSize: number;
+    },
+    rotateInShader: boolean,
+    pitchWithMap: boolean,
+    painter: Painter,
+    matrix: mat4,
+    labelPlaneMatrix: mat4,
+    glCoordMatrix: mat4,
+    isText: boolean,
+    texSize: [number, number]
 ): UniformValues<SymbolIconUniformsType> => {
     const transform = painter.transform;
 
@@ -174,20 +174,20 @@ const symbolIconUniformValues = (
 };
 
 const symbolSDFUniformValues = (
-  functionType: string,
-  size: {
-    uSizeT: number;
-    uSize: number;
-  },
-  rotateInShader: boolean,
-  pitchWithMap: boolean,
-  painter: Painter,
-  matrix: mat4,
-  labelPlaneMatrix: mat4,
-  glCoordMatrix: mat4,
-  isText: boolean,
-  texSize: [number, number],
-  isHalo: boolean
+    functionType: string,
+    size: {
+        uSizeT: number;
+        uSize: number;
+    },
+    rotateInShader: boolean,
+    pitchWithMap: boolean,
+    painter: Painter,
+    matrix: mat4,
+    labelPlaneMatrix: mat4,
+    glCoordMatrix: mat4,
+    isText: boolean,
+    texSize: [number, number],
+    isHalo: boolean
 ): UniformValues<SymbolSDFUniformsType> => {
     const transform = painter.transform;
 
@@ -201,19 +201,19 @@ const symbolSDFUniformValues = (
 };
 
 const symbolTextAndIconUniformValues = (
-  functionType: string,
-  size: {
-    uSizeT: number;
-    uSize: number;
-  },
-  rotateInShader: boolean,
-  pitchWithMap: boolean,
-  painter: Painter,
-  matrix: mat4,
-  labelPlaneMatrix: mat4,
-  glCoordMatrix: mat4,
-  texSizeSDF: [number, number],
-  texSizeIcon: [number, number]
+    functionType: string,
+    size: {
+        uSizeT: number;
+        uSize: number;
+    },
+    rotateInShader: boolean,
+    pitchWithMap: boolean,
+    painter: Painter,
+    matrix: mat4,
+    labelPlaneMatrix: mat4,
+    glCoordMatrix: mat4,
+    texSizeSDF: [number, number],
+    texSizeIcon: [number, number]
 ): UniformValues<SymbolIconUniformsType> => {
     return extend(symbolSDFUniformValues(functionType, size,
         rotateInShader, pitchWithMap, painter, matrix, labelPlaneMatrix,

--- a/src/render/texture.ts
+++ b/src/render/texture.ts
@@ -7,9 +7,9 @@ export type TextureFilter = WebGLRenderingContext['LINEAR'] | WebGLRenderingCont
 export type TextureWrap = WebGLRenderingContext['REPEAT'] | WebGLRenderingContext['CLAMP_TO_EDGE'] | WebGLRenderingContext['MIRRORED_REPEAT'];
 
 type EmptyImage = {
-  width: number;
-  height: number;
-  data: null;
+    width: number;
+    height: number;
+    data: null;
 };
 
 type DataTextureImage = RGBAImage | AlphaImage | EmptyImage;
@@ -25,8 +25,8 @@ class Texture {
     useMipmap: boolean;
 
     constructor(context: Context, image: TextureImage, format: TextureFormat, options?: {
-      premultiply?: boolean;
-      useMipmap?: boolean;
+        premultiply?: boolean;
+        useMipmap?: boolean;
     } | null) {
         this.context = context;
         this.format = format;
@@ -35,11 +35,11 @@ class Texture {
     }
 
     update(image: TextureImage, options?: {
-      premultiply?: boolean;
-      useMipmap?: boolean;
+        premultiply?: boolean;
+        useMipmap?: boolean;
     } | null, position?: {
-      x: number;
-      y: number;
+        x: number;
+        y: number;
     }) {
         const {width, height} = image;
         const resize = (!this.size || this.size[0] !== width || this.size[1] !== height) && !position;

--- a/src/render/uniform_binding.ts
+++ b/src/render/uniform_binding.ts
@@ -4,7 +4,7 @@ import type Context from '../gl/context';
 import {mat4, vec2, vec3, vec4} from 'gl-matrix';
 
 type $ObjMap<T extends {}, F extends (v: any) => any> = {
-  [K in keyof T]: F extends (v: T[K]) => infer R ? R : never;
+    [K in keyof T]: F extends (v: T[K]) => infer R ? R : never;
 };
 
 export type UniformValues<Us extends any> = $ObjMap<Us, <V>(u: Uniform<V>) => V>;

--- a/src/render/vertex_array_object.ts
+++ b/src/render/vertex_array_object.ts
@@ -27,13 +27,13 @@ class VertexArrayObject {
     }
 
     bind(context: Context,
-         program: Program<any>,
-         layoutVertexBuffer: VertexBuffer,
-         paintVertexBuffers: Array<VertexBuffer>,
-         indexBuffer?: IndexBuffer | null,
-         vertexOffset?: number | null,
-         dynamicVertexBuffer?: VertexBuffer | null,
-         dynamicVertexBuffer2?: VertexBuffer | null) {
+        program: Program<any>,
+        layoutVertexBuffer: VertexBuffer,
+        paintVertexBuffers: Array<VertexBuffer>,
+        indexBuffer?: IndexBuffer | null,
+        vertexOffset?: number | null,
+        dynamicVertexBuffer?: VertexBuffer | null,
+        dynamicVertexBuffer2?: VertexBuffer | null) {
 
         this.context = context;
 
@@ -76,12 +76,12 @@ class VertexArrayObject {
     }
 
     freshBind(program: Program<any>,
-              layoutVertexBuffer: VertexBuffer,
-              paintVertexBuffers: Array<VertexBuffer>,
-              indexBuffer?: IndexBuffer | null,
-              vertexOffset?: number | null,
-              dynamicVertexBuffer?: VertexBuffer | null,
-              dynamicVertexBuffer2?: VertexBuffer | null) {
+        layoutVertexBuffer: VertexBuffer,
+        paintVertexBuffers: Array<VertexBuffer>,
+        indexBuffer?: IndexBuffer | null,
+        vertexOffset?: number | null,
+        dynamicVertexBuffer?: VertexBuffer | null,
+        dynamicVertexBuffer2?: VertexBuffer | null) {
         let numPrevAttributes;
         const numNextAttributes = program.numAttributes;
 

--- a/src/source/canvas_source.ts
+++ b/src/source/canvas_source.ts
@@ -11,10 +11,10 @@ import type Dispatcher from '../util/dispatcher';
 import type {Evented} from '../util/evented';
 
 export type CanvasSourceSpecification = {
-  'type': 'canvas';
-  'coordinates': [[number, number], [number, number], [number, number], [number, number]];
-  'animate'?: boolean;
-  'canvas': string | HTMLCanvasElement;
+    'type': 'canvas';
+    'coordinates': [[number, number], [number, number], [number, number], [number, number]];
+    'animate'?: boolean;
+    'canvas': string | HTMLCanvasElement;
 };
 
 /**

--- a/src/source/geojson_worker_source.ts
+++ b/src/source/geojson_worker_source.ts
@@ -23,24 +23,24 @@ import type {RequestParameters, ResponseCallback} from '../util/ajax';
 import type {Callback} from '../types/callback';
 
 export type LoadGeoJSONParameters = {
-  request?: RequestParameters;
-  data?: string;
-  source: string;
-  cluster: boolean;
-  superclusterOptions?: any;
-  geojsonVtOptions?: any;
-  clusterProperties?: any;
-  filter?: Array<unknown>;
+    request?: RequestParameters;
+    data?: string;
+    source: string;
+    cluster: boolean;
+    superclusterOptions?: any;
+    geojsonVtOptions?: any;
+    clusterProperties?: any;
+    filter?: Array<unknown>;
 };
 
 export type LoadGeoJSON = (params: LoadGeoJSONParameters, callback: ResponseCallback<any>) => void;
 
 export interface GeoJSONIndex {
-  getTile(z: number, x: number, y: number): any;
-  // supercluster methods
-  getClusterExpansionZoom(clusterId: number): number;
-  getChildren(clusterId: number): Array<GeoJSON.Feature>;
-  getLeaves(clusterId: number, limit: number, offset: number): Array<GeoJSON.Feature>;
+    getTile(z: number, x: number, y: number): any;
+    // supercluster methods
+    getClusterExpansionZoom(clusterId: number): number;
+    getChildren(clusterId: number): Array<GeoJSON.Feature>;
+    getLeaves(clusterId: number, limit: number, offset: number): Array<GeoJSON.Feature>;
 }
 
 function loadGeoJSONTile(params: WorkerTileParameters, callback: LoadVectorDataCallback): (() => void) | void {
@@ -89,8 +89,8 @@ export type SourceState = // Source empty or data loaded
 class GeoJSONWorkerSource extends VectorTileWorkerSource {
     _state: SourceState;
     _pendingCallback: Callback<{
-      resourceTiming?: {[_: string]: Array<PerformanceResourceTiming>};
-      abandoned?: boolean;
+        resourceTiming?: {[_: string]: Array<PerformanceResourceTiming>};
+        abandoned?: boolean;
     }>;
     _pendingLoadDataParams: LoadGeoJSONParameters;
     _geoJSONIndex: GeoJSONIndex;
@@ -126,8 +126,8 @@ class GeoJSONWorkerSource extends VectorTileWorkerSource {
      * @private
      */
     loadData(params: LoadGeoJSONParameters, callback: Callback<{
-      resourceTiming?: {[_: string]: Array<PerformanceResourceTiming>};
-      abandoned?: boolean;
+        resourceTiming?: {[_: string]: Array<PerformanceResourceTiming>};
+        abandoned?: boolean;
     }>) {
         if (this._pendingCallback) {
             // Tell the foreground the previous call has been abandoned
@@ -285,7 +285,7 @@ class GeoJSONWorkerSource extends VectorTileWorkerSource {
     }
 
     removeSource(params: {
-      source: string;
+        source: string;
     }, callback: WorkerTileCallback) {
         if (this._pendingCallback) {
             // Don't leak callbacks
@@ -295,7 +295,7 @@ class GeoJSONWorkerSource extends VectorTileWorkerSource {
     }
 
     getClusterExpansionZoom(params: {
-      clusterId: number;
+        clusterId: number;
     }, callback: Callback<number>) {
         try {
             callback(null, this._geoJSONIndex.getClusterExpansionZoom(params.clusterId));
@@ -305,7 +305,7 @@ class GeoJSONWorkerSource extends VectorTileWorkerSource {
     }
 
     getClusterChildren(params: {
-      clusterId: number;
+        clusterId: number;
     }, callback: Callback<Array<GeoJSON.Feature>>) {
         try {
             callback(null, this._geoJSONIndex.getChildren(params.clusterId));
@@ -315,9 +315,9 @@ class GeoJSONWorkerSource extends VectorTileWorkerSource {
     }
 
     getClusterLeaves(params: {
-      clusterId: number;
-      limit: number;
-      offset: number;
+        clusterId: number;
+        limit: number;
+        offset: number;
     }, callback: Callback<Array<GeoJSON.Feature>>) {
         try {
             callback(null, this._geoJSONIndex.getLeaves(params.clusterId, params.limit, params.offset));

--- a/src/source/geojson_wrapper.ts
+++ b/src/source/geojson_wrapper.ts
@@ -8,15 +8,15 @@ import EXTENT from '../data/extent';
 // The feature type used by geojson-vt and supercluster. Should be extracted to
 // global type and used in module definitions for those two modules.
 export type Feature = {
-  type: 1;
-  id: any;
-  tags: {[_: string]: string | number | boolean};
-  geometry: Array<[number, number]>;
+    type: 1;
+    id: any;
+    tags: {[_: string]: string | number | boolean};
+    geometry: Array<[number, number]>;
 } | {
-  type: 2 | 3;
-  id: any;
-  tags: {[_: string]: string | number | boolean};
-  geometry: Array<Array<[number, number]>>;
+    type: 2 | 3;
+    id: any;
+    tags: {[_: string]: string | number | boolean};
+    geometry: Array<Array<[number, number]>>;
 };
 
 class FeatureWrapper implements VectorTileFeature {

--- a/src/source/image_source.ts
+++ b/src/source/image_source.ts
@@ -143,8 +143,8 @@ class ImageSource extends Evented implements Source {
      * @returns {ImageSource} this
      */
     updateImage(options: {
-      url: string;
-      coordinates?: Coordinates;
+        url: string;
+        coordinates?: Coordinates;
     }) {
         if (!this.image || !options.url) {
             return this;
@@ -299,9 +299,9 @@ export function getCoordinatesCenterTileID(coords: Array<MercatorCoordinate>) {
     const tilesAtZoom = Math.pow(2, zoom);
 
     return new CanonicalTileID(
-            zoom,
-            Math.floor((minX + maxX) / 2 * tilesAtZoom),
-            Math.floor((minY + maxY) / 2 * tilesAtZoom));
+        zoom,
+        Math.floor((minX + maxX) / 2 * tilesAtZoom),
+        Math.floor((minY + maxY) / 2 * tilesAtZoom));
 }
 
 export default ImageSource;

--- a/src/source/pixels_to_tile_units.ts
+++ b/src/source/pixels_to_tile_units.ts
@@ -15,12 +15,12 @@ import type {OverscaledTileID} from './tile_id';
  * @private
  */
 export default function(
-  tile: {
-    tileID: OverscaledTileID;
-    tileSize: number;
-  },
-  pixelValue: number,
-  z: number
+    tile: {
+        tileID: OverscaledTileID;
+        tileSize: number;
+    },
+    pixelValue: number,
+    z: number
 ): number {
     return pixelValue * (EXTENT / (tile.tileSize * Math.pow(2, z - tile.tileID.overscaledZ)));
 }

--- a/src/source/query_features.ts
+++ b/src/source/query_features.ts
@@ -91,18 +91,18 @@ export function queryRenderedFeatures(
 }
 
 export function queryRenderedSymbols(styleLayers: {[_: string]: StyleLayer},
-                            serializedLayers: {[_: string]: StyleLayer},
-                            sourceCaches: {[_: string]: SourceCache},
-                            queryGeometry: Array<Point>,
-                            params: {
-                              filter: FilterSpecification;
-                              layers: Array<string>;
-                              availableImages: Array<string>;
-                            },
-                            collisionIndex: CollisionIndex,
-                            retainedQueryData: {
-                              [_: number]: RetainedQueryData;
-                            }) {
+    serializedLayers: {[_: string]: StyleLayer},
+    sourceCaches: {[_: string]: SourceCache},
+    queryGeometry: Array<Point>,
+    params: {
+        filter: FilterSpecification;
+        layers: Array<string>;
+        availableImages: Array<string>;
+    },
+    collisionIndex: CollisionIndex,
+    retainedQueryData: {
+        [_: number]: RetainedQueryData;
+    }) {
     const result = {};
     const renderedSymbols = collisionIndex.queryRenderedSymbols(queryGeometry);
     const bucketQueryData = [];
@@ -113,14 +113,14 @@ export function queryRenderedSymbols(styleLayers: {[_: string]: StyleLayer},
 
     for (const queryData of bucketQueryData) {
         const bucketSymbols = queryData.featureIndex.lookupSymbolFeatures(
-                renderedSymbols[queryData.bucketInstanceId],
-                serializedLayers,
-                queryData.bucketIndex,
-                queryData.sourceLayerIndex,
-                params.filter,
-                params.layers,
-                params.availableImages,
-                styleLayers);
+            renderedSymbols[queryData.bucketInstanceId],
+            serializedLayers,
+            queryData.bucketIndex,
+            queryData.sourceLayerIndex,
+            params.filter,
+            params.layers,
+            params.availableImages,
+            styleLayers);
 
         for (const layerID in bucketSymbols) {
             const resultFeatures = result[layerID] = result[layerID] || [];

--- a/src/source/rtl_text_plugin.ts
+++ b/src/source/rtl_text_plugin.ts
@@ -13,8 +13,8 @@ const status = {
 };
 
 export type PluginState = {
-  pluginStatus: typeof status[keyof typeof status];
-  pluginURL: string;
+    pluginStatus: typeof status[keyof typeof status];
+    pluginURL: string;
 };
 
 type ErrorCallback = (error?: Error | null) => void;
@@ -93,14 +93,14 @@ export const downloadRTLTextPlugin = function() {
 };
 
 export const plugin: {
-  applyArabicShaping: Function;
-  processBidirectionalText: ((b: string, a: Array<number>) => Array<string>);
-  processStyledBidirectionalText: ((c: string, b: Array<number>, a: Array<number>) => Array<[string, Array<number>]>);
-  isLoaded: () => boolean;
-  isLoading: () => boolean;
-  setState: (state: PluginState) => void;
-  isParsed: () => boolean;
-  getPluginURL: () => string;
+    applyArabicShaping: Function;
+    processBidirectionalText: ((b: string, a: Array<number>) => Array<string>);
+    processStyledBidirectionalText: ((c: string, b: Array<number>, a: Array<number>) => Array<[string, Array<number>]>);
+    isLoaded: () => boolean;
+    isLoading: () => boolean;
+    setState: (state: PluginState) => void;
+    isParsed: () => boolean;
+    getPluginURL: () => string;
 } = {
     applyArabicShaping: null,
     processBidirectionalText: null,

--- a/src/source/source.ts
+++ b/src/source/source.ts
@@ -33,47 +33,47 @@ import {CanonicalTileID} from './tile_id';
  * if they are floor-ed to the nearest integer.
  */
 export interface Source {
-  readonly type: string;
-  id: string;
-  minzoom: number;
-  maxzoom: number;
-  tileSize: number;
-  attribution?: string;
-  roundZoom?: boolean;
-  isTileClipped?: boolean;
-  maplibreLogo?: boolean;
-  tileID?: CanonicalTileID;
-  reparseOverscaled?: boolean;
-  vectorLayerIds?: Array<string>;
-  hasTransition(): boolean;
-  loaded(): boolean;
-  fire(event: Event): unknown;
-  readonly onAdd?: (map: Map) => void;
-  readonly onRemove?: (map: Map) => void;
-  loadTile(tile: Tile, callback: Callback<void>): void;
-  readonly hasTile?: (tileID: OverscaledTileID) => boolean;
-  readonly abortTile?: (tile: Tile, callback: Callback<void>) => void;
-  readonly unloadTile?: (tile: Tile, callback: Callback<void>) => void;
-  /**
+    readonly type: string;
+    id: string;
+    minzoom: number;
+    maxzoom: number;
+    tileSize: number;
+    attribution?: string;
+    roundZoom?: boolean;
+    isTileClipped?: boolean;
+    maplibreLogo?: boolean;
+    tileID?: CanonicalTileID;
+    reparseOverscaled?: boolean;
+    vectorLayerIds?: Array<string>;
+    hasTransition(): boolean;
+    loaded(): boolean;
+    fire(event: Event): unknown;
+    readonly onAdd?: (map: Map) => void;
+    readonly onRemove?: (map: Map) => void;
+    loadTile(tile: Tile, callback: Callback<void>): void;
+    readonly hasTile?: (tileID: OverscaledTileID) => boolean;
+    readonly abortTile?: (tile: Tile, callback: Callback<void>) => void;
+    readonly unloadTile?: (tile: Tile, callback: Callback<void>) => void;
+    /**
      * @returns A plain (stringifiable) JS object representing the current state of the source.
      * Creating a source using the returned object as the `options` should result in a Source that is
      * equivalent to this one.
      * @private
      */
-  serialize(): any;
-  readonly prepare?: () => void;
+    serialize(): any;
+    readonly prepare?: () => void;
 }
 
 type SourceStatics = {
-  /*
+    /*
      * An optional URL to a script which, when run by a Worker, registers a {@link WorkerSource}
      * implementation for this Source type by calling `self.registerWorkerSource(workerSource: WorkerSource)`.
      */
-  workerSourceURL?: URL;
+    workerSourceURL?: URL;
 };
 
 export type SourceClass = {
-  new (...args: any): Source;
+    new (...args: any): Source;
 } & SourceStatics;
 
 import vector from '../source/vector_tile_source';
@@ -122,11 +122,11 @@ export const getSourceType = function (name: string) {
 };
 
 export const setSourceType = function (name: string, type: {
-  new (...args: any): Source;
+    new (...args: any): Source;
 }) {
     sourceTypes[name] = type;
 };
 
 export interface Actor {
-  send(type: string, data: any, callback: Callback<any>): void;
+    send(type: string, data: any, callback: Callback<any>): void;
 }

--- a/src/source/source_cache.ts
+++ b/src/source/source_cache.ts
@@ -46,10 +46,10 @@ class SourceCache extends Evented {
     _prevLng: number;
     _cache: TileCache;
     _timers: {
-      [_ in any]: ReturnType<typeof setTimeout>;
+        [_ in any]: ReturnType<typeof setTimeout>;
     };
     _cacheTimers: {
-      [_ in any]: ReturnType<typeof setTimeout>;
+        [_ in any]: ReturnType<typeof setTimeout>;
     };
     _maxTileCacheSize: number;
     _paused: boolean;
@@ -333,12 +333,12 @@ class SourceCache extends Evented {
      */
     _retainLoadedChildren(
         idealTiles: {
-          [_ in any]: OverscaledTileID;
+            [_ in any]: OverscaledTileID;
         },
         zoom: number,
         maxCoveringZoom: number,
         retain: {
-          [_ in any]: OverscaledTileID;
+            [_ in any]: OverscaledTileID;
         }
     ) {
         for (const id in this._tiles) {

--- a/src/source/source_state.ts
+++ b/src/source/source_state.ts
@@ -102,7 +102,7 @@ class SourceFeatureState {
     }
 
     coalesceChanges(tiles: {
-      [_ in any]: Tile;
+        [_ in any]: Tile;
     }, painter: any) {
         //track changes with full state objects, but only for features that got modified
         const featuresChanged: LayerFeatureStates = {};

--- a/src/source/tile.ts
+++ b/src/source/tile.ts
@@ -268,20 +268,20 @@ class Tile {
     // Queries non-symbol features rendered for this tile.
     // Symbol features are queried globally
     queryRenderedFeatures(
-      layers: {[_: string]: StyleLayer},
-      serializedLayers: {[_: string]: any},
-      sourceFeatureState: SourceFeatureState,
-      queryGeometry: Array<Point>,
-      cameraQueryGeometry: Array<Point>,
-      scale: number,
-      params: {
-        filter: FilterSpecification;
-        layers: Array<string>;
-        availableImages: Array<string>;
-      },
-      transform: Transform,
-      maxPitchScaleFactor: number,
-      pixelPosMatrix: mat4
+        layers: {[_: string]: StyleLayer},
+        serializedLayers: {[_: string]: any},
+        sourceFeatureState: SourceFeatureState,
+        queryGeometry: Array<Point>,
+        cameraQueryGeometry: Array<Point>,
+        scale: number,
+        params: {
+            filter: FilterSpecification;
+            layers: Array<string>;
+            availableImages: Array<string>;
+        },
+        transform: Transform,
+        maxPitchScaleFactor: number,
+        pixelPosMatrix: mat4
     ): {[_: string]: Array<{featureIndex: number; feature: GeoJSONFeature}>} {
         if (!this.latestFeatureIndex || !this.latestFeatureIndex.rawTileData)
             return {};

--- a/src/source/tile_cache.ts
+++ b/src/source/tile_cache.ts
@@ -11,10 +11,10 @@ import type Tile from './tile';
 class TileCache {
     max: number;
     data: {
-      [key: string]: Array<{
-        value: Tile;
-        timeout: ReturnType<typeof setTimeout>;
-      }>;
+        [key: string]: Array<{
+            value: Tile;
+            timeout: ReturnType<typeof setTimeout>;
+        }>;
     };
     order: Array<string>;
     onRemove: (element: Tile) => void;
@@ -157,8 +157,8 @@ class TileCache {
      * @private
      */
     remove(tileID: OverscaledTileID, value?: {
-      value: Tile;
-      timeout: ReturnType<typeof setTimeout>;
+        value: Tile;
+        timeout: ReturnType<typeof setTimeout>;
     }) {
         if (!this.has(tileID)) { return this; }
         const key = tileID.wrapped().key;

--- a/src/source/vector_tile_source.ts
+++ b/src/source/vector_tile_source.ts
@@ -64,7 +64,7 @@ class VectorTileSource extends Evented implements Source {
     _loaded: boolean;
 
     constructor(id: string, options: VectorSourceSpecification & {
-      collectResourceTiming: boolean;
+        collectResourceTiming: boolean;
     }, dispatcher: Dispatcher, eventedParent: Evented) {
         super();
         this.id = id;

--- a/src/source/vector_tile_worker_source.ts
+++ b/src/source/vector_tile_worker_source.ts
@@ -19,11 +19,11 @@ import type {Callback} from '../types/callback';
 import type {VectorTile} from '@mapbox/vector-tile';
 
 export type LoadVectorTileResult = {
-  vectorTile: VectorTile;
-  rawData: ArrayBuffer;
-  expires?: any;
-  cacheControl?: any;
-  resourceTiming?: Array<PerformanceResourceTiming>;
+    vectorTile: VectorTile;
+    rawData: ArrayBuffer;
+    expires?: any;
+    cacheControl?: any;
+    resourceTiming?: Array<PerformanceResourceTiming>;
 };
 
 /**

--- a/src/source/worker.ts
+++ b/src/source/worker.ts
@@ -31,21 +31,21 @@ export default class Worker {
     layerIndexes: {[_: string]: StyleLayerIndex};
     availableImages: {[_: string]: Array<string>};
     workerSourceTypes: {
-      [_: string]: {
-        new (...args: any): WorkerSource;
-      };
+        [_: string]: {
+            new (...args: any): WorkerSource;
+        };
     };
     workerSources: {
-      [_: string]: {
         [_: string]: {
-          [_: string]: WorkerSource;
+            [_: string]: {
+                [_: string]: WorkerSource;
+            };
         };
-      };
     };
     demWorkerSources: {
-      [_: string]: {
-        [_: string]: RasterDEMTileWorkerSource;
-      };
+        [_: string]: {
+            [_: string]: RasterDEMTileWorkerSource;
+        };
     };
     referrer: string;
 
@@ -66,7 +66,7 @@ export default class Worker {
         this.demWorkerSources = {};
 
         this.self.registerWorkerSource = (name: string, WorkerSource: {
-          new (...args: any): WorkerSource;
+            new (...args: any): WorkerSource;
         }) => {
             if (this.workerSourceTypes[name]) {
                 throw new Error(`Worker source with name "${name}" already registered.`);
@@ -76,9 +76,9 @@ export default class Worker {
 
         // This is invoked by the RTL text plugin when the download via the `importScripts` call has finished, and the code has been parsed.
         this.self.registerRTLTextPlugin = (rtlTextPlugin: {
-          applyArabicShaping: Function;
-          processBidirectionalText: ((b: string, a: Array<number>) => Array<string>);
-          processStyledBidirectionalText?: ((c: string, b: Array<number>, a: Array<number>) => Array<[string, Array<number>]>);
+            applyArabicShaping: Function;
+            processBidirectionalText: ((b: string, a: Array<number>) => Array<string>);
+            processStyledBidirectionalText?: ((c: string, b: Array<number>, a: Array<number>) => Array<[string, Array<number>]>);
         }) => {
             if (globalRTLTextPlugin.isParsed()) {
                 throw new Error('RTL text plugin already registered.');
@@ -110,15 +110,15 @@ export default class Worker {
     }
 
     updateLayers(mapId: string, params: {
-      layers: Array<LayerSpecification>;
-      removedIds: Array<string>;
+        layers: Array<LayerSpecification>;
+        removedIds: Array<string>;
     }, callback: WorkerTileCallback) {
         this.getLayerIndex(mapId).update(params.layers, params.removedIds);
         callback();
     }
 
     loadTile(mapId: string, params: WorkerTileParameters & {
-      type: string;
+        type: string;
     }, callback: WorkerTileCallback) {
         assert(params.type);
         this.getWorkerSource(mapId, params.type, params.source).loadTile(params, callback);
@@ -129,21 +129,21 @@ export default class Worker {
     }
 
     reloadTile(mapId: string, params: WorkerTileParameters & {
-      type: string;
+        type: string;
     }, callback: WorkerTileCallback) {
         assert(params.type);
         this.getWorkerSource(mapId, params.type, params.source).reloadTile(params, callback);
     }
 
     abortTile(mapId: string, params: TileParameters & {
-      type: string;
+        type: string;
     }, callback: WorkerTileCallback) {
         assert(params.type);
         this.getWorkerSource(mapId, params.type, params.source).abortTile(params, callback);
     }
 
     removeTile(mapId: string, params: TileParameters & {
-      type: string;
+        type: string;
     }, callback: WorkerTileCallback) {
         assert(params.type);
         this.getWorkerSource(mapId, params.type, params.source).removeTile(params, callback);
@@ -154,9 +154,9 @@ export default class Worker {
     }
 
     removeSource(mapId: string, params: {
-      source: string;
+        source: string;
     } & {
-      type: string;
+        type: string;
     }, callback: WorkerTileCallback) {
         assert(params.type);
         assert(params.source);
@@ -184,7 +184,7 @@ export default class Worker {
      *  @private
      */
     loadWorkerSource(map: string, params: {
-      url: string;
+        url: string;
     }, callback: Callback<void>) {
         try {
             this.self.importScripts(params.url);

--- a/src/source/worker_source.ts
+++ b/src/source/worker_source.ts
@@ -12,52 +12,52 @@ import type {StyleImage} from '../style/style_image';
 import type {PromoteIdSpecification} from '../style-spec/types';
 
 export type TileParameters = {
-  source: string;
-  uid: string;
+    source: string;
+    uid: string;
 };
 
 export type WorkerTileParameters = TileParameters & {
-  tileID: OverscaledTileID;
-  request: RequestParameters;
-  zoom: number;
-  maxZoom: number;
-  tileSize: number;
-  promoteId: PromoteIdSpecification;
-  pixelRatio: number;
-  showCollisionBoxes: boolean;
-  collectResourceTiming?: boolean;
-  returnDependencies?: boolean;
+    tileID: OverscaledTileID;
+    request: RequestParameters;
+    zoom: number;
+    maxZoom: number;
+    tileSize: number;
+    promoteId: PromoteIdSpecification;
+    pixelRatio: number;
+    showCollisionBoxes: boolean;
+    collectResourceTiming?: boolean;
+    returnDependencies?: boolean;
 };
 
 export type WorkerDEMTileParameters = TileParameters & {
-  coord: {
-    z: number;
-    x: number;
-    y: number;
-    w: number;
-  };
-  rawImageData: RGBAImage | ImageBitmap;
-  encoding: 'mapbox' | 'terrarium';
+    coord: {
+        z: number;
+        x: number;
+        y: number;
+        w: number;
+    };
+    rawImageData: RGBAImage | ImageBitmap;
+    encoding: 'mapbox' | 'terrarium';
 };
 
 export type WorkerTileResult = {
-  buckets: Array<Bucket>;
-  imageAtlas: ImageAtlas;
-  glyphAtlasImage: AlphaImage;
-  featureIndex: FeatureIndex;
-  collisionBoxArray: CollisionBoxArray;
-  rawTileData?: ArrayBuffer;
-  resourceTiming?: Array<PerformanceResourceTiming>;
-  // Only used for benchmarking:
-  glyphMap?: {
-    [_: string]: {
-      [_: number]: StyleGlyph;
-    };
-  } | null;
-  iconMap?: {
-    [_: string]: StyleImage;
-  } | null;
-  glyphPositions?: GlyphPositions | null;
+    buckets: Array<Bucket>;
+    imageAtlas: ImageAtlas;
+    glyphAtlasImage: AlphaImage;
+    featureIndex: FeatureIndex;
+    collisionBoxArray: CollisionBoxArray;
+    rawTileData?: ArrayBuffer;
+    resourceTiming?: Array<PerformanceResourceTiming>;
+    // Only used for benchmarking:
+    glyphMap?: {
+        [_: string]: {
+            [_: number]: StyleGlyph;
+        };
+    } | null;
+    iconMap?: {
+        [_: string]: StyleImage;
+    } | null;
+    glyphPositions?: GlyphPositions | null;
 };
 
 export type WorkerTileCallback = (error?: Error | null, result?: WorkerTileResult | null) => void;
@@ -78,38 +78,38 @@ export type WorkerDEMTileCallback = (err?: Error | null, result?: DEMData | null
  * @param layerIndex
  */
 export interface WorkerSource {
-  availableImages: Array<string>;
-  // Disabled due to https://github.com/facebook/flow/issues/5208
-  // constructor(actor: Actor, layerIndex: StyleLayerIndex): WorkerSource;
+    availableImages: Array<string>;
+    // Disabled due to https://github.com/facebook/flow/issues/5208
+    // constructor(actor: Actor, layerIndex: StyleLayerIndex): WorkerSource;
 
-  /**
+    /**
      * Loads a tile from the given params and parse it into buckets ready to send
      * back to the main thread for rendering.  Should call the callback with:
      * `{ buckets, featureIndex, collisionIndex, rawTileData}`.
      */
-  loadTile(params: WorkerTileParameters, callback: WorkerTileCallback): void;
-  /**
+    loadTile(params: WorkerTileParameters, callback: WorkerTileCallback): void;
+    /**
      * Re-parses a tile that has already been loaded.  Yields the same data as
      * {@link WorkerSource#loadTile}.
      */
-  reloadTile(params: WorkerTileParameters, callback: WorkerTileCallback): void;
-  /**
+    reloadTile(params: WorkerTileParameters, callback: WorkerTileCallback): void;
+    /**
      * Aborts loading a tile that is in progress.
      */
-  abortTile(params: TileParameters, callback: WorkerTileCallback): void;
-  /**
+    abortTile(params: TileParameters, callback: WorkerTileCallback): void;
+    /**
      * Removes this tile from any local caches.
      */
-  removeTile(params: TileParameters, callback: WorkerTileCallback): void;
-  /**
+    removeTile(params: TileParameters, callback: WorkerTileCallback): void;
+    /**
      * Tells the WorkerSource to abort in-progress tasks and release resources.
      * The foreground Source is responsible for ensuring that 'removeSource' is
      * the last message sent to the WorkerSource.
      */
-  removeSource?: (
-    params: {
-      source: string;
-    },
-    callback: WorkerTileCallback
-  ) => void;
+    removeSource?: (
+        params: {
+            source: string;
+        },
+        callback: WorkerTileCallback
+    ) => void;
 }

--- a/src/source/worker_tile.ts
+++ b/src/source/worker_tile.ts
@@ -130,9 +130,9 @@ class WorkerTile {
 
         let error: Error;
         let glyphMap: {
-          [_: string]: {
-            [_: number]: StyleGlyph;
-          };
+            [_: string]: {
+                [_: number]: StyleGlyph;
+            };
         };
         let iconMap: {[_: string]: StyleImage};
         let patternMap: {[_: string]: StyleImage};

--- a/src/style-spec/error/validation_error.ts
+++ b/src/style-spec/error/validation_error.ts
@@ -6,7 +6,7 @@ export default class ValidationError {
     line: number;
 
     constructor(key: string, value: {
-      __line__: number;
+        __line__: number;
     }, message: string, identifier?: string | null) {
         this.message = (key ? `${key}: ` : '') + message;
         if (identifier) this.identifier = identifier;

--- a/src/style-spec/expression/compound_expression.ts
+++ b/src/style-spec/expression/compound_expression.ts
@@ -9,14 +9,14 @@ import type {Type} from './types';
 import type {Value} from './values';
 
 export type Varargs = {
-  type: Type;
+    type: Type;
 };
 type Signature = Array<Type> | Varargs;
 type Evaluate = (b: EvaluationContext, a: Array<Expression>) => Value;
 
 type Definition = [Type, Signature, Evaluate] | {
-  type: Type;
-  overloads: Array<[Signature, Evaluate]>;
+    type: Type;
+    overloads: Array<[Signature, Evaluate]>;
 };
 
 class CompoundExpression implements Expression {

--- a/src/style-spec/expression/definitions/format.ts
+++ b/src/style-spec/expression/definitions/format.ts
@@ -16,12 +16,12 @@ import type ParsingContext from '../parsing_context';
 import type {Type} from '../types';
 
 type FormattedSectionExpression = {
-  // Content of a section may be Image expression or other
-  // type of expression that is coercable to 'string'.
-  content: Expression;
-  scale: Expression | null;
-  font: Expression | null;
-  textColor: Expression | null;
+    // Content of a section may be Image expression or other
+    // type of expression that is coercable to 'string'.
+    content: Expression;
+    scale: Expression | null;
+    font: Expression | null;
+    textColor: Expression | null;
 };
 
 export default class FormatExpression implements Expression {
@@ -97,11 +97,11 @@ export default class FormatExpression implements Expression {
             }
 
             return new FormattedSection(
-                    toString(evaluatedContent),
-                    null,
-                    section.scale ? section.scale.evaluate(ctx) : null,
-                    section.font ? section.font.evaluate(ctx).join(',') : null,
-                    section.textColor ? section.textColor.evaluate(ctx) : null
+                toString(evaluatedContent),
+                null,
+                section.scale ? section.scale.evaluate(ctx) : null,
+                section.font ? section.font.evaluate(ctx).join(',') : null,
+                section.textColor ? section.textColor.evaluate(ctx) : null
             );
         };
 

--- a/src/style-spec/expression/definitions/interpolate.ts
+++ b/src/style-spec/expression/definitions/interpolate.ts
@@ -12,13 +12,13 @@ import type EvaluationContext from '../evaluation_context';
 import type {Type} from '../types';
 
 export type InterpolationType = {
-  name: 'linear';
+    name: 'linear';
 } | {
-  name: 'exponential';
-  base: number;
+    name: 'exponential';
+    base: number;
 } | {
-  name: 'cubic-bezier';
-  controlPoints: [number, number, number, number];
+    name: 'cubic-bezier';
+    controlPoints: [number, number, number, number];
 };
 
 class Interpolate implements Expression {

--- a/src/style-spec/expression/definitions/match.ts
+++ b/src/style-spec/expression/definitions/match.ts
@@ -11,7 +11,7 @@ import type EvaluationContext from '../evaluation_context';
 
 // Map input label values to output expression index
 type Cases = {
-  [k in number | string]: number;
+    [k in number | string]: number;
 };
 
 class Match implements Expression {
@@ -128,7 +128,7 @@ class Match implements Expression {
         // serializations of the form [case1, case2, ...] -> matchExpression
         const groupedByOutput: Array<[number, Array<number | string>]> = [];
         const outputLookup: {
-          [index: number]: number;
+            [index: number]: number;
         } = {}; // lookup index into groupedByOutput for a given output expression
         for (const label of sortedLabels) {
             const outputIndex = outputLookup[this.cases[label]];

--- a/src/style-spec/expression/definitions/number_format.ts
+++ b/src/style-spec/expression/definitions/number_format.ts
@@ -6,9 +6,9 @@ import type ParsingContext from '../parsing_context';
 import type {Type} from '../types';
 
 declare let Intl: {
-  NumberFormat: {
-    new (...args: any): Intl$NumberFormat;
-  };
+    NumberFormat: {
+        new (...args: any): Intl$NumberFormat;
+    };
 };
 
 declare class Intl$NumberFormat {
@@ -18,10 +18,10 @@ declare class Intl$NumberFormat {
 }
 
 type NumberFormatOptions = {
-  style?: 'decimal' | 'currency' | 'percent';
-  currency?: null | string;
-  minimumFractionDigits?: null | string;
-  maximumFractionDigits?: null | string;
+    style?: 'decimal' | 'currency' | 'percent';
+    currency?: null | string;
+    minimumFractionDigits?: null | string;
+    maximumFractionDigits?: null | string;
 };
 
 export default class NumberFormat implements Expression {
@@ -33,10 +33,10 @@ export default class NumberFormat implements Expression {
     maxFractionDigits: Expression | null; // Default 3
 
     constructor(number: Expression,
-                locale: Expression | null,
-                currency: Expression | null,
-                minFractionDigits: Expression | null,
-                maxFractionDigits: Expression | null) {
+        locale: Expression | null,
+        currency: Expression | null,
+        minFractionDigits: Expression | null,
+        maxFractionDigits: Expression | null) {
         this.type = StringType;
         this.number = number;
         this.locale = locale;

--- a/src/style-spec/expression/expression.ts
+++ b/src/style-spec/expression/expression.ts
@@ -5,21 +5,21 @@ import type EvaluationContext from './evaluation_context';
 type SerializedExpression = Array<unknown> | string | number | boolean | null;
 
 export interface Expression {
-  readonly type: Type;
-  evaluate(ctx: EvaluationContext): any;
-  eachChild(fn: (a: Expression) => void): void;
-  /**
+    readonly type: Type;
+    evaluate(ctx: EvaluationContext): any;
+    eachChild(fn: (a: Expression) => void): void;
+    /**
      * Statically analyze the expression, attempting to enumerate possible outputs. Returns
      * false if the complete set of outputs is statically undecidable, otherwise true.
      */
-  outputDefined(): boolean;
-  serialize(): SerializedExpression;
+    outputDefined(): boolean;
+    serialize(): SerializedExpression;
 }
 
 export type ExpressionParser = (args: ReadonlyArray<unknown>, context: ParsingContext) => Expression;
 export type ExpressionRegistration = {
-  new (...args: any): Expression;
+    new (...args: any): Expression;
 } & {
-  readonly parse: ExpressionParser;
+    readonly parse: ExpressionParser;
 };
 export type ExpressionRegistry = {[_: string]: ExpressionRegistration};

--- a/src/style-spec/expression/index.ts
+++ b/src/style-spec/expression/index.ts
@@ -27,27 +27,27 @@ import type Point from '@mapbox/point-geometry';
 import type {CanonicalTileID} from '../../source/tile_id';
 
 export type Feature = {
-  readonly type: 1 | 2 | 3 | 'Unknown' | 'Point' | 'MultiPoint' | 'LineString' | 'MultiLineString' | 'Polygon' | 'MultiPolygon';
-  readonly id?: any;
-  readonly properties: {[_: string]: any};
-  readonly patterns?: {
-    [_: string]: {
-      'min': string;
-      'mid': string;
-      'max': string;
+    readonly type: 1 | 2 | 3 | 'Unknown' | 'Point' | 'MultiPoint' | 'LineString' | 'MultiLineString' | 'Polygon' | 'MultiPolygon';
+    readonly id?: any;
+    readonly properties: {[_: string]: any};
+    readonly patterns?: {
+        [_: string]: {
+            'min': string;
+            'mid': string;
+            'max': string;
+        };
     };
-  };
-  readonly geometry?: Array<Array<Point>>;
+    readonly geometry?: Array<Array<Point>>;
 };
 
 export type FeatureState = {[_: string]: any};
 
 export type GlobalProperties = Readonly<{
-  zoom: number;
-  heatmapDensity?: number;
-  lineProgress?: number;
-  isSupportedScript?: (_: string) => boolean;
-  accumulated?: Value;
+    zoom: number;
+    heatmapDensity?: number;
+    lineProgress?: number;
+    isSupportedScript?: (_: string) => boolean;
+    accumulated?: Value;
 }>;
 
 export class StyleExpression {
@@ -67,12 +67,12 @@ export class StyleExpression {
     }
 
     evaluateWithoutErrorHandling(
-      globals: GlobalProperties,
-      feature?: Feature,
-      featureState?: FeatureState,
-      canonical?: CanonicalTileID,
-      availableImages?: Array<string>,
-      formattedSection?: FormattedSection
+        globals: GlobalProperties,
+        feature?: Feature,
+        featureState?: FeatureState,
+        canonical?: CanonicalTileID,
+        availableImages?: Array<string>,
+        formattedSection?: FormattedSection
     ): any {
         this._evaluator.globals = globals;
         this._evaluator.feature = feature;
@@ -85,12 +85,12 @@ export class StyleExpression {
     }
 
     evaluate(
-      globals: GlobalProperties,
-      feature?: Feature,
-      featureState?: FeatureState,
-      canonical?: CanonicalTileID,
-      availableImages?: Array<string>,
-      formattedSection?: FormattedSection
+        globals: GlobalProperties,
+        feature?: Feature,
+        featureState?: FeatureState,
+        canonical?: CanonicalTileID,
+        availableImages?: Array<string>,
+        formattedSection?: FormattedSection
     ): any {
         this._evaluator.globals = globals;
         this._evaluator.feature = feature || null;
@@ -162,23 +162,23 @@ export class ZoomConstantExpression<Kind extends EvaluationKind> {
     }
 
     evaluateWithoutErrorHandling(
-      globals: GlobalProperties,
-      feature?: Feature,
-      featureState?: FeatureState,
-      canonical?: CanonicalTileID,
-      availableImages?: Array<string>,
-      formattedSection?: FormattedSection
+        globals: GlobalProperties,
+        feature?: Feature,
+        featureState?: FeatureState,
+        canonical?: CanonicalTileID,
+        availableImages?: Array<string>,
+        formattedSection?: FormattedSection
     ): any {
         return this._styleExpression.evaluateWithoutErrorHandling(globals, feature, featureState, canonical, availableImages, formattedSection);
     }
 
     evaluate(
-      globals: GlobalProperties,
-      feature?: Feature,
-      featureState?: FeatureState,
-      canonical?: CanonicalTileID,
-      availableImages?: Array<string>,
-      formattedSection?: FormattedSection
+        globals: GlobalProperties,
+        feature?: Feature,
+        featureState?: FeatureState,
+        canonical?: CanonicalTileID,
+        availableImages?: Array<string>,
+        formattedSection?: FormattedSection
     ): any {
         return this._styleExpression.evaluate(globals, feature, featureState, canonical, availableImages, formattedSection);
     }
@@ -201,23 +201,23 @@ export class ZoomDependentExpression<Kind extends EvaluationKind> {
     }
 
     evaluateWithoutErrorHandling(
-      globals: GlobalProperties,
-      feature?: Feature,
-      featureState?: FeatureState,
-      canonical?: CanonicalTileID,
-      availableImages?: Array<string>,
-      formattedSection?: FormattedSection
+        globals: GlobalProperties,
+        feature?: Feature,
+        featureState?: FeatureState,
+        canonical?: CanonicalTileID,
+        availableImages?: Array<string>,
+        formattedSection?: FormattedSection
     ): any {
         return this._styleExpression.evaluateWithoutErrorHandling(globals, feature, featureState, canonical, availableImages, formattedSection);
     }
 
     evaluate(
-      globals: GlobalProperties,
-      feature?: Feature,
-      featureState?: FeatureState,
-      canonical?: CanonicalTileID,
-      availableImages?: Array<string>,
-      formattedSection?: FormattedSection
+        globals: GlobalProperties,
+        feature?: Feature,
+        featureState?: FeatureState,
+        canonical?: CanonicalTileID,
+        availableImages?: Array<string>,
+        formattedSection?: FormattedSection
     ): any {
         return this._styleExpression.evaluate(globals, feature, featureState, canonical, availableImages, formattedSection);
     }
@@ -232,57 +232,57 @@ export class ZoomDependentExpression<Kind extends EvaluationKind> {
 }
 
 export type ConstantExpression = {
-  kind: 'constant';
-  readonly evaluate: (
-    globals: GlobalProperties,
-    feature?: Feature,
-    featureState?: FeatureState,
-    canonical?: CanonicalTileID,
-    availableImages?: Array<string>
-  ) => any;
+    kind: 'constant';
+    readonly evaluate: (
+        globals: GlobalProperties,
+        feature?: Feature,
+        featureState?: FeatureState,
+        canonical?: CanonicalTileID,
+        availableImages?: Array<string>
+    ) => any;
 };
 
 export type SourceExpression = {
-  kind: 'source';
-  isStateDependent: boolean;
-  readonly evaluate: (
-    globals: GlobalProperties,
-    feature?: Feature,
-    featureState?: FeatureState,
-    canonical?: CanonicalTileID,
-    availableImages?: Array<string>,
-    formattedSection?: FormattedSection
-  ) => any;
+    kind: 'source';
+    isStateDependent: boolean;
+    readonly evaluate: (
+        globals: GlobalProperties,
+        feature?: Feature,
+        featureState?: FeatureState,
+        canonical?: CanonicalTileID,
+        availableImages?: Array<string>,
+        formattedSection?: FormattedSection
+    ) => any;
 };
 
 export type CameraExpression = {
-  kind: 'camera';
-  readonly evaluate: (
-    globals: GlobalProperties,
-    feature?: Feature,
-    featureState?: FeatureState,
-    canonical?: CanonicalTileID,
-    availableImages?: Array<string>
-  ) => any;
-  readonly interpolationFactor: (input: number, lower: number, upper: number) => number;
-  zoomStops: Array<number>;
-  interpolationType: InterpolationType;
+    kind: 'camera';
+    readonly evaluate: (
+        globals: GlobalProperties,
+        feature?: Feature,
+        featureState?: FeatureState,
+        canonical?: CanonicalTileID,
+        availableImages?: Array<string>
+    ) => any;
+    readonly interpolationFactor: (input: number, lower: number, upper: number) => number;
+    zoomStops: Array<number>;
+    interpolationType: InterpolationType;
 };
 
 export type CompositeExpression = {
-  kind: 'composite';
-  isStateDependent: boolean;
-  readonly evaluate: (
-    globals: GlobalProperties,
-    feature?: Feature,
-    featureState?: FeatureState,
-    canonical?: CanonicalTileID,
-    availableImages?: Array<string>,
-    formattedSection?: FormattedSection
-  ) => any;
-  readonly interpolationFactor: (input: number, lower: number, upper: number) => number;
-  zoomStops: Array<number>;
-  interpolationType: InterpolationType;
+    kind: 'composite';
+    isStateDependent: boolean;
+    readonly evaluate: (
+        globals: GlobalProperties,
+        feature?: Feature,
+        featureState?: FeatureState,
+        canonical?: CanonicalTileID,
+        availableImages?: Array<string>,
+        formattedSection?: FormattedSection
+    ) => any;
+    readonly interpolationFactor: (input: number, lower: number, upper: number) => number;
+    zoomStops: Array<number>;
+    interpolationType: InterpolationType;
 };
 
 export type StylePropertyExpression = ConstantExpression | SourceExpression | CameraExpression | CompositeExpression;
@@ -348,8 +348,8 @@ export class StylePropertyFunction<T> {
     }
 
     static deserialize<T>(serialized: {
-      _parameters: PropertyValueSpecification<T>;
-      _specification: StylePropertySpecification;
+        _parameters: PropertyValueSpecification<T>;
+        _specification: StylePropertySpecification;
     }) {
         return new StylePropertyFunction(serialized._parameters, serialized._specification) as StylePropertyFunction<T>;
     }
@@ -363,8 +363,8 @@ export class StylePropertyFunction<T> {
 }
 
 export function normalizePropertyExpression<T>(
-  value: PropertyValueSpecification<T>,
-  specification: StylePropertySpecification
+    value: PropertyValueSpecification<T>,
+    specification: StylePropertySpecification
 ): StylePropertyExpression {
     if (isFunction(value)) {
         return new StylePropertyFunction(value, specification) as any;

--- a/src/style-spec/expression/parsing_context.ts
+++ b/src/style-spec/expression/parsing_context.ts
@@ -54,13 +54,13 @@ class ParsingContext {
      * @private
      */
     parse(
-      expr: unknown,
-      index?: number,
-      expectedType?: Type | null,
-      bindings?: Array<[string, Expression]>,
-      options: {
-        typeAnnotation?: 'assert' | 'coerce' | 'omit';
-      } = {}
+        expr: unknown,
+        index?: number,
+        expectedType?: Type | null,
+        bindings?: Array<[string, Expression]>,
+        options: {
+            typeAnnotation?: 'assert' | 'coerce' | 'omit';
+        } = {}
     ): Expression {
         if (index) {
             return this.concat(index, expectedType, bindings)._parse(expr, options);
@@ -69,10 +69,10 @@ class ParsingContext {
     }
 
     _parse(
-      expr: unknown,
-      options: {
-        typeAnnotation?: 'assert' | 'coerce' | 'omit';
-      }
+        expr: unknown,
+        options: {
+            typeAnnotation?: 'assert' | 'coerce' | 'omit';
+        }
     ): Expression {
         if (expr === null || typeof expr === 'string' || typeof expr === 'boolean' || typeof expr === 'number') {
             expr = ['literal', expr];

--- a/src/style-spec/expression/types.ts
+++ b/src/style-spec/expression/types.ts
@@ -1,35 +1,35 @@
 export type NullTypeT = {
-  kind: 'null';
+    kind: 'null';
 };
 export type NumberTypeT = {
-  kind: 'number';
+    kind: 'number';
 };
 export type StringTypeT = {
-  kind: 'string';
+    kind: 'string';
 };
 export type BooleanTypeT = {
-  kind: 'boolean';
+    kind: 'boolean';
 };
 export type ColorTypeT = {
-  kind: 'color';
+    kind: 'color';
 };
 export type ObjectTypeT = {
-  kind: 'object';
+    kind: 'object';
 };
 export type ValueTypeT = {
-  kind: 'value';
+    kind: 'value';
 };
 export type ErrorTypeT = {
-  kind: 'error';
+    kind: 'error';
 };
 export type CollatorTypeT = {
-  kind: 'collator';
+    kind: 'collator';
 };
 export type FormattedTypeT = {
-  kind: 'formatted';
+    kind: 'formatted';
 };
 export type ResolvedImageTypeT = {
-  kind: 'resolvedImage';
+    kind: 'resolvedImage';
 };
 
 export type EvaluationKind = 'constant' | 'source' | 'camera' | 'composite';
@@ -38,9 +38,9 @@ export type Type = NullTypeT | NumberTypeT | StringTypeT | BooleanTypeT | ColorT
 ArrayType | ErrorTypeT | CollatorTypeT | FormattedTypeT | ResolvedImageTypeT;
 
 export type ArrayType = {
-  kind: 'array';
-  itemType: Type;
-  N: number;
+    kind: 'array';
+    itemType: Type;
+    N: number;
 };
 
 export type NativeType = 'number' | 'string' | 'boolean' | 'null' | 'array' | 'object';

--- a/src/style-spec/expression/types/collator.ts
+++ b/src/style-spec/expression/types/collator.ts
@@ -2,9 +2,9 @@
 // https://github.com/facebook/flow/issues/1270
 
 declare let Intl: {
-  Collator: {
-    new (...args: any): Intl$Collator;
-  };
+    Collator: {
+        new (...args: any): Intl$Collator;
+    };
 };
 
 declare class Intl$Collator {
@@ -14,12 +14,12 @@ declare class Intl$Collator {
 }
 
 type CollatorOptions = {
-  localeMatcher?: 'lookup' | 'best fit';
-  usage?: 'sort' | 'search';
-  sensitivity?: 'base' | 'accent' | 'case' | 'variant';
-  ignorePunctuation?: boolean;
-  numeric?: boolean;
-  caseFirst?: 'upper' | 'lower' | 'false';
+    localeMatcher?: 'lookup' | 'best fit';
+    usage?: 'sort' | 'search';
+    sensitivity?: 'base' | 'accent' | 'case' | 'variant';
+    ignorePunctuation?: boolean;
+    numeric?: boolean;
+    caseFirst?: 'upper' | 'lower' | 'false';
 };
 
 export default class Collator {

--- a/src/style-spec/expression/types/resolved_image.ts
+++ b/src/style-spec/expression/types/resolved_image.ts
@@ -1,6 +1,6 @@
 export type ResolvedImageOptions = {
-  name: string;
-  available: boolean;
+    name: string;
+    available: boolean;
 };
 
 export default class ResolvedImage {

--- a/src/style-spec/expression/values.ts
+++ b/src/style-spec/expression/values.ts
@@ -28,7 +28,7 @@ export function validateRGBA(r: unknown, g: unknown, b: unknown, a?: unknown): s
 }
 
 export type Value = null | string | boolean | number | Color | Collator | Formatted | ResolvedImage | ReadonlyArray<Value> | {
-  readonly [x: string]: Value;
+    readonly [x: string]: Value;
 };
 
 export function isValue(mixed: unknown): boolean {

--- a/src/style-spec/feature_filter/index.ts
+++ b/src/style-spec/feature_filter/index.ts
@@ -4,14 +4,14 @@ import type {CanonicalTileID} from '../../source/tile_id';
 import {StylePropertySpecification} from '../style-spec';
 
 type FilterExpression = (
-  globalProperties: GlobalProperties,
-  feature: Feature,
-  canonical?: CanonicalTileID
+    globalProperties: GlobalProperties,
+    feature: Feature,
+    canonical?: CanonicalTileID
 ) => boolean;
 
 export type FeatureFilter = {
-  filter: FilterExpression;
-  needGeometry: boolean;
+    filter: FilterExpression;
+    needGeometry: boolean;
 };
 
 export default createFilter;
@@ -26,36 +26,36 @@ function isExpressionFilter(filter: any) {
         return false;
     }
     switch (filter[0]) {
-    case 'has':
-        return filter.length >= 2 && filter[1] !== '$id' && filter[1] !== '$type';
+        case 'has':
+            return filter.length >= 2 && filter[1] !== '$id' && filter[1] !== '$type';
 
-    case 'in':
-        return filter.length >= 3 && (typeof filter[1] !== 'string' || Array.isArray(filter[2]));
+        case 'in':
+            return filter.length >= 3 && (typeof filter[1] !== 'string' || Array.isArray(filter[2]));
 
-    case '!in':
-    case '!has':
-    case 'none':
-        return false;
+        case '!in':
+        case '!has':
+        case 'none':
+            return false;
 
-    case '==':
-    case '!=':
-    case '>':
-    case '>=':
-    case '<':
-    case '<=':
-        return filter.length !== 3 || (Array.isArray(filter[1]) || Array.isArray(filter[2]));
+        case '==':
+        case '!=':
+        case '>':
+        case '>=':
+        case '<':
+        case '<=':
+            return filter.length !== 3 || (Array.isArray(filter[1]) || Array.isArray(filter[2]));
 
-    case 'any':
-    case 'all':
-        for (const f of filter.slice(1)) {
-            if (!isExpressionFilter(f) && typeof f !== 'boolean') {
-                return false;
+        case 'any':
+        case 'all':
+            for (const f of filter.slice(1)) {
+                if (!isExpressionFilter(f) && typeof f !== 'boolean') {
+                    return false;
+                }
             }
-        }
-        return true;
+            return true;
 
-    default:
-        return true;
+        default:
+            return true;
     }
 }
 
@@ -118,31 +118,31 @@ function convertFilter(filter?: Array<any> | null): unknown {
     if (filter.length <= 1) return (op !== 'any');
     const converted =
         op === '==' ? convertComparisonOp(filter[1], filter[2], '==') :
-        op === '!=' ? convertNegation(convertComparisonOp(filter[1], filter[2], '==')) :
-        op === '<' ||
+            op === '!=' ? convertNegation(convertComparisonOp(filter[1], filter[2], '==')) :
+                op === '<' ||
         op === '>' ||
         op === '<=' ||
         op === '>=' ? convertComparisonOp(filter[1], filter[2], op) :
-        op === 'any' ? convertDisjunctionOp(filter.slice(1)) :
-        op === 'all' ? ['all' as unknown].concat(filter.slice(1).map(convertFilter)) :
-        op === 'none' ? ['all' as unknown].concat(filter.slice(1).map(convertFilter).map(convertNegation)) :
-        op === 'in' ? convertInOp(filter[1], filter.slice(2)) :
-        op === '!in' ? convertNegation(convertInOp(filter[1], filter.slice(2))) :
-        op === 'has' ? convertHasOp(filter[1]) :
-        op === '!has' ? convertNegation(convertHasOp(filter[1])) :
-        op === 'within' ? filter :
-        true;
+                    op === 'any' ? convertDisjunctionOp(filter.slice(1)) :
+                        op === 'all' ? ['all' as unknown].concat(filter.slice(1).map(convertFilter)) :
+                            op === 'none' ? ['all' as unknown].concat(filter.slice(1).map(convertFilter).map(convertNegation)) :
+                                op === 'in' ? convertInOp(filter[1], filter.slice(2)) :
+                                    op === '!in' ? convertNegation(convertInOp(filter[1], filter.slice(2))) :
+                                        op === 'has' ? convertHasOp(filter[1]) :
+                                            op === '!has' ? convertNegation(convertHasOp(filter[1])) :
+                                                op === 'within' ? filter :
+                                                    true;
     return converted;
 }
 
 function convertComparisonOp(property: string, value: any, op: string) {
     switch (property) {
-    case '$type':
-        return [`filter-type-${op}`, value];
-    case '$id':
-        return [`filter-id-${op}`, value];
-    default:
-        return [`filter-${op}`, property, value];
+        case '$type':
+            return [`filter-type-${op}`, value];
+        case '$id':
+            return [`filter-id-${op}`, value];
+        default:
+            return [`filter-${op}`, property, value];
     }
 }
 
@@ -153,27 +153,27 @@ function convertDisjunctionOp(filters: Array<Array<any>>) {
 function convertInOp(property: string, values: Array<any>) {
     if (values.length === 0) { return false; }
     switch (property) {
-    case '$type':
-        return ['filter-type-in', ['literal', values]];
-    case '$id':
-        return ['filter-id-in', ['literal', values]];
-    default:
-        if (values.length > 200 && !values.some(v => typeof v !== typeof values[0])) {
-            return ['filter-in-large', property, ['literal', values.sort(compare)]];
-        } else {
-            return ['filter-in-small', property, ['literal', values]];
-        }
+        case '$type':
+            return ['filter-type-in', ['literal', values]];
+        case '$id':
+            return ['filter-id-in', ['literal', values]];
+        default:
+            if (values.length > 200 && !values.some(v => typeof v !== typeof values[0])) {
+                return ['filter-in-large', property, ['literal', values.sort(compare)]];
+            } else {
+                return ['filter-in-small', property, ['literal', values]];
+            }
     }
 }
 
 function convertHasOp(property: string) {
     switch (property) {
-    case '$type':
-        return true;
-    case '$id':
-        return ['filter-has-id'];
-    default:
-        return ['filter-has', property];
+        case '$type':
+            return true;
+        case '$id':
+            return ['filter-has-id'];
+        default:
+            return ['filter-has', property];
     }
 }
 

--- a/src/style-spec/function/convert.ts
+++ b/src/style-spec/function/convert.ts
@@ -60,9 +60,9 @@ function convertIdentityFunction(parameters, propertySpec): Array<unknown> {
 
 function getInterpolateOperator(parameters) {
     switch (parameters.colorSpace) {
-    case 'hcl': return 'interpolate-hcl';
-    case 'lab': return 'interpolate-lab';
-    default: return 'interpolate';
+        case 'hcl': return 'interpolate-hcl';
+        case 'lab': return 'interpolate-lab';
+        default: return 'interpolate';
     }
 }
 

--- a/src/style-spec/style-spec.ts
+++ b/src/style-spec/style-spec.ts
@@ -2,59 +2,59 @@ type ExpressionType = 'data-driven' | 'cross-faded' | 'cross-faded-data-driven' 
 type ExpressionParameters = Array<'zoom' | 'feature' | 'feature-state' | 'heatmap-density' | 'line-progress'>;
 
 type ExpressionSpecification = {
-  interpolated: boolean;
-  parameters: ExpressionParameters;
+    interpolated: boolean;
+    parameters: ExpressionParameters;
 };
 
 export type StylePropertySpecification = {
-  type: 'number';
-  'property-type': ExpressionType;
-  expression?: ExpressionSpecification;
-  transition: boolean;
-  default?: number;
+    type: 'number';
+    'property-type': ExpressionType;
+    expression?: ExpressionSpecification;
+    transition: boolean;
+    default?: number;
 } | {
-  type: 'string';
-  'property-type': ExpressionType;
-  expression?: ExpressionSpecification;
-  transition: boolean;
-  default?: string;
-  tokens?: boolean;
+    type: 'string';
+    'property-type': ExpressionType;
+    expression?: ExpressionSpecification;
+    transition: boolean;
+    default?: string;
+    tokens?: boolean;
 } | {
-  type: 'boolean';
-  'property-type': ExpressionType;
-  expression?: ExpressionSpecification;
-  transition: boolean;
-  default?: boolean;
+    type: 'boolean';
+    'property-type': ExpressionType;
+    expression?: ExpressionSpecification;
+    transition: boolean;
+    default?: boolean;
 } | {
-  type: 'enum';
-  'property-type': ExpressionType;
-  expression?: ExpressionSpecification;
-  values: {[_: string]: {}};
-  transition: boolean;
-  default?: string;
+    type: 'enum';
+    'property-type': ExpressionType;
+    expression?: ExpressionSpecification;
+    values: {[_: string]: {}};
+    transition: boolean;
+    default?: string;
 } | {
-  type: 'color';
-  'property-type': ExpressionType;
-  expression?: ExpressionSpecification;
-  transition: boolean;
-  default?: string;
-  overridable: boolean;
+    type: 'color';
+    'property-type': ExpressionType;
+    expression?: ExpressionSpecification;
+    transition: boolean;
+    default?: string;
+    overridable: boolean;
 } | {
-  type: 'array';
-  value: 'number';
-  'property-type': ExpressionType;
-  expression?: ExpressionSpecification;
-  length?: number;
-  transition: boolean;
-  default?: Array<number>;
+    type: 'array';
+    value: 'number';
+    'property-type': ExpressionType;
+    expression?: ExpressionSpecification;
+    length?: number;
+    transition: boolean;
+    default?: Array<number>;
 } | {
-  type: 'array';
-  value: 'string';
-  'property-type': ExpressionType;
-  expression?: ExpressionSpecification;
-  length?: number;
-  transition: boolean;
-  default?: Array<string>;
+    type: 'array';
+    value: 'string';
+    'property-type': ExpressionType;
+    expression?: ExpressionSpecification;
+    length?: number;
+    transition: boolean;
+    default?: Array<string>;
 };
 
 import v8 from './reference/v8.json';

--- a/src/style-spec/util/color_spaces.ts
+++ b/src/style-spec/util/color_spaces.ts
@@ -3,17 +3,17 @@ import Color from './color';
 import {number as interpolateNumber} from './interpolate';
 
 type LABColor = {
-  l: number;
-  a: number;
-  b: number;
-  alpha: number;
+    l: number;
+    a: number;
+    b: number;
+    alpha: number;
 };
 
 type HCLColor = {
-  h: number;
-  c: number;
-  l: number;
-  alpha: number;
+    h: number;
+    c: number;
+    l: number;
+    alpha: number;
 };
 
 // Constants

--- a/src/style-spec/util/result.ts
+++ b/src/style-spec/util/result.ts
@@ -5,11 +5,11 @@
  * @private
  */
 export type Result<T, E> = {
-  result: 'success';
-  value: T;
+    result: 'success';
+    value: T;
 } | {
-  result: 'error';
-  value: E;
+    result: 'error';
+    value: E;
 };
 
 export function success<T, E>(value: T): Result<T, E> {

--- a/src/style-spec/validate/validate_filter.ts
+++ b/src/style-spec/validate/validate_filter.ts
@@ -44,74 +44,74 @@ function validateNonExpressionFilter(options) {
     }));
 
     switch (unbundle(value[0])) {
-    case '<':
-    case '<=':
-    case '>':
-    case '>=':
-        if (value.length >= 2 && unbundle(value[1]) === '$type') {
-            errors.push(new ValidationError(key, value, `"$type" cannot be use with operator "${value[0]}"`));
-        }
-        /* falls through */
-    case '==':
-    case '!=':
-        if (value.length !== 3) {
-            errors.push(new ValidationError(key, value, `filter array for operator "${value[0]}" must have 3 elements`));
-        }
-        /* falls through */
-    case 'in':
-    case '!in':
-        if (value.length >= 2) {
-            type = getType(value[1]);
-            if (type !== 'string') {
-                errors.push(new ValidationError(`${key}[1]`, value[1], `string expected, ${type} found`));
+        case '<':
+        case '<=':
+        case '>':
+        case '>=':
+            if (value.length >= 2 && unbundle(value[1]) === '$type') {
+                errors.push(new ValidationError(key, value, `"$type" cannot be use with operator "${value[0]}"`));
             }
-        }
-        for (let i = 2; i < value.length; i++) {
-            type = getType(value[i]);
-            if (unbundle(value[1]) === '$type') {
-                errors = errors.concat(validateEnum({
+        /* falls through */
+        case '==':
+        case '!=':
+            if (value.length !== 3) {
+                errors.push(new ValidationError(key, value, `filter array for operator "${value[0]}" must have 3 elements`));
+            }
+        /* falls through */
+        case 'in':
+        case '!in':
+            if (value.length >= 2) {
+                type = getType(value[1]);
+                if (type !== 'string') {
+                    errors.push(new ValidationError(`${key}[1]`, value[1], `string expected, ${type} found`));
+                }
+            }
+            for (let i = 2; i < value.length; i++) {
+                type = getType(value[i]);
+                if (unbundle(value[1]) === '$type') {
+                    errors = errors.concat(validateEnum({
+                        key: `${key}[${i}]`,
+                        value: value[i],
+                        valueSpec: styleSpec.geometry_type,
+                        style: options.style,
+                        styleSpec: options.styleSpec
+                    }));
+                } else if (type !== 'string' && type !== 'number' && type !== 'boolean') {
+                    errors.push(new ValidationError(`${key}[${i}]`, value[i], `string, number, or boolean expected, ${type} found`));
+                }
+            }
+            break;
+
+        case 'any':
+        case 'all':
+        case 'none':
+            for (let i = 1; i < value.length; i++) {
+                errors = errors.concat(validateNonExpressionFilter({
                     key: `${key}[${i}]`,
                     value: value[i],
-                    valueSpec: styleSpec.geometry_type,
                     style: options.style,
                     styleSpec: options.styleSpec
                 }));
-            } else if (type !== 'string' && type !== 'number' && type !== 'boolean') {
-                errors.push(new ValidationError(`${key}[${i}]`, value[i], `string, number, or boolean expected, ${type} found`));
             }
-        }
-        break;
+            break;
 
-    case 'any':
-    case 'all':
-    case 'none':
-        for (let i = 1; i < value.length; i++) {
-            errors = errors.concat(validateNonExpressionFilter({
-                key: `${key}[${i}]`,
-                value: value[i],
-                style: options.style,
-                styleSpec: options.styleSpec
-            }));
-        }
-        break;
-
-    case 'has':
-    case '!has':
-        type = getType(value[1]);
-        if (value.length !== 2) {
-            errors.push(new ValidationError(key, value, `filter array for "${value[0]}" operator must have 2 elements`));
-        } else if (type !== 'string') {
-            errors.push(new ValidationError(`${key}[1]`, value[1], `string expected, ${type} found`));
-        }
-        break;
-    case 'within':
-        type = getType(value[1]);
-        if (value.length !== 2) {
-            errors.push(new ValidationError(key, value, `filter array for "${value[0]}" operator must have 2 elements`));
-        } else if (type !== 'object') {
-            errors.push(new ValidationError(`${key}[1]`, value[1], `object expected, ${type} found`));
-        }
-        break;
+        case 'has':
+        case '!has':
+            type = getType(value[1]);
+            if (value.length !== 2) {
+                errors.push(new ValidationError(key, value, `filter array for "${value[0]}" operator must have 2 elements`));
+            } else if (type !== 'string') {
+                errors.push(new ValidationError(`${key}[1]`, value[1], `string expected, ${type} found`));
+            }
+            break;
+        case 'within':
+            type = getType(value[1]);
+            if (value.length !== 2) {
+                errors.push(new ValidationError(key, value, `filter array for "${value[0]}" operator must have 2 elements`));
+            } else if (type !== 'object') {
+                errors.push(new ValidationError(`${key}[1]`, value[1], `object expected, ${type} found`));
+            }
+            break;
     }
     return errors;
 }

--- a/src/style-spec/validate/validate_source.ts
+++ b/src/style-spec/validate/validate_source.ts
@@ -25,76 +25,76 @@ export default function validateSource(options) {
     let errors;
 
     switch (type) {
-    case 'vector':
-    case 'raster':
-    case 'raster-dem':
-        errors = validateObject({
-            key,
-            value,
-            valueSpec: styleSpec[`source_${type.replace('-', '_')}`],
-            style: options.style,
-            styleSpec,
-            objectElementValidators
-        });
-        return errors;
+        case 'vector':
+        case 'raster':
+        case 'raster-dem':
+            errors = validateObject({
+                key,
+                value,
+                valueSpec: styleSpec[`source_${type.replace('-', '_')}`],
+                style: options.style,
+                styleSpec,
+                objectElementValidators
+            });
+            return errors;
 
-    case 'geojson':
-        errors = validateObject({
-            key,
-            value,
-            valueSpec: styleSpec.source_geojson,
-            style,
-            styleSpec,
-            objectElementValidators
-        });
-        if (value.cluster) {
-            for (const prop in value.clusterProperties) {
-                const [operator, mapExpr] = value.clusterProperties[prop];
-                const reduceExpr = typeof operator === 'string' ? [operator, ['accumulated'], ['get', prop]] : operator;
+        case 'geojson':
+            errors = validateObject({
+                key,
+                value,
+                valueSpec: styleSpec.source_geojson,
+                style,
+                styleSpec,
+                objectElementValidators
+            });
+            if (value.cluster) {
+                for (const prop in value.clusterProperties) {
+                    const [operator, mapExpr] = value.clusterProperties[prop];
+                    const reduceExpr = typeof operator === 'string' ? [operator, ['accumulated'], ['get', prop]] : operator;
 
-                errors.push(...validateExpression({
-                    key: `${key}.${prop}.map`,
-                    value: mapExpr,
-                    expressionContext: 'cluster-map'
-                }));
-                errors.push(...validateExpression({
-                    key: `${key}.${prop}.reduce`,
-                    value: reduceExpr,
-                    expressionContext: 'cluster-reduce'
-                }));
+                    errors.push(...validateExpression({
+                        key: `${key}.${prop}.map`,
+                        value: mapExpr,
+                        expressionContext: 'cluster-map'
+                    }));
+                    errors.push(...validateExpression({
+                        key: `${key}.${prop}.reduce`,
+                        value: reduceExpr,
+                        expressionContext: 'cluster-reduce'
+                    }));
+                }
             }
-        }
-        return errors;
+            return errors;
 
-    case 'video':
-        return validateObject({
-            key,
-            value,
-            valueSpec: styleSpec.source_video,
-            style,
-            styleSpec
-        });
+        case 'video':
+            return validateObject({
+                key,
+                value,
+                valueSpec: styleSpec.source_video,
+                style,
+                styleSpec
+            });
 
-    case 'image':
-        return validateObject({
-            key,
-            value,
-            valueSpec: styleSpec.source_image,
-            style,
-            styleSpec
-        });
+        case 'image':
+            return validateObject({
+                key,
+                value,
+                valueSpec: styleSpec.source_image,
+                style,
+                styleSpec
+            });
 
-    case 'canvas':
-        return [new ValidationError(key, null, 'Please use runtime APIs to add canvas sources, rather than including them in stylesheets.', 'source.canvas')];
+        case 'canvas':
+            return [new ValidationError(key, null, 'Please use runtime APIs to add canvas sources, rather than including them in stylesheets.', 'source.canvas')];
 
-    default:
-        return validateEnum({
-            key: `${key}.type`,
-            value: value.type,
-            valueSpec: {values: ['vector', 'raster', 'raster-dem', 'geojson', 'video', 'image']},
-            style,
-            styleSpec
-        });
+        default:
+            return validateEnum({
+                key: `${key}.type`,
+                value: value.type,
+                valueSpec: {values: ['vector', 'raster', 'raster-dem', 'geojson', 'video', 'image']},
+                style,
+                styleSpec
+            });
     }
 }
 

--- a/src/style-spec/visit.ts
+++ b/src/style-spec/visit.ts
@@ -36,22 +36,22 @@ export function eachLayer(style: StyleSpecification, callback: (_: LayerSpecific
 }
 
 type PropertyCallback = (
-  a: {
-    path: [string, 'paint' | 'layout', string]; // [layerid, paint/layout, property key],
-    key: string;
-    value: PropertyValueSpecification<unknown> | DataDrivenPropertyValueSpecification<unknown>;
-    reference: StylePropertySpecification;
-    set: (
-      a: PropertyValueSpecification<unknown> | DataDrivenPropertyValueSpecification<unknown>
-    ) => void;
-  }
+    a: {
+        path: [string, 'paint' | 'layout', string]; // [layerid, paint/layout, property key],
+        key: string;
+        value: PropertyValueSpecification<unknown> | DataDrivenPropertyValueSpecification<unknown>;
+        reference: StylePropertySpecification;
+        set: (
+            a: PropertyValueSpecification<unknown> | DataDrivenPropertyValueSpecification<unknown>
+        ) => void;
+    }
 ) => void;
 
 export function eachProperty(
     style: StyleSpecification,
     options: {
-      paint?: boolean;
-      layout?: boolean;
+        paint?: boolean;
+        layout?: boolean;
     },
     callback: PropertyCallback
 ) {

--- a/src/style/evaluation_parameters.ts
+++ b/src/style/evaluation_parameters.ts
@@ -5,9 +5,9 @@ import {plugin as rtlTextPlugin} from '../source/rtl_text_plugin';
 import type {TransitionSpecification} from '../style-spec/types';
 
 export type CrossfadeParameters = {
-  fromScale: number;
-  toScale: number;
-  t: number;
+    fromScale: number;
+    toScale: number;
+    t: number;
 };
 
 class EvaluationParameters {

--- a/src/style/light.ts
+++ b/src/style/light.ts
@@ -24,9 +24,9 @@ import type {
 import type {LightSpecification} from '../style-spec/types';
 
 type LightPosition = {
-  x: number;
-  y: number;
-  z: number;
+    x: number;
+    y: number;
+    z: number;
 };
 
 class LightPositionProperty implements Property<[number, number, number], LightPosition> {
@@ -37,8 +37,8 @@ class LightPositionProperty implements Property<[number, number, number], LightP
     }
 
     possiblyEvaluate(
-      value: PropertyValue<[number, number, number], LightPosition>,
-      parameters: EvaluationParameters
+        value: PropertyValue<[number, number, number], LightPosition>,
+        parameters: EvaluationParameters
     ): LightPosition {
         return sphericalToCartesian(value.expression.evaluate(parameters));
     }
@@ -53,10 +53,10 @@ class LightPositionProperty implements Property<[number, number, number], LightP
 }
 
 type Props = {
-  'anchor': DataConstantProperty<'map' | 'viewport'>;
-  'position': LightPositionProperty;
-  'color': DataConstantProperty<Color>;
-  'intensity': DataConstantProperty<number>;
+    'anchor': DataConstantProperty<'map' | 'viewport'>;
+    'position': LightPositionProperty;
+    'color': DataConstantProperty<Color>;
+    'intensity': DataConstantProperty<number>;
 };
 
 type PropsPossiblyEvaluated = {
@@ -122,7 +122,7 @@ class Light extends Evented {
     }
 
     _validate(validate: Function, value: unknown, options?: {
-      validate?: boolean;
+        validate?: boolean;
     }) {
         if (options && options.validate === false) {
             return false;

--- a/src/style/load_glyph_range.ts
+++ b/src/style/load_glyph_range.ts
@@ -7,12 +7,12 @@ import type {RequestManager} from '../util/request_manager';
 import type {Callback} from '../types/callback';
 
 export default function loadGlyphRange(fontstack: string,
-                           range: number,
-                           urlTemplate: string,
-                           requestManager: RequestManager,
-                           callback: Callback<{
-                             [_: number]: StyleGlyph | null;
-                           }>) {
+    range: number,
+    urlTemplate: string,
+    requestManager: RequestManager,
+    callback: Callback<{
+        [_: number]: StyleGlyph | null;
+    }>) {
     const begin = range * 256;
     const end = begin + 255;
 

--- a/src/style/load_sprite.ts
+++ b/src/style/load_sprite.ts
@@ -9,10 +9,10 @@ import type {Callback} from '../types/callback';
 import type {Cancelable} from '../types/cancelable';
 
 export default function(
-  baseURL: string,
-  requestManager: RequestManager,
-  pixelRatio: number,
-  callback: Callback<{[_: string]: StyleImage}>
+    baseURL: string,
+    requestManager: RequestManager,
+    pixelRatio: number,
+    callback: Callback<{[_: string]: StyleImage}>
 ): Cancelable {
     let json: any, image, error;
     const format = pixelRatio > 1 ? '@2x' : '';

--- a/src/style/pauseable_placement.ts
+++ b/src/style/pauseable_placement.ts
@@ -13,7 +13,7 @@ class LayerPlacement {
     _currentTileIndex: number;
     _currentPartIndex: number;
     _seenCrossTileIDs: {
-      [k in string | number]: boolean;
+        [k in string | number]: boolean;
     };
     _bucketParts: Array<BucketPart>;
 

--- a/src/style/properties.ts
+++ b/src/style/properties.ts
@@ -24,8 +24,8 @@ import {
 type TimePoint = number;
 
 export type CrossFaded<T> = {
-  to: T;
-  from: T;
+    to: T;
+    from: T;
 };
 
 /**
@@ -64,14 +64,14 @@ export type CrossFaded<T> = {
  * @private
  */
 export interface Property<T, R> {
-  specification: StylePropertySpecification;
-  possiblyEvaluate(
-    value: PropertyValue<T, R>,
-    parameters: EvaluationParameters,
-    canonical?: CanonicalTileID,
-    availableImages?: Array<string>
-  ): R;
-  interpolate(a: R, b: R, t: number): R;
+    specification: StylePropertySpecification;
+    possiblyEvaluate(
+        value: PropertyValue<T, R>,
+        parameters: EvaluationParameters,
+        canonical?: CanonicalTileID,
+        availableImages?: Array<string>
+    ): R;
+    interpolate(a: R, b: R, t: number): R;
 }
 
 /**
@@ -109,9 +109,9 @@ export class PropertyValue<T, R> {
     }
 
     possiblyEvaluate(
-      parameters: EvaluationParameters,
-      canonical?: CanonicalTileID,
-      availableImages?: Array<string>
+        parameters: EvaluationParameters,
+        canonical?: CanonicalTileID,
+        availableImages?: Array<string>
     ): R {
         return this.property.possiblyEvaluate(this, parameters, canonical, availableImages);
     }
@@ -120,8 +120,8 @@ export class PropertyValue<T, R> {
 // ------- Transitionable -------
 
 export type TransitionParameters = {
-  now: TimePoint;
-  transition: TransitionSpecification;
+    now: TimePoint;
+    transition: TransitionSpecification;
 };
 
 /**
@@ -248,10 +248,10 @@ class TransitioningPropertyValue<T, R> {
     end: TimePoint;
 
     constructor(property: Property<T, R>,
-                value: PropertyValue<T, R>,
-                prior: TransitioningPropertyValue<T, R>,
-                transition: TransitionSpecification,
-                now: TimePoint) {
+        value: PropertyValue<T, R>,
+        prior: TransitioningPropertyValue<T, R>,
+        transition: TransitionSpecification,
+        now: TimePoint) {
         this.property = property;
         this.value = value;
         this.begin = now + transition.delay || 0;
@@ -262,9 +262,9 @@ class TransitioningPropertyValue<T, R> {
     }
 
     possiblyEvaluate(
-      parameters: EvaluationParameters,
-      canonical: CanonicalTileID,
-      availableImages: Array<string>
+        parameters: EvaluationParameters,
+        canonical: CanonicalTileID,
+        availableImages: Array<string>
     ): R {
         const now = parameters.now || 0;
         const finalValue = this.value.possiblyEvaluate(parameters, canonical, availableImages);
@@ -310,9 +310,9 @@ export class Transitioning<Props> {
     }
 
     possiblyEvaluate(
-      parameters: EvaluationParameters,
-      canonical?: CanonicalTileID,
-      availableImages?: Array<string>
+        parameters: EvaluationParameters,
+        canonical?: CanonicalTileID,
+        availableImages?: Array<string>
     ): PossiblyEvaluated<Props, any> {
         const result = new PossiblyEvaluated(this._properties); // eslint-disable-line no-use-before-define
         for (const property of Object.keys(this._values)) {
@@ -373,9 +373,9 @@ export class Layout<Props> {
     }
 
     possiblyEvaluate(
-      parameters: EvaluationParameters,
-      canonical?: CanonicalTileID,
-      availableImages?: Array<string>
+        parameters: EvaluationParameters,
+        canonical?: CanonicalTileID,
+        availableImages?: Array<string>
     ): PossiblyEvaluated<Props, any> {
         const result = new PossiblyEvaluated(this._properties); // eslint-disable-line no-use-before-define
         for (const property of Object.keys(this._values)) {
@@ -409,8 +409,8 @@ export class Layout<Props> {
  * @private
  */
 type PossiblyEvaluatedValue<T> = {
-  kind: 'constant';
-  value: T;
+    kind: 'constant';
+    value: T;
 } | SourceExpression | CompositeExpression;
 
 /**
@@ -445,10 +445,10 @@ export class PossiblyEvaluatedPropertyValue<T> {
     }
 
     evaluate(
-      feature: Feature,
-      featureState: FeatureState,
-      canonical?: CanonicalTileID,
-      availableImages?: Array<string>
+        feature: Feature,
+        featureState: FeatureState,
+        canonical?: CanonicalTileID,
+        availableImages?: Array<string>
     ): T {
         return this.property.evaluate(this.value, this.parameters, feature, featureState, canonical, availableImages);
     }
@@ -519,10 +519,10 @@ export class DataDrivenProperty<T> implements Property<T, PossiblyEvaluatedPrope
     }
 
     possiblyEvaluate(
-      value: PropertyValue<T, PossiblyEvaluatedPropertyValue<T>>,
-      parameters: EvaluationParameters,
-      canonical?: CanonicalTileID,
-      availableImages?: Array<string>
+        value: PropertyValue<T, PossiblyEvaluatedPropertyValue<T>>,
+        parameters: EvaluationParameters,
+        canonical?: CanonicalTileID,
+        availableImages?: Array<string>
     ): PossiblyEvaluatedPropertyValue<T> {
         if (value.expression.kind === 'constant' || value.expression.kind === 'camera') {
             return new PossiblyEvaluatedPropertyValue(this, {kind: 'constant', value: value.expression.evaluate(parameters, null, {}, canonical, availableImages)}, parameters);
@@ -532,9 +532,9 @@ export class DataDrivenProperty<T> implements Property<T, PossiblyEvaluatedPrope
     }
 
     interpolate(
-      a: PossiblyEvaluatedPropertyValue<T>,
-      b: PossiblyEvaluatedPropertyValue<T>,
-      t: number
+        a: PossiblyEvaluatedPropertyValue<T>,
+        b: PossiblyEvaluatedPropertyValue<T>,
+        t: number
     ): PossiblyEvaluatedPropertyValue<T> {
         // If either possibly-evaluated value is non-constant, give up: we aren't able to interpolate data-driven values.
         if (a.value.kind !== 'constant' || b.value.kind !== 'constant') {
@@ -561,12 +561,12 @@ export class DataDrivenProperty<T> implements Property<T, PossiblyEvaluatedPrope
     }
 
     evaluate(
-      value: PossiblyEvaluatedValue<T>,
-      parameters: EvaluationParameters,
-      feature: Feature,
-      featureState: FeatureState,
-      canonical?: CanonicalTileID,
-      availableImages?: Array<string>
+        value: PossiblyEvaluatedValue<T>,
+        parameters: EvaluationParameters,
+        feature: Feature,
+        featureState: FeatureState,
+        canonical?: CanonicalTileID,
+        availableImages?: Array<string>
     ): T {
         if (value.kind === 'constant') {
             return value.value;
@@ -586,10 +586,10 @@ export class DataDrivenProperty<T> implements Property<T, PossiblyEvaluatedPrope
 export class CrossFadedDataDrivenProperty<T> extends DataDrivenProperty<CrossFaded<T>> {
 
     possiblyEvaluate(
-      value: PropertyValue<CrossFaded<T>, PossiblyEvaluatedPropertyValue<CrossFaded<T>>>,
-      parameters: EvaluationParameters,
-      canonical?: CanonicalTileID,
-      availableImages?: Array<string>
+        value: PropertyValue<CrossFaded<T>, PossiblyEvaluatedPropertyValue<CrossFaded<T>>>,
+        parameters: EvaluationParameters,
+        canonical?: CanonicalTileID,
+        availableImages?: Array<string>
     ): PossiblyEvaluatedPropertyValue<CrossFaded<T>> {
         if (value.value === undefined) {
             return new PossiblyEvaluatedPropertyValue(this, {kind: 'constant', value: undefined}, parameters);
@@ -601,10 +601,10 @@ export class CrossFadedDataDrivenProperty<T> extends DataDrivenProperty<CrossFad
             return new PossiblyEvaluatedPropertyValue(this, {kind: 'constant', value: constant}, parameters);
         } else if (value.expression.kind === 'camera') {
             const cameraVal = this._calculate(
-                    value.expression.evaluate({zoom: parameters.zoom - 1.0}),
-                    value.expression.evaluate({zoom: parameters.zoom}),
-                    value.expression.evaluate({zoom: parameters.zoom + 1.0}),
-                    parameters);
+                value.expression.evaluate({zoom: parameters.zoom - 1.0}),
+                value.expression.evaluate({zoom: parameters.zoom}),
+                value.expression.evaluate({zoom: parameters.zoom + 1.0}),
+                parameters);
             return new PossiblyEvaluatedPropertyValue(this, {kind: 'constant', value: cameraVal}, parameters);
         } else {
             // source or composite expression
@@ -613,12 +613,12 @@ export class CrossFadedDataDrivenProperty<T> extends DataDrivenProperty<CrossFad
     }
 
     evaluate(
-      value: PossiblyEvaluatedValue<CrossFaded<T>>,
-      globals: EvaluationParameters,
-      feature: Feature,
-      featureState: FeatureState,
-      canonical?: CanonicalTileID,
-      availableImages?: Array<string>
+        value: PossiblyEvaluatedValue<CrossFaded<T>>,
+        globals: EvaluationParameters,
+        feature: Feature,
+        featureState: FeatureState,
+        canonical?: CanonicalTileID,
+        availableImages?: Array<string>
     ): CrossFaded<T> {
         if (value.kind === 'source') {
             const constant = value.evaluate(globals, feature, featureState, canonical, availableImages);
@@ -657,10 +657,10 @@ export class CrossFadedProperty<T> implements Property<T, CrossFaded<T>> {
     }
 
     possiblyEvaluate(
-      value: PropertyValue<T, CrossFaded<T>>,
-      parameters: EvaluationParameters,
-      canonical?: CanonicalTileID,
-      availableImages?: Array<string>
+        value: PropertyValue<T, CrossFaded<T>>,
+        parameters: EvaluationParameters,
+        canonical?: CanonicalTileID,
+        availableImages?: Array<string>
     ): CrossFaded<T> {
         if (value.value === undefined) {
             return undefined;
@@ -703,10 +703,10 @@ export class ColorRampProperty implements Property<Color, boolean> {
     }
 
     possiblyEvaluate(
-      value: PropertyValue<Color, boolean>,
-      parameters: EvaluationParameters,
-      canonical?: CanonicalTileID,
-      availableImages?: Array<string>
+        value: PropertyValue<Color, boolean>,
+        parameters: EvaluationParameters,
+        canonical?: CanonicalTileID,
+        availableImages?: Array<string>
     ): boolean {
         return !!value.expression.evaluate(parameters, null, {}, canonical, availableImages);
     }

--- a/src/style/query_utils.ts
+++ b/src/style/query_utils.ts
@@ -6,9 +6,9 @@ import type CircleBucket from '../data/bucket/circle_bucket';
 import type LineBucket from '../data/bucket/line_bucket';
 
 export function getMaximumPaintValue(
-  property: string,
-  layer: StyleLayer,
-  bucket: CircleBucket<any> | LineBucket
+    property: string,
+    layer: StyleLayer,
+    bucket: CircleBucket<any> | LineBucket
 ): number {
     const value = ((layer.paint as any).get(property) as PossiblyEvaluatedPropertyValue<any>).value;
     if (value.kind === 'constant') {
@@ -23,10 +23,10 @@ export function translateDistance(translate: [number, number]) {
 }
 
 export function translate(queryGeometry: Array<Point>,
-                   translate: [number, number],
-                   translateAnchor: 'viewport' | 'map',
-                   bearing: number,
-                   pixelsToTileUnits: number) {
+    translate: [number, number],
+    translateAnchor: 'viewport' | 'map',
+    bearing: number,
+    pixelsToTileUnits: number) {
     if (!translate[0] && !translate[1]) {
         return queryGeometry;
     }

--- a/src/style/style.ts
+++ b/src/style/style.ts
@@ -37,8 +37,8 @@ import {validateCustomStyleLayer} from './style_layer/custom_style_layer';
 // to continue to allow canvas sources to be added at runtime/updated in
 // smart setStyle (see https://github.com/mapbox/mapbox-gl-js/pull/6424):
 const emitValidationErrors = (evented: Evented, errors?: ReadonlyArray<{
-  message: string;
-  identifier?: string;
+    message: string;
+    identifier?: string;
 }> | null) =>
     _emitValidationErrors(evented, errors && errors.filter(error => error.identifier !== 'source.canvas'));
 
@@ -88,12 +88,12 @@ const ignoredDiffOperations = pick(diffOperations, [
 const empty = emptyStyle() as StyleSpecification;
 
 export type StyleOptions = {
-  validate?: boolean;
-  localIdeographFontFamily?: string;
+    validate?: boolean;
+    localIdeographFontFamily?: string;
 };
 
 export type StyleSetterOptions = {
-  validate?: boolean;
+    validate?: boolean;
 };
 /**
  * @private
@@ -203,7 +203,7 @@ class Style extends Evented {
     }
 
     loadURL(url: string, options: {
-      validate?: boolean;
+        validate?: boolean;
     } = {}) {
         this.fire(new Event('dataloading', {dataType: 'style'}));
 
@@ -913,9 +913,9 @@ class Style extends Evented {
     }
 
     setFeatureState(target: {
-      source: string;
-      sourceLayer?: string;
-      id: string | number;
+        source: string;
+        sourceLayer?: string;
+        id: string | number;
     }, state: any) {
         this._checkLoaded();
         const sourceId = target.source;
@@ -943,9 +943,9 @@ class Style extends Evented {
     }
 
     removeFeatureState(target: {
-      source: string;
-      sourceLayer?: string;
-      id?: string | number;
+        source: string;
+        sourceLayer?: string;
+        id?: string | number;
     }, key?: string) {
         this._checkLoaded();
         const sourceId = target.source;
@@ -973,9 +973,9 @@ class Style extends Evented {
     }
 
     getFeatureState(target: {
-      source: string;
-      sourceLayer?: string;
-      id: string | number;
+        source: string;
+        sourceLayer?: string;
+        id: string | number;
     }) {
         this._checkLoaded();
         const sourceId = target.source;
@@ -1218,7 +1218,7 @@ class Style extends Evented {
     }
 
     _validate(validate: Validator, key: string, value: any, props: any, options: {
-      validate?: boolean;
+        validate?: boolean;
     } = {}) {
         if (options && options.validate === false) {
             return false;
@@ -1354,14 +1354,14 @@ class Style extends Evented {
     // Callbacks from web workers
 
     getImages(
-      mapId: string,
-      params: {
-        icons: Array<string>;
-        source: string;
-        tileID: OverscaledTileID;
-        type: string;
-      },
-      callback: Callback<{[_: string]: StyleImage}>
+        mapId: string,
+        params: {
+            icons: Array<string>;
+            source: string;
+            tileID: OverscaledTileID;
+            type: string;
+        },
+        callback: Callback<{[_: string]: StyleImage}>
     ) {
         this.imageManager.getImages(params.icons, callback);
 

--- a/src/style/style_glyph.ts
+++ b/src/style/style_glyph.ts
@@ -1,15 +1,15 @@
 import type {AlphaImage} from '../util/image';
 
 export type GlyphMetrics = {
-  width: number;
-  height: number;
-  left: number;
-  top: number;
-  advance: number;
+    width: number;
+    height: number;
+    left: number;
+    top: number;
+    advance: number;
 };
 
 export type StyleGlyph = {
-  id: number;
-  bitmap: AlphaImage;
-  metrics: GlyphMetrics;
+    id: number;
+    bitmap: AlphaImage;
+    metrics: GlyphMetrics;
 };

--- a/src/style/style_image.ts
+++ b/src/style/style_image.ts
@@ -3,18 +3,18 @@ import {RGBAImage} from '../util/image';
 import type Map from '../ui/map';
 
 export type StyleImageData = {
-  data: RGBAImage;
-  version: number;
-  hasRenderCallback?: boolean;
-  userImage?: StyleImageInterface;
+    data: RGBAImage;
+    version: number;
+    hasRenderCallback?: boolean;
+    userImage?: StyleImageInterface;
 };
 
 export type StyleImageMetadata = {
-  pixelRatio: number;
-  sdf: boolean;
-  stretchX?: Array<[number, number]>;
-  stretchY?: Array<[number, number]>;
-  content?: [number, number, number, number];
+    pixelRatio: number;
+    sdf: boolean;
+    stretchX?: Array<[number, number]>;
+    stretchY?: Array<[number, number]>;
+    content?: [number, number, number, number];
 };
 
 export type StyleImage = StyleImageData & StyleImageMetadata;
@@ -73,19 +73,19 @@ export type StyleImage = StyleImageData & StyleImageMetadata;
  */
 
 export interface StyleImageInterface {
-  /**
+    /**
    * @property {number} width
    */
-  width: number;
-  /**
+    width: number;
+    /**
   * @property {number} height
   */
-  height: number;
-  /**
+    height: number;
+    /**
    * @property {Uint8Array | Uint8ClampedArray} data
   */
-  data: Uint8Array | Uint8ClampedArray;
-  /**
+    data: Uint8Array | Uint8ClampedArray;
+    /**
    * This method is called once before every frame where the icon will be used.
    * The method can optionally update the image's `data` member with a new image.
    *
@@ -101,8 +101,8 @@ export interface StyleImageInterface {
    * @name render
    * @return {boolean} `true` if this method updated the image. `false` if the image was not changed.
    */
-  render?: () => boolean;
-  /**
+    render?: () => boolean;
+    /**
    * Optional method called when the layer has been added to the Map with {@link Map#addImage}.
    *
    * @function
@@ -111,8 +111,8 @@ export interface StyleImageInterface {
    * @name onAdd
    * @param {Map} map The Map this custom layer was just added to.
    */
-  onAdd?: (map: Map, id: string) => void;
-  /**
+    onAdd?: (map: Map, id: string) => void;
+    /**
    * Optional method called when the icon is removed from the map with {@link Map#removeImage}.
    * This gives the image a chance to clean up resources and event listeners.
    *
@@ -121,7 +121,7 @@ export interface StyleImageInterface {
    * @instance
    * @name onRemove
    */
-  onRemove?: () => void;
+    onRemove?: () => void;
 }
 
 export function renderStyleImage(image: StyleImage) {

--- a/src/style/style_layer.ts
+++ b/src/style/style_layer.ts
@@ -58,19 +58,19 @@ abstract class StyleLayer extends Evented {
 
     queryRadius?(bucket: Bucket): number;
     queryIntersectsFeature?(
-      queryGeometry: Array<Point>,
-      feature: VectorTileFeature,
-      featureState: FeatureState,
-      geometry: Array<Array<Point>>,
-      zoom: number,
-      transform: Transform,
-      pixelsToTileUnits: number,
-      pixelPosMatrix: mat4
+        queryGeometry: Array<Point>,
+        feature: VectorTileFeature,
+        featureState: FeatureState,
+        geometry: Array<Array<Point>>,
+        zoom: number,
+        transform: Transform,
+        pixelsToTileUnits: number,
+        pixelPosMatrix: mat4
     ): boolean | number;
 
     constructor(layer: LayerSpecification | CustomLayerInterface, properties: Readonly<{
-      layout?: Properties<any>;
-      paint?: Properties<any>;
+        layout?: Properties<any>;
+        paint?: Properties<any>;
     }>) {
         super();
 

--- a/src/style/style_layer/circle_style_layer.ts
+++ b/src/style/style_layer/circle_style_layer.ts
@@ -38,14 +38,14 @@ class CircleStyleLayer extends StyleLayer {
     }
 
     queryIntersectsFeature(
-      queryGeometry: Array<Point>,
-      feature: VectorTileFeature,
-      featureState: FeatureState,
-      geometry: Array<Array<Point>>,
-      zoom: number,
-      transform: Transform,
-      pixelsToTileUnits: number,
-      pixelPosMatrix: mat4
+        queryGeometry: Array<Point>,
+        feature: VectorTileFeature,
+        featureState: FeatureState,
+        geometry: Array<Array<Point>>,
+        zoom: number,
+        transform: Transform,
+        pixelsToTileUnits: number,
+        pixelPosMatrix: mat4
     ): boolean {
         const translatedPolygon = translate(queryGeometry,
             this.paint.get('circle-translate'),

--- a/src/style/style_layer/custom_style_layer.ts
+++ b/src/style/style_layer/custom_style_layer.ts
@@ -75,15 +75,15 @@ export interface CustomLayerInterface {
     /**
      * @property {string} id A unique layer id.
      */
-  id: string;
+    id: string;
     /**
      * @property {string} type The layer's type. Must be `"custom"`.
      */
-  type: 'custom';
+    type: 'custom';
     /**
      * @property {string} renderingMode Either `"2d"` or `"3d"`. Defaults to `"2d"`.
      */
-  renderingMode: '2d' | '3d';
+    renderingMode: '2d' | '3d';
     /**
      * Called during a render frame allowing the layer to draw into the GL context.
      *
@@ -112,7 +112,7 @@ export interface CustomLayerInterface {
      * lengths in mercator units would be rendered as a cube. {@link MercatorCoordinate}.fromLngLat
      * can be used to project a `LngLat` to a mercator coordinate.
      */
-  render: CustomRenderMethod;
+    render: CustomRenderMethod;
     /**
      * Optional method called during a render frame to allow a layer to prepare resources or render into a texture.
      *
@@ -130,7 +130,7 @@ export interface CustomLayerInterface {
      * lengths in mercator units would be rendered as a cube. {@link MercatorCoordinate}.fromLngLat
      * can be used to project a `LngLat` to a mercator coordinate.
      */
-  prerender: CustomRenderMethod;
+    prerender: CustomRenderMethod;
     /**
      * Optional method called when the layer has been added to the Map with {@link Map#addLayer}. This
      * gives the layer a chance to initialize gl resources and register event listeners.
@@ -142,7 +142,7 @@ export interface CustomLayerInterface {
      * @param {Map} map The Map this custom layer was just added to.
      * @param {WebGLRenderingContext} gl The gl context for the map.
      */
-  onAdd(map: Map, gl: WebGLRenderingContext): void;
+    onAdd(map: Map, gl: WebGLRenderingContext): void;
     /**
     * Optional method called when the layer has been removed from the Map with {@link Map#removeLayer}. This
     * gives the layer a chance to clean up gl resources and event listeners.
@@ -154,7 +154,7 @@ export interface CustomLayerInterface {
     * @param {Map} map The Map this custom layer was just added to.
     * @param {WebGLRenderingContext} gl The gl context for the map.
     */
-  onRemove(map: Map, gl: WebGLRenderingContext): void;
+    onRemove(map: Map, gl: WebGLRenderingContext): void;
 }
 
 export function validateCustomStyleLayer(layerObject: CustomLayerInterface) {

--- a/src/style/style_layer/fill_extrusion_style_layer.ts
+++ b/src/style/style_layer/fill_extrusion_style_layer.ts
@@ -40,14 +40,14 @@ class FillExtrusionStyleLayer extends StyleLayer {
     }
 
     queryIntersectsFeature(
-      queryGeometry: Array<Point>,
-      feature: VectorTileFeature,
-      featureState: FeatureState,
-      geometry: Array<Array<Point>>,
-      zoom: number,
-      transform: Transform,
-      pixelsToTileUnits: number,
-      pixelPosMatrix: mat4
+        queryGeometry: Array<Point>,
+        feature: VectorTileFeature,
+        featureState: FeatureState,
+        geometry: Array<Array<Point>>,
+        zoom: number,
+        transform: Transform,
+        pixelsToTileUnits: number,
+        pixelPosMatrix: mat4
     ): boolean | number {
 
         const translatedPolygon = translate(queryGeometry,

--- a/src/style/style_layer/fill_style_layer.ts
+++ b/src/style/style_layer/fill_style_layer.ts
@@ -45,13 +45,13 @@ class FillStyleLayer extends StyleLayer {
     }
 
     queryIntersectsFeature(
-      queryGeometry: Array<Point>,
-      feature: VectorTileFeature,
-      featureState: FeatureState,
-      geometry: Array<Array<Point>>,
-      zoom: number,
-      transform: Transform,
-      pixelsToTileUnits: number
+        queryGeometry: Array<Point>,
+        feature: VectorTileFeature,
+        featureState: FeatureState,
+        geometry: Array<Array<Point>>,
+        zoom: number,
+        transform: Transform,
+        pixelsToTileUnits: number
     ): boolean {
         const translatedPolygon = translate(queryGeometry,
             this.paint.get('fill-translate'),

--- a/src/style/style_layer/line_style_layer.ts
+++ b/src/style/style_layer/line_style_layer.ts
@@ -88,13 +88,13 @@ class LineStyleLayer extends StyleLayer {
     }
 
     queryIntersectsFeature(
-      queryGeometry: Array<Point>,
-      feature: VectorTileFeature,
-      featureState: FeatureState,
-      geometry: Array<Array<Point>>,
-      zoom: number,
-      transform: Transform,
-      pixelsToTileUnits: number
+        queryGeometry: Array<Point>,
+        feature: VectorTileFeature,
+        featureState: FeatureState,
+        geometry: Array<Array<Point>>,
+        zoom: number,
+        transform: Transform,
+        pixelsToTileUnits: number
     ): boolean {
         const translatedPolygon = translate(queryGeometry,
             this.paint.get('line-translate'),

--- a/src/style/style_layer/symbol_style_layer.ts
+++ b/src/style/style_layer/symbol_style_layer.ts
@@ -127,13 +127,13 @@ class SymbolStyleLayer extends StyleLayer {
                 expression = (new ZoomConstantExpression('source', styleExpression) as SourceExpression);
             } else {
                 expression = (new ZoomDependentExpression('composite',
-                                                          styleExpression,
-                                                          overriden.value.zoomStops,
-                                                          (overriden.value as any)._interpolationType) as CompositeExpression);
+                    styleExpression,
+                    overriden.value.zoomStops,
+                    (overriden.value as any)._interpolationType) as CompositeExpression);
             }
             this.paint._values[overridable] = new PossiblyEvaluatedPropertyValue(overriden.property,
-                                                                                 expression,
-                                                                                 overriden.parameters);
+                expression,
+                overriden.parameters);
         }
     }
 

--- a/src/style/style_layer_index.ts
+++ b/src/style/style_layer_index.ts
@@ -12,9 +12,9 @@ export type Family<Layer extends TypedStyleLayer> = Array<Layer>;
 
 class StyleLayerIndex {
     familiesBySource: {
-      [source: string]: {
-        [sourceLayer: string]: Array<Family<any>>;
-      };
+        [source: string]: {
+            [sourceLayer: string]: Array<Family<any>>;
+        };
     };
     keyCache: {[source: string]: string};
 

--- a/src/style/validate_style.ts
+++ b/src/style/validate_style.ts
@@ -4,21 +4,21 @@ import {ErrorEvent} from '../util/evented';
 import type {Evented} from '../util/evented';
 
 type ValidationError = {
-  message: string;
-  line: number;
-  identifier?: string;
+    message: string;
+    line: number;
+    identifier?: string;
 };
 
 export type Validator = (a: any) => ReadonlyArray<ValidationError>;
 
 type ValidateStyle = {
-  source: Validator;
-  layer: Validator;
-  light: Validator;
-  filter: Validator;
-  paintProperty: Validator;
-  layoutProperty: Validator;
-  (b: any, a?: any | null): ReadonlyArray<ValidationError>;
+    source: Validator;
+    layer: Validator;
+    light: Validator;
+    filter: Validator;
+    paintProperty: Validator;
+    layoutProperty: Validator;
+    (b: any, a?: any | null): ReadonlyArray<ValidationError>;
 };
 
 export const validateStyle = (validateStyleMin as ValidateStyle);
@@ -30,11 +30,11 @@ export const validatePaintProperty = validateStyle.paintProperty;
 export const validateLayoutProperty = validateStyle.layoutProperty;
 
 export function emitValidationErrors(
-  emitter: Evented,
-  errors?: ReadonlyArray<{
-    message: string;
-    identifier?: string;
-  }> | null
+    emitter: Evented,
+    errors?: ReadonlyArray<{
+        message: string;
+        identifier?: string;
+    }> | null
 ): boolean {
     let hasErrors = false;
     if (errors && errors.length) {

--- a/src/symbol/collision_feature.ts
+++ b/src/symbol/collision_feature.ts
@@ -27,15 +27,15 @@ class CollisionFeature {
      * @private
      */
     constructor(collisionBoxArray: CollisionBoxArray,
-                anchor: Anchor,
-                featureIndex: number,
-                sourceLayerIndex: number,
-                bucketIndex: number,
-                shaped: any,
-                boxScale: number,
-                padding: number,
-                alignLine: boolean,
-                rotate: number) {
+        anchor: Anchor,
+        featureIndex: number,
+        sourceLayerIndex: number,
+        bucketIndex: number,
+        shaped: any,
+        boxScale: number,
+        padding: number,
+        alignLine: boolean,
+        rotate: number) {
 
         this.boxStartIndex = collisionBoxArray.length;
 

--- a/src/symbol/collision_index.ts
+++ b/src/symbol/collision_index.ts
@@ -73,15 +73,15 @@ class CollisionIndex {
     }
 
     placeCollisionBox(
-      collisionBox: SingleCollisionBox,
-      overlapMode: OverlapMode,
-      textPixelRatio: number,
-      posMatrix: mat4,
-      collisionGroupPredicate?: (key: FeatureKey) => boolean
+        collisionBox: SingleCollisionBox,
+        overlapMode: OverlapMode,
+        textPixelRatio: number,
+        posMatrix: mat4,
+        collisionGroupPredicate?: (key: FeatureKey) => boolean
     ): {
-      box: Array<number>;
-      offscreen: boolean;
-    } {
+            box: Array<number>;
+            offscreen: boolean;
+        } {
         const projectedPoint = this.projectAndGetPerspectiveRatio(posMatrix, collisionBox.anchorPointX, collisionBox.anchorPointY);
         const tileToViewport = textPixelRatio * projectedPoint.perspectiveRatio;
         const tlX = collisionBox.x1 * tileToViewport + projectedPoint.point.x;
@@ -104,24 +104,24 @@ class CollisionIndex {
     }
 
     placeCollisionCircles(
-      overlapMode: OverlapMode,
-      symbol: any,
-      lineVertexArray: SymbolLineVertexArray,
-      glyphOffsetArray: GlyphOffsetArray,
-      fontSize: number,
-      posMatrix: mat4,
-      labelPlaneMatrix: mat4,
-      labelToScreenMatrix: mat4,
-      showCollisionCircles: boolean,
-      pitchWithMap: boolean,
-      collisionGroupPredicate: (key: FeatureKey) => boolean,
-      circlePixelDiameter: number,
-      textPixelPadding: number
+        overlapMode: OverlapMode,
+        symbol: any,
+        lineVertexArray: SymbolLineVertexArray,
+        glyphOffsetArray: GlyphOffsetArray,
+        fontSize: number,
+        posMatrix: mat4,
+        labelPlaneMatrix: mat4,
+        labelToScreenMatrix: mat4,
+        showCollisionCircles: boolean,
+        pitchWithMap: boolean,
+        collisionGroupPredicate: (key: FeatureKey) => boolean,
+        circlePixelDiameter: number,
+        textPixelPadding: number
     ): {
-      circles: Array<number>;
-      offscreen: boolean;
-      collisionDetected: boolean;
-    } {
+            circles: Array<number>;
+            offscreen: boolean;
+            collisionDetected: boolean;
+        } {
         const placedCollisionCircles = [];
 
         const tileUnitAnchorPoint = new Point(symbol.anchorX, symbol.anchorY);

--- a/src/symbol/cross_tile_symbol_index.ts
+++ b/src/symbol/cross_tile_symbol_index.ts
@@ -28,13 +28,13 @@ const roundingFactor = 512 / EXTENT / 2;
 class TileLayerIndex {
     tileID: OverscaledTileID;
     indexedSymbolInstances: {
-      [_: number]: Array<{
-        crossTileID: number;
-        coord: {
-          x: number;
-          y: number;
-        };
-      }>;
+        [_: number]: Array<{
+            crossTileID: number;
+            coord: {
+                x: number;
+                y: number;
+            };
+        }>;
     };
     bucketInstanceId: number;
 
@@ -74,7 +74,7 @@ class TileLayerIndex {
     }
 
     findMatches(symbolInstances: SymbolInstanceArray, newTileID: OverscaledTileID, zoomCrossTileIDs: {
-      [crossTileID: number]: boolean;
+        [crossTileID: number]: boolean;
     }) {
         const tolerance = this.tileID.canonical.z < newTileID.canonical.z ? 1 : Math.pow(2, this.tileID.canonical.z - newTileID.canonical.z);
 
@@ -123,14 +123,14 @@ class CrossTileIDs {
 
 class CrossTileSymbolLayerIndex {
     indexes: {
-      [zoom in string | number]: {
-        [tileId in string | number]: TileLayerIndex;
-      };
+        [zoom in string | number]: {
+            [tileId in string | number]: TileLayerIndex;
+        };
     };
     usedCrossTileIDs: {
-      [zoom in string | number]: {
-        [crossTileID: number]: boolean;
-      };
+        [zoom in string | number]: {
+            [crossTileID: number]: boolean;
+        };
     };
     lng: number;
 
@@ -234,7 +234,7 @@ class CrossTileSymbolLayerIndex {
     }
 
     removeStaleBuckets(currentIDs: {
-      [k in string | number]: boolean;
+        [k in string | number]: boolean;
     }) {
         let tilesChanged = false;
         for (const z in this.indexes) {

--- a/src/symbol/get_anchors.ts
+++ b/src/symbol/get_anchors.ts
@@ -17,9 +17,9 @@ function getLineLength(line: Array<Point>): number {
 }
 
 function getAngleWindowSize(
-  shapedText: Shaping,
-  glyphSize: number,
-  boxScale: number
+    shapedText: Shaping,
+    glyphSize: number,
+    boxScale: number
 ): number {
     return shapedText ?
         3 / 5 * glyphSize * boxScale :
@@ -33,11 +33,11 @@ function getShapedLabelLength(shapedText?: Shaping | null, shapedIcon?: Position
 }
 
 function getCenterAnchor(line: Array<Point>,
-                         maxAngle: number,
-                         shapedText: Shaping,
-                         shapedIcon: PositionedIcon,
-                         glyphSize: number,
-                         boxScale: number) {
+    maxAngle: number,
+    shapedText: Shaping,
+    shapedIcon: PositionedIcon,
+    glyphSize: number,
+    boxScale: number) {
     const angleWindowSize = getAngleWindowSize(shapedText, glyphSize, boxScale);
     const labelLength = getShapedLabelLength(shapedText, shapedIcon) * boxScale;
 
@@ -71,14 +71,14 @@ function getCenterAnchor(line: Array<Point>,
 }
 
 function getAnchors(line: Array<Point>,
-                    spacing: number,
-                    maxAngle: number,
-                    shapedText: Shaping,
-                    shapedIcon: PositionedIcon,
-                    glyphSize: number,
-                    boxScale: number,
-                    overscaling: number,
-                    tileExtent: number) {
+    spacing: number,
+    maxAngle: number,
+    shapedText: Shaping,
+    shapedIcon: PositionedIcon,
+    glyphSize: number,
+    boxScale: number,
+    overscaling: number,
+    tileExtent: number) {
 
     // Resample a line to get anchor points for labels and check that each
     // potential label passes text-max-angle check and has enough froom to fit

--- a/src/symbol/grid_index.ts
+++ b/src/symbol/grid_index.ts
@@ -381,13 +381,13 @@ class GridIndex<T extends GridKey> {
     }
 
     private _circleAndRectCollide(
-      circleX: number,
-      circleY: number,
-      radius: number,
-      x1: number,
-      y1: number,
-      x2: number,
-      y2: number
+        circleX: number,
+        circleY: number,
+        radius: number,
+        x1: number,
+        y1: number,
+        x2: number,
+        y2: number
     ): boolean {
         const halfRectWidth = (x2 - x1) / 2;
         const distX = Math.abs(circleX - (x1 + halfRectWidth));

--- a/src/symbol/placement.ts
+++ b/src/symbol/placement.ts
@@ -87,10 +87,10 @@ export class RetainedQueryData {
     tileID: OverscaledTileID;
     featureSortOrder: Array<number>;
     constructor(bucketInstanceId: number,
-                featureIndex: FeatureIndex,
-                sourceLayerIndex: number,
-                bucketIndex: number,
-                tileID: OverscaledTileID) {
+        featureIndex: FeatureIndex,
+        sourceLayerIndex: number,
+        bucketIndex: number,
+        tileID: OverscaledTileID) {
         this.bucketInstanceId = bucketInstanceId;
         this.featureIndex = featureIndex;
         this.sourceLayerIndex = sourceLayerIndex;
@@ -100,8 +100,8 @@ export class RetainedQueryData {
 }
 
 type CollisionGroup = {
-  ID: number;
-  predicate?: (key: FeatureKey) => boolean;
+    ID: number;
+    predicate?: (key: FeatureKey) => boolean;
 };
 
 class CollisionGroups {
@@ -137,11 +137,11 @@ class CollisionGroups {
 }
 
 function calculateVariableLayoutShift(
-  anchor: TextAnchor,
-  width: number,
-  height: number,
-  textOffset: [number, number],
-  textBoxScale: number
+    anchor: TextAnchor,
+    width: number,
+    height: number,
+    textOffset: [number, number],
+    textBoxScale: number
 ): Point {
     const {horizontalAlign, verticalAlign} = getAnchorAlignment(anchor);
     const shiftX = -(horizontalAlign - 0.5) * width;
@@ -154,9 +154,9 @@ function calculateVariableLayoutShift(
 }
 
 function shiftVariableCollisionBox(collisionBox: SingleCollisionBox,
-                                  shiftX: number, shiftY: number,
-                                  rotateWithMap: boolean, pitchWithMap: boolean,
-                                  angle: number) {
+    shiftX: number, shiftY: number,
+    rotateWithMap: boolean, pitchWithMap: boolean,
+    angle: number) {
     const {x1, x2, y1, y2, anchorPointX, anchorPointY} = collisionBox;
     const rotatedOffset = new Point(shiftX, shiftY);
     if (rotateWithMap) {
@@ -183,20 +183,20 @@ export type VariableOffset = {
 };
 
 type TileLayerParameters = {
-  bucket: SymbolBucket;
-  layout: PossiblyEvaluated<SymbolLayoutProps, SymbolLayoutPropsPossiblyEvaluated>;
-  posMatrix: mat4;
-  textLabelPlaneMatrix: mat4;
-  labelToScreenMatrix: mat4;
-  scale: number;
-  textPixelRatio: number;
-  holdingForFade: boolean;
-  collisionBoxArray: CollisionBoxArray;
-  partiallyEvaluatedTextSize: {
-    uSize: number;
-    uSizeT: number;
-  };
-  collisionGroup: CollisionGroup;
+    bucket: SymbolBucket;
+    layout: PossiblyEvaluated<SymbolLayoutProps, SymbolLayoutPropsPossiblyEvaluated>;
+    posMatrix: mat4;
+    textLabelPlaneMatrix: mat4;
+    labelToScreenMatrix: mat4;
+    scale: number;
+    textPixelRatio: number;
+    holdingForFade: boolean;
+    collisionBoxArray: CollisionBoxArray;
+    partiallyEvaluatedTextSize: {
+        uSize: number;
+        uSizeT: number;
+    };
+    collisionGroup: CollisionGroup;
 };
 
 export type BucketPart = {
@@ -212,16 +212,16 @@ export class Placement {
     transform: Transform;
     collisionIndex: CollisionIndex;
     placements: {
-      [_ in CrossTileID]: JointPlacement;
+        [_ in CrossTileID]: JointPlacement;
     };
     opacities: {
-      [_ in CrossTileID]: JointOpacityState;
+        [_ in CrossTileID]: JointOpacityState;
     };
     variableOffsets: {
-      [_ in CrossTileID]: VariableOffset;
+        [_ in CrossTileID]: VariableOffset;
     };
     placedOrientations: {
-      [_ in CrossTileID]: number;
+        [_ in CrossTileID]: number;
     };
     commitTime: number;
     prevZoomAdjustment: number;
@@ -229,13 +229,13 @@ export class Placement {
     stale: boolean;
     fadeDuration: number;
     retainedQueryData: {
-      [_: number]: RetainedQueryData;
+        [_: number]: RetainedQueryData;
     };
     collisionGroups: CollisionGroups;
     prevPlacement: Placement;
     zoomAtLastRecencyCheck: number;
     collisionCircleArrays: {
-      [k in any]: CollisionCircleArray;
+        [k in any]: CollisionCircleArray;
     };
 
     constructor(transform: Transform, fadeDuration: number, crossSourceCollisions: boolean, prevPlacement?: Placement) {
@@ -279,10 +279,10 @@ export class Placement {
         const pixelsToTiles = pixelsToTileUnits(tile, 1, this.transform.zoom);
 
         const textLabelPlaneMatrix = projection.getLabelPlaneMatrix(posMatrix,
-                pitchWithMap,
-                rotateWithMap,
-                this.transform,
-                pixelsToTiles);
+            pitchWithMap,
+            rotateWithMap,
+            this.transform,
+            pixelsToTiles);
 
         let labelToScreenMatrix = null;
 
@@ -336,28 +336,28 @@ export class Placement {
     }
 
     attemptAnchorPlacement(
-      anchor: TextAnchor,
-      textBox: SingleCollisionBox,
-      width: number,
-      height: number,
-      textBoxScale: number,
-      rotateWithMap: boolean,
-      pitchWithMap: boolean,
-      textPixelRatio: number,
-      posMatrix: mat4,
-      collisionGroup: CollisionGroup,
-      textOverlapMode: OverlapMode,
-      symbolInstance: SymbolInstance,
-      bucket: SymbolBucket,
-      orientation: number,
-      iconBox?: SingleCollisionBox | null
+        anchor: TextAnchor,
+        textBox: SingleCollisionBox,
+        width: number,
+        height: number,
+        textBoxScale: number,
+        rotateWithMap: boolean,
+        pitchWithMap: boolean,
+        textPixelRatio: number,
+        posMatrix: mat4,
+        collisionGroup: CollisionGroup,
+        textOverlapMode: OverlapMode,
+        symbolInstance: SymbolInstance,
+        bucket: SymbolBucket,
+        orientation: number,
+        iconBox?: SingleCollisionBox | null
     ): {
-      shift: Point;
-      placedGlyphBoxes: {
-        box: Array<number>;
-        offscreen: boolean;
-      };
-    } {
+            shift: Point;
+            placedGlyphBoxes: {
+                box: Array<number>;
+                offscreen: boolean;
+            };
+        } {
 
         const textOffset = [symbolInstance.textOffset0, symbolInstance.textOffset1] as [number, number];
         const shift = calculateVariableLayoutShift(anchor, width, height, textOffset, textBoxScale);
@@ -408,7 +408,7 @@ export class Placement {
     }
 
     placeLayerBucketPart(bucketPart: BucketPart, seenCrossTileIDs: {
-      [k in string | number]: boolean;
+        [k in string | number]: boolean;
     }, showCollisionBoxes: boolean) {
 
         const {
@@ -573,8 +573,8 @@ export class Placement {
                         const variableIconBox = hasIconTextFit && (iconOverlapMode === 'never') ? collisionIconBox : null;
 
                         let placedBox: {
-                          box: Array<number>;
-                          offscreen: boolean;
+                            box: Array<number>;
+                            offscreen: boolean;
                         } = {box: [], offscreen: false};
                         const placementAttempts = (textOverlapMode !== 'never') ? anchors.length * 2 : anchors.length;
                         for (let i = 0; i < placementAttempts; ++i) {
@@ -924,7 +924,7 @@ export class Placement {
     }
 
     updateBucketOpacities(bucket: SymbolBucket, seenCrossTileIDs: {
-      [k in string | number]: boolean;
+        [k in string | number]: boolean;
     }, collisionBoxArray?: CollisionBoxArray | null) {
         if (bucket.hasTextData()) bucket.text.opacityVertexArray.clear();
         if (bucket.hasIconData()) bucket.icon.opacityVertexArray.clear();
@@ -944,9 +944,9 @@ export class Placement {
         // with allow-overlap: false.
         // See https://github.com/mapbox/mapbox-gl-js/issues/7032
         const defaultOpacityState = new JointOpacityState(null, 0,
-                textAllowOverlap && (iconAllowOverlap || !bucket.hasIconData() || layout.get('icon-optional')),
-                iconAllowOverlap && (textAllowOverlap || !bucket.hasTextData() || layout.get('text-optional')),
-                true);
+            textAllowOverlap && (iconAllowOverlap || !bucket.hasIconData() || layout.get('icon-optional')),
+            iconAllowOverlap && (textAllowOverlap || !bucket.hasTextData() || layout.get('text-optional')),
+            true);
 
         if (!bucket.collisionArrays && collisionBoxArray && ((bucket.hasIconCollisionBoxData() || bucket.hasTextCollisionBoxData()))) {
             bucket.deserializeCollisionBoxes(collisionBoxArray);
@@ -1060,10 +1060,10 @@ export class Placement {
                                 // just made the symbol disappear, and the most likely place for the
                                 // symbol to come back)
                                 shift = calculateVariableLayoutShift(variableOffset.anchor,
-                                   variableOffset.width,
-                                   variableOffset.height,
-                                   variableOffset.textOffset,
-                                   variableOffset.textBoxScale);
+                                    variableOffset.width,
+                                    variableOffset.height,
+                                    variableOffset.textOffset,
+                                    variableOffset.textBoxScale);
                                 if (rotateWithMap) {
                                     shift._rotate(pitchWithMap ? this.transform.angle : -this.transform.angle);
                                 }

--- a/src/symbol/projection.ts
+++ b/src/symbol/projection.ts
@@ -65,10 +65,10 @@ export {updateLineLabels, hideGlyphs, getLabelPlaneMatrix, getGlCoordMatrix, pro
  * Returns a matrix for converting from tile units to the correct label coordinate space.
  */
 function getLabelPlaneMatrix(posMatrix: mat4,
-                             pitchWithMap: boolean,
-                             rotateWithMap: boolean,
-                             transform: Transform,
-                             pixelsToTileUnits: number) {
+    pitchWithMap: boolean,
+    rotateWithMap: boolean,
+    transform: Transform,
+    pixelsToTileUnits: number) {
     const m = mat4.create();
     if (pitchWithMap) {
         mat4.scale(m, m, [1 / pixelsToTileUnits, 1 / pixelsToTileUnits, 1]);
@@ -85,10 +85,10 @@ function getLabelPlaneMatrix(posMatrix: mat4,
  * Returns a matrix for converting from the correct label coordinate space to gl coords.
  */
 function getGlCoordMatrix(posMatrix: mat4,
-                          pitchWithMap: boolean,
-                          rotateWithMap: boolean,
-                          transform: Transform,
-                          pixelsToTileUnits: number) {
+    pitchWithMap: boolean,
+    rotateWithMap: boolean,
+    transform: Transform,
+    pixelsToTileUnits: number) {
     if (pitchWithMap) {
         const m = mat4.clone(posMatrix);
         mat4.scale(m, m, [pixelsToTileUnits, pixelsToTileUnits, 1]);
@@ -116,7 +116,7 @@ function getPerspectiveRatio(cameraToCenterDistance: number, signedDistanceFromC
 }
 
 function isVisible(anchorPos: vec4,
-                   clippingBuffer: [number, number]) {
+    clippingBuffer: [number, number]) {
     const x = anchorPos[0] / anchorPos[3];
     const y = anchorPos[1] / anchorPos[3];
     const inPaddedViewport = (
@@ -132,13 +132,13 @@ function isVisible(anchorPos: vec4,
  *  This is only run on labels that are aligned with lines. Horizontal labels are handled entirely in the shader.
  */
 function updateLineLabels(bucket: SymbolBucket,
-                          posMatrix: mat4,
-                          painter: Painter,
-                          isText: boolean,
-                          labelPlaneMatrix: mat4,
-                          glCoordMatrix: mat4,
-                          pitchWithMap: boolean,
-                          keepUpright: boolean) {
+    posMatrix: mat4,
+    painter: Painter,
+    isText: boolean,
+    labelPlaneMatrix: mat4,
+    glCoordMatrix: mat4,
+    pitchWithMap: boolean,
+    keepUpright: boolean) {
 
     const sizeData = isText ? bucket.textSizeData : bucket.iconSizeData;
     const partiallyEvaluatedSize = symbolSize.evaluateSizeForZoom(sizeData, painter.transform.zoom);
@@ -334,19 +334,19 @@ function projectTruncatedLineSegment(previousTilePoint: Point, currentTilePoint:
 }
 
 function placeGlyphAlongLine(offsetX: number,
-                             lineOffsetX: number,
-                             lineOffsetY: number,
-                             flip: boolean,
-                             anchorPoint: Point,
-                             tileAnchorPoint: Point,
-                             anchorSegment: number,
-                             lineStartIndex: number,
-                             lineEndIndex: number,
-                             lineVertexArray: SymbolLineVertexArray,
-                             labelPlaneMatrix: mat4,
-                             projectionCache: {
-                               [_: number]: Point;
-                             }) {
+    lineOffsetX: number,
+    lineOffsetY: number,
+    flip: boolean,
+    anchorPoint: Point,
+    tileAnchorPoint: Point,
+    anchorSegment: number,
+    lineStartIndex: number,
+    lineEndIndex: number,
+    lineVertexArray: SymbolLineVertexArray,
+    labelPlaneMatrix: mat4,
+    projectionCache: {
+        [_: number]: Point;
+    }) {
 
     const combinedOffsetX = flip ?
         offsetX - lineOffsetX :

--- a/src/symbol/quads.ts
+++ b/src/symbol/quads.ts
@@ -26,24 +26,24 @@ import {Rect} from '../render/glyph_atlas';
  * @private
  */
 export type SymbolQuad = {
-  tl: Point;
-  tr: Point;
-  bl: Point;
-  br: Point;
-  tex: {
-    x: number;
-    y: number;
-    w: number;
-    h: number;
-  };
-  pixelOffsetTL: Point;
-  pixelOffsetBR: Point;
-  writingMode: any | void;
-  glyphOffset: [number, number];
-  sectionIndex: number;
-  isSDF: boolean;
-  minFontScaleX: number;
-  minFontScaleY: number;
+    tl: Point;
+    tr: Point;
+    bl: Point;
+    br: Point;
+    tex: {
+        x: number;
+        y: number;
+        w: number;
+        h: number;
+    };
+    pixelOffsetTL: Point;
+    pixelOffsetBR: Point;
+    writingMode: any | void;
+    glyphOffset: [number, number];
+    sectionIndex: number;
+    isSDF: boolean;
+    minFontScaleX: number;
+    minFontScaleY: number;
 };
 
 // If you have a 10px icon that isn't perfectly aligned to the pixel grid it will cover 11 actual
@@ -56,10 +56,10 @@ const border = IMAGE_PADDING;
  * @private
  */
 export function getIconQuads(
-  shapedIcon: PositionedIcon,
-  iconRotate: number,
-  isSDFIcon: boolean,
-  hasIconTextFit: boolean
+    shapedIcon: PositionedIcon,
+    iconRotate: number,
+    isSDFIcon: boolean,
+    hasIconTextFit: boolean
 ): Array<SymbolQuad> {
     const quads = [];
 
@@ -220,14 +220,14 @@ function getPxOffset(fixedOffset, fixedSize, stretchOffset, stretchSize) {
  * @private
  */
 export function getGlyphQuads(
-  anchor: Anchor,
-  shaping: Shaping,
-  textOffset: [number, number],
-  layer: SymbolStyleLayer,
-  alongLine: boolean,
-  feature: Feature,
-  imageMap: {[_: string]: StyleImage},
-  allowVerticalPlacement: boolean
+    anchor: Anchor,
+    shaping: Shaping,
+    textOffset: [number, number],
+    layer: SymbolStyleLayer,
+    alongLine: boolean,
+    feature: Feature,
+    imageMap: {[_: string]: StyleImage},
+    allowVerticalPlacement: boolean
 ): Array<SymbolQuad> {
 
     const textRotate = layer.layout.get('text-rotate').evaluate(feature, {}) * Math.PI / 180;

--- a/src/symbol/shaping.ts
+++ b/src/symbol/shaping.ts
@@ -28,34 +28,34 @@ export {shapeText, shapeIcon, fitIconToText, getAnchorAlignment, WritingMode, SH
 
 // The position of a glyph relative to the text's anchor point.
 export type PositionedGlyph = {
-  glyph: number;
-  imageName: string | null;
-  x: number;
-  y: number;
-  vertical: boolean;
-  scale: number;
-  fontStack: string;
-  sectionIndex: number;
-  metrics: GlyphMetrics;
-  rect: Rect | null;
+    glyph: number;
+    imageName: string | null;
+    x: number;
+    y: number;
+    vertical: boolean;
+    scale: number;
+    fontStack: string;
+    sectionIndex: number;
+    metrics: GlyphMetrics;
+    rect: Rect | null;
 };
 
 export type PositionedLine = {
-  positionedGlyphs: Array<PositionedGlyph>;
-  lineOffset: number;
+    positionedGlyphs: Array<PositionedGlyph>;
+    lineOffset: number;
 };
 
 // A collection of positioned glyphs and some metadata
 export type Shaping = {
-  positionedLines: Array<PositionedLine>;
-  top: number;
-  bottom: number;
-  left: number;
-  right: number;
-  writingMode: WritingMode.horizontal | WritingMode.vertical;
-  text: string;
-  iconsInText: boolean;
-  verticalizable: boolean;
+    positionedLines: Array<PositionedLine>;
+    top: number;
+    bottom: number;
+    left: number;
+    right: number;
+    writingMode: WritingMode.horizontal | WritingMode.vertical;
+    text: string;
+    iconsInText: boolean;
+    verticalizable: boolean;
 };
 
 function isEmpty(positionedLines: Array<PositionedLine>) {
@@ -236,30 +236,30 @@ function breakLines(input: TaggedString, lineBreakPoints: Array<number>): Array<
 }
 
 function shapeText(
-  text: Formatted,
-  glyphMap: {
-    [_: string]: {
-      [_: number]: StyleGlyph;
-    };
-  },
-  glyphPositions: {
-    [_: string]: {
-      [_: number]: GlyphPosition;
-    };
-  },
-  imagePositions: {[_: string]: ImagePosition},
-  defaultFontStack: string,
-  maxWidth: number,
-  lineHeight: number,
-  textAnchor: SymbolAnchor,
-  textJustify: TextJustify,
-  spacing: number,
-  translate: [number, number],
-  writingMode: WritingMode.horizontal | WritingMode.vertical,
-  allowVerticalPlacement: boolean,
-  symbolPlacement: string,
-  layoutTextSize: number,
-  layoutTextSizeThisZoom: number
+    text: Formatted,
+    glyphMap: {
+        [_: string]: {
+            [_: number]: StyleGlyph;
+        };
+    },
+    glyphPositions: {
+        [_: string]: {
+            [_: number]: GlyphPosition;
+        };
+    },
+    imagePositions: {[_: string]: ImagePosition},
+    defaultFontStack: string,
+    maxWidth: number,
+    lineHeight: number,
+    textAnchor: SymbolAnchor,
+    textJustify: TextJustify,
+    spacing: number,
+    translate: [number, number],
+    writingMode: WritingMode.horizontal | WritingMode.vertical,
+    allowVerticalPlacement: boolean,
+    symbolPlacement: string,
+    layoutTextSize: number,
+    layoutTextSizeThisZoom: number
 ): Shaping | false {
     const logicalInput = TaggedString.fromFeature(text, defaultFontStack);
 
@@ -275,7 +275,7 @@ function shapeText(
         lines = [];
         const untaggedLines =
             processBidirectionalText(logicalInput.toString(),
-                                     determineLineBreaks(logicalInput, spacing, maxWidth, glyphMap, imagePositions, symbolPlacement, layoutTextSize));
+                determineLineBreaks(logicalInput, spacing, maxWidth, glyphMap, imagePositions, symbolPlacement, layoutTextSize));
         for (const line of untaggedLines) {
             const taggedLine = new TaggedString();
             taggedLine.text = line;
@@ -291,8 +291,8 @@ function shapeText(
         lines = [];
         const processedLines =
             processStyledBidirectionalText(logicalInput.text,
-                                           logicalInput.sectionIndex,
-                                           determineLineBreaks(logicalInput, spacing, maxWidth, glyphMap, imagePositions, symbolPlacement, layoutTextSize));
+                logicalInput.sectionIndex,
+                determineLineBreaks(logicalInput, spacing, maxWidth, glyphMap, imagePositions, symbolPlacement, layoutTextSize));
         for (const line of processedLines) {
             const taggedLine = new TaggedString();
             taggedLine.text = line[0];
@@ -327,7 +327,7 @@ function shapeText(
 /* eslint no-useless-computed-key: 0 */
 
 const whitespace: {
-  [_: number]: boolean;
+    [_: number]: boolean;
 } = {
     [0x09]: true, // tab
     [0x0a]: true, // newline
@@ -338,7 +338,7 @@ const whitespace: {
 };
 
 const breakable: {
-  [_: number]: boolean;
+    [_: number]: boolean;
 } = {
     [0x0a]:   true, // newline
     [0x20]:   true, // space
@@ -360,16 +360,16 @@ const breakable: {
 };
 
 function getGlyphAdvance(
-  codePoint: number,
-  section: SectionOptions,
-  glyphMap: {
-    [_: string]: {
-      [_: number]: StyleGlyph;
-    };
-  },
-  imagePositions: {[_: string]: ImagePosition},
-  spacing: number,
-  layoutTextSize: number
+    codePoint: number,
+    section: SectionOptions,
+    glyphMap: {
+        [_: string]: {
+            [_: number]: StyleGlyph;
+        };
+    },
+    imagePositions: {[_: string]: ImagePosition},
+    spacing: number,
+    layoutTextSize: number
 ): number {
     if (!section.imageName) {
         const positions = glyphMap[section.fontStack];
@@ -384,15 +384,15 @@ function getGlyphAdvance(
 }
 
 function determineAverageLineWidth(logicalInput: TaggedString,
-                                   spacing: number,
-                                   maxWidth: number,
-                                   glyphMap: {
-                                     [_: string]: {
-                                       [_: number]: StyleGlyph;
-                                     };
-                                   },
-                                   imagePositions: {[_: string]: ImagePosition},
-                                   layoutTextSize: number) {
+    spacing: number,
+    maxWidth: number,
+    glyphMap: {
+        [_: string]: {
+            [_: number]: StyleGlyph;
+        };
+    },
+    imagePositions: {[_: string]: ImagePosition},
+    layoutTextSize: number) {
     let totalWidth = 0;
 
     for (let index = 0; index < logicalInput.length(); index++) {
@@ -405,9 +405,9 @@ function determineAverageLineWidth(logicalInput: TaggedString,
 }
 
 function calculateBadness(lineWidth: number,
-                          targetWidth: number,
-                          penalty: number,
-                          isLastBreak: boolean) {
+    targetWidth: number,
+    penalty: number,
+    isLastBreak: boolean) {
     const raggedness = Math.pow(lineWidth - targetWidth, 2);
     if (isLastBreak) {
         // Favor finals lines shorter than average over longer than average
@@ -446,19 +446,19 @@ function calculatePenalty(codePoint: number, nextCodePoint: number, penalizableI
 }
 
 type Break = {
-  index: number;
-  x: number;
-  priorBreak: Break;
-  badness: number;
+    index: number;
+    x: number;
+    priorBreak: Break;
+    badness: number;
 };
 
 function evaluateBreak(
-  breakIndex: number,
-  breakX: number,
-  targetWidth: number,
-  potentialBreaks: Array<Break>,
-  penalty: number,
-  isLastBreak: boolean
+    breakIndex: number,
+    breakX: number,
+    targetWidth: number,
+    potentialBreaks: Array<Break>,
+    penalty: number,
+    isLastBreak: boolean
 ): Break {
     // We could skip evaluating breaks where the line length (breakX - priorBreak.x) > maxWidth
     //  ...but in fact we allow lines longer than maxWidth (if there's no break points)
@@ -494,17 +494,17 @@ function leastBadBreaks(lastLineBreak?: Break | null): Array<number> {
 }
 
 function determineLineBreaks(
-  logicalInput: TaggedString,
-  spacing: number,
-  maxWidth: number,
-  glyphMap: {
-    [_: string]: {
-      [_: number]: StyleGlyph;
-    };
-  },
-  imagePositions: {[_: string]: ImagePosition},
-  symbolPlacement: string,
-  layoutTextSize: number
+    logicalInput: TaggedString,
+    spacing: number,
+    maxWidth: number,
+    glyphMap: {
+        [_: string]: {
+            [_: number]: StyleGlyph;
+        };
+    },
+    imagePositions: {[_: string]: ImagePosition},
+    symbolPlacement: string,
+    layoutTextSize: number
 ): Array<number> {
     if (symbolPlacement !== 'point')
         return [];
@@ -556,54 +556,54 @@ function getAnchorAlignment(anchor: SymbolAnchor) {
     let horizontalAlign = 0.5, verticalAlign = 0.5;
 
     switch (anchor) {
-    case 'right':
-    case 'top-right':
-    case 'bottom-right':
-        horizontalAlign = 1;
-        break;
-    case 'left':
-    case 'top-left':
-    case 'bottom-left':
-        horizontalAlign = 0;
-        break;
+        case 'right':
+        case 'top-right':
+        case 'bottom-right':
+            horizontalAlign = 1;
+            break;
+        case 'left':
+        case 'top-left':
+        case 'bottom-left':
+            horizontalAlign = 0;
+            break;
     }
 
     switch (anchor) {
-    case 'bottom':
-    case 'bottom-right':
-    case 'bottom-left':
-        verticalAlign = 1;
-        break;
-    case 'top':
-    case 'top-right':
-    case 'top-left':
-        verticalAlign = 0;
-        break;
+        case 'bottom':
+        case 'bottom-right':
+        case 'bottom-left':
+            verticalAlign = 1;
+            break;
+        case 'top':
+        case 'top-right':
+        case 'top-left':
+            verticalAlign = 0;
+            break;
     }
 
     return {horizontalAlign, verticalAlign};
 }
 
 function shapeLines(shaping: Shaping,
-                    glyphMap: {
-                      [_: string]: {
-                        [_: number]: StyleGlyph;
-                      };
-                    },
-                    glyphPositions: {
-                      [_: string]: {
-                        [_: number]: GlyphPosition;
-                      };
-                    },
-                    imagePositions: {[_: string]: ImagePosition},
-                    lines: Array<TaggedString>,
-                    lineHeight: number,
-                    textAnchor: SymbolAnchor,
-                    textJustify: TextJustify,
-                    writingMode: WritingMode.horizontal | WritingMode.vertical,
-                    spacing: number,
-                    allowVerticalPlacement: boolean,
-                    layoutTextSizeThisZoom: number) {
+    glyphMap: {
+        [_: string]: {
+            [_: number]: StyleGlyph;
+        };
+    },
+    glyphPositions: {
+        [_: string]: {
+            [_: number]: GlyphPosition;
+        };
+    },
+    imagePositions: {[_: string]: ImagePosition},
+    lines: Array<TaggedString>,
+    lineHeight: number,
+    textAnchor: SymbolAnchor,
+    textJustify: TextJustify,
+    writingMode: WritingMode.horizontal | WritingMode.vertical,
+    spacing: number,
+    allowVerticalPlacement: boolean,
+    layoutTextSizeThisZoom: number) {
 
     let x = 0;
     let y = SHAPING_DEFAULT_OFFSET;
@@ -613,7 +613,7 @@ function shapeLines(shaping: Shaping,
 
     const justify =
         textJustify === 'right' ? 1 :
-        textJustify === 'left' ? 0 : 0.5;
+            textJustify === 'left' ? 0 : 0.5;
 
     let lineIndex = 0;
     for (const line of lines) {
@@ -736,10 +736,10 @@ function shapeLines(shaping: Shaping,
 
 // justify right = 1, left = 0, center = 0.5
 function justifyLine(positionedGlyphs: Array<PositionedGlyph>,
-                     start: number,
-                     end: number,
-                     justify: 1 | 0 | 0.5,
-                     lineOffset: number) {
+    start: number,
+    end: number,
+    justify: 1 | 0 | 0.5,
+    lineOffset: number) {
     if (!justify && !lineOffset)
         return;
 
@@ -754,14 +754,14 @@ function justifyLine(positionedGlyphs: Array<PositionedGlyph>,
 }
 
 function align(positionedLines: Array<PositionedLine>,
-               justify: number,
-               horizontalAlign: number,
-               verticalAlign: number,
-               maxLineLength: number,
-               maxLineHeight: number,
-               lineHeight: number,
-               blockHeight: number,
-               lineCount: number) {
+    justify: number,
+    horizontalAlign: number,
+    verticalAlign: number,
+    maxLineLength: number,
+    maxLineHeight: number,
+    lineHeight: number,
+    blockHeight: number,
+    lineCount: number) {
     const shiftX = (justify - horizontalAlign) * maxLineLength;
     let shiftY = 0;
 
@@ -780,18 +780,18 @@ function align(positionedLines: Array<PositionedLine>,
 }
 
 export type PositionedIcon = {
-  image: ImagePosition;
-  top: number;
-  bottom: number;
-  left: number;
-  right: number;
-  collisionPadding?: [number, number, number, number];
+    image: ImagePosition;
+    top: number;
+    bottom: number;
+    left: number;
+    right: number;
+    collisionPadding?: [number, number, number, number];
 };
 
 function shapeIcon(
-  image: ImagePosition,
-  iconOffset: [number, number],
-  iconAnchor: SymbolAnchor
+    image: ImagePosition,
+    iconOffset: [number, number],
+    iconAnchor: SymbolAnchor
 ): PositionedIcon {
     const {horizontalAlign, verticalAlign} = getAnchorAlignment(iconAnchor);
     const dx = iconOffset[0];
@@ -804,12 +804,12 @@ function shapeIcon(
 }
 
 function fitIconToText(
-  shapedIcon: PositionedIcon,
-  shapedText: Shaping,
-  textFit: string,
-  padding: [number, number, number, number],
-  iconOffset: [number, number],
-  fontScale: number
+    shapedIcon: PositionedIcon,
+    shapedText: Shaping,
+    textFit: string,
+    padding: [number, number, number, number],
+    iconOffset: [number, number],
+    fontScale: number
 ): PositionedIcon {
     assert(textFit !== 'none');
     assert(Array.isArray(padding) && padding.length === 4);

--- a/src/symbol/symbol_layout.ts
+++ b/src/symbol/symbol_layout.ts
@@ -46,11 +46,11 @@ import murmur3 from 'murmurhash-js';
 // (1) and (2) are stored in `bucket.layers[0].layout`. The remainder are below.
 //
 type Sizes = {
-  layoutTextSize: PossiblyEvaluatedPropertyValue<number>; // (3),
-  layoutIconSize: PossiblyEvaluatedPropertyValue<number>; // (3),
-  textMaxSize: PossiblyEvaluatedPropertyValue<number>;    // (4),
-  compositeTextSizes: [PossiblyEvaluatedPropertyValue<number>, PossiblyEvaluatedPropertyValue<number>]; // (5),
-  compositeIconSizes: [PossiblyEvaluatedPropertyValue<number>, PossiblyEvaluatedPropertyValue<number>]; // (5)
+    layoutTextSize: PossiblyEvaluatedPropertyValue<number>; // (3),
+    layoutIconSize: PossiblyEvaluatedPropertyValue<number>; // (3),
+    textMaxSize: PossiblyEvaluatedPropertyValue<number>;    // (4),
+    compositeTextSizes: [PossiblyEvaluatedPropertyValue<number>, PossiblyEvaluatedPropertyValue<number>]; // (5),
+    compositeIconSizes: [PossiblyEvaluatedPropertyValue<number>, PossiblyEvaluatedPropertyValue<number>]; // (5)
 };
 
 type ShapedTextOrientations = {
@@ -76,37 +76,37 @@ export function evaluateVariableOffset(anchor: TextAnchor, offset: [number, numb
         // solve for r where r^2 + r^2 = radialOffset^2
         const hypotenuse = radialOffset / Math.sqrt(2);
         switch (anchor) {
-        case 'top-right':
-        case 'top-left':
-            y = hypotenuse - baselineOffset;
-            break;
-        case 'bottom-right':
-        case 'bottom-left':
-            y = -hypotenuse + baselineOffset;
-            break;
-        case 'bottom':
-            y = -radialOffset + baselineOffset;
-            break;
-        case 'top':
-            y = radialOffset - baselineOffset;
-            break;
+            case 'top-right':
+            case 'top-left':
+                y = hypotenuse - baselineOffset;
+                break;
+            case 'bottom-right':
+            case 'bottom-left':
+                y = -hypotenuse + baselineOffset;
+                break;
+            case 'bottom':
+                y = -radialOffset + baselineOffset;
+                break;
+            case 'top':
+                y = radialOffset - baselineOffset;
+                break;
         }
 
         switch (anchor) {
-        case 'top-right':
-        case 'bottom-right':
-            x = -hypotenuse;
-            break;
-        case 'top-left':
-        case 'bottom-left':
-            x = hypotenuse;
-            break;
-        case 'left':
-            x = radialOffset;
-            break;
-        case 'right':
-            x = -radialOffset;
-            break;
+            case 'top-right':
+            case 'bottom-right':
+                x = -hypotenuse;
+                break;
+            case 'top-left':
+            case 'bottom-left':
+                x = hypotenuse;
+                break;
+            case 'left':
+                x = radialOffset;
+                break;
+            case 'right':
+                x = -radialOffset;
+                break;
         }
 
         return [x, y];
@@ -119,29 +119,29 @@ export function evaluateVariableOffset(anchor: TextAnchor, offset: [number, numb
         offsetY = Math.abs(offsetY);
 
         switch (anchor) {
-        case 'top-right':
-        case 'top-left':
-        case 'top':
-            y = offsetY - baselineOffset;
-            break;
-        case 'bottom-right':
-        case 'bottom-left':
-        case 'bottom':
-            y = -offsetY + baselineOffset;
-            break;
+            case 'top-right':
+            case 'top-left':
+            case 'top':
+                y = offsetY - baselineOffset;
+                break;
+            case 'bottom-right':
+            case 'bottom-left':
+            case 'bottom':
+                y = -offsetY + baselineOffset;
+                break;
         }
 
         switch (anchor) {
-        case 'top-right':
-        case 'bottom-right':
-        case 'right':
-            x = -offsetX;
-            break;
-        case 'top-left':
-        case 'bottom-left':
-        case 'left':
-            x = offsetX;
-            break;
+            case 'top-right':
+            case 'bottom-right':
+            case 'right':
+                x = -offsetX;
+                break;
+            case 'top-left':
+            case 'bottom-left':
+            case 'left':
+                x = offsetX;
+                break;
         }
 
         return [x, y];
@@ -255,7 +255,7 @@ export function performSymbolLayout(
                     // writing mode, thus, default left justification is used. If Latin
                     // scripts would need to be supported, this should take into account other justifications.
                     shapedTextOrientations.vertical = shapeText(text, glyphMap, glyphPositions, imagePositions, fontstack, maxWidth, lineHeight, textAnchor,
-                                                                'left', spacingIfAllowed, textOffset, WritingMode.vertical, true, symbolPlacement, layoutTextSize, layoutTextSizeThisZoom);
+                        'left', spacingIfAllowed, textOffset, WritingMode.vertical, true, symbolPlacement, layoutTextSize, layoutTextSizeThisZoom);
                 }
             };
 
@@ -277,7 +277,7 @@ export function performSymbolLayout(
                         // If using text-variable-anchor for the layer, we use a center anchor for all shapings and apply
                         // the offsets for the anchor in the placement step.
                         const shaping = shapeText(text, glyphMap, glyphPositions, imagePositions, fontstack, maxWidth, lineHeight, 'center',
-                                                  justification, spacingIfAllowed, textOffset, WritingMode.horizontal, false, symbolPlacement, layoutTextSize, layoutTextSizeThisZoom);
+                            justification, spacingIfAllowed, textOffset, WritingMode.horizontal, false, symbolPlacement, layoutTextSize, layoutTextSizeThisZoom);
                         if (shaping) {
                             shapedTextOrientations.horizontal[justification] = shaping;
                             singleLine = shaping.positionedLines.length === 1;
@@ -293,7 +293,7 @@ export function performSymbolLayout(
 
                 // Horizontal point or line label.
                 const shaping = shapeText(text, glyphMap, glyphPositions, imagePositions, fontstack, maxWidth, lineHeight, textAnchor, textJustify, spacingIfAllowed,
-                                          textOffset, WritingMode.horizontal, false, symbolPlacement, layoutTextSize, layoutTextSizeThisZoom);
+                    textOffset, WritingMode.horizontal, false, symbolPlacement, layoutTextSize, layoutTextSizeThisZoom);
                 if (shaping) shapedTextOrientations.horizontal[textJustify] = shaping;
 
                 // Vertical point label (if allowVerticalPlacement is enabled).
@@ -302,7 +302,7 @@ export function performSymbolLayout(
                 // Verticalized line label.
                 if (allowsVerticalWritingMode(unformattedText) && textAlongLine && keepUpright) {
                     shapedTextOrientations.vertical = shapeText(text, glyphMap, glyphPositions, imagePositions, fontstack, maxWidth, lineHeight, textAnchor, textJustify,
-                                                                spacingIfAllowed, textOffset, WritingMode.vertical, false, symbolPlacement, layoutTextSize, layoutTextSizeThisZoom);
+                        spacingIfAllowed, textOffset, WritingMode.vertical, false, symbolPlacement, layoutTextSize, layoutTextSizeThisZoom);
                 }
             }
         }
@@ -346,14 +346,14 @@ export function performSymbolLayout(
 // Choose the justification that matches the direction of the TextAnchor
 export function getAnchorJustification(anchor: TextAnchor): TextJustify {
     switch (anchor) {
-    case 'right':
-    case 'top-right':
-    case 'bottom-right':
-        return 'right';
-    case 'left':
-    case 'top-left':
-    case 'bottom-left':
-        return 'left';
+        case 'right':
+        case 'top-right':
+        case 'bottom-right':
+            return 'right';
+        case 'left':
+        case 'top-left':
+        case 'bottom-left':
+            return 'left';
     }
     return 'center';
 }
@@ -366,15 +366,15 @@ export function getAnchorJustification(anchor: TextAnchor): TextJustify {
  * @private
  */
 function addFeature(bucket: SymbolBucket,
-                    feature: SymbolFeature,
-                    shapedTextOrientations: ShapedTextOrientations,
-                    shapedIcon: PositionedIcon,
-                    imageMap: {[_: string]: StyleImage},
-                    sizes: Sizes,
-                    layoutTextSize: number,
-                    layoutIconSize: number,
-                    textOffset: [number, number],
-                    isSDFIcon: boolean, canonical: CanonicalTileID) {
+    feature: SymbolFeature,
+    shapedTextOrientations: ShapedTextOrientations,
+    shapedIcon: PositionedIcon,
+    imageMap: {[_: string]: StyleImage},
+    sizes: Sizes,
+    layoutTextSize: number,
+    layoutIconSize: number,
+    textOffset: [number, number],
+    isSDFIcon: boolean, canonical: CanonicalTileID) {
     // To reduce the number of labels that jump around when zooming we need
     // to use a text-size value that is the same for all zoom levels.
     // bucket calculates text-size at a high zoom level so that all tiles can
@@ -410,7 +410,7 @@ function addFeature(bucket: SymbolBucket,
         }
         if (defaultHorizontalShaping) {
             shapedIcon = fitIconToText(shapedIcon, defaultHorizontalShaping, iconTextFit,
-                                       layout.get('icon-text-fit-padding'), iconOffset, fontScale);
+                layout.get('icon-text-fit-padding'), iconOffset, fontScale);
         }
     }
 
@@ -491,25 +491,25 @@ const MAX_PACKED_SIZE = MAX_GLYPH_ICON_SIZE * SIZE_PACK_FACTOR;
 export {MAX_PACKED_SIZE};
 
 function addTextVertices(bucket: SymbolBucket,
-                         anchor: Point,
-                         shapedText: Shaping,
-                         imageMap: {[_: string]: StyleImage},
-                         layer: SymbolStyleLayer,
-                         textAlongLine: boolean,
-                         feature: SymbolFeature,
-                         textOffset: [number, number],
-                         lineArray: {
-                           lineStartIndex: number;
-                           lineLength: number;
-                         },
-                         writingMode: WritingMode,
-                         placementTypes: Array<'vertical' | 'center' | 'left' | 'right'>,
-                         placedTextSymbolIndices: {[_: string]: number},
-                         placedIconIndex: number,
-                         sizes: Sizes,
-                         canonical: CanonicalTileID) {
+    anchor: Point,
+    shapedText: Shaping,
+    imageMap: {[_: string]: StyleImage},
+    layer: SymbolStyleLayer,
+    textAlongLine: boolean,
+    feature: SymbolFeature,
+    textOffset: [number, number],
+    lineArray: {
+        lineStartIndex: number;
+        lineLength: number;
+    },
+    writingMode: WritingMode,
+    placementTypes: Array<'vertical' | 'center' | 'left' | 'right'>,
+    placedTextSymbolIndices: {[_: string]: number},
+    placedIconIndex: number,
+    sizes: Sizes,
+    canonical: CanonicalTileID) {
     const glyphQuads = getGlyphQuads(anchor, shapedText, textOffset,
-                            layer, textAlongLine, feature, imageMap, bucket.allowVerticalPlacement);
+        layer, textAlongLine, feature, imageMap, bucket.allowVerticalPlacement);
 
     const sizeData = bucket.textSizeData;
     let textSizeData = null;
@@ -555,7 +555,7 @@ function addTextVertices(bucket: SymbolBucket,
 }
 
 function getDefaultHorizontalShaping(
-  horizontalShaping: Record<TextJustify, Shaping>
+    horizontalShaping: Record<TextJustify, Shaping>
 ): Shaping | null {
     // We don't care which shaping we get because this is used for collision purposes
     // and all the justifications have the same collision box
@@ -571,30 +571,30 @@ function getDefaultHorizontalShaping(
  * @private
  */
 function addSymbol(bucket: SymbolBucket,
-                   anchor: Anchor,
-                   line: Array<Point>,
-                   shapedTextOrientations: ShapedTextOrientations,
-                   shapedIcon: PositionedIcon | void,
-                   imageMap: {[_: string]: StyleImage},
-                   verticallyShapedIcon: PositionedIcon | void,
-                   layer: SymbolStyleLayer,
-                   collisionBoxArray: CollisionBoxArray,
-                   featureIndex: number,
-                   sourceLayerIndex: number,
-                   bucketIndex: number,
-                   textBoxScale: number,
-                   textPadding: number,
-                   textAlongLine: boolean,
-                   textOffset: [number, number],
-                   iconBoxScale: number,
-                   iconPadding: number,
-                   iconAlongLine: boolean,
-                   iconOffset: [number, number],
-                   feature: SymbolFeature,
-                   sizes: Sizes,
-                   isSDFIcon: boolean,
-                   canonical: CanonicalTileID,
-                   layoutTextSize: number) {
+    anchor: Anchor,
+    line: Array<Point>,
+    shapedTextOrientations: ShapedTextOrientations,
+    shapedIcon: PositionedIcon | void,
+    imageMap: {[_: string]: StyleImage},
+    verticallyShapedIcon: PositionedIcon | void,
+    layer: SymbolStyleLayer,
+    collisionBoxArray: CollisionBoxArray,
+    featureIndex: number,
+    sourceLayerIndex: number,
+    bucketIndex: number,
+    textBoxScale: number,
+    textPadding: number,
+    textAlongLine: boolean,
+    textOffset: [number, number],
+    iconBoxScale: number,
+    iconPadding: number,
+    iconAlongLine: boolean,
+    iconOffset: [number, number],
+    feature: SymbolFeature,
+    sizes: Sizes,
+    isSDFIcon: boolean,
+    canonical: CanonicalTileID,
+    layoutTextSize: number) {
     const lineArray = bucket.addToLineVertexArray(anchor, line);
 
     let textCollisionFeature, iconCollisionFeature, verticalTextCollisionFeature, verticalIconCollisionFeature;

--- a/src/symbol/symbol_size.ts
+++ b/src/symbol/symbol_size.ts
@@ -11,29 +11,29 @@ const SIZE_PACK_FACTOR = 128;
 export {getSizeData, evaluateSizeForFeature, evaluateSizeForZoom, SIZE_PACK_FACTOR};
 
 export type SizeData = {
-  kind: 'constant';
-  layoutSize: number;
+    kind: 'constant';
+    layoutSize: number;
 } | {
-  kind: 'source';
+    kind: 'source';
 } | {
-  kind: 'camera';
-  minZoom: number;
-  maxZoom: number;
-  minSize: number;
-  maxSize: number;
-  interpolationType: InterpolationType;
+    kind: 'camera';
+    minZoom: number;
+    maxZoom: number;
+    minSize: number;
+    maxSize: number;
+    interpolationType: InterpolationType;
 } | {
-  kind: 'composite';
-  minZoom: number;
-  maxZoom: number;
-  interpolationType: InterpolationType;
+    kind: 'composite';
+    minZoom: number;
+    maxZoom: number;
+    interpolationType: InterpolationType;
 };
 
 // For {text,icon}-size, get the bucket-level data that will be needed by
 // the painter to set symbol-size-related uniforms
 function getSizeData(
-  tileZoom: number,
-  value: PropertyValue<number, PossiblyEvaluatedPropertyValue<number>>
+    tileZoom: number,
+    value: PropertyValue<number, PossiblyEvaluatedPropertyValue<number>>
 ): SizeData {
     const {expression} = value;
 
@@ -75,20 +75,20 @@ function getSizeData(
 }
 
 function evaluateSizeForFeature(sizeData: SizeData,
-                                {
-                                    uSize,
-                                    uSizeT
-                                }: {
-                                  uSize: number;
-                                  uSizeT: number;
-                                },
-                                {
-                                    lowerSize,
-                                    upperSize
-                                }: {
-                                  lowerSize: number;
-                                  upperSize: number;
-                                }) {
+    {
+        uSize,
+        uSizeT
+    }: {
+        uSize: number;
+        uSizeT: number;
+    },
+    {
+        lowerSize,
+        upperSize
+    }: {
+        lowerSize: number;
+        upperSize: number;
+    }) {
     if (sizeData.kind === 'source') {
         return lowerSize / SIZE_PACK_FACTOR;
     } else if (sizeData.kind === 'composite') {

--- a/src/types/cancelable.ts
+++ b/src/types/cancelable.ts
@@ -1,3 +1,3 @@
 export type Cancelable = {
-  cancel: () => void;
+    cancel: () => void;
 };

--- a/src/types/tilejson.ts
+++ b/src/types/tilejson.ts
@@ -1,15 +1,15 @@
 export type TileJSON = {
-  tilejson: '2.2.0' | '2.1.0' | '2.0.1' | '2.0.0' | '1.0.0';
-  name?: string;
-  description?: string;
-  version?: string;
-  attribution?: string;
-  template?: string;
-  tiles: Array<string>;
-  grids?: Array<string>;
-  data?: Array<string>;
-  minzoom?: number;
-  maxzoom?: number;
-  bounds?: [number, number, number, number];
-  center?: [number, number, number];
+    tilejson: '2.2.0' | '2.1.0' | '2.0.1' | '2.0.0' | '1.0.0';
+    name?: string;
+    description?: string;
+    version?: string;
+    attribution?: string;
+    template?: string;
+    tiles: Array<string>;
+    grids?: Array<string>;
+    data?: Array<string>;
+    minzoom?: number;
+    maxzoom?: number;
+    bounds?: [number, number, number, number];
+    center?: [number, number, number];
 };

--- a/src/ui/anchor.ts
+++ b/src/ui/anchor.ts
@@ -1,7 +1,7 @@
 export type PositionAnchor = 'center' | 'top' | 'bottom' | 'left' | 'right' | 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right';
 
 export const anchorTranslate: {
-  [_ in PositionAnchor]: string;
+    [_ in PositionAnchor]: string;
 } = {
     'center': 'translate(-50%,-50%)',
     'top': 'translate(-50%,0)',

--- a/src/ui/camera.test.ts
+++ b/src/ui/camera.test.ts
@@ -747,8 +747,8 @@ describe('#easeTo', () => {
             });
 
         camera.easeTo(
-                {center: [100, 0], zoom: 3.2, bearing: 90, duration: 0, pitch: 45},
-                eventData);
+            {center: [100, 0], zoom: 3.2, bearing: 90, duration: 0, pitch: 45},
+            eventData);
         done();
     });
 
@@ -1091,8 +1091,8 @@ describe('#flyTo', () => {
             });
 
         camera.flyTo(
-                {center: [100, 0], zoom: 3.2, bearing: 90, duration: 0, pitch: 45, animate: false},
-                eventData);
+            {center: [100, 0], zoom: 3.2, bearing: 90, duration: 0, pitch: 45, animate: false},
+            eventData);
         done();
     });
 

--- a/src/ui/camera.ts
+++ b/src/ui/camera.ts
@@ -58,8 +58,8 @@ export type RequireAtLeastOne<T> = { [K in keyof T]-?: Required<Pick<T, K>> & Pa
  * @see [Display buildings in 3D](https://maplibre.org/maplibre-gl-js-docs/example/3d-buildings/)
  */
 export type CameraOptions = CenterZoomBearing & {
-  pitch?: number;
-  around?: LngLatLike;
+    pitch?: number;
+    around?: LngLatLike;
 };
 
 export type CenterZoomBearing = {
@@ -115,11 +115,11 @@ export type FitBoundsOptions = FlyToOptions & {
  *   [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion).
  */
 export type AnimationOptions = {
-  duration?: number;
-  easing?: (_: number) => number;
-  offset?: PointLike;
-  animate?: boolean;
-  essential?: boolean;
+    duration?: number;
+    easing?: (_: number) => number;
+    offset?: PointLike;
+    animate?: boolean;
+    essential?: boolean;
 };
 
 abstract class Camera extends Evented {
@@ -133,8 +133,8 @@ abstract class Camera extends Evented {
     _bearingSnap: number;
     _easeStart: number;
     _easeOptions: {
-      duration?: number;
-      easing?: (_: number) => number;
+        duration?: number;
+        easing?: (_: number) => number;
     };
     _easeId: string | void;
 
@@ -146,7 +146,7 @@ abstract class Camera extends Evented {
     abstract _cancelRenderFrame(_: TaskID): void;
 
     constructor(transform: Transform, options: {
-      bearingSnap: number;
+        bearingSnap: number;
     }) {
         super();
         this._moving = false;
@@ -802,8 +802,8 @@ abstract class Camera extends Evented {
      * @see [Navigate the map with game-like controls](https://maplibre.org/maplibre-gl-js-docs/example/game-controls/)
      */
     easeTo(options: EaseToOptions & {
-      easeId?: string;
-      noMoveStart?: boolean;
+        easeId?: string;
+        noMoveStart?: boolean;
     }, eventData?: any) {
         this._stop(false, options.easeId);
 
@@ -1209,12 +1209,12 @@ abstract class Camera extends Evented {
     }
 
     _ease(frame: (_: number) => void,
-          finish: () => void,
-          options: {
+        finish: () => void,
+        options: {
             animate?: boolean;
             duration?: number;
             easing?: (_: number) => number;
-          }) {
+        }) {
         if (options.animate === false || options.duration === 0) {
             frame(1);
             finish();
@@ -1256,7 +1256,7 @@ abstract class Camera extends Evented {
         const delta = center.lng - tr.center.lng;
         center.lng +=
             delta > 180 ? -360 :
-            delta < -180 ? 360 : 0;
+                delta < -180 ? 360 : 0;
     }
 }
 

--- a/src/ui/control/attribution_control.test.ts
+++ b/src/ui/control/attribution_control.test.ts
@@ -35,7 +35,7 @@ describe('AttributionControl', () => {
         map.addControl(new AttributionControl());
 
         expect(
-        map.getContainer().querySelectorAll('.maplibregl-ctrl-bottom-right .maplibregl-ctrl-attrib')
+            map.getContainer().querySelectorAll('.maplibregl-ctrl-bottom-right .maplibregl-ctrl-attrib')
         ).toHaveLength(1);
     });
 
@@ -43,7 +43,7 @@ describe('AttributionControl', () => {
         map.addControl(new AttributionControl(), 'top-left');
 
         expect(
-        map.getContainer().querySelectorAll('.maplibregl-ctrl-top-left .maplibregl-ctrl-attrib')
+            map.getContainer().querySelectorAll('.maplibregl-ctrl-top-left .maplibregl-ctrl-attrib')
         ).toHaveLength(1);
     });
 
@@ -58,7 +58,7 @@ describe('AttributionControl', () => {
         const container = map.getContainer();
 
         expect(
-        container.querySelectorAll('.maplibregl-ctrl-attrib.maplibregl-compact')
+            container.querySelectorAll('.maplibregl-ctrl-attrib.maplibregl-compact')
         ).toHaveLength(1);
         map.removeControl(attributionControl);
 
@@ -69,7 +69,7 @@ describe('AttributionControl', () => {
 
         map.addControl(attributionControl);
         expect(
-        container.querySelectorAll('.maplibregl-ctrl-attrib:not(.maplibregl-compact)')
+            container.querySelectorAll('.maplibregl-ctrl-attrib:not(.maplibregl-compact)')
         ).toHaveLength(1);
     });
 
@@ -80,14 +80,14 @@ describe('AttributionControl', () => {
         const container = map.getContainer();
 
         expect(
-        container.querySelectorAll('.maplibregl-ctrl-attrib:not(.maplibregl-compact)')
+            container.querySelectorAll('.maplibregl-ctrl-attrib:not(.maplibregl-compact)')
         ).toHaveLength(1);
 
         Object.defineProperty(map.getCanvasContainer(), 'offsetWidth', {value: 600, configurable: true});
         map.resize();
 
         expect(
-        container.querySelectorAll('.maplibregl-ctrl-attrib.maplibregl-compact')
+            container.querySelectorAll('.maplibregl-ctrl-attrib.maplibregl-compact')
         ).toHaveLength(1);
     });
 

--- a/src/ui/control/attribution_control.ts
+++ b/src/ui/control/attribution_control.ts
@@ -5,8 +5,8 @@ import type Map from '../map';
 import type {ControlPosition, IControl} from './control';
 
 type AttributionOptions = {
-  compact?: boolean;
-  customAttribution?: string | Array<string>;
+    compact?: boolean;
+    customAttribution?: string | Array<string>;
 };
 
 /**

--- a/src/ui/control/control.ts
+++ b/src/ui/control/control.ts
@@ -45,7 +45,7 @@ import type Map from '../map';
  * };
  */
 export interface IControl {
-  /**
+    /**
    * Register a control on the map and give it a chance to register event listeners
    * and resources. This method is called by {@link Map#addControl}
    * internally.
@@ -61,7 +61,7 @@ export interface IControl {
    * as necessary.
    */
     onAdd(map: Map): HTMLElement;
-  /**
+    /**
    * Unregister a control on the map and give it a chance to detach event listeners
    * and resources. This method is called by {@link Map#removeControl}
    * internally.
@@ -74,7 +74,7 @@ export interface IControl {
    * @returns {undefined} there is no required return value for this method
    */
     onRemove(map: Map): void;
-  /**
+    /**
    * Optionally provide a default position for this control. If this method
    * is implemented and {@link Map#addControl} is called without the `position`
    * parameter, the value returned by getDefaultPosition will be used as the
@@ -86,5 +86,5 @@ export interface IControl {
    * @name getDefaultPosition
    * @returns {ControlPosition} a control position, one of the values valid in addControl.
    */
-  readonly getDefaultPosition?: () => ControlPosition;
+    readonly getDefaultPosition?: () => ControlPosition;
 }

--- a/src/ui/control/fullscreen_control.ts
+++ b/src/ui/control/fullscreen_control.ts
@@ -6,7 +6,7 @@ import type Map from '../map';
 import type {IControl} from './control';
 
 type FullscreenOptions = {
-  container?: HTMLElement;
+    container?: HTMLElement;
 };
 
 /**

--- a/src/ui/control/geolocate_control.test.ts
+++ b/src/ui/control/geolocate_control.test.ts
@@ -222,7 +222,7 @@ describe('GeolocateControl with no options', () => {
             expect(lngLatAsFixed(map.getCenter(), 4)).toEqual({'lat': '10.0000', 'lng': '20.0000'});
             expect(geolocate._userLocationDotMarker._map).toBeTruthy();
             expect(
-            geolocate._userLocationDotMarker._element.classList.contains('maplibregl-user-location-dot-stale')
+                geolocate._userLocationDotMarker._element.classList.contains('maplibregl-user-location-dot-stale')
             ).toBeFalsy();
             map.once('moveend', () => {
                 expect(lngLatAsFixed(map.getCenter(), 4)).toEqual({'lat': '40.0000', 'lng': '50.0000'});

--- a/src/ui/control/geolocate_control.ts
+++ b/src/ui/control/geolocate_control.ts
@@ -10,11 +10,11 @@ import type {FitBoundsOptions} from '../camera';
 import type {IControl} from './control';
 
 type GeolocateOptions = {
-  positionOptions?: PositionOptions;
-  fitBoundsOptions?: FitBoundsOptions;
-  trackUserLocation?: boolean;
-  showAccuracyCircle?: boolean;
-  showUserLocation?: boolean;
+    positionOptions?: PositionOptions;
+    fitBoundsOptions?: FitBoundsOptions;
+    trackUserLocation?: boolean;
+    showAccuracyCircle?: boolean;
+    showUserLocation?: boolean;
 };
 
 const defaultOptions: GeolocateOptions = {
@@ -173,29 +173,29 @@ class GeolocateControl extends Evented implements IControl {
 
     _setErrorState() {
         switch (this._watchState) {
-        case 'WAITING_ACTIVE':
-            this._watchState = 'ACTIVE_ERROR';
-            this._geolocateButton.classList.remove('maplibregl-ctrl-geolocate-active', 'mapboxgl-ctrl-geolocate-active');
-            this._geolocateButton.classList.add('maplibregl-ctrl-geolocate-active-error', 'mapboxgl-ctrl-geolocate-active-error');
-            break;
-        case 'ACTIVE_LOCK':
-            this._watchState = 'ACTIVE_ERROR';
-            this._geolocateButton.classList.remove('maplibregl-ctrl-geolocate-active', 'mapboxgl-ctrl-geolocate-active');
-            this._geolocateButton.classList.add('maplibregl-ctrl-geolocate-active-error', 'mapboxgl-ctrl-geolocate-active-error');
-            this._geolocateButton.classList.add('maplibregl-ctrl-geolocate-waiting', 'mapboxgl-ctrl-geolocate-waiting');
-            // turn marker grey
-            break;
-        case 'BACKGROUND':
-            this._watchState = 'BACKGROUND_ERROR';
-            this._geolocateButton.classList.remove('maplibregl-ctrl-geolocate-background', 'mapboxgl-ctrl-geolocate-background');
-            this._geolocateButton.classList.add('maplibregl-ctrl-geolocate-background-error', 'mapboxgl-ctrl-geolocate-background-error');
-            this._geolocateButton.classList.add('maplibregl-ctrl-geolocate-waiting', 'mapboxgl-ctrl-geolocate-waiting');
-            // turn marker grey
-            break;
-        case 'ACTIVE_ERROR':
-            break;
-        default:
-            assert(false, `Unexpected watchState ${this._watchState}`);
+            case 'WAITING_ACTIVE':
+                this._watchState = 'ACTIVE_ERROR';
+                this._geolocateButton.classList.remove('maplibregl-ctrl-geolocate-active', 'mapboxgl-ctrl-geolocate-active');
+                this._geolocateButton.classList.add('maplibregl-ctrl-geolocate-active-error', 'mapboxgl-ctrl-geolocate-active-error');
+                break;
+            case 'ACTIVE_LOCK':
+                this._watchState = 'ACTIVE_ERROR';
+                this._geolocateButton.classList.remove('maplibregl-ctrl-geolocate-active', 'mapboxgl-ctrl-geolocate-active');
+                this._geolocateButton.classList.add('maplibregl-ctrl-geolocate-active-error', 'mapboxgl-ctrl-geolocate-active-error');
+                this._geolocateButton.classList.add('maplibregl-ctrl-geolocate-waiting', 'mapboxgl-ctrl-geolocate-waiting');
+                // turn marker grey
+                break;
+            case 'BACKGROUND':
+                this._watchState = 'BACKGROUND_ERROR';
+                this._geolocateButton.classList.remove('maplibregl-ctrl-geolocate-background', 'mapboxgl-ctrl-geolocate-background');
+                this._geolocateButton.classList.add('maplibregl-ctrl-geolocate-background-error', 'mapboxgl-ctrl-geolocate-background-error');
+                this._geolocateButton.classList.add('maplibregl-ctrl-geolocate-waiting', 'mapboxgl-ctrl-geolocate-waiting');
+                // turn marker grey
+                break;
+            case 'ACTIVE_ERROR':
+                break;
+            default:
+                assert(false, `Unexpected watchState ${this._watchState}`);
         }
     }
 
@@ -228,23 +228,23 @@ class GeolocateControl extends Evented implements IControl {
             this._lastKnownPosition = position;
 
             switch (this._watchState) {
-            case 'WAITING_ACTIVE':
-            case 'ACTIVE_LOCK':
-            case 'ACTIVE_ERROR':
-                this._watchState = 'ACTIVE_LOCK';
-                this._geolocateButton.classList.remove('maplibregl-ctrl-geolocate-waiting', 'mapboxgl-ctrl-geolocate-waiting');
-                this._geolocateButton.classList.remove('maplibregl-ctrl-geolocate-active-error', 'mapboxgl-ctrl-geolocate-active-error');
-                this._geolocateButton.classList.add('maplibregl-ctrl-geolocate-active', 'mapboxgl-ctrl-geolocate-active');
-                break;
-            case 'BACKGROUND':
-            case 'BACKGROUND_ERROR':
-                this._watchState = 'BACKGROUND';
-                this._geolocateButton.classList.remove('maplibregl-ctrl-geolocate-waiting', 'mapboxgl-ctrl-geolocate-waiting');
-                this._geolocateButton.classList.remove('maplibregl-ctrl-geolocate-background-error', 'mapboxgl-ctrl-geolocate-background-error');
-                this._geolocateButton.classList.add('maplibregl-ctrl-geolocate-background', 'mapboxgl-ctrl-geolocate-background');
-                break;
-            default:
-                assert(false, `Unexpected watchState ${this._watchState}`);
+                case 'WAITING_ACTIVE':
+                case 'ACTIVE_LOCK':
+                case 'ACTIVE_ERROR':
+                    this._watchState = 'ACTIVE_LOCK';
+                    this._geolocateButton.classList.remove('maplibregl-ctrl-geolocate-waiting', 'mapboxgl-ctrl-geolocate-waiting');
+                    this._geolocateButton.classList.remove('maplibregl-ctrl-geolocate-active-error', 'mapboxgl-ctrl-geolocate-active-error');
+                    this._geolocateButton.classList.add('maplibregl-ctrl-geolocate-active', 'mapboxgl-ctrl-geolocate-active');
+                    break;
+                case 'BACKGROUND':
+                case 'BACKGROUND_ERROR':
+                    this._watchState = 'BACKGROUND';
+                    this._geolocateButton.classList.remove('maplibregl-ctrl-geolocate-waiting', 'mapboxgl-ctrl-geolocate-waiting');
+                    this._geolocateButton.classList.remove('maplibregl-ctrl-geolocate-background-error', 'mapboxgl-ctrl-geolocate-background-error');
+                    this._geolocateButton.classList.add('maplibregl-ctrl-geolocate-background', 'mapboxgl-ctrl-geolocate-background');
+                    break;
+                default:
+                    assert(false, `Unexpected watchState ${this._watchState}`);
             }
         }
 
@@ -454,53 +454,53 @@ class GeolocateControl extends Evented implements IControl {
         if (this.options.trackUserLocation) {
             // update watchState and do any outgoing state cleanup
             switch (this._watchState) {
-            case 'OFF':
+                case 'OFF':
                 // turn on the Geolocate Control
-                this._watchState = 'WAITING_ACTIVE';
+                    this._watchState = 'WAITING_ACTIVE';
 
-                this.fire(new Event('trackuserlocationstart'));
-                break;
-            case 'WAITING_ACTIVE':
-            case 'ACTIVE_LOCK':
-            case 'ACTIVE_ERROR':
-            case 'BACKGROUND_ERROR':
+                    this.fire(new Event('trackuserlocationstart'));
+                    break;
+                case 'WAITING_ACTIVE':
+                case 'ACTIVE_LOCK':
+                case 'ACTIVE_ERROR':
+                case 'BACKGROUND_ERROR':
                 // turn off the Geolocate Control
-                numberOfWatches--;
-                noTimeout = false;
-                this._watchState = 'OFF';
-                this._geolocateButton.classList.remove('maplibregl-ctrl-geolocate-waiting', 'mapboxgl-ctrl-geolocate-waiting');
-                this._geolocateButton.classList.remove('maplibregl-ctrl-geolocate-active', 'mapboxgl-ctrl-geolocate-active');
-                this._geolocateButton.classList.remove('maplibregl-ctrl-geolocate-active-error', 'mapboxgl-ctrl-geolocate-active-error');
-                this._geolocateButton.classList.remove('maplibregl-ctrl-geolocate-background', 'mapboxgl-ctrl-geolocate-background');
-                this._geolocateButton.classList.remove('maplibregl-ctrl-geolocate-background-error', 'mapboxgl-ctrl-geolocate-background-error');
+                    numberOfWatches--;
+                    noTimeout = false;
+                    this._watchState = 'OFF';
+                    this._geolocateButton.classList.remove('maplibregl-ctrl-geolocate-waiting', 'mapboxgl-ctrl-geolocate-waiting');
+                    this._geolocateButton.classList.remove('maplibregl-ctrl-geolocate-active', 'mapboxgl-ctrl-geolocate-active');
+                    this._geolocateButton.classList.remove('maplibregl-ctrl-geolocate-active-error', 'mapboxgl-ctrl-geolocate-active-error');
+                    this._geolocateButton.classList.remove('maplibregl-ctrl-geolocate-background', 'mapboxgl-ctrl-geolocate-background');
+                    this._geolocateButton.classList.remove('maplibregl-ctrl-geolocate-background-error', 'mapboxgl-ctrl-geolocate-background-error');
 
-                this.fire(new Event('trackuserlocationend'));
-                break;
-            case 'BACKGROUND':
-                this._watchState = 'ACTIVE_LOCK';
-                this._geolocateButton.classList.remove('maplibregl-ctrl-geolocate-background', 'mapboxgl-ctrl-geolocate-background');
-                // set camera to last known location
-                if (this._lastKnownPosition) this._updateCamera(this._lastKnownPosition);
+                    this.fire(new Event('trackuserlocationend'));
+                    break;
+                case 'BACKGROUND':
+                    this._watchState = 'ACTIVE_LOCK';
+                    this._geolocateButton.classList.remove('maplibregl-ctrl-geolocate-background', 'mapboxgl-ctrl-geolocate-background');
+                    // set camera to last known location
+                    if (this._lastKnownPosition) this._updateCamera(this._lastKnownPosition);
 
-                this.fire(new Event('trackuserlocationstart'));
-                break;
-            default:
-                assert(false, `Unexpected watchState ${this._watchState}`);
+                    this.fire(new Event('trackuserlocationstart'));
+                    break;
+                default:
+                    assert(false, `Unexpected watchState ${this._watchState}`);
             }
 
             // incoming state setup
             switch (this._watchState) {
-            case 'WAITING_ACTIVE':
-                this._geolocateButton.classList.add('maplibregl-ctrl-geolocate-waiting', 'mapboxgl-ctrl-geolocate-waiting');
-                this._geolocateButton.classList.add('maplibregl-ctrl-geolocate-active', 'mapboxgl-ctrl-geolocate-active');
-                break;
-            case 'ACTIVE_LOCK':
-                this._geolocateButton.classList.add('maplibregl-ctrl-geolocate-active', 'mapboxgl-ctrl-geolocate-active');
-                break;
-            case 'OFF':
-                break;
-            default:
-                assert(false, `Unexpected watchState ${this._watchState}`);
+                case 'WAITING_ACTIVE':
+                    this._geolocateButton.classList.add('maplibregl-ctrl-geolocate-waiting', 'mapboxgl-ctrl-geolocate-waiting');
+                    this._geolocateButton.classList.add('maplibregl-ctrl-geolocate-active', 'mapboxgl-ctrl-geolocate-active');
+                    break;
+                case 'ACTIVE_LOCK':
+                    this._geolocateButton.classList.add('maplibregl-ctrl-geolocate-active', 'mapboxgl-ctrl-geolocate-active');
+                    break;
+                case 'OFF':
+                    break;
+                default:
+                    assert(false, `Unexpected watchState ${this._watchState}`);
             }
 
             // manage geolocation.watchPosition / geolocation.clearWatch

--- a/src/ui/control/logo_control.test.ts
+++ b/src/ui/control/logo_control.test.ts
@@ -56,7 +56,7 @@ describe('LogoControl', () => {
         const map = createMap(undefined, undefined);
         map.on('load', () => {
             expect(map.getContainer().querySelectorAll(
-            '.maplibregl-ctrl-bottom-left .maplibregl-ctrl-logo'
+                '.maplibregl-ctrl-bottom-left .maplibregl-ctrl-logo'
             )).toHaveLength(1);
             done();
         });
@@ -66,7 +66,7 @@ describe('LogoControl', () => {
         const map = createMap('top-left', undefined);
         map.on('load', () => {
             expect(map.getContainer().querySelectorAll(
-            '.maplibregl-ctrl-top-left .maplibregl-ctrl-logo'
+                '.maplibregl-ctrl-top-left .maplibregl-ctrl-logo'
             )).toHaveLength(1);
             done();
         });
@@ -112,13 +112,13 @@ describe('LogoControl', () => {
         Object.defineProperty(map.getCanvasContainer(), 'offsetWidth', {value: 255, configurable: true});
         map.resize();
         expect(
-        container.querySelectorAll('.maplibregl-ctrl-logo:not(.maplibregl-compact)')
+            container.querySelectorAll('.maplibregl-ctrl-logo:not(.maplibregl-compact)')
         ).toHaveLength(1);
 
         Object.defineProperty(map.getCanvasContainer(), 'offsetWidth', {value: 245, configurable: true});
         map.resize();
         expect(
-        container.querySelectorAll('.maplibregl-ctrl-logo.maplibregl-compact')
+            container.querySelectorAll('.maplibregl-ctrl-logo.maplibregl-compact')
         ).toHaveLength(1);
     });
 

--- a/src/ui/control/navigation_control.ts
+++ b/src/ui/control/navigation_control.ts
@@ -8,9 +8,9 @@ import type Map from '../map';
 import type {IControl} from './control';
 
 type NavigationOptions = {
-  showCompass?: boolean;
-  showZoom?: boolean;
-  visualizePitch?: boolean;
+    showCompass?: boolean;
+    showZoom?: boolean;
+    visualizePitch?: boolean;
 };
 
 const defaultOptions: NavigationOptions = {

--- a/src/ui/control/scale_control.test.ts
+++ b/src/ui/control/scale_control.test.ts
@@ -12,7 +12,7 @@ describe('ScaleControl', () => {
         map.addControl(new ScaleControl(undefined));
 
         expect(
-        map.getContainer().querySelectorAll('.maplibregl-ctrl-bottom-left .maplibregl-ctrl-scale')
+            map.getContainer().querySelectorAll('.maplibregl-ctrl-bottom-left .maplibregl-ctrl-scale')
         ).toHaveLength(1);
     });
 
@@ -21,7 +21,7 @@ describe('ScaleControl', () => {
         map.addControl(new ScaleControl(undefined), 'top-left');
 
         expect(
-        map.getContainer().querySelectorAll('.maplibregl-ctrl-top-left .maplibregl-ctrl-scale')
+            map.getContainer().querySelectorAll('.maplibregl-ctrl-top-left .maplibregl-ctrl-scale')
         ).toHaveLength(1);
     });
 

--- a/src/ui/control/scale_control.ts
+++ b/src/ui/control/scale_control.ts
@@ -7,8 +7,8 @@ import type {ControlPosition, IControl} from './control';
 export type Unit = 'imperial' | 'metric' | 'nautical';
 
 type ScaleOptions = {
-  maxWidth?: number;
-  unit?: Unit;
+    maxWidth?: number;
+    unit?: Unit;
 };
 
 const defaultOptions: ScaleOptions = {
@@ -133,9 +133,9 @@ function getRoundNum(num) {
 
     d = d >= 10 ? 10 :
         d >= 5 ? 5 :
-        d >= 3 ? 3 :
-        d >= 2 ? 2 :
-        d >= 1 ? 1 : getDecimalRoundNum(d);
+            d >= 3 ? 3 :
+                d >= 2 ? 2 :
+                    d >= 1 ? 1 : getDecimalRoundNum(d);
 
     return pow10 * d;
 }

--- a/src/ui/events.ts
+++ b/src/ui/events.ts
@@ -15,40 +15,40 @@ export type MapLayerTouchEvent = MapTouchEvent & { features?: GeoJSON.Feature[] 
 export type MapSourceDataType = 'content' | 'metadata';
 
 export type MapLayerEventType = {
-     click: MapLayerMouseEvent;
-     dblclick: MapLayerMouseEvent;
-     mousedown: MapLayerMouseEvent;
-     mouseup: MapLayerMouseEvent;
-     mousemove: MapLayerMouseEvent;
-     mouseenter: MapLayerMouseEvent;
-     mouseleave: MapLayerMouseEvent;
-     mouseover: MapLayerMouseEvent;
-     mouseout: MapLayerMouseEvent;
-     contextmenu: MapLayerMouseEvent;
+    click: MapLayerMouseEvent;
+    dblclick: MapLayerMouseEvent;
+    mousedown: MapLayerMouseEvent;
+    mouseup: MapLayerMouseEvent;
+    mousemove: MapLayerMouseEvent;
+    mouseenter: MapLayerMouseEvent;
+    mouseleave: MapLayerMouseEvent;
+    mouseover: MapLayerMouseEvent;
+    mouseout: MapLayerMouseEvent;
+    contextmenu: MapLayerMouseEvent;
 
-     touchstart: MapLayerTouchEvent;
-     touchend: MapLayerTouchEvent;
-     touchcancel: MapLayerTouchEvent;
- };
+    touchstart: MapLayerTouchEvent;
+    touchend: MapLayerTouchEvent;
+    touchcancel: MapLayerTouchEvent;
+};
 
 export interface MapLibreEvent<TOrig = undefined> {
-     type: string;
-     target: Map;
-     originalEvent: TOrig;
- }
+    type: string;
+    target: Map;
+    originalEvent: TOrig;
+}
 
 export interface MapStyleDataEvent extends MapLibreEvent {
-     dataType: 'style';
- }
+    dataType: 'style';
+}
 
 export interface MapSourceDataEvent extends MapLibreEvent {
-     dataType: 'source';
-     isSourceLoaded: boolean;
-     source: SourceSpecification;
-     sourceId: string;
-     sourceDataType: MapSourceDataType;
-     tile: any;
- }
+    dataType: 'source';
+    isSourceLoaded: boolean;
+    source: SourceSpecification;
+    sourceId: string;
+    sourceDataType: MapSourceDataType;
+    tile: any;
+}
 /**
  * `MapMouseEvent` is the event type for mouse-related map events.
  * @extends {Event}
@@ -272,9 +272,9 @@ export class MapWheelEvent extends Event {
  * @property {Map} target The `Map` instance that triggerred the event
  */
 export type MapLibreZoomEvent = {
-  type: 'boxzoomstart' | 'boxzoomend' | 'boxzoomcancel';
-  target: Map;
-  originalEvent: MouseEvent;
+    type: 'boxzoomstart' | 'boxzoomend' | 'boxzoomcancel';
+    target: Map;
+    originalEvent: MouseEvent;
 };
 
 /**
@@ -306,86 +306,86 @@ export type MapLibreZoomEvent = {
  * });
  */
 export type MapDataEvent = {
-  type: string;
-  dataType: string;
-  sourceDataType: MapSourceDataType;
+    type: string;
+    dataType: string;
+    sourceDataType: MapSourceDataType;
 };
 
 export type MapContextEvent = {
-  type: 'webglcontextlost' | 'webglcontextrestored';
-  originalEvent: WebGLContextEvent;
+    type: 'webglcontextlost' | 'webglcontextrestored';
+    originalEvent: WebGLContextEvent;
 };
 
 export interface MapStyleImageMissingEvent extends MapLibreEvent {
-     type: 'styleimagemissing';
-     id: string;
+    type: 'styleimagemissing';
+    id: string;
 }
 
 /**
 * MapEventType - a mapping between the event name and the event value
 */
 export type MapEventType = {
-     error: ErrorEvent;
+    error: ErrorEvent;
 
-     load: MapLibreEvent;
-     idle: MapLibreEvent;
-     remove: MapLibreEvent;
-     render: MapLibreEvent;
-     resize: MapLibreEvent;
+    load: MapLibreEvent;
+    idle: MapLibreEvent;
+    remove: MapLibreEvent;
+    render: MapLibreEvent;
+    resize: MapLibreEvent;
 
-     webglcontextlost: MapContextEvent;
-     webglcontextrestored: MapContextEvent;
+    webglcontextlost: MapContextEvent;
+    webglcontextrestored: MapContextEvent;
 
-     dataloading: MapDataEvent;
-     data: MapDataEvent;
-     tiledataloading: MapDataEvent;
-     sourcedataloading: MapSourceDataEvent;
-     styledataloading: MapStyleDataEvent;
-     sourcedata: MapSourceDataEvent;
-     styledata: MapStyleDataEvent;
-     styleimagemissing: MapStyleImageMissingEvent;
-     dataabort: MapDataEvent;
-     sourcedataabort: MapSourceDataEvent;
+    dataloading: MapDataEvent;
+    data: MapDataEvent;
+    tiledataloading: MapDataEvent;
+    sourcedataloading: MapSourceDataEvent;
+    styledataloading: MapStyleDataEvent;
+    sourcedata: MapSourceDataEvent;
+    styledata: MapStyleDataEvent;
+    styleimagemissing: MapStyleImageMissingEvent;
+    dataabort: MapDataEvent;
+    sourcedataabort: MapSourceDataEvent;
 
-     boxzoomcancel: MapLibreZoomEvent;
-     boxzoomstart: MapLibreZoomEvent;
-     boxzoomend: MapLibreZoomEvent;
+    boxzoomcancel: MapLibreZoomEvent;
+    boxzoomstart: MapLibreZoomEvent;
+    boxzoomend: MapLibreZoomEvent;
 
-     touchcancel: MapTouchEvent;
-     touchmove: MapTouchEvent;
-     touchend: MapTouchEvent;
-     touchstart: MapTouchEvent;
+    touchcancel: MapTouchEvent;
+    touchmove: MapTouchEvent;
+    touchend: MapTouchEvent;
+    touchstart: MapTouchEvent;
 
-     click: MapMouseEvent;
-     contextmenu: MapMouseEvent;
-     dblclick: MapMouseEvent;
-     mousemove: MapMouseEvent;
-     mouseup: MapMouseEvent;
-     mousedown: MapMouseEvent;
-     mouseout: MapMouseEvent;
-     mouseover: MapMouseEvent;
+    click: MapMouseEvent;
+    contextmenu: MapMouseEvent;
+    dblclick: MapMouseEvent;
+    mousemove: MapMouseEvent;
+    mouseup: MapMouseEvent;
+    mousedown: MapMouseEvent;
+    mouseout: MapMouseEvent;
+    mouseover: MapMouseEvent;
 
-     movestart: MapLibreEvent<MouseEvent | TouchEvent | WheelEvent | undefined>;
-     move: MapLibreEvent<MouseEvent | TouchEvent | WheelEvent | undefined>;
-     moveend: MapLibreEvent<MouseEvent | TouchEvent | WheelEvent | undefined>;
+    movestart: MapLibreEvent<MouseEvent | TouchEvent | WheelEvent | undefined>;
+    move: MapLibreEvent<MouseEvent | TouchEvent | WheelEvent | undefined>;
+    moveend: MapLibreEvent<MouseEvent | TouchEvent | WheelEvent | undefined>;
 
-     zoomstart: MapLibreEvent<MouseEvent | TouchEvent | WheelEvent | undefined>;
-     zoom: MapLibreEvent<MouseEvent | TouchEvent | WheelEvent | undefined>;
-     zoomend: MapLibreEvent<MouseEvent | TouchEvent | WheelEvent | undefined>;
+    zoomstart: MapLibreEvent<MouseEvent | TouchEvent | WheelEvent | undefined>;
+    zoom: MapLibreEvent<MouseEvent | TouchEvent | WheelEvent | undefined>;
+    zoomend: MapLibreEvent<MouseEvent | TouchEvent | WheelEvent | undefined>;
 
-     rotatestart: MapLibreEvent<MouseEvent | TouchEvent | undefined>;
-     rotate: MapLibreEvent<MouseEvent | TouchEvent | undefined>;
-     rotateend: MapLibreEvent<MouseEvent | TouchEvent | undefined>;
+    rotatestart: MapLibreEvent<MouseEvent | TouchEvent | undefined>;
+    rotate: MapLibreEvent<MouseEvent | TouchEvent | undefined>;
+    rotateend: MapLibreEvent<MouseEvent | TouchEvent | undefined>;
 
-     dragstart: MapLibreEvent<MouseEvent | TouchEvent | undefined>;
-     drag: MapLibreEvent<MouseEvent | TouchEvent | undefined>;
-     dragend: MapLibreEvent<MouseEvent | TouchEvent | undefined>;
+    dragstart: MapLibreEvent<MouseEvent | TouchEvent | undefined>;
+    drag: MapLibreEvent<MouseEvent | TouchEvent | undefined>;
+    dragend: MapLibreEvent<MouseEvent | TouchEvent | undefined>;
 
-     pitchstart: MapLibreEvent<MouseEvent | TouchEvent | undefined>;
-     pitch: MapLibreEvent<MouseEvent | TouchEvent | undefined>;
-     pitchend: MapLibreEvent<MouseEvent | TouchEvent | undefined>;
+    pitchstart: MapLibreEvent<MouseEvent | TouchEvent | undefined>;
+    pitch: MapLibreEvent<MouseEvent | TouchEvent | undefined>;
+    pitchend: MapLibreEvent<MouseEvent | TouchEvent | undefined>;
 
-     wheel: MapWheelEvent;
+    wheel: MapWheelEvent;
 };
 
 export type MapEvent = /**

--- a/src/ui/handler/box_zoom.ts
+++ b/src/ui/handler/box_zoom.ts
@@ -24,7 +24,7 @@ class BoxZoomHandler {
      * @private
      */
     constructor(map: Map, options: {
-      clickTolerance: number;
+        clickTolerance: number;
     }) {
         this._map = map;
         this._el = map.getCanvasContainer();

--- a/src/ui/handler/keyboard.ts
+++ b/src/ui/handler/keyboard.ts
@@ -53,57 +53,57 @@ class KeyboardHandler {
         let yDir = 0;
 
         switch (e.keyCode) {
-        case 61:
-        case 107:
-        case 171:
-        case 187:
-            zoomDir = 1;
-            break;
+            case 61:
+            case 107:
+            case 171:
+            case 187:
+                zoomDir = 1;
+                break;
 
-        case 189:
-        case 109:
-        case 173:
-            zoomDir = -1;
-            break;
+            case 189:
+            case 109:
+            case 173:
+                zoomDir = -1;
+                break;
 
-        case 37:
-            if (e.shiftKey) {
-                bearingDir = -1;
-            } else {
-                e.preventDefault();
-                xDir = -1;
-            }
-            break;
+            case 37:
+                if (e.shiftKey) {
+                    bearingDir = -1;
+                } else {
+                    e.preventDefault();
+                    xDir = -1;
+                }
+                break;
 
-        case 39:
-            if (e.shiftKey) {
-                bearingDir = 1;
-            } else {
-                e.preventDefault();
-                xDir = 1;
-            }
-            break;
+            case 39:
+                if (e.shiftKey) {
+                    bearingDir = 1;
+                } else {
+                    e.preventDefault();
+                    xDir = 1;
+                }
+                break;
 
-        case 38:
-            if (e.shiftKey) {
-                pitchDir = 1;
-            } else {
-                e.preventDefault();
-                yDir = -1;
-            }
-            break;
+            case 38:
+                if (e.shiftKey) {
+                    pitchDir = 1;
+                } else {
+                    e.preventDefault();
+                    yDir = -1;
+                }
+                break;
 
-        case 40:
-            if (e.shiftKey) {
-                pitchDir = -1;
-            } else {
-                e.preventDefault();
-                yDir = 1;
-            }
-            break;
+            case 40:
+                if (e.shiftKey) {
+                    pitchDir = -1;
+                } else {
+                    e.preventDefault();
+                    yDir = 1;
+                }
+                break;
 
-        default:
-            return;
+            default:
+                return;
         }
 
         if (this._rotationDisabled) {

--- a/src/ui/handler/map_event.ts
+++ b/src/ui/handler/map_event.ts
@@ -10,7 +10,7 @@ export class MapEventHandler implements Handler {
     _map: Map;
 
     constructor(map: Map, options: {
-      clickTolerance: number;
+        clickTolerance: number;
     }) {
         this._map = map;
         this._clickTolerance = options.clickTolerance;

--- a/src/ui/handler/mouse.ts
+++ b/src/ui/handler/mouse.ts
@@ -25,7 +25,7 @@ class MouseHandler {
     _clickTolerance: number;
 
     constructor(options: {
-      clickTolerance: number;
+        clickTolerance: number;
     }) {
         this.reset();
         this._clickTolerance = options.clickTolerance || 1;

--- a/src/ui/handler/scroll_zoom.ts
+++ b/src/ui/handler/scroll_zoom.ts
@@ -47,9 +47,9 @@ class ScrollZoomHandler {
     _delta: number;
     _easing: ((a: number) => number);
     _prevEase: {
-      start: number;
-      duration: number;
-      easing: (_: number) => number;
+        start: number;
+        duration: number;
+        easing: (_: number) => number;
     };
 
     _frameId: boolean;

--- a/src/ui/handler/shim/drag_pan.ts
+++ b/src/ui/handler/shim/drag_pan.ts
@@ -2,10 +2,10 @@ import type {MousePanHandler} from '../mouse';
 import type TouchPanHandler from './../touch_pan';
 
 export type DragPanOptions = {
-  linearity?: number;
-  easing?: (t: number) => number;
-  deceleration?: number;
-  maxSpeed?: number;
+    linearity?: number;
+    easing?: (t: number) => number;
+    deceleration?: number;
+    maxSpeed?: number;
 };
 
 /**

--- a/src/ui/handler/shim/drag_rotate.ts
+++ b/src/ui/handler/shim/drag_rotate.ts
@@ -18,7 +18,7 @@ export default class DragRotateHandler {
      * @private
      */
     constructor(options: {
-      pitchWithRotate: boolean;
+        pitchWithRotate: boolean;
     }, mouseRotate: MouseRotateHandler, mousePitch: MousePitchHandler) {
         this._pitchWithRotate = options.pitchWithRotate;
         this._mouseRotate = mouseRotate;

--- a/src/ui/handler/shim/touch_zoom_rotate.ts
+++ b/src/ui/handler/shim/touch_zoom_rotate.ts
@@ -41,7 +41,7 @@ export default class TouchZoomRotateHandler {
      *   map.touchZoomRotate.enable({ around: 'center' });
      */
     enable(options?: {
-      around?: 'center';
+        around?: 'center';
     } | null) {
         this._touchZoom.enable(options);
         if (!this._rotationDisabled) this._touchRotate.enable(options);

--- a/src/ui/handler/tap_recognizer.ts
+++ b/src/ui/handler/tap_recognizer.ts
@@ -20,11 +20,11 @@ export class SingleTapRecognizer {
     startTime: number;
     aborted: boolean;
     touches: {
-      [k in number | string]: Point;
+        [k in number | string]: Point;
     };
 
     constructor(options: {
-      numTouches: number;
+        numTouches: number;
     }) {
         this.reset();
         this.numTouches = options.numTouches;
@@ -92,8 +92,8 @@ export class TapRecognizer {
     count: number;
 
     constructor(options: {
-      numTaps: number;
-      numTouches: number;
+        numTaps: number;
+        numTouches: number;
     }) {
         this.singleTap = new SingleTapRecognizer(options);
         this.numTaps = options.numTaps;

--- a/src/ui/handler/touch_pan.ts
+++ b/src/ui/handler/touch_pan.ts
@@ -6,14 +6,14 @@ export default class TouchPanHandler {
     _enabled: boolean;
     _active: boolean;
     _touches: {
-      [k in string | number]: Point;
+        [k in string | number]: Point;
     };
     _minTouches: number;
     _clickTolerance: number;
     _sum: Point;
 
     constructor(options: {
-      clickTolerance: number;
+        clickTolerance: number;
     }) {
         this._minTouches = 1;
         this._clickTolerance = options.clickTolerance || 1;

--- a/src/ui/handler/touch_zoom_rotate.ts
+++ b/src/ui/handler/touch_zoom_rotate.ts
@@ -70,7 +70,7 @@ class TwoTouchHandler {
     }
 
     enable(options?: {
-      around?: 'center';
+        around?: 'center';
     } | null) {
         this._enabled = true;
         this._aroundCenter = !!options && options.around === 'center';

--- a/src/ui/handler_inertia.ts
+++ b/src/ui/handler_inertia.ts
@@ -30,10 +30,10 @@ const defaultPitchInertiaOptions = extend({
 }, defaultInertiaOptions);
 
 export type InertiaOptions = {
-  linearity: number;
-  easing: (t: number) => number;
-  deceleration: number;
-  maxSpeed: number;
+    linearity: number;
+    easing: (t: number) => number;
+    deceleration: number;
+    maxSpeed: number;
 };
 
 export type InputEvent = MouseEvent | TouchEvent | KeyboardEvent | WheelEvent;
@@ -41,8 +41,8 @@ export type InputEvent = MouseEvent | TouchEvent | KeyboardEvent | WheelEvent;
 export default class HandlerInertia {
     _map: Map;
     _inertiaBuffer: Array<{
-      time: number;
-      settings: any;
+        time: number;
+        settings: any;
     }>;
 
     constructor(map: Map) {

--- a/src/ui/handler_manager.ts
+++ b/src/ui/handler_manager.ts
@@ -36,49 +36,49 @@ class RenderFrameEvent extends Event {
 // For example, if there is a mousedown and mousemove, the mousePan handler
 // would return a `panDelta` on the mousemove.
 export interface Handler {
-  enable(): void;
-  disable(): void;
-  isEnabled(): boolean;
-  isActive(): boolean;
-  // `reset` can be called by the manager at any time and must reset everything to it's original state
-  reset(): void;
-  // Handlers can optionally implement these methods.
-  // They are called with dom events whenever those dom evens are received.
-  readonly touchstart?: (e: TouchEvent, points: Array<Point>, mapTouches: Array<Touch>) => HandlerResult | void;
-  readonly touchmove?: (e: TouchEvent, points: Array<Point>, mapTouches: Array<Touch>) => HandlerResult | void;
-  readonly touchend?: (e: TouchEvent, points: Array<Point>, mapTouches: Array<Touch>) => HandlerResult | void;
-  readonly touchcancel?: (e: TouchEvent, points: Array<Point>, mapTouches: Array<Touch>) => HandlerResult | void;
-  readonly mousedown?: (e: MouseEvent, point: Point) => HandlerResult | void;
-  readonly mousemove?: (e: MouseEvent, point: Point) => HandlerResult | void;
-  readonly mouseup?: (e: MouseEvent, point: Point) => HandlerResult | void;
-  readonly dblclick?: (e: MouseEvent, point: Point) => HandlerResult | void;
-  readonly wheel?: (e: WheelEvent, point: Point) => HandlerResult | void;
-  readonly keydown?: (e: KeyboardEvent) => HandlerResult | void;
-  readonly keyup?: (e: KeyboardEvent) => HandlerResult | void;
-  // `renderFrame` is the only non-dom event. It is called during render
-  // frames and can be used to smooth camera changes (see scroll handler).
-  readonly renderFrame?: () => HandlerResult | void;
+    enable(): void;
+    disable(): void;
+    isEnabled(): boolean;
+    isActive(): boolean;
+    // `reset` can be called by the manager at any time and must reset everything to it's original state
+    reset(): void;
+    // Handlers can optionally implement these methods.
+    // They are called with dom events whenever those dom evens are received.
+    readonly touchstart?: (e: TouchEvent, points: Array<Point>, mapTouches: Array<Touch>) => HandlerResult | void;
+    readonly touchmove?: (e: TouchEvent, points: Array<Point>, mapTouches: Array<Touch>) => HandlerResult | void;
+    readonly touchend?: (e: TouchEvent, points: Array<Point>, mapTouches: Array<Touch>) => HandlerResult | void;
+    readonly touchcancel?: (e: TouchEvent, points: Array<Point>, mapTouches: Array<Touch>) => HandlerResult | void;
+    readonly mousedown?: (e: MouseEvent, point: Point) => HandlerResult | void;
+    readonly mousemove?: (e: MouseEvent, point: Point) => HandlerResult | void;
+    readonly mouseup?: (e: MouseEvent, point: Point) => HandlerResult | void;
+    readonly dblclick?: (e: MouseEvent, point: Point) => HandlerResult | void;
+    readonly wheel?: (e: WheelEvent, point: Point) => HandlerResult | void;
+    readonly keydown?: (e: KeyboardEvent) => HandlerResult | void;
+    readonly keyup?: (e: KeyboardEvent) => HandlerResult | void;
+    // `renderFrame` is the only non-dom event. It is called during render
+    // frames and can be used to smooth camera changes (see scroll handler).
+    readonly renderFrame?: () => HandlerResult | void;
 }
 
 // All handler methods that are called with events can optionally return a `HandlerResult`.
 export type HandlerResult = {
-  panDelta?: Point;
-  zoomDelta?: number;
-  bearingDelta?: number;
-  pitchDelta?: number;
-  // the point to not move when changing the camera
-  around?: Point | null;
-  // same as above, except for pinch actions, which are given higher priority
-  pinchAround?: Point | null;
-  // A method that can fire a one-off easing by directly changing the map's camera.
-  cameraAnimation?: (map: Map) => any;
-  // The last three properties are needed by only one handler: scrollzoom.
-  // The DOM event to be used as the `originalEvent` on any camera change events.
-  originalEvent?: any;
-  // Makes the manager trigger a frame, allowing the handler to return multiple results over time (see scrollzoom).
-  needsRenderFrame?: boolean;
-  // The camera changes won't get recorded for inertial zooming.
-  noInertia?: boolean;
+    panDelta?: Point;
+    zoomDelta?: number;
+    bearingDelta?: number;
+    pitchDelta?: number;
+    // the point to not move when changing the camera
+    around?: Point | null;
+    // same as above, except for pinch actions, which are given higher priority
+    pinchAround?: Point | null;
+    // A method that can fire a one-off easing by directly changing the map's camera.
+    cameraAnimation?: (map: Map) => any;
+    // The last three properties are needed by only one handler: scrollzoom.
+    // The DOM event to be used as the `originalEvent` on any camera change events.
+    originalEvent?: any;
+    // Makes the manager trigger a frame, allowing the handler to return multiple results over time (see scrollzoom).
+    needsRenderFrame?: boolean;
+    // The camera changes won't get recorded for inertial zooming.
+    noInertia?: boolean;
 };
 
 function hasChange(result: HandlerResult) {
@@ -89,9 +89,9 @@ class HandlerManager {
     _map: Map;
     _el: HTMLElement;
     _handlers: Array<{
-      handlerName: string;
-      handler: Handler;
-      allowed: any;
+        handlerName: string;
+        handler: Handler;
+        allowed: any;
     }>;
     _eventsInProgress: any;
     _frameId: number;
@@ -102,8 +102,8 @@ class HandlerManager {
     _changes: Array<[HandlerResult, any, any]>;
     _previousActiveHandlers: {[x: string]: Handler};
     _listeners: Array<[Window | Document | HTMLElement, string, {
-      passive?: boolean;
-      capture?: boolean;
+        passive?: boolean;
+        capture?: boolean;
     } | undefined]>;
 
     constructor(map: Map, options: CompleteMapOptions) {

--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -59,49 +59,49 @@ import type {ControlPosition, IControl} from './control/control';
 /* eslint-enable no-use-before-define */
 
 export type MapOptions = {
-  hash?: boolean | string;
-  interactive?: boolean;
-  container: HTMLElement | string;
-  bearingSnap?: number;
-  attributionControl?: boolean;
-  customAttribution?: string | Array<string>;
-  logoPosition?: ControlPosition;
-  failIfMajorPerformanceCaveat?: boolean;
-  preserveDrawingBuffer?: boolean;
-  antialias?: boolean;
-  refreshExpiredTiles?: boolean;
-  maxBounds?: LngLatBoundsLike;
-  scrollZoom?: boolean;
-  minZoom?: number | null;
-  maxZoom?: number | null;
-  minPitch?: number | null;
-  maxPitch?: number | null;
-  boxZoom?: boolean;
-  dragRotate?: boolean;
-  dragPan?: DragPanOptions | boolean;
-  keyboard?: boolean;
-  doubleClickZoom?: boolean;
-  touchZoomRotate?: boolean;
-  touchPitch?: boolean;
-  trackResize?: boolean;
-  center?: LngLatLike;
-  zoom?: number;
-  bearing?: number;
-  pitch?: number;
-  renderWorldCopies?: boolean;
-  maxTileCacheSize?: number;
-  transformRequest?: RequestTransformFunction;
-  locale?: any;
-  fadeDuration?: number;
-  crossSourceCollisions?: boolean;
-  collectResourceTiming?: boolean;
-  clickTolerance?: number;
-  bounds?: LngLatBoundsLike;
-  fitBoundsOptions?: Object;
-  localIdeographFontFamily?: string;
-  style: StyleSpecification | string;
-  pitchWithRotate?: boolean;
-  pixelRatio?: number;
+    hash?: boolean | string;
+    interactive?: boolean;
+    container: HTMLElement | string;
+    bearingSnap?: number;
+    attributionControl?: boolean;
+    customAttribution?: string | Array<string>;
+    logoPosition?: ControlPosition;
+    failIfMajorPerformanceCaveat?: boolean;
+    preserveDrawingBuffer?: boolean;
+    antialias?: boolean;
+    refreshExpiredTiles?: boolean;
+    maxBounds?: LngLatBoundsLike;
+    scrollZoom?: boolean;
+    minZoom?: number | null;
+    maxZoom?: number | null;
+    minPitch?: number | null;
+    maxPitch?: number | null;
+    boxZoom?: boolean;
+    dragRotate?: boolean;
+    dragPan?: DragPanOptions | boolean;
+    keyboard?: boolean;
+    doubleClickZoom?: boolean;
+    touchZoomRotate?: boolean;
+    touchPitch?: boolean;
+    trackResize?: boolean;
+    center?: LngLatLike;
+    zoom?: number;
+    bearing?: number;
+    pitch?: number;
+    renderWorldCopies?: boolean;
+    maxTileCacheSize?: number;
+    transformRequest?: RequestTransformFunction;
+    locale?: any;
+    fadeDuration?: number;
+    crossSourceCollisions?: boolean;
+    collectResourceTiming?: boolean;
+    clickTolerance?: number;
+    bounds?: LngLatBoundsLike;
+    fitBoundsOptions?: Object;
+    localIdeographFontFamily?: string;
+    style: StyleSpecification | string;
+    pitchWithRotate?: boolean;
+    pixelRatio?: number;
 };
 
 // See article here: https://medium.com/terria/typescript-transforming-optional-properties-to-required-properties-that-may-be-undefined-7482cb4e1585
@@ -1343,9 +1343,9 @@ class Map extends Camera {
      *
      */
     querySourceFeatures(sourceId: string, parameters?: {
-      sourceLayer: string;
-      filter: Array<any>;
-      validate?: boolean;
+        sourceLayer: string;
+        filter: Array<any>;
+        validate?: boolean;
     } | null) {
         return this.style.querySourceFeatures(sourceId, parameters);
     }
@@ -1377,7 +1377,7 @@ class Map extends Camera {
      *
      */
     setStyle(style: StyleSpecification | string | null, options?: {
-      diff?: boolean;
+        diff?: boolean;
     } & StyleOptions) {
         options = extend({}, {localIdeographFontFamily: this._localIdeographFontFamily}, options);
 
@@ -1416,7 +1416,7 @@ class Map extends Camera {
     }
 
     _updateStyle(style: StyleSpecification | string | null,  options?: {
-      diff?: boolean;
+        diff?: boolean;
     } & StyleOptions) {
         if (this.style) {
             this.style.setEventedParent(null);
@@ -1450,7 +1450,7 @@ class Map extends Camera {
     }
 
     _diffStyle(style: StyleSpecification | string,  options?: {
-      diff?: boolean;
+        diff?: boolean;
     } & StyleOptions) {
         if (typeof style === 'string') {
             const url = style;
@@ -1468,7 +1468,7 @@ class Map extends Camera {
     }
 
     _updateDiff(style: StyleSpecification,  options?: {
-      diff?: boolean;
+        diff?: boolean;
     } & StyleOptions) {
         try {
             if (this.style.setState(style)) {
@@ -1684,18 +1684,18 @@ class Map extends Camera {
      * @see Use `ImageData`: [Add a generated icon to the map](https://maplibre.org/maplibre-gl-js-docs/example/add-image-generated/)
      */
     addImage(id: string,
-             image: HTMLImageElement | ImageBitmap | ImageData | {
-               width: number;
-               height: number;
-               data: Uint8Array | Uint8ClampedArray;
-             } | StyleImageInterface,
-             {
-                 pixelRatio = 1,
-                 sdf = false,
-                 stretchX,
-                 stretchY,
-                 content
-             }: Partial<StyleImageMetadata> = {}) {
+        image: HTMLImageElement | ImageBitmap | ImageData | {
+            width: number;
+            height: number;
+            data: Uint8Array | Uint8ClampedArray;
+        } | StyleImageInterface,
+        {
+            pixelRatio = 1,
+            sdf = false,
+            stretchX,
+            stretchY,
+            content
+        }: Partial<StyleImageMetadata> = {}) {
         this._lazyInitEmptyStyle();
         const version = 0;
 
@@ -1747,9 +1747,9 @@ class Map extends Camera {
      */
     updateImage(id: string,
         image: HTMLImageElement | ImageBitmap | ImageData | {
-          width: number;
-          height: number;
-          data: Uint8Array | Uint8ClampedArray;
+            width: number;
+            height: number;
+            data: Uint8Array | Uint8ClampedArray;
         } | StyleImageInterface) {
 
         const existingImage = this.style.getImage(id);
@@ -2212,9 +2212,9 @@ class Map extends Camera {
      * @see [Create a hover effect](https://maplibre.org/maplibre-gl-js-docs/example/hover-styles/)
      */
     setFeatureState(feature: {
-      source: string;
-      sourceLayer?: string;
-      id: string | number;
+        source: string;
+        sourceLayer?: string;
+        id: string | number;
     }, state: any) {
         this.style.setFeatureState(feature, state);
         return this._update();
@@ -2268,9 +2268,9 @@ class Map extends Camera {
      *
     */
     removeFeatureState(target: {
-      source: string;
-      sourceLayer?: string;
-      id?: string | number;
+        source: string;
+        sourceLayer?: string;
+        id?: string | number;
     }, key?: string) {
         this.style.removeFeatureState(target, key);
         return this._update();
@@ -2306,11 +2306,11 @@ class Map extends Camera {
      *
      */
     getFeatureState(
-      feature: {
-        source: string;
-        sourceLayer?: string;
-        id: string | number;
-      }
+        feature: {
+            source: string;
+            sourceLayer?: string;
+            id: string | number;
+        }
     ): any {
         return this.style.getFeatureState(feature);
     }

--- a/src/ui/marker.test.ts
+++ b/src/ui/marker.test.ts
@@ -46,16 +46,16 @@ describe('marker', () => {
 
         // initial dimensions of svg element
         expect(
-        defaultMarker.getElement().children[0].getAttribute('height').includes('41')
+            defaultMarker.getElement().children[0].getAttribute('height').includes('41')
         ).toBeTruthy();
         expect(defaultMarker.getElement().children[0].getAttribute('width').includes('27')).toBeTruthy();
 
         // (41 * 0.8) = 32.8, (27 * 0.8) = 21.6
         expect(
-        smallerMarker.getElement().children[0].getAttribute('height').includes('32.8')
+            smallerMarker.getElement().children[0].getAttribute('height').includes('32.8')
         ).toBeTruthy();
         expect(
-        smallerMarker.getElement().children[0].getAttribute('width').includes('21.6')
+            smallerMarker.getElement().children[0].getAttribute('width').includes('21.6')
         ).toBeTruthy();
 
         // (41 * 2) = 82, (27 * 2) = 54
@@ -287,49 +287,49 @@ describe('marker', () => {
 
         // marker should default to above since it has enough space
         expect(
-        marker.getPopup()._container.classList.contains('maplibregl-popup-anchor-bottom')
+            marker.getPopup()._container.classList.contains('maplibregl-popup-anchor-bottom')
         ).toBeTruthy();
 
         // move marker to the top forcing the popup to below
         marker.setLngLat(map.unproject([mapHeight / 2, markerTop]));
         expect(
-        marker.getPopup()._container.classList.contains('maplibregl-popup-anchor-top')
+            marker.getPopup()._container.classList.contains('maplibregl-popup-anchor-top')
         ).toBeTruthy();
 
         // move marker to the right forcing the popup to the left
         marker.setLngLat(map.unproject([mapHeight - markerRight, mapHeight / 2]));
         expect(
-        marker.getPopup()._container.classList.contains('maplibregl-popup-anchor-right')
+            marker.getPopup()._container.classList.contains('maplibregl-popup-anchor-right')
         ).toBeTruthy();
 
         // move marker to the left forcing the popup to the right
         marker.setLngLat(map.unproject([markerRight, mapHeight / 2]));
         expect(
-        marker.getPopup()._container.classList.contains('maplibregl-popup-anchor-left')
+            marker.getPopup()._container.classList.contains('maplibregl-popup-anchor-left')
         ).toBeTruthy();
 
         // move marker to the top left forcing the popup to the bottom right
         marker.setLngLat(map.unproject([markerRight, markerTop]));
         expect(
-        marker.getPopup()._container.classList.contains('maplibregl-popup-anchor-top-left')
+            marker.getPopup()._container.classList.contains('maplibregl-popup-anchor-top-left')
         ).toBeTruthy();
 
         // move marker to the top right forcing the popup to the bottom left
         marker.setLngLat(map.unproject([mapHeight - markerRight, markerTop]));
         expect(
-        marker.getPopup()._container.classList.contains('maplibregl-popup-anchor-top-right')
+            marker.getPopup()._container.classList.contains('maplibregl-popup-anchor-top-right')
         ).toBeTruthy();
 
         // move marker to the bottom left forcing the popup to the top right
         marker.setLngLat(map.unproject([markerRight, mapHeight]));
         expect(
-        marker.getPopup()._container.classList.contains('maplibregl-popup-anchor-bottom-left')
+            marker.getPopup()._container.classList.contains('maplibregl-popup-anchor-bottom-left')
         ).toBeTruthy();
 
         // move marker to the bottom right forcing the popup to the top left
         marker.setLngLat(map.unproject([mapHeight - markerRight, mapHeight]));
         expect(
-        marker.getPopup()._container.classList.contains('maplibregl-popup-anchor-bottom-right')
+            marker.getPopup()._container.classList.contains('maplibregl-popup-anchor-bottom-right')
         ).toBeTruthy();
 
     });

--- a/src/ui/marker.ts
+++ b/src/ui/marker.ts
@@ -13,16 +13,16 @@ import type {MapMouseEvent, MapTouchEvent} from './events';
 import type {PointLike} from './camera';
 
 type MarkerOptions = {
-  element?: HTMLElement;
-  offset?: PointLike;
-  anchor?: PositionAnchor;
-  color?: string;
-  scale?: number;
-  draggable?: boolean;
-  clickTolerance?: number;
-  rotation?: number;
-  rotationAlignment?: string;
-  pitchAlignment?: string;
+    element?: HTMLElement;
+    offset?: PointLike;
+    anchor?: PositionAnchor;
+    color?: string;
+    scale?: number;
+    draggable?: boolean;
+    clickTolerance?: number;
+    rotation?: number;
+    rotationAlignment?: string;
+    pitchAlignment?: string;
 };
 
 /**
@@ -437,7 +437,7 @@ export default class Marker extends Evented {
     }
 
     _update(e?: {
-      type: 'move' | 'moveend';
+        type: 'move' | 'moveend';
     }) {
         if (!this._map) return;
 

--- a/src/ui/popup.test.ts
+++ b/src/ui/popup.test.ts
@@ -91,7 +91,7 @@ describe('popup', () => {
             .addTo(map);
 
         expect(
-        popup.getElement().querySelectorAll('.maplibregl-popup-close-button')
+            popup.getElement().querySelectorAll('.maplibregl-popup-close-button')
         ).toHaveLength(0);
     });
 
@@ -561,7 +561,7 @@ describe('popup', () => {
             .addTo(map);
 
         expect(
-        popup._container.classList.value
+            popup._container.classList.value
         ).toContain('maplibregl-popup-track-pointer');
     });
 
@@ -574,7 +574,7 @@ describe('popup', () => {
         popup.setText('Test');
 
         expect(
-        popup._container.classList.value
+            popup._container.classList.value
         ).toContain('maplibregl-popup-track-pointer');
     });
 
@@ -587,7 +587,7 @@ describe('popup', () => {
         popup.trackPointer();
 
         expect(
-        popup._container.classList.value
+            popup._container.classList.value
         ).toContain('maplibregl-popup-track-pointer');
     });
 
@@ -601,7 +601,7 @@ describe('popup', () => {
 
         expect(popup._pos).toEqual(map.project([0, 0]));
         expect(
-        popup._container.classList.value
+            popup._container.classList.value
         ).not.toContain('maplibregl-popup-track-pointer');
     });
 
@@ -613,7 +613,7 @@ describe('popup', () => {
             .addTo(map);
 
         expect(
-        popup._container.classList.value
+            popup._container.classList.value
         ).not.toContain('maplibregl-popup-track-pointer');
     });
 

--- a/src/ui/popup.ts
+++ b/src/ui/popup.ts
@@ -21,18 +21,18 @@ const defaultOptions = {
 };
 
 export type Offset = number | PointLike | {
-  [_ in PositionAnchor]: PointLike;
+    [_ in PositionAnchor]: PointLike;
 };
 
 export type PopupOptions = {
-  closeButton?: boolean;
-  closeOnClick?: boolean;
-  closeOnMove?: boolean;
-  focusAfterOpen?: boolean;
-  anchor?: PositionAnchor;
-  offset?: Offset;
-  className?: string;
-  maxWidth?: string;
+    closeButton?: boolean;
+    closeOnClick?: boolean;
+    closeOnMove?: boolean;
+    focusAfterOpen?: boolean;
+    anchor?: PositionAnchor;
+    offset?: Offset;
+    className?: string;
+    maxWidth?: string;
 };
 
 const focusQuerySelector = [

--- a/src/util/actor.ts
+++ b/src/util/actor.ts
@@ -21,15 +21,15 @@ class Actor {
     parent: any;
     mapId: number;
     callbacks: {
-      number: any;
+        number: any;
     };
     name: string;
     tasks: {
-      number: any;
+        number: any;
     };
     taskQueue: Array<number>;
     cancelCallbacks: {
-      number: Cancelable;
+        number: Cancelable;
     };
     invoker: ThrottledInvoker;
     globalScope: any;
@@ -57,11 +57,11 @@ class Actor {
      * @private
      */
     send(
-      type: string,
-      data: unknown,
-      callback?: Function | null,
-      targetMapId?: string | null,
-      mustQueue: boolean = false
+        type: string,
+        data: unknown,
+        callback?: Function | null,
+        targetMapId?: string | null,
+        mustQueue: boolean = false
     ): Cancelable {
         // We're using a string ID instead of numbers because they are being used as object keys
         // anyway, and thus stringified implicitly. We use random IDs because an actor may receive

--- a/src/util/ajax.ts
+++ b/src/util/ajax.ts
@@ -64,20 +64,20 @@ if (typeof Object.freeze == 'function') {
  *
  */
 export type RequestParameters = {
-  url: string;
-  headers?: any;
-  method?: 'GET' | 'POST' | 'PUT';
-  body?: string;
-  type?: 'string' | 'json' | 'arrayBuffer';
-  credentials?: 'same-origin' | 'include';
-  collectResourceTiming?: boolean;
+    url: string;
+    headers?: any;
+    method?: 'GET' | 'POST' | 'PUT';
+    body?: string;
+    type?: 'string' | 'json' | 'arrayBuffer';
+    credentials?: 'same-origin' | 'include';
+    collectResourceTiming?: boolean;
 };
 
 export type ResponseCallback<T> = (
-  error?: Error | null,
-  data?: T | null,
-  cacheControl?: string | null,
-  expires?: string | null
+    error?: Error | null,
+    data?: T | null,
+    cacheControl?: string | null,
+    expires?: string | null
 ) => void;
 
 class AJAXError extends Error {
@@ -173,8 +173,8 @@ function makeFetchRequest(requestParameters: RequestParameters, callback: Respon
     const finishRequest = (response, cacheableResponse?, requestTime?) => {
         (
             requestParameters.type === 'arrayBuffer' ? response.arrayBuffer() :
-            requestParameters.type === 'json' ? response.json() :
-            response.text()
+                requestParameters.type === 'json' ? response.json() :
+                    response.text()
         ).then(result => {
             if (aborted) return;
             if (cacheableResponse && requestTime) {
@@ -277,8 +277,8 @@ export const getJSON = function(requestParameters: RequestParameters, callback: 
 };
 
 export const getArrayBuffer = function(
-  requestParameters: RequestParameters,
-  callback: ResponseCallback<ArrayBuffer>
+    requestParameters: RequestParameters,
+    callback: ResponseCallback<ArrayBuffer>
 ): Cancelable {
     return makeRequest(extend(requestParameters, {type: 'arrayBuffer'}), callback);
 };
@@ -339,8 +339,8 @@ export const resetImageRequestQueue = () => {
 resetImageRequestQueue();
 
 export const getImage = function(
-  requestParameters: RequestParameters,
-  callback: Callback<HTMLImageElement | ImageBitmap>
+    requestParameters: RequestParameters,
+    callback: Callback<HTMLImageElement | ImageBitmap>
 ): Cancelable {
     if (webpSupported.supported) {
         if (!requestParameters.headers) {

--- a/src/util/color_ramp.ts
+++ b/src/util/color_ramp.ts
@@ -5,11 +5,11 @@ import assert from 'assert';
 import type {StylePropertyExpression} from '../style-spec/expression/index';
 
 export type ColorRampParams = {
-  expression: StylePropertyExpression;
-  evaluationKey: string;
-  resolution?: number;
-  image?: RGBAImage;
-  clips?: Array<any>;
+    expression: StylePropertyExpression;
+    evaluationKey: string;
+    resolution?: number;
+    image?: RGBAImage;
+    clips?: Array<any>;
 };
 
 /**

--- a/src/util/config.ts
+++ b/src/util/config.ts
@@ -1,6 +1,6 @@
 type Config = {
-  MAX_PARALLEL_IMAGE_REQUESTS: number;
-  REGISTERED_PROTOCOLS: {[x: string]: any};
+    MAX_PARALLEL_IMAGE_REQUESTS: number;
+    REGISTERED_PROTOCOLS: {[x: string]: any};
 };
 
 const config: Config = {

--- a/src/util/dispatcher.ts
+++ b/src/util/dispatcher.ts
@@ -18,7 +18,7 @@ class Dispatcher {
 
     // exposed to allow stubbing in unit tests
     static Actor: {
-      new (...args: any): Actor;
+        new (...args: any): Actor;
     };
 
     constructor(workerPool: WorkerPool, parent: any) {

--- a/src/util/dom.ts
+++ b/src/util/dom.ts
@@ -53,7 +53,7 @@ export default class DOM {
     public static addEventListener(target: any, type: any, callback: any, options: {
         passive?: boolean;
         capture?: boolean;
-      } = {}) {
+    } = {}) {
         if ('passive' in options) {
             target.addEventListener(type, callback, options);
         } else {
@@ -64,7 +64,7 @@ export default class DOM {
     public static removeEventListener(target: any, type: any, callback: any, options: {
         passive?: boolean;
         capture?: boolean;
-      } = {}) {
+    } = {}) {
         if ('passive' in options) {
             target.removeEventListener(type, callback, options);
         } else {

--- a/src/util/evented.ts
+++ b/src/util/evented.ts
@@ -31,7 +31,7 @@ export class Event {
 }
 
 interface ErrorLike {
-  message: string;
+    message: string;
 }
 
 export class ErrorEvent extends Event {

--- a/src/util/find_pole_of_inaccessibility.ts
+++ b/src/util/find_pole_of_inaccessibility.ts
@@ -14,9 +14,9 @@ import {distToSegmentSquared} from './intersection_tests';
  * @private
  */
 export default function(
-  polygonRings: Array<Array<Point>>,
-  precision: number = 1,
-  debug: boolean = false
+    polygonRings: Array<Array<Point>>,
+    precision: number = 1,
+    debug: boolean = false
 ): Point {
     // find the bounding box of the outer ring
     let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;

--- a/src/util/image.ts
+++ b/src/util/image.ts
@@ -3,13 +3,13 @@ import assert from 'assert';
 import {register} from './web_worker_transfer';
 
 export type Size = {
-  width: number;
-  height: number;
+    width: number;
+    height: number;
 };
 
 type Point2D = {
-  x: number;
-  y: number;
+    x: number;
+    y: number;
 };
 
 function createImage(image: any, {

--- a/src/util/performance.ts
+++ b/src/util/performance.ts
@@ -1,10 +1,10 @@
 import type {RequestParameters} from '../util/ajax';
 
 export type PerformanceMetrics = {
-  loadTime: number;
-  fullLoadTime: number;
-  fps: number;
-  percentDroppedFrames: number;
+    loadTime: number;
+    fullLoadTime: number;
+    fps: number;
+    percentDroppedFrames: number;
 };
 
 export enum PerformanceMarkers {
@@ -76,9 +76,9 @@ export const PerformanceUtils = {
  */
 export class RequestPerformance {
     _marks: {
-      start: string;
-      end: string;
-      measure: string;
+        start: string;
+        end: string;
+        measure: string;
     };
 
     constructor (request: RequestParameters) {

--- a/src/util/request_manager.ts
+++ b/src/util/request_manager.ts
@@ -6,10 +6,10 @@ type ResourceTypeEnum = keyof IResourceType;
 export type RequestTransformFunction = (url: string, resourceType?: ResourceTypeEnum) => RequestParameters;
 
 type UrlObject = {
-  protocol: string;
-  authority: string;
-  path: string;
-  params: Array<string>;
+    protocol: string;
+    authority: string;
+    path: string;
+    params: Array<string>;
 };
 
 export class RequestManager {

--- a/src/util/resolve_tokens.ts
+++ b/src/util/resolve_tokens.ts
@@ -9,10 +9,10 @@ export default resolveTokens;
  * @private
  */
 function resolveTokens(
-  properties: {
-    readonly [x: string]: unknown;
-  },
-  text: string
+    properties: {
+        readonly [x: string]: unknown;
+    },
+    text: string
 ): string {
     return text.replace(/{([^{}]+)}/g, (match, key: string) => {
         return key in properties ? String(properties[key]) : '';

--- a/src/util/struct_array.ts
+++ b/src/util/struct_array.ts
@@ -47,21 +47,21 @@ const DEFAULT_CAPACITY = 128;
 const RESIZE_MULTIPLIER = 5;
 
 export type StructArrayMember = {
-  name: string;
-  type: ViewType;
-  components: number;
-  offset: number;
+    name: string;
+    type: ViewType;
+    components: number;
+    offset: number;
 };
 
 export type StructArrayLayout = {
-  members: Array<StructArrayMember>;
-  size: number;
-  alignment: number;
+    members: Array<StructArrayMember>;
+    size: number;
+    alignment: number;
 };
 
 export type SerializedStructArray = {
-  length: number;
-  arrayBuffer: ArrayBuffer;
+    length: number;
+    arrayBuffer: ArrayBuffer;
 };
 
 /**
@@ -198,12 +198,12 @@ abstract class StructArray {
  * @private
  */
 function createLayout(
-  members: Array<{
-    name: string;
-    type: ViewType;
-    readonly components?: number;
-  }>,
-  alignment: number = 1
+    members: Array<{
+        name: string;
+        type: ViewType;
+        readonly components?: number;
+    }>,
+    alignment: number = 1
 ): StructArrayLayout {
 
     let offset = 0;

--- a/src/util/task_queue.ts
+++ b/src/util/task_queue.ts
@@ -3,9 +3,9 @@ import assert from 'assert';
 export type TaskID = number; // can't mark opaque due to https://github.com/flowtype/flow-remove-types/pull/61
 
 type Task = {
-  callback: (timeStamp: number) => void;
-  id: TaskID;
-  cancelled: boolean;
+    callback: (timeStamp: number) => void;
+    id: TaskID;
+    cancelled: boolean;
 };
 
 class TaskQueue {

--- a/src/util/tile_request_cache.ts
+++ b/src/util/tile_request_cache.ts
@@ -9,9 +9,9 @@ let cacheCheckThreshold = 50;
 const MIN_TIME_UNTIL_EXPIRY = 1000 * 60 * 7; // 7 minutes. Skip caching tiles with a short enough max age.
 
 export type ResponseOptions = {
-  status: number;
-  statusText: string;
-  headers: Headers;
+    status: number;
+    statusText: string;
+    headers: Headers;
 };
 
 // We're using a global shared cache object. Normally, requesting ad-hoc Cache objects is fine, but

--- a/src/util/transferable_grid_index.ts
+++ b/src/util/transferable_grid_index.ts
@@ -148,10 +148,10 @@ class TransferableGridIndex {
             for (let y = cy1; y <= cy2; y++) {
                 const cellIndex = this.d * y + x;
                 if (intersectionTest && !intersectionTest(
-                            this._convertFromCellCoord(x),
-                            this._convertFromCellCoord(y),
-                            this._convertFromCellCoord(x + 1),
-                            this._convertFromCellCoord(y + 1))) continue;
+                    this._convertFromCellCoord(x),
+                    this._convertFromCellCoord(y),
+                    this._convertFromCellCoord(x + 1),
+                    this._convertFromCellCoord(y + 1))) continue;
                 if (fn.call(this, x1, y1, x2, y2, cellIndex, arg1, arg2, intersectionTest)) return;
             }
         }

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -88,9 +88,9 @@ export function wrap(n: number, min: number, max: number): number {
  * @private
  */
 export function asyncAll<Item, Result>(
-  array: Array<Item>,
-  fn: (item: Item, fnCallback: Callback<Result>) => void,
-  callback: Callback<Array<Result>>
+    array: Array<Item>,
+    fn: (item: Item, fnCallback: Callback<Result>) => void,
+    callback: Callback<Array<Result>>
 ) {
     if (!array.length) { return callback(null, []); }
     let remaining = array.length;
@@ -113,8 +113,8 @@ export function asyncAll<Item, Result>(
  * @private
  */
 export function keysDifference<S, T>(
-  obj: {[key: string]: S},
-  other: {[key: string]: T}
+    obj: {[key: string]: S},
+    other: {[key: string]: T}
 ): Array<string> {
     const difference = [];
     for (const i in obj) {
@@ -365,9 +365,9 @@ export function isClosedPolygon(points: Array<Point>): boolean {
  */
 
 export function sphericalToCartesian([r, azimuthal, polar]: [number, number, number]): {
-  x: number;
-  y: number;
-  z: number;
+    x: number;
+    y: number;
+    z: number;
 } {
     // We abstract "north"/"up" (compass-wise) to be 0° when really this is 90° (π/2):
     // correct for that here

--- a/src/util/web_worker_transfer.ts
+++ b/src/util/web_worker_transfer.ts
@@ -11,25 +11,25 @@ import type {Transferable} from '../types/transferable';
 import {isImageBitmap} from './util';
 
 type SerializedObject = {
-  [_: string]: Serialized;
+    [_: string]: Serialized;
 }; // eslint-disable-line
 
 export type Serialized = null | void | boolean | number | string | Boolean | Number | String | Date | RegExp | ArrayBuffer | ArrayBufferView | ImageData | ImageBitmap | Array<Serialized> | SerializedObject;
 
 type Registry = {
-  [_: string]: {
-    klass: {
-      new (...args: any): any;
-      deserialize?: (input: Serialized) => unknown;
+    [_: string]: {
+        klass: {
+            new (...args: any): any;
+            deserialize?: (input: Serialized) => unknown;
+        };
+        omit: ReadonlyArray<string>;
+        shallow: ReadonlyArray<string>;
     };
-    omit: ReadonlyArray<string>;
-    shallow: ReadonlyArray<string>;
-  };
 };
 
 type RegisterOptions<T> = {
-  omit?: ReadonlyArray<keyof T>;
-  shallow?: ReadonlyArray<keyof T>;
+    omit?: ReadonlyArray<keyof T>;
+    shallow?: ReadonlyArray<keyof T>;
 };
 
 const registry: Registry = {};
@@ -44,11 +44,11 @@ const registry: Registry = {};
  * @private
  */
 export function register<T extends any>(
-  name: string,
-  klass: {
-    new (...args: any): T;
-  },
-  options: RegisterOptions<T> = {}
+    name: string,
+    klass: {
+        new (...args: any): T;
+    },
+    options: RegisterOptions<T> = {}
 ) {
     assert(!registry[name], `${name} is already registered.`);
     ((Object.defineProperty as any))(klass, '_classRegistryKey', {

--- a/src/util/worker_pool.ts
+++ b/src/util/worker_pool.ts
@@ -12,7 +12,7 @@ export default class WorkerPool {
     static workerCount: number;
 
     active: {
-      [_ in number | string]: boolean;
+        [_ in number | string]: boolean;
     };
     workers: Array<WorkerInterface>;
 

--- a/test/browser/browser.test.ts
+++ b/test/browser/browser.test.ts
@@ -61,7 +61,7 @@ describe('drag and zoom', () => {
     // start server
     beforeAll((done) => {
         server = http.createServer(
-        st(process.cwd())
+            st(process.cwd())
         ).listen(port, ip, () => {
             done();
         });

--- a/test/build/dev.test.ts
+++ b/test/build/dev.test.ts
@@ -3,10 +3,10 @@ import fs from 'fs';
 describe('dev build', () => {
     test('contains asserts', () => {
         expect(
-        fs.readFileSync('dist/maplibre-gl-dev.js', 'utf8').indexOf('canary assert') !== -1
+            fs.readFileSync('dist/maplibre-gl-dev.js', 'utf8').indexOf('canary assert') !== -1
         ).toBeTruthy();
         expect(
-        fs.readFileSync('dist/maplibre-gl-dev.js', 'utf8').indexOf('canary debug run') !== -1
+            fs.readFileSync('dist/maplibre-gl-dev.js', 'utf8').indexOf('canary debug run') !== -1
         ).toBeTruthy();
     });
 });

--- a/test/integration/lib/expression.js
+++ b/test/integration/lib/expression.js
@@ -31,7 +31,7 @@ function stripPrecision(x) {
 
         const multiplier = Math.pow(10,
             Math.max(0,
-                     decimalSigFigs - Math.ceil(Math.log10(Math.abs(x)))));
+                decimalSigFigs - Math.ceil(Math.log10(Math.abs(x)))));
 
         // We strip precision twice in a row here to avoid cases where
         // stripping an already stripped number will modify its value


### PR DESCRIPTION
## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

Indenting after statements like the following is often not consistent. 

```ts
export type MapSomething = {
     a: number
 }
export type MapElse = {
 b: number
}
```

This pull requests introduces the `@typescript-eslint/indent` rule. I run `npm run lint -- --fix` to create the changes automatically.

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [ ] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [ ] Manually test the debug page.
 - [ ] Suggest a changelog category: bug/feature/docs/etc. or "skip changelog".
 - [ ] Add an entry inside this element for inclusion in the `maplibre-gl-js` changelog: `<changelog></changelog>`.
