### PR TITLE
Add missing builds to release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,9 @@ jobs:
       - name: Build
         run: |
           npm run build-prod-min
+          npm run build-prod
+          npm run build-csp
+          npm run build-dev
           npm run build-css
           npm run build-benchmarks
           npm run generate-typings

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Add adjustment for glyph rendering, CJK fonts are mainly affected (#1002).
 - Improve typings to fix Angular strict mode failure (#790, #970, #934)
 - Fix `SourceCache.loaded()` always returning `true` following a load error (#1025)
+- Added back csp and dev builds to npm package (#1042)
 - *...Add new stuff here...*
 
 ## 2.1.6


### PR DESCRIPTION
## Launch Checklist

Fixes #1042 - Adds dev, csp and prod to release pipeline in order for it to be in the npm package

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Add an entry inside this element for inclusion in the `maplibre-gl-js` changelog: `<changelog></changelog>`.
