### PR TITLE
Stylelint - Ignore dist folder

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -15,5 +15,8 @@
     "property-no-vendor-prefix": null,
     "selector-no-vendor-prefix": null,
     "value-no-vendor-prefix": null
-  }
+  },
+  "ignoreFiles": [
+      "dist/**/*.css"
+  ]
 }


### PR DESCRIPTION
Stylelint makes 1000 warnings because it is linting our minified output in the dist folder. This pr exludes that folder.