### PR TITLE
Fix SourceCache.loaded() returning true when a source load error occurs while the source still has pending loads

### DIFF
--- a/src/source/source_cache.test.ts
+++ b/src/source/source_cache.test.ts
@@ -448,6 +448,21 @@ describe('SourceCache / Source lifecycle', () => {
         sourceCache.onAdd(undefined);
     });
 
+    test('loaded() false when error occurs while source is not loaded', done => {
+        const sourceCache = createSourceCache({
+            error: 'Error loading source',
+
+            loaded() {
+                return false;
+            }
+        }).on('error', () => {
+            expect(sourceCache.loaded()).toBeFalsy();
+            done();
+        });
+
+        sourceCache.onAdd(undefined);
+    });
+
     test('reloads tiles after a data event where source is updated', () => {
         const transform = new Transform();
         transform.resize(511, 511);

--- a/src/source/source_cache.ts
+++ b/src/source/source_cache.ts
@@ -89,7 +89,8 @@ class SourceCache extends Evented {
         });
 
         this.on('error', () => {
-            this._sourceErrored = true;
+            // Only set _sourceErrored if the source does not have pending loads.
+            this._sourceErrored = this._source.loaded();
         });
 
         this._source = createSource(id, options, dispatcher, this);


### PR DESCRIPTION
<changelog>Fix SourceCache.loaded() returning true when a source load error occurs while the source still has pending loads</changelog>

This PR fixes an issue related to #1025. When calling `GeoJSONSource.setData()` with an argument that can be successfully loaded right after a call to the same method with an argument that causes a load error (e.g. a URL pointing to a nonexistent resource), `Map.isStyleLoaded()` would return `true` after the `error` event had fired even though the `GeoJSONSource` still had a pending load. Here is an example: https://jsbin.com/hedesi/3/edit?html,console,output.

## Launch Checklist

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Write tests for all new functionality.
 - [x] Manually test the debug page.
 - [x] Add an entry inside this element for inclusion in the `maplibre-gl-js` changelog: `<changelog></changelog>`.
