### PR TITLE
Revert "Move bench to ES modules"

### DIFF
--- a/bench/rollup_config_benchmarks.ts
+++ b/bench/rollup_config_benchmarks.ts
@@ -38,7 +38,7 @@ const splitConfig = (name: string): RollupOptions[] => [{
     input: [`${srcDir}bench/${name}/benchmarks.${inputExt}`, `${srcDir}src/source/worker.${inputExt}`],
     output: {
         dir: `rollup/build/benchmarks/${name}`,
-        format: 'es',
+        format: 'amd',
         indent: false,
         sourcemap: 'inline',
         chunkFileNames: 'shared.js'
@@ -48,7 +48,7 @@ const splitConfig = (name: string): RollupOptions[] => [{
     input: `rollup/benchmarks_${name}.js`,
     output: {
         file: `bench/${name}/benchmarks_generated.js`,
-        format: 'es',
+        format: 'umd',
         indent: false,
         sourcemap: true,
         intro
@@ -62,7 +62,7 @@ const viewConfig: RollupOptions = {
     output: {
         name: 'Benchmarks',
         file: 'bench/benchmarks_view_generated.js',
-        format: 'es',
+        format: 'umd',
         indent: false,
         sourcemap: false
     },

--- a/bench/styles/index.html
+++ b/bench/styles/index.html
@@ -12,12 +12,10 @@
 
 <body>
     <div id="benchmarks"></div>
-
-    <script type="module">
-        await import('/bench/styles/benchmarks_generated.js');
-        const {run} = await import('/bench/benchmarks_view_generated.js');
-
-        run(benchmarks);
+    <script src="/bench/styles/benchmarks_generated.js"></script>
+    <script src="/bench/benchmarks_view_generated.js"></script>
+    <script>
+        window.Benchmarks.run(benchmarks);
     </script>
 </body>
 

--- a/bench/versions/index.html
+++ b/bench/versions/index.html
@@ -12,9 +12,8 @@
 
 <body>
     <div id="benchmarks"></div>
-    <!-- <script type="module" src="/bench/benchmarks_view_generated.js"></script> -->
-    <script type="module">
-        const {run} = await import('/bench/benchmarks_view_generated.js');
+    <script src="/bench/benchmarks_view_generated.js"></script>
+    <script>
         runComparison();
 
         async function runComparison() {
@@ -53,7 +52,7 @@
                     benchmarks.push({name, versions});
                 }
 
-                const results = await run(benchmarks);
+                const results = await window.Benchmarks.run(benchmarks);
                 // eslint-disable-next-line require-atomic-updates
                 window.maplibreglBenchmarkResults = {};
                 for (const result of results) {
@@ -73,7 +72,6 @@
             return new Promise((resolve, reject) => {
                 const s = document.createElement('script');
                 s.src = src;
-                s.type = 'module';
                 s.onload = resolve;
                 s.onerror = reject;
                 document.head.appendChild(s);


### PR DESCRIPTION
Reverts maplibre/maplibre-gl-js#964

Benchmarks has troubling me most of the day, and it turns out this might be the root cause. I suggest we revert it for now to get things stabilized