### PR TITLE
Use husky to lint on precommit

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+npm run lint

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-npm run lint
+npm run lint -- --fix

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "earcut": "^2.2.3",
         "geojson-vt": "^3.2.1",
         "gl-matrix": "^3.4.3",
+        "husky": "^7.0.4",
         "murmurhash-js": "^1.0.0",
         "pbf": "^3.2.1",
         "potpack": "^1.0.2",
@@ -10339,6 +10340,20 @@
       "license": "MIT",
       "dependencies": {
         "ms": "^2.0.0"
+      }
+    },
+    "node_modules/husky": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-7.0.4.tgz",
+      "integrity": "sha512-vbaCKN2QLtP/vD4yvs6iz6hBEo6wkSzs8HpRah1Z6aGmF2KW5PdYuAd7uX5a+OyBZHBhd+TFLqgjUgytQr4RvQ==",
+      "bin": {
+        "husky": "lib/bin.js"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/iconv-lite": {
@@ -28453,6 +28468,11 @@
       "requires": {
         "ms": "^2.0.0"
       }
+    },
+    "husky": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-7.0.4.tgz",
+      "integrity": "sha512-vbaCKN2QLtP/vD4yvs6iz6hBEo6wkSzs8HpRah1Z6aGmF2KW5PdYuAd7uX5a+OyBZHBhd+TFLqgjUgytQr4RvQ=="
     },
     "iconv-lite": {
       "version": "0.4.24",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "earcut": "^2.2.3",
     "geojson-vt": "^3.2.1",
     "gl-matrix": "^3.4.3",
+    "husky": "^7.0.4",
     "murmurhash-js": "^1.0.0",
     "pbf": "^3.2.1",
     "potpack": "^1.0.2",
@@ -181,7 +182,8 @@
     "codegen": "npm run generate-style-code && npm run generate-struct-arrays && npm run generate-style-spec && npm run generate-shaders",
     "benchmark": "node bench/run-benchmarks.js",
     "gl-stats": "node bench/gl-stats.js",
-    "postinstall": "npm run codegen && npm run generate-query-test-fixtures"
+    "postinstall": "npm run codegen && npm run generate-query-test-fixtures",
+    "prepare": "husky install"
   },
   "files": [
     "build/",


### PR DESCRIPTION
## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

Sometimes CI fails because contributors forget to check for linting errors before pushing. 

This pull requests enables a pre-commit hook which runs `npm run lint` on every commit.

It uses husky https://github.com/typicode/husky which we have in the docs repo, too. I like it. 

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [ ] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [ ] Manually test the debug page.
 - [ ] Suggest a changelog category: bug/feature/docs/etc. or "skip changelog".
 - [ ] Add an entry inside this element for inclusion in the `maplibre-gl-js` changelog: `<changelog></changelog>`.
