### PR TITLE
Fix SourceCache.loaded() always returning true following a load error (#1025)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 - Add adjustment for glyph rendering, CJK fonts are mainly affected (#1002).
 - Improve typings to fix Angular strict mode failure (#790, #970, #934)
-- Fix SourceCache.loaded() always returning true following a load error (#1025)
+- Fix `SourceCache.loaded()` always returning `true` following a load error (#1025)
 - *...Add new stuff here...*
 
 ## 2.1.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - Add adjustment for glyph rendering, CJK fonts are mainly affected (#1002).
 - Improve typings to fix Angular strict mode failure (#790, #970, #934)
+- Fix SourceCache.loaded() always returning true following a load error (#1025)
 - *...Add new stuff here...*
 
 ## 2.1.6

--- a/src/source/source_cache.test.ts
+++ b/src/source/source_cache.test.ts
@@ -436,6 +436,18 @@ describe('SourceCache / Source lifecycle', () => {
         sourceCache.onAdd(undefined);
     });
 
+    test('loaded() false after source begins loading following error', done => {
+        const sourceCache = createSourceCache({error: 'Error loading source'}).on('error', () => {
+            sourceCache.on('dataloading', () => {
+                expect(sourceCache.loaded()).toBeFalsy();
+                done();
+            });
+            sourceCache.getSource().fire(new Event('dataloading'));
+        });
+
+        sourceCache.onAdd(undefined);
+    });
+
     test('reloads tiles after a data event where source is updated', () => {
         const transform = new Transform();
         transform.resize(511, 511);

--- a/src/source/source_cache.ts
+++ b/src/source/source_cache.ts
@@ -84,6 +84,10 @@ class SourceCache extends Evented {
             }
         });
 
+        this.on('dataloading', () => {
+            this._sourceErrored = false;
+        });
+
         this.on('error', () => {
             this._sourceErrored = true;
         });


### PR DESCRIPTION
<changelog>Fix SourceCache.loaded() always returning true following a load error (#1025)</changelog>

## Launch Checklist

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Write tests for all new functionality.
 - [x] Manually test the debug page.
 - [x] Add an entry inside this element for inclusion in the `maplibre-gl-js` changelog: `<changelog></changelog>`.
