### PR TITLE
Allow catching AJAXError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Features and improvements
 
+- Make `AJAXError` public so network errors can be handled differently from other errors.
 - *...Add new stuff here...*
 
 ### 🐞 Bug fixes

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,7 @@ import WorkerPool from './util/worker_pool';
 import {prewarm, clearPrewarmedResources} from './util/global_worker_pool';
 import {clearTileCache} from './util/tile_request_cache';
 import {PerformanceUtils} from './util/performance';
+import {AJAXError} from './util/ajax';
 import type {RequestParameters, ResponseCallback} from './util/ajax';
 import type {Cancelable} from './types/cancelable';
 
@@ -44,6 +45,7 @@ const exported = {
     Point,
     MercatorCoordinate,
     Evented,
+    AJAXError,
     config,
     /**
      * Initializes resources like WebWorkers that can be shared across maps to lower load

--- a/src/util/ajax.test.ts
+++ b/src/util/ajax.test.ts
@@ -3,12 +3,22 @@ import {
     getJSON,
     postData,
     getImage,
-    resetImageRequestQueue
+    resetImageRequestQueue,
+    AJAXError
 } from './ajax';
 import config from './config';
 import webpSupported from './webp_supported';
 import {fakeServer, FakeServer} from 'nise';
 import {stubAjaxGetImage} from './test/util';
+
+function readAsText(blob) {
+    return new Promise((resolve, reject) => {
+        const fileReader = new FileReader();
+        fileReader.onload = () => resolve(fileReader.result);
+        fileReader.onerror = () => reject(fileReader.error);
+        fileReader.readAsText(blob);
+    });
+}
 
 describe('ajax', () => {
     let server: FakeServer;
@@ -22,10 +32,15 @@ describe('ajax', () => {
 
     test('getArrayBuffer, 404', done => {
         server.respondWith(request => {
-            request.respond(404, undefined, undefined);
+            request.respond(404, undefined, '404 Not Found');
         });
-        getArrayBuffer({url:''}, (error) => {
-            expect((error as any).status).toBe(404);
+        getArrayBuffer({url:'http://example.com/test.bin'}, async (error) => {
+            const ajaxError = error as AJAXError;
+            const body = await readAsText(ajaxError.body);
+            expect(ajaxError.status).toBe(404);
+            expect(ajaxError.statusText).toBe('Not Found');
+            expect(ajaxError.url).toBe('http://example.com/test.bin');
+            expect(body).toBe('404 Not Found');
             done();
         });
         server.respond();
@@ -56,22 +71,15 @@ describe('ajax', () => {
 
     test('getJSON, 404', done => {
         server.respondWith(request => {
-            request.respond(404, undefined, undefined);
+            request.respond(404, undefined, '404 Not Found');
         });
-        getJSON({url:''}, (error) => {
-            expect((error as any).status).toBe(404);
-            done();
-        });
-        server.respond();
-    });
-
-    test('getJSON, 401: non-Mapbox domain', done => {
-        server.respondWith(request => {
-            request.respond(401, undefined, undefined);
-        });
-        getJSON({url:''}, (error) => {
-            expect((error as any).status).toBe(401);
-            expect(error.message).toBe('Unauthorized');
+        getJSON({url:'http://example.com/test.json'}, async (error) => {
+            const ajaxError = error as AJAXError;
+            const body = await readAsText(ajaxError.body);
+            expect(ajaxError.status).toBe(404);
+            expect(ajaxError.statusText).toBe('Not Found');
+            expect(ajaxError.url).toBe('http://example.com/test.json');
+            expect(body).toBe('404 Not Found');
             done();
         });
         server.respond();

--- a/src/util/ajax.ts
+++ b/src/util/ajax.ts
@@ -80,17 +80,38 @@ export type ResponseCallback<T> = (
   expires?: string | null
 ) => void;
 
-class AJAXError extends Error {
+/**
+ * An error thrown when a HTTP request results in an error response.
+ * @extends Error
+ * @param {number} status The response's HTTP status code.
+ * @param {string} statusText The response's HTTP status text.
+ * @param {string} url The request's URL.
+ */
+export class AJAXError extends Error {
+    /**
+     * The response's HTTP status code.
+     */
     status: number;
+
+    /**
+     * The response's HTTP status text.
+     */
+    statusText: string;
+
+    /**
+     * The request's URL.
+     */
     url: string;
-    constructor(message: string, status: number, url: string) {
-        super(message);
+
+    constructor(status: number, statusText: string, url: string) {
+        super(statusText);
         this.status = status;
+        this.statusText = statusText;
         this.url = url;
 
         // work around for https://github.com/Rich-Harris/buble/issues/40
         this.name = this.constructor.name;
-        this.message = message;
+        this.message = statusText;
     }
 
     toString() {
@@ -159,7 +180,7 @@ function makeFetchRequest(requestParameters: RequestParameters, callback: Respon
                 return finishRequest(response, cacheableResponse, requestTime);
 
             } else {
-                return callback(new AJAXError(response.statusText, response.status, requestParameters.url));
+                return callback(new AJAXError(response.status, response.statusText, requestParameters.url));
             }
         }).catch(error => {
             if (error.code === 20) {
@@ -235,7 +256,7 @@ function makeXMLHttpRequest(requestParameters: RequestParameters, callback: Resp
             }
             callback(null, data, xhr.getResponseHeader('Cache-Control'), xhr.getResponseHeader('Expires'));
         } else {
-            callback(new AJAXError(xhr.statusText, xhr.status, requestParameters.url));
+            callback(new AJAXError(xhr.status, xhr.statusText, requestParameters.url));
         }
     };
     xhr.send(requestParameters.body);

--- a/src/util/ajax.ts
+++ b/src/util/ajax.ts
@@ -110,19 +110,11 @@ export class AJAXError extends Error {
     body: Blob;
 
     constructor(status: number, statusText: string, url: string, body: Blob) {
-        super(statusText);
+        super(`AJAXError: ${statusText} (${status}): ${url}`);
         this.status = status;
         this.statusText = statusText;
         this.url = url;
         this.body = body;
-
-        // work around for https://github.com/Rich-Harris/buble/issues/40
-        this.name = this.constructor.name;
-        this.message = statusText;
-    }
-
-    toString() {
-        return `${this.name}: ${this.message} (${this.status}): ${this.url}`;
     }
 }
 

--- a/src/util/web_worker_transfer.ts
+++ b/src/util/web_worker_transfer.ts
@@ -15,7 +15,7 @@ type SerializedObject = {
   [_: string]: Serialized;
 }; // eslint-disable-line
 
-export type Serialized = null | void | boolean | number | string | Boolean | Number | String | Date | RegExp | ArrayBuffer | ArrayBufferView | ImageData | ImageBitmap | Array<Serialized> | SerializedObject;
+export type Serialized = null | void | boolean | number | string | Boolean | Number | String | Date | RegExp | ArrayBuffer | ArrayBufferView | ImageData | ImageBitmap | Blob | Array<Serialized> | SerializedObject;
 
 type Registry = {
   [_: string]: {
@@ -111,7 +111,8 @@ export function serialize(input: unknown, transferables?: Array<Transferable> | 
         input instanceof Number ||
         input instanceof String ||
         input instanceof Date ||
-        input instanceof RegExp) {
+        input instanceof RegExp ||
+        input instanceof Blob) {
         return input;
     }
 
@@ -212,6 +213,7 @@ export function deserialize(input: Serialized): unknown {
         input instanceof String ||
         input instanceof Date ||
         input instanceof RegExp ||
+        input instanceof Blob ||
         isArrayBuffer(input) ||
         isImageBitmap(input) ||
         ArrayBuffer.isView(input) ||

--- a/src/util/web_worker_transfer.ts
+++ b/src/util/web_worker_transfer.ts
@@ -6,6 +6,7 @@ import {StylePropertyFunction, StyleExpression, ZoomDependentExpression, ZoomCon
 import CompoundExpression from '../style-spec/expression/compound_expression';
 import expressions from '../style-spec/expression/definitions';
 import ResolvedImage from '../style-spec/expression/types/resolved_image';
+import {AJAXError} from './ajax';
 
 import type {Transferable} from '../types/transferable';
 import {isImageBitmap} from './util';
@@ -67,6 +68,7 @@ register('TransferableGridIndex', TransferableGridIndex);
 
 register('Color', Color);
 register('Error', Error);
+register('AJAXError', AJAXError);
 register('ResolvedImage', ResolvedImage);
 
 register('StylePropertyFunction', StylePropertyFunction);


### PR DESCRIPTION
<changelog>Make `AJAXError` public so error HTTP responses can be handled differently from other errors.</changelog>

This PR makes `AJAXError` public. It also makes it serializable so instances can be recreated when passed between workers. Finally, it adds a `body` property to `AJAXError` that contains the response's body.

## Launch Checklist

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Write tests for all new functionality.
 - [x] Document any changes to public APIs.
 - [ ] Manually test the debug page.
 - [x] Add an entry inside this element for inclusion in the `maplibre-gl-js` changelog: `<changelog></changelog>`.
