### PR TITLE
Move bench to ES modules

### DIFF
--- a/bench/rollup_config_benchmarks.ts
+++ b/bench/rollup_config_benchmarks.ts
@@ -38,7 +38,7 @@ const splitConfig = (name: string): RollupOptions[] => [{
     input: [`${srcDir}bench/${name}/benchmarks.${inputExt}`, `${srcDir}src/source/worker.${inputExt}`],
     output: {
         dir: `rollup/build/benchmarks/${name}`,
-        format: 'amd',
+        format: 'es',
         indent: false,
         sourcemap: 'inline',
         chunkFileNames: 'shared.js'
@@ -48,7 +48,7 @@ const splitConfig = (name: string): RollupOptions[] => [{
     input: `rollup/benchmarks_${name}.js`,
     output: {
         file: `bench/${name}/benchmarks_generated.js`,
-        format: 'umd',
+        format: 'es',
         indent: false,
         sourcemap: true,
         intro
@@ -62,7 +62,7 @@ const viewConfig: RollupOptions = {
     output: {
         name: 'Benchmarks',
         file: 'bench/benchmarks_view_generated.js',
-        format: 'umd',
+        format: 'es',
         indent: false,
         sourcemap: false
     },

--- a/bench/styles/index.html
+++ b/bench/styles/index.html
@@ -12,10 +12,12 @@
 
 <body>
     <div id="benchmarks"></div>
-    <script src="/bench/styles/benchmarks_generated.js"></script>
-    <script src="/bench/benchmarks_view_generated.js"></script>
-    <script>
-        window.Benchmarks.run(benchmarks);
+
+    <script type="module">
+        await import("/bench/styles/benchmarks_generated.js")
+        const {run} = await import("/bench/benchmarks_view_generated.js");
+
+        run(benchmarks);
     </script>
 </body>
 

--- a/bench/styles/index.html
+++ b/bench/styles/index.html
@@ -14,8 +14,8 @@
     <div id="benchmarks"></div>
 
     <script type="module">
-        await import("/bench/styles/benchmarks_generated.js")
-        const {run} = await import("/bench/benchmarks_view_generated.js");
+        await import('/bench/styles/benchmarks_generated.js');
+        const {run} = await import('/bench/benchmarks_view_generated.js');
 
         run(benchmarks);
     </script>

--- a/bench/versions/index.html
+++ b/bench/versions/index.html
@@ -14,8 +14,7 @@
     <div id="benchmarks"></div>
     <!-- <script type="module" src="/bench/benchmarks_view_generated.js"></script> -->
     <script type="module">
-
-        const {run} = await import("/bench/benchmarks_view_generated.js");
+        const {run} = await import('/bench/benchmarks_view_generated.js');
         runComparison();
 
         async function runComparison() {
@@ -74,7 +73,7 @@
             return new Promise((resolve, reject) => {
                 const s = document.createElement('script');
                 s.src = src;
-                s.type = "module";
+                s.type = 'module';
                 s.onload = resolve;
                 s.onerror = reject;
                 document.head.appendChild(s);

--- a/bench/versions/index.html
+++ b/bench/versions/index.html
@@ -12,8 +12,10 @@
 
 <body>
     <div id="benchmarks"></div>
-    <script src="/bench/benchmarks_view_generated.js"></script>
-    <script>
+    <!-- <script type="module" src="/bench/benchmarks_view_generated.js"></script> -->
+    <script type="module">
+
+        const {run} = await import("/bench/benchmarks_view_generated.js");
         runComparison();
 
         async function runComparison() {
@@ -52,7 +54,7 @@
                     benchmarks.push({name, versions});
                 }
 
-                const results = await window.Benchmarks.run(benchmarks);
+                const results = await run(benchmarks);
                 // eslint-disable-next-line require-atomic-updates
                 window.maplibreglBenchmarkResults = {};
                 for (const result of results) {
@@ -72,6 +74,7 @@
             return new Promise((resolve, reject) => {
                 const s = document.createElement('script');
                 s.src = src;
+                s.type = "module";
                 s.onload = resolve;
                 s.onerror = reject;
                 document.head.appendChild(s);


### PR DESCRIPTION
Slowly adapting for the new standard, I have moved benchmarks to use ES module format rather than UMD and AMD