### PR TITLE
Fix web worker in watch mode

### DIFF
--- a/bench/rollup_config_benchmarks.ts
+++ b/bench/rollup_config_benchmarks.ts
@@ -67,7 +67,11 @@ const viewConfig: RollupOptions = {
         sourcemap: false
     },
     plugins: [
-        resolve({browser: true, preferBuiltins: false}),
+        resolve({
+            browser: true,
+            preferBuiltins: false,
+            extensions: ['.mjs', '.js', '.json', '.node', '.ts']
+        }),
         watch ? typescript() : null,
         commonjs(),
         replace(replaceConfig)

--- a/bench/rollup_config_benchmarks.ts
+++ b/bench/rollup_config_benchmarks.ts
@@ -67,11 +67,7 @@ const viewConfig: RollupOptions = {
         sourcemap: false
     },
     plugins: [
-        resolve({
-            browser: true,
-            preferBuiltins: false,
-            extensions: ['.mjs', '.js', '.json', '.node', '.ts']
-        }),
+        resolve({browser: true, preferBuiltins: false}),
         watch ? typescript() : null,
         commonjs(),
         replace(replaceConfig)

--- a/bench/rollup_config_benchmarks.ts
+++ b/bench/rollup_config_benchmarks.ts
@@ -1,8 +1,7 @@
 import fs from 'fs';
 import sourcemaps from 'rollup-plugin-sourcemaps';
 import replace from '@rollup/plugin-replace';
-import {plugins} from '../build/rollup_plugins';
-import resolve from '@rollup/plugin-node-resolve';
+import {plugins, nodeResolve} from '../build/rollup_plugins';
 import commonjs from '@rollup/plugin-commonjs';
 import typescript from '@rollup/plugin-typescript';
 import {execSync} from 'child_process';
@@ -67,11 +66,7 @@ const viewConfig: RollupOptions = {
         sourcemap: false
     },
     plugins: [
-        resolve({
-            browser: true,
-            preferBuiltins: false,
-            extensions: ['.mjs', '.js', '.json', '.node', '.ts']
-        }),
+        nodeResolve,
         watch ? typescript() : null,
         commonjs(),
         replace(replaceConfig)

--- a/build/rollup_plugins.ts
+++ b/build/rollup_plugins.ts
@@ -12,6 +12,12 @@ import {Plugin} from 'rollup';
 // Common set of plugins/transformations shared across different rollup
 // builds (main maplibre bundle, style-spec package, benchmarks bundle)
 
+export const nodeResolve = resolve({
+    browser: true,
+    preferBuiltins: false,
+    extensions: ['.mjs', '.js', '.json', '.node', '.ts']
+});
+
 export const plugins = (minified: boolean, production: boolean, watch: boolean): Plugin[] => [
     minifyStyleSpec(),
     json(),
@@ -38,11 +44,7 @@ export const plugins = (minified: boolean, production: boolean, watch: boolean):
     production ? unassert({
         include: ['**/*'], // by default, unassert only includes .js files
     }) : false,
-    resolve({
-        browser: true,
-        preferBuiltins: false,
-        extensions: ['.mjs', '.js', '.json', '.node', '.ts']
-    }),
+    nodeResolve,
     watch ? typescript() : false,
     commonjs({
         // global keyword handling causes Webpack compatibility issues, so we disabled it:

--- a/build/rollup_plugins.ts
+++ b/build/rollup_plugins.ts
@@ -40,7 +40,8 @@ export const plugins = (minified: boolean, production: boolean, watch: boolean):
     }) : false,
     resolve({
         browser: true,
-        preferBuiltins: false
+        preferBuiltins: false,
+        extensions: ['.mjs', '.js', '.json', '.node', '.ts']
     }),
     watch ? typescript() : false,
     commonjs({

--- a/build/web_worker_replacement.ts
+++ b/build/web_worker_replacement.ts
@@ -1,4 +1,4 @@
-import maplibregl from '../rollup/build/tsc/src/index'
+import maplibregl from '../src/index';
 
 export default function () {
     return new Worker(maplibregl.workerUrl);

--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
     "typescript": "^4.5.5"
   },
   "browser": {
-    "./rollup/build/tsc/src/util/web_worker.js": "./build/web_worker_replacement.js"
+    "./src/util/web_worker.ts": "./build/web_worker_replacement.ts"
   },
   "scripts": {
     "generate-shaders": "node --loader ts-node/esm --experimental-specifier-resolution=node build/generate-shaders.ts",

--- a/rollup.config.style-spec.ts
+++ b/rollup.config.style-spec.ts
@@ -1,11 +1,11 @@
 import path, {dirname} from 'path';
 import replace from '@rollup/plugin-replace';
-import resolve from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
 import unassert from 'rollup-plugin-unassert';
 import json from '@rollup/plugin-json';
 import {fileURLToPath, pathToFileURL} from 'url';
 import {RollupOptions} from 'rollup';
+import {nodeResolve} from './build/rollup_plugins';
 
 const esm = 'esm' in process.env;
 
@@ -47,11 +47,7 @@ const config: RollupOptions[] = [{
         }),
         json(),
         unassert(),
-        resolve({
-            browser: true,
-            preferBuiltins: false,
-            extensions: ['.mjs', '.js', '.json', '.node', '.ts']
-        }),
+        nodeResolve,
         commonjs()
     ]
 }];

--- a/rollup.config.style-spec.ts
+++ b/rollup.config.style-spec.ts
@@ -49,7 +49,8 @@ const config: RollupOptions[] = [{
         unassert(),
         resolve({
             browser: true,
-            preferBuiltins: false
+            preferBuiltins: false,
+            extensions: ['.mjs', '.js', '.json', '.node', '.ts']
         }),
         commonjs()
     ]

--- a/rollup.config.style-spec.ts
+++ b/rollup.config.style-spec.ts
@@ -49,8 +49,7 @@ const config: RollupOptions[] = [{
         unassert(),
         resolve({
             browser: true,
-            preferBuiltins: false,
-            extensions: ['.mjs', '.js', '.json', '.node', '.ts']
+            preferBuiltins: false
         }),
         commonjs()
     ]


### PR DESCRIPTION
Currently, the web worker is only enabled if watch mode is off, because the rollup node-resolve plugin doesn't look at typescript files by default, and it was configured to the wrong path. This pr fixes that, and it can hopefully unblock #961 
To test this PR, first go to the main branch and:

1. Delete the rollup/build/tsc/src folder
2. Run `npm run start-debug`
3. Open chrome dev console, and go to "sources" tap - there will be just "top -> localhost -> local files" in the left pane, which indicates that the web worker ain't running.

Now checkout this pr, and do the same.

The sources tap should now have "top" and some web workers, like in the image

![Screenshot from 2022-02-08 20-46-32](https://user-images.githubusercontent.com/74932975/153063971-35055303-ae83-4782-8405-7d988f2122b9.png).