### PR TITLE
Fix render tests due to environment change

### DIFF
--- a/.github/workflows/test-render.yml
+++ b/.github/workflows/test-render.yml
@@ -11,10 +11,10 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v2
-      - name: Use Node.js 16 x64
+      - name: Use Node.js 16.13 x64
         uses: actions/setup-node@v2
         with:
-          node-version: 16
+          node-version: 16.13
           architecture: x64
       - run: npm ci
       - run: npm run build-dev

--- a/.github/workflows/test-render.yml
+++ b/.github/workflows/test-render.yml
@@ -23,4 +23,4 @@ jobs:
         if: always()
         with:
           name: index.html
-          path: test/integration/render-tests/index.html
+          path: test/integration/render/index.html

--- a/README.md
+++ b/README.md
@@ -82,3 +82,5 @@ Please keep in mind: Unauthorized backports are the biggest threat to the MapLib
 ## License
 
 **MapLibre GL** is licensed under the [3-Clause BSD license](./LICENSE.txt).
+
+No actual change...

--- a/test/integration/render/resultItemTemplate.ts
+++ b/test/integration/render/resultItemTemplate.ts
@@ -1,8 +1,8 @@
 // eslint-disable-next-line no-unused-expressions
 (meta) => `<div class="test ${meta.r.status} ${(meta.hasFailedTests && /passed/.test(meta.r.status) || /ignored/.test(meta.r.status)) ? 'hide' : ''} }">
     <h2><span class="label" style="background: ${meta.r.color}">${meta.r.status}</span> ${meta.r.id}</h2>
-    ${meta.r.status !== 'errored' ? `
-        <img width="${meta.r.width}" height="${meta.r.height}" src="data:image/png;base64,${meta.r.actual}" data-alt-src="data:image/png;base64,${meta.r.expected}"><img style="width: ${meta.r.width}; height: ${meta.r.height}" src="data:image/png;base64,${meta.r.diff}">` : ''
+    ${meta.r.status === 'failed' ? `
+        <img width="${meta.r.width}" height="${meta.r.height}" src="data:image/png;base64,${meta.r.actual}" data-alt-src="data:image/png;base64,${meta.r.expected}"><img style="width: ${meta.r.width}; height: ${meta.r.height}" src="data:image/png;base64,${meta.r.expected}">` : ''
 }
     ${meta.r.error ? `<p style="color: red"><strong>Error:</strong> ${meta.r.error.message}</p>` : ''}
     ${meta.r.difference ? `<p class="diff"><strong>Diff:</strong> ${meta.r.difference}</p>` : ''}


### PR DESCRIPTION
## Launch Checklist

The following indicate a change in the ubuntu environment yesterday:
https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu1804-Readme.md
Which I believe is the root cause of the render test failure.
I'll see if I can make them pass as part of this PR...

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [ ] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [ ] Manually test the debug page.
 - [ ] Suggest a changelog category: bug/feature/docs/etc. or "skip changelog".
 - [ ] Add an entry inside this element for inclusion in the `maplibre-gl-js` changelog: `<changelog></changelog>`.
