### PR TITLE
Fixes #790 - improve typings for angular strict mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### 🐞 Bug fixes
 
 - Add adjustment for glyph rendering, CJK fonts are mainly affected (#1002).
+- Improve typings to fix Angular strict mode failure (#790, #970, #934)
 - *...Add new stuff here...*
 
 ## 2.1.6

--- a/src/render/uniform_binding.ts
+++ b/src/render/uniform_binding.ts
@@ -7,7 +7,7 @@ type $ObjMap<T extends {}, F extends (v: any) => any> = {
     [K in keyof T]: F extends (v: T[K]) => infer R ? R : never;
 };
 
-export type UniformValues<Us extends any> = $ObjMap<Us, <V>(u: Uniform<V>) => V>;
+export type UniformValues<Us extends {}> = $ObjMap<Us, <V>(u: Uniform<V>) => V>;
 export type UniformLocations = {[_: string]: WebGLUniformLocation};
 
 abstract class Uniform<T> {

--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -917,7 +917,12 @@ class Map extends Camera {
         return this._rotating || this.handlers.isRotating();
     }
 
-    _createDelegatedListener(type: MapEvent, layerId: any, listener: any) {
+    _createDelegatedListener(type: MapEvent, layerId: string, listener: Listener):
+    {
+        layer: string;
+        listener: Listener;
+        delegates: {[type in keyof MapEventType]?: (e: any) => void};
+    } {
         if (type === 'mouseenter' || type === 'mouseover') {
             let mousein = false;
             const mousemove = (e) => {
@@ -1078,14 +1083,14 @@ class Map extends Camera {
             return super.on(type, layerIdOrListener as Listener);
         }
 
-        const delegatedListener = this._createDelegatedListener(type, layerIdOrListener, listener);
+        const delegatedListener = this._createDelegatedListener(type, layerIdOrListener as string, listener);
 
         this._delegatedListeners = this._delegatedListeners || {};
         this._delegatedListeners[type] = this._delegatedListeners[type] || [];
         this._delegatedListeners[type].push(delegatedListener);
 
         for (const event in delegatedListener.delegates) {
-            this.on(event as any, delegatedListener.delegates[event]);
+            this.on(event as MapEvent, delegatedListener.delegates[event]);
         }
 
         return this;
@@ -1133,10 +1138,10 @@ class Map extends Camera {
             return super.once(type, layerIdOrListener as Listener);
         }
 
-        const delegatedListener = this._createDelegatedListener(type, layerIdOrListener, listener);
+        const delegatedListener = this._createDelegatedListener(type, layerIdOrListener as string, listener);
 
         for (const event in delegatedListener.delegates) {
-            this.once(event as any, delegatedListener.delegates[event]);
+            this.once(event as MapEvent, delegatedListener.delegates[event]);
         }
 
         return this;


### PR DESCRIPTION
## Launch Checklist

Improve typings.
See linked issues in the changelog.
Fixes #790 

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Add an entry inside this element for inclusion in the `maplibre-gl-js` changelog: `<changelog></changelog>`.
