### PR TITLE
Change type of map.on, map.off, and map.once parameter from "type:  MapEvent" to "type: MapEvent | string"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,6 @@
 - Add FeatureIdentifier type to define feature parameter in setFeatureState, removeFeatureState, and getFeatureState methods. Change FeatureIdentifier.id from `id: string | number;` to `id?: string | number | undefined;` (#1095)
 - Change map.on, map.off, and map.once type parameter from "type: MapEvent" to "type: MapEvent | string" (#1094)
 
->>>>>>> 88f499fdb090e3cbdb42fb70a202bfb898dd999b
-
 ## 2.1.7
 
 ### 🐞 Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🐞 Bug fixes
 
-- *...Add new stuff here...*
+- Change map.on, map.off, and map.once type parameter from "type: MapEvent" to "type: MapEvent | string"
 
 ## 2.1.7
 

--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -917,7 +917,7 @@ class Map extends Camera {
         return this._rotating || this.handlers.isRotating();
     }
 
-    _createDelegatedListener(type: MapEvent, layerId: string, listener: Listener):
+    _createDelegatedListener(type: MapEvent | string, layerId: string, listener: Listener):
     {
         layer: string;
         listener: Listener;
@@ -1077,8 +1077,8 @@ class Map extends Camera {
         listener: (ev: MapLayerEventType[T] & Object) => void,
     ): this;
     on<T extends keyof MapEventType>(type: T, listener: (ev: MapEventType[T] & Object) => void): this;
-    on(type: MapEvent, listener: Listener): this;
-    on(type: MapEvent, layerIdOrListener: string | Listener, listener?: Listener): this {
+    on(type: MapEvent | string, listener: Listener): this;
+    on(type: MapEvent | string, layerIdOrListener: string | Listener, listener?: Listener): this {
         if (listener === undefined) {
             return super.on(type, layerIdOrListener as Listener);
         }
@@ -1131,8 +1131,8 @@ class Map extends Camera {
         listener: (ev: MapLayerEventType[T] & Object) => void,
     ): this;
     once<T extends keyof MapEventType>(type: T, listener: (ev: MapEventType[T] & Object) => void): this;
-    once(type: MapEvent, listener: Listener): this;
-    once(type: MapEvent, layerIdOrListener: string | Listener, listener?: Listener): this {
+    once(type: MapEvent | string, listener: Listener): this;
+    once(type: MapEvent | string, layerIdOrListener: string | Listener, listener?: Listener): this {
 
         if (listener === undefined) {
             return super.once(type, layerIdOrListener as Listener);
@@ -1173,8 +1173,8 @@ class Map extends Camera {
         listener: (ev: MapLayerEventType[T] & Object) => void,
     ): this;
     off<T extends keyof MapEventType>(type: T, listener: (ev: MapEventType[T] & Object) => void): this;
-    off(type: MapEvent, listener: Listener): this;
-    off(type: MapEvent, layerIdOrListener: string | Listener, listener?: Listener): this {
+    off(type: MapEvent | string, listener: Listener): this;
+    off(type: MapEvent | string, layerIdOrListener: string | Listener, listener?: Listener): this {
         if (listener === undefined) {
             return super.off(type, layerIdOrListener as Listener);
         }


### PR DESCRIPTION
Libraries like [mapbox-gl-draw](https://github.com/mapbox/mapbox-gl-draw) can extend Map with new events, for example, [draw.create](https://github.com/mapbox/mapbox-gl-draw/blob/main/docs/API.md#events). Maplibre map.on, map.off, and map.once type parameter needs to support `string` to support these libraries and avoid type failures like 

"No overload matches this call.
  Overload 1 of 3, '(type: keyof MapEventType, listener: (ev: (MapMouseEvent | MapLibreEvent<MouseEvent | TouchEvent | WheelEvent | undefined> | ... 10 more ... | MapWheelEvent) & Object) => void): Map', gave the following error.
    Argument of type '"draw.create"' is not assignable to parameter of type 'keyof MapEventType'.
  Overload 2 of 3, '(type: MapEvent, listener: Listener): Map', gave the following error.
    Argument of type '"draw.create"' is not assignable to parameter of type 'MapEvent'.".

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [ ] Manually test the debug page.
 - [ ] Suggest a changelog category: bug/feature/docs/etc. or "skip changelog".
 - [ ] Add an entry inside this element for inclusion in the `maplibre-gl-js` changelog: `<changelog></changelog>`.
