### PR TITLE
fix: dispose SourceCache resources on Style remove

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🐞 Bug fixes
 
-- *...Add new stuff here...*
+- Dispose source resources on map style removal (It also fixes `cannot read properties of undefined (reading 'sourceCaches')` error).
 
 ## 2.1.8-pre.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
 
 ### 🐞 Bug fixes
 
-- Dispose source resources on map style removal (It also fixes `cannot read properties of undefined (reading 'sourceCaches')` error).
+- *...Add new stuff here...*
+- Dispose source resources on map style removal, it also fixes `cannot read properties of undefined (reading 'sourceCaches')` error (#1099).
 
 ## 2.1.8-pre.1
 

--- a/src/source/source_cache.test.ts
+++ b/src/source/source_cache.test.ts
@@ -1651,3 +1651,25 @@ describe('SourceCache sets max cache size correctly', () => {
     });
 
 });
+
+describe('SourceCache#onRemove', () => {
+    test('clears tiles', () => {
+        const sourceCache = createSourceCache();
+        jest.spyOn(sourceCache, 'clearTiles');
+
+        sourceCache.onRemove(undefined);
+
+        expect(sourceCache.clearTiles).toHaveBeenCalled();
+    });
+
+    test('calls onRemove on source', () => {
+        const sourceOnRemove = jest.fn();
+        const sourceCache = createSourceCache({
+            onRemove: sourceOnRemove
+        });
+
+        sourceCache.onRemove(undefined);
+
+        expect(sourceOnRemove).toHaveBeenCalled();
+    });
+});

--- a/src/source/source_cache.ts
+++ b/src/source/source_cache.ts
@@ -115,6 +115,7 @@ class SourceCache extends Evented {
     }
 
     onRemove(map: Map) {
+        this.clearTiles();
         if (this._source && this._source.onRemove) {
             this._source.onRemove(map);
         }

--- a/src/style/style.test.ts
+++ b/src/style/style.test.ts
@@ -390,16 +390,15 @@ describe('Style#_remove', () => {
 
         style.on('style.load', () => {
             const sourceCache = style.sourceCaches['source-id'];
-            jest.spyOn(sourceCache, 'clearTiles');
             jest.spyOn(sourceCache, 'setEventedParent');
             jest.spyOn(sourceCache, 'onRemove');
+            jest.spyOn(sourceCache, 'clearTiles');
 
             style._remove();
 
-            expect(sourceCache.clearTiles).toHaveBeenCalledTimes(1);
-            expect(sourceCache.setEventedParent).toHaveBeenCalledTimes(1);
             expect(sourceCache.setEventedParent).toHaveBeenCalledWith(null);
-            expect(sourceCache.onRemove).toHaveBeenCalledTimes(1);
+            expect(sourceCache.onRemove).toHaveBeenCalledWith(style.map);
+            expect(sourceCache.clearTiles).toHaveBeenCalled();
 
             done();
         });

--- a/src/style/style.test.ts
+++ b/src/style/style.test.ts
@@ -382,7 +382,7 @@ describe('Style#loadJSON', () => {
 });
 
 describe('Style#_remove', () => {
-    test('clears tiles', done => {
+    test('removes cache sources and clears their tiles', done => {
         const style = new Style(getStubMap());
         style.loadJSON(createStyleJSON({
             sources: {'source-id': createGeoJSONSource()}
@@ -391,8 +391,16 @@ describe('Style#_remove', () => {
         style.on('style.load', () => {
             const sourceCache = style.sourceCaches['source-id'];
             jest.spyOn(sourceCache, 'clearTiles');
+            jest.spyOn(sourceCache, 'setEventedParent');
+            jest.spyOn(sourceCache, 'onRemove');
+
             style._remove();
+
             expect(sourceCache.clearTiles).toHaveBeenCalledTimes(1);
+            expect(sourceCache.setEventedParent).toHaveBeenCalledTimes(1);
+            expect(sourceCache.setEventedParent).toHaveBeenCalledWith(null);
+            expect(sourceCache.onRemove).toHaveBeenCalledTimes(1);
+
             done();
         });
     });

--- a/src/style/style.ts
+++ b/src/style/style.ts
@@ -610,9 +610,7 @@ class Style extends Evented {
         delete this._updatedSources[id];
         sourceCache.fire(new Event('data', {sourceDataType: 'metadata', dataType:'source', sourceId: id}));
         sourceCache.setEventedParent(null);
-        sourceCache.clearTiles();
-
-        if (sourceCache.onRemove) sourceCache.onRemove(this.map);
+        sourceCache.onRemove(this.map);
         this._changed = true;
     }
 
@@ -1241,9 +1239,8 @@ class Style extends Evented {
         }
         for (const id in this.sourceCaches) {
             const sourceCache = this.sourceCaches[id];
-            sourceCache.clearTiles();
             sourceCache.setEventedParent(null);
-            if (sourceCache.onRemove) sourceCache.onRemove(this.map);
+            sourceCache.onRemove(this.map);
         }
         this.imageManager.setEventedParent(null);
         this.setEventedParent(null);

--- a/src/style/style.ts
+++ b/src/style/style.ts
@@ -1240,8 +1240,10 @@ class Style extends Evented {
             layer.setEventedParent(null);
         }
         for (const id in this.sourceCaches) {
-            this.sourceCaches[id].clearTiles();
-            this.sourceCaches[id].setEventedParent(null);
+            const sourceCache = this.sourceCaches[id];
+            sourceCache.clearTiles();
+            sourceCache.setEventedParent(null);
+            if (sourceCache.onRemove) sourceCache.onRemove(this.map);
         }
         this.imageManager.setEventedParent(null);
         this.setEventedParent(null);


### PR DESCRIPTION
After Style instance removal all initialized sources and their resources (like HTTP requests) stay to live, that produce race conditions – like map style access after receiving of GeoJSON source response.

One of known issues is `cannot read properties of undefined (reading 'sourceCaches')` when you destroy the map instance during tiles load request.

## Launch Checklist

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Write tests for all new functionality.
 - [x] Add an entry inside this element for inclusion in the `maplibre-gl-js` changelog: `<changelog></changelog>`.
