### PR TITLE
Move gl-stats and run-benchmarks to ts

### DIFF
--- a/bench/gl-stats.html
+++ b/bench/gl-stats.html
@@ -16,7 +16,7 @@ maplibregl.workerCount = 1;
 
 const map = new maplibregl.Map({
     container: document.getElementById('map'),
-    style: 'https://api.maptiler.com/maps/streets/style.json?key=get_your_own_OpIi9ZULNHzrESv6T2vL',
+    style: 'https://api.maptiler.com/maps/streets/style.json?key=get_a_key_at_maptiler_cloud',
     center: [-77.07842066675323, 38.890315130853566],
     zoom: 11
 });

--- a/bench/gl-stats.ts
+++ b/bench/gl-stats.ts
@@ -21,7 +21,8 @@ function waitForConsole(page) {
 }
 
 const browser = await puppeteer.launch({
-    args: ['--no-sandbox', '--disable-setuid-sandbox']
+    args: ['--no-sandbox', '--disable-setuid-sandbox'],
+    headless: false
 });
 try {
     const page = await browser.newPage();
@@ -30,6 +31,7 @@ try {
     await page.setViewport({width: 600, height: 600, deviceScaleFactor: 2});
     await page.setContent(benchHTML);
 
+    // @ts-ignore
     const stats = JSON.parse(await waitForConsole(page));
     stats['bundle_size'] = maplibreGLJSSrc.length + maplibreGLCSSSrc.length;
     stats['bundle_size_gz'] = zlib.gzipSync(maplibreGLJSSrc).length + zlib.gzipSync(maplibreGLCSSSrc).length;

--- a/bench/run-benchmarks.ts
+++ b/bench/run-benchmarks.ts
@@ -27,9 +27,13 @@ try {
     const webPage = await browser.newPage();
 
     url.hash = 'NONE';
-    await webPage.goto(url);
+    await webPage.goto(url.toString());
+
+    // @ts-ignore
     await webPage.waitForFunction(() => window.maplibreglBenchmarkFinished);
+    // @ts-ignore
     const allNames = await webPage.evaluate(() => Object.keys(window.maplibreglBenchmarks));
+    // @ts-ignore
     const versions = await webPage.evaluate((name) => Object.keys(window.maplibreglBenchmarks[name]), allNames[0]);
 
     const toRun = argv._.length > 0 ? argv._ : allNames;
@@ -44,17 +48,18 @@ try {
         process.stdout.write(name.padStart(nameWidth));
 
         url.hash = name;
-        await webPage.goto(url);
+        await webPage.goto(url.toString());
         await webPage.reload();
 
         await webPage.waitForFunction(
+            // @ts-ignore
             () => window.maplibreglBenchmarkFinished,
             {
                 polling: 200,
                 timeout: 0
             }
         );
-
+        // @ts-ignore
         const results = await webPage.evaluate((name) => window.maplibreglBenchmarkResults[name], name);
         const output = versions.map((v) => formatTime(results[v].summary.trimmedMean).padStart(timeWidth) + formatRegression(results[v].regression));
         if (versions.length === 2) {
@@ -65,7 +70,7 @@ try {
         console.log(...output);
 
         merger.add(await webPage.pdf({
-            format: 'A4',
+            format: 'a4',
             path: `${dir}/${name}.pdf`,
             printBackground: true,
             margin: {

--- a/package.json
+++ b/package.json
@@ -182,8 +182,8 @@
     "test-expression": "node --loader ts-node/esm --experimental-specifier-resolution=node test/integration/expression/expression.test.ts",
     "test-unit": "jest ./src",
     "codegen": "npm run generate-style-code && npm run generate-struct-arrays && npm run generate-style-spec && npm run generate-shaders",
-    "benchmark": "node bench/run-benchmarks.js",
-    "gl-stats": "node bench/gl-stats.js",
+    "benchmark": "node --loader ts-node/esm --experimental-specifier-resolution=node bench/run-benchmarks.ts",
+    "gl-stats": "node --loader ts-node/esm --experimental-specifier-resolution=node bench/gl-stats.ts",
     "postinstall": "npm run codegen && npm run generate-query-test-fixtures",
     "prepare": "husky install"
   },


### PR DESCRIPTION
bench/gl-stats.js > .ts
bench/run-benchmarks.js > .ts

Currently there is an issue in gl-stats where it doesn't load maplibre properly, and it's more clear when disabling headless mode for puppeteer. I have verified that the behavior is the same with js and ts, so it must have been introduced earlier.