### PR TITLE
FeatureIdentifier interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🐞 Bug fixes
 
-- *...Add new stuff here...*
+- Add FeatureIdentifier interface to define feature parameter in setFeatureState, removeFeatureState, and getFeatureState methods. Change FeatureIdentifier.id from `id: string | number;` to `id?: string | number | undefined;` (#1095)
 
 ## 2.1.7
 

--- a/src/style/style.ts
+++ b/src/style/style.ts
@@ -87,11 +87,11 @@ const ignoredDiffOperations = pick(diffOperations, [
 
 const empty = emptyStyle() as StyleSpecification;
 
-export interface FeatureIdentifier {
+export type FeatureIdentifier = {
     id?: string | number | undefined;
     source: string;
     sourceLayer?: string | undefined;
-}
+};
 
 export type StyleOptions = {
     validate?: boolean;

--- a/src/style/style.ts
+++ b/src/style/style.ts
@@ -87,6 +87,12 @@ const ignoredDiffOperations = pick(diffOperations, [
 
 const empty = emptyStyle() as StyleSpecification;
 
+export interface FeatureIdentifier {
+    id?: string | number | undefined;
+    source: string;
+    sourceLayer?: string | undefined;
+}
+
 export type StyleOptions = {
     validate?: boolean;
     localIdeographFontFamily?: string;
@@ -912,11 +918,7 @@ class Style extends Evented {
         return this.getLayer(layer).getPaintProperty(name);
     }
 
-    setFeatureState(target: {
-        source: string;
-        sourceLayer?: string;
-        id: string | number;
-    }, state: any) {
+    setFeatureState(target: FeatureIdentifier, state: any) {
         this._checkLoaded();
         const sourceId = target.source;
         const sourceLayer = target.sourceLayer;
@@ -942,11 +944,7 @@ class Style extends Evented {
         sourceCache.setFeatureState(sourceLayer, target.id, state);
     }
 
-    removeFeatureState(target: {
-        source: string;
-        sourceLayer?: string;
-        id?: string | number;
-    }, key?: string) {
+    removeFeatureState(target: FeatureIdentifier, key?: string) {
         this._checkLoaded();
         const sourceId = target.source;
         const sourceCache = this.sourceCaches[sourceId];
@@ -972,11 +970,7 @@ class Style extends Evented {
         sourceCache.removeFeatureState(sourceLayer, target.id, key);
     }
 
-    getFeatureState(target: {
-        source: string;
-        sourceLayer?: string;
-        id: string | number;
-    }) {
+    getFeatureState(target: FeatureIdentifier) {
         this._checkLoaded();
         const sourceId = target.source;
         const sourceLayer = target.sourceLayer;

--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -29,7 +29,7 @@ import StyleLayer from '../style/style_layer';
 import type {RequestTransformFunction} from '../util/request_manager';
 import type {LngLatLike} from '../geo/lng_lat';
 import type {LngLatBoundsLike} from '../geo/lng_lat_bounds';
-import type {StyleOptions, StyleSetterOptions} from '../style/style';
+import type {FeatureIdentifier, StyleOptions, StyleSetterOptions} from '../style/style';
 import type {MapEvent, MapDataEvent} from './events';
 import type {CustomLayerInterface} from '../style/style_layer/custom_style_layer';
 import type {StyleImageInterface, StyleImageMetadata} from '../style/style_image';
@@ -2216,11 +2216,7 @@ class Map extends Camera {
      *
      * @see [Create a hover effect](https://maplibre.org/maplibre-gl-js-docs/example/hover-styles/)
      */
-    setFeatureState(feature: {
-        source: string;
-        sourceLayer?: string;
-        id: string | number;
-    }, state: any) {
+    setFeatureState(feature: FeatureIdentifier, state: any) {
         this.style.setFeatureState(feature, state);
         return this._update();
     }
@@ -2272,11 +2268,7 @@ class Map extends Camera {
      * });
      *
      */
-    removeFeatureState(target: {
-        source: string;
-        sourceLayer?: string;
-        id?: string | number;
-    }, key?: string) {
+    removeFeatureState(target: FeatureIdentifier, key?: string) {
         this.style.removeFeatureState(target, key);
         return this._update();
     }
@@ -2310,13 +2302,7 @@ class Map extends Camera {
      * });
      *
      */
-    getFeatureState(
-        feature: {
-            source: string;
-            sourceLayer?: string;
-            id: string | number;
-        }
-    ): any {
+    getFeatureState(feature: FeatureIdentifier): any {
         return this.style.getFeatureState(feature);
     }
 


### PR DESCRIPTION
This PR adds FeatureIdentifier interface. This interface existed in [mapbox DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/mapbox-gl/index.d.ts#L940)

The interface changes `id: string | number` to `id?: string | number | undefined;`. Adding type support for undefined in the interface is supported because Style.setFeatureState, Style.removeFeatureState, and Style.getFeatureState implementations have logic to ensure target.id === undefined is safely handled.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [ ] Manually test the debug page.
 - [ ] Suggest a changelog category: bug/feature/docs/etc. or "skip changelog".
 - [ ] Add an entry inside this element for inclusion in the `maplibre-gl-js` changelog: `<changelog></changelog>`.
