### PR TITLE
Instructions for missing node_canvas dependencies

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,6 +23,11 @@ Clone the repository
 git clone git@github.com:maplibre/maplibre-gl-js.git
 ```
 
+Install dependencies for node_canvas (https://github.com/Automattic/node-canvas)
+```bash
+brew install pkg-config cairo pango libpng jpeg giflib librsvg
+```
+
 Install node module dependencies
 ```bash
 cd maplibre-gl-js &&


### PR DESCRIPTION
On new macOS installation, 'npm install' results in errors with the node_canvas module. Update CONTRIBUTING.md with missing setup step.

