### PR TITLE
Do not fire the data event for aborted tiles

### DIFF
--- a/src/source/source_cache.test.ts
+++ b/src/source/source_cache.test.ts
@@ -368,6 +368,23 @@ describe('SourceCache#removeTile', () => {
         expect(onAbort).toHaveBeenCalledTimes(0);
     });
 
+    test('does not fire data event when the tile has already been aborted', () => {
+        const onData = jest.fn();
+        const sourceCache = createSourceCache({
+            loadTile(tile, callback) {
+                sourceCache.once('dataabort', () => {
+                    tile.state = 'loaded';
+                    callback();
+                    expect(onData).toHaveBeenCalledTimes(0);
+                });
+            }
+        });
+        sourceCache.once('data', onData);
+        const tileID = new OverscaledTileID(0, 0, 0, 0, 0);
+        sourceCache._addTile(tileID);
+        sourceCache._removeTile(tileID.key);
+    });
+
 });
 
 describe('SourceCache / Source lifecycle', () => {

--- a/src/source/source_cache.ts
+++ b/src/source/source_cache.ts
@@ -272,7 +272,9 @@ class SourceCache extends Evented {
         if (this.getSource().type === 'raster-dem' && tile.dem) this._backfillDEM(tile);
         this._state.initializeTileState(tile, this.map ? this.map.painter : null);
 
-        this._source.fire(new Event('data', {dataType: 'source', tile, coord: tile.tileID}));
+        if (!tile.aborted) {
+            this._source.fire(new Event('data', {dataType: 'source', tile, coord: tile.tileID}));
+        }
     }
 
     /**


### PR DESCRIPTION
<changelog>Do not fire the data event for aborted tiles</changelog>

## Launch Checklist

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Write tests for all new functionality.
 - [x] Manually test the debug page.
 - [x] Add an entry inside this element for inclusion in the `maplibre-gl-js` changelog: `<changelog></changelog>`.
