### PR TITLE
Fix benchmark paths

### DIFF
--- a/test/bench/README.md
+++ b/test/bench/README.md
@@ -6,11 +6,11 @@ Benchmarks help us catch performance regressions and improve performance.
 
 Start the benchmark server with `npm run start-bench`.
 
-To run all benchmarks, open [the benchmark page, `http://localhost:9966/bench/versions`](http://localhost:9966/bench/versions).
+To run all benchmarks, open [the benchmark page, `http://localhost:9966/test/bench/versions`](http://localhost:9966/test/bench/versions).
 
-To run a specific benchmark, add its name to the url hash, for example [`http://localhost:9966/bench/versions#Layout`](http://localhost:9966/bench/versions#Layout).
+To run a specific benchmark, add its name to the url hash, for example [`http://localhost:9966/test/bench/versions#Layout`](http://localhost:9966/test/bench/versions#Layout).
 
-By default, the benchmark page will compare the local branch against `main` and the latest release. To change this, include one or more `compare` query parameters in the URL: E.g., [localhost:9966/bench/versions?compare=main](http://localhost:9966/bench/versions?compare=main) or [localhost:9966/bench/versions?compare=main#Layout](http://localhost:9966/bench/versions?compare=main#Layout) to compare only to main, or [localhost:9966/bench/versions?compare=v1.13.1](http://localhost:9966/bench/versions?compare=v1.13.1) to compare to `v1.13.1` (but not `main`).  Versions available for comparison are the ones stored in the `gh-pages` branch, see [here](https://github.com/maplibre/maplibre-gl-js/tree/gh-pages/benchmarks).
+By default, the benchmark page will compare the local branch against `main` and the latest release. To change this, include one or more `compare` query parameters in the URL: E.g., [localhost:9966/test/bench/versions?compare=main](http://localhost:9966/test/bench/versions?compare=main) or [localhost:9966/test/bench/versions?compare=main#Layout](http://localhost:9966/test/bench/versions?compare=main#Layout) to compare only to main, or [localhost:9966/test/bench/versions?compare=v1.13.1](http://localhost:9966/test/bench/versions?compare=v1.13.1) to compare to `v1.13.1` (but not `main`).  Versions available for comparison are the ones stored in the `gh-pages` branch, see [here](https://github.com/maplibre/maplibre-gl-js/tree/gh-pages/benchmarks).
 
 To run all benchmarks in headless chromium use `npm run benchmark`. As with the browser you can include one or more `--compare` arguments to change the default comparison, e.g. `npm run benchmark -- --compare main`. You can also run only specific benchmarks by passing their names as positional arguments, e.g. `npm run benchmark -- Layout Paint`.
 
@@ -23,9 +23,9 @@ MAPLIBRE_STYLES={YOUR STYLES HERE} npm run start-bench
 ```
 Note: `MAPLIBRE_STYLES` takes a comma-separated list of up to 3 MapLibre styles provided as a style URL or file system path (e.g. `path/to/style-a.json,path/to/style-b.json`)
 
-To run all benchmarks, open [the benchmark page, `http://localhost:9966/bench/styles`](http://localhost:9966/bench/styles).
+To run all benchmarks, open [the benchmark page, `http://localhost:9966/test/bench/styles`](http://localhost:9966/test/bench/styles).
 
-To run a specific benchmark, add its name to the url hash, for example [`http://localhost:9966/bench/styles#Layout`](http://localhost:9966/bench/styles#Layout).
+To run a specific benchmark, add its name to the url hash, for example [`http://localhost:9966/test/bench/styles#Layout`](http://localhost:9966/test/bench/styles#Layout).
 
 By default, the style benchmark page will run its benchmarks against `https://api.maptiler.com/maps/streets/style.json?key=get_your_own_OpIi9ZULNHzrESv6T2vL`. `Layout` and `Paint` styles will run one instance of the test for each tile/location in an internal list of tiles. This behavior helps visualize the ways in which a style performs given various conditions present in each tile (CJK text, dense urban areas, rural areas, etc). `QueryBox` and `QueryPoint` use the internal list of tiles but otherwise run the same as their non-style benchmark equivalents. `StyleLayerCreate` and `StyleValidate` are not tile/location dependent and run the same way as their non-style benchmark equivalents. All other benchmark tests from the non-style suite are not used when benchmarking styles.
 
@@ -75,11 +75,11 @@ minimum and maximum sample, and sample values at the first quartile, second quar
 We recommend installing a browser extension that can take full-page snapshots, e.g.
 [FireShot](https://chrome.google.com/webstore/detail/take-webpage-screenshots/mcbpblocgmgfnpjjppndjkmgjaogfceg).
 
-Alternatively there is a suitable pdf at `bench/results/all.pdf` after a successful run of `npm run benchmark`.
+Alternatively there is a suitable pdf at `test/bench/results/all.pdf` after a successful run of `npm run benchmark`.
 
 ## GitHub Pages and the benchmarks
 
-The benchmarks run in a browser. A website stored at `bench/versions/index.html` serves as a shell to load the benchmark code (which is in `benchmarks_generated.js`), run the benchmarks, and display the measurement results with some nice plots. The whole transpiled and minified library is stored in `benchmarks_generated.js`, so to compare different versions of the library the browser loads multiple `benchmarks_generated.js` files which are hosted in the GitHub Pages of this repository. Whenever a new version of MapLibre GL JS gets published, a new `benchmarks_generated.js` file will be created and uploaded to the GitHub Pages branch. See
+The benchmarks run in a browser. A website stored at `test/bench/versions/index.html` serves as a shell to load the benchmark code (which is in `benchmarks_generated.js`), run the benchmarks, and display the measurement results with some nice plots. The whole transpiled and minified library is stored in `benchmarks_generated.js`, so to compare different versions of the library the browser loads multiple `benchmarks_generated.js` files which are hosted in the GitHub Pages of this repository. Whenever a new version of MapLibre GL JS gets published, a new `benchmarks_generated.js` file will be created and uploaded to the GitHub Pages branch. See
 
 * https://github.com/maplibre/maplibre-gl-js/tree/gh-pages/benchmarks
 * https://github.com/maplibre/maplibre-gl-js/blob/main/.github/workflows/upload-benchmarks.yml

--- a/test/bench/benchmarks/filter_evaluate.ts
+++ b/test/bench/benchmarks/filter_evaluate.ts
@@ -10,7 +10,7 @@ export default class FilterEvaluate extends Benchmark {
     layers: any[];
 
     setup() {
-        return fetch('test/bench/data/785.vector.pbf')
+        return fetch('/test/bench/data/785.vector.pbf')
             .then(response => response.arrayBuffer())
             .then(data => {
                 const tile = new VectorTile(new Pbf(data));

--- a/test/bench/benchmarks/filter_evaluate.ts
+++ b/test/bench/benchmarks/filter_evaluate.ts
@@ -10,7 +10,7 @@ export default class FilterEvaluate extends Benchmark {
     layers: any[];
 
     setup() {
-        return fetch('/bench/data/785.vector.pbf')
+        return fetch('test/bench/data/785.vector.pbf')
             .then(response => response.arrayBuffer())
             .then(data => {
                 const tile = new VectorTile(new Pbf(data));

--- a/test/bench/benchmarks/layers.ts
+++ b/test/bench/benchmarks/layers.ts
@@ -111,7 +111,7 @@ export class LayerFillExtrusion extends LayerBenchmark {
 
 export class LayerHeatmap extends LayerBenchmark {
     setup() {
-        return fetch('/bench/data/naturalearth-land.json')
+        return fetch('/test/bench/data/naturalearth-land.json')
             .then(response => response.json())
             .then(data => {
                 this.layerStyle = Object.assign({}, style, {

--- a/test/bench/benchmarks/paint_states.ts
+++ b/test/bench/benchmarks/paint_states.ts
@@ -28,7 +28,7 @@ export default class PaintStates extends Benchmark {
     }
 
     setup() {
-        return fetch('/bench/data/naturalearth-land.json')
+        return fetch('/test/bench/data/naturalearth-land.json')
             .then(response => response.json())
             .then(data => {
                 this.numFeatures = data.features.length;

--- a/test/bench/benchmarks/remove_paint_state.ts
+++ b/test/bench/benchmarks/remove_paint_state.ts
@@ -28,7 +28,7 @@ class RemovePaintState extends Benchmark {
     }
 
     setup() {
-        return fetch('/bench/data/naturalearth-land.json')
+        return fetch('/test/bench/data/naturalearth-land.json')
             .then(response => response.json())
             .then(data => {
                 this.numFeatures = data.features.length;

--- a/test/bench/run-benchmarks.ts
+++ b/test/bench/run-benchmarks.ts
@@ -13,7 +13,7 @@ if (!fs.existsSync(dir)) {
     fs.mkdirSync(dir);
 }
 
-const url = new URL('http://localhost:9966/bench/versions');
+const url = new URL('http://localhost:9966/test/bench/versions');
 
 for (const compare of [].concat(argv.compare).filter(Boolean))
     url.searchParams.append('compare', compare);

--- a/test/bench/styles/index.html
+++ b/test/bench/styles/index.html
@@ -9,8 +9,8 @@
 
 <body>
     <div id="benchmarks"></div>
-    <script src="/bench/styles/benchmarks_generated.js"></script>
-    <script src="/bench/benchmarks_view_generated.js"></script>
+    <script src="/test/bench/styles/benchmarks_generated.js"></script>
+    <script src="/test/bench/benchmarks_view_generated.js"></script>
     <script>
         window.Benchmarks.run(benchmarks);
     </script>

--- a/test/bench/versions/index.html
+++ b/test/bench/versions/index.html
@@ -11,7 +11,7 @@
 
 <body>
     <div id="benchmarks"></div>
-    <script src="/bench/benchmarks_view_generated.js"></script>
+    <script src="/test/bench/benchmarks_view_generated.js"></script>
     <script>
         runComparison();
 
@@ -29,7 +29,7 @@
                 }
                 console.log(`Comparing versions: ${versions}`);
                 const versionsScripts = versions.map(v => `https://maplibre.org/maplibre-gl-js/benchmarks/${v}/benchmarks_generated.js`)
-                    .concat('/bench/versions/benchmarks_generated.js');
+                    .concat('/test/bench/versions/benchmarks_generated.js');
                 for (const script of versionsScripts) {
                     await loadScript(script);
                 }


### PR DESCRIPTION
## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

Fixes benchmark paths after the folder `bench` was moved to `test/bench` in #979. Maybe we did not catch this because we did not delete the `bench` folder with the generated files.

TODO: fix branch comparison. Currently I see a comparison between `main`, `main` and `move-bench` which is strange.

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [ ] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [ ] Manually test the debug page.
 - [ ] Suggest a changelog category: bug/feature/docs/etc. or "skip changelog".
 - [ ] Add an entry inside this element for inclusion in the `maplibre-gl-js` changelog: `<changelog></changelog>`.
