### PR TITLE
Cancel pending GeoJSON requests when GeoJSONSource.setData() is called

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### ✨ Features and improvements
 
-- Cancel pending GeoJSON requests when `GeoJSONSource.setData()` is called instead of waiting for any pending request to complete before issuing the request for the new URL
+- Cancel pending GeoJSON requests when `GeoJSONSource.setData()` is called instead of waiting for any pending request to complete before issuing the request for the new URL (#1102)
 - *...Add new stuff here...*
 
 ### 🐞 Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### ✨ Features and improvements
 
+- Cancel pending GeoJSON requests when `GeoJSONSource.setData()` is called instead of waiting for any pending request to complete before issuing the request for the new URL
 - *...Add new stuff here...*
 
 ### 🐞 Bug fixes

--- a/src/source/geojson_source.test.ts
+++ b/src/source/geojson_source.test.ts
@@ -90,6 +90,18 @@ describe('GeoJSONSource#setData', () => {
         source.load();
     });
 
+    test('fires "dataabort" event', done => {
+        const source = new GeoJSONSource('id', {} as any, wrapDispatcher({
+            send(type, data, callback) {
+                setTimeout(() => callback(null, {abandoned: true}));
+            }
+        }), undefined);
+        source.on('dataabort', () => {
+            done();
+        });
+        source.load();
+    });
+
     test('respects collectResourceTiming parameter on source', done => {
         const source = createSource({collectResourceTiming: true});
         source.map = {
@@ -132,6 +144,19 @@ describe('GeoJSONSource#setData', () => {
     test('marks source as loaded before firing "data" event', done => {
         const source = createSource();
         source.once('data', () => {
+            expect(source.loaded()).toBeTruthy();
+            done();
+        });
+        source.setData({} as GeoJSON.GeoJSON);
+    });
+
+    test('marks source as loaded before firing "dataabort" event', done => {
+        const source = new GeoJSONSource('id', {} as any, wrapDispatcher({
+            send(type, data, callback) {
+                setTimeout(() => callback(null, {abandoned: true}));
+            }
+        }), undefined);
+        source.on('dataabort', () => {
             expect(source.loaded()).toBeTruthy();
             done();
         });

--- a/src/source/geojson_source.ts
+++ b/src/source/geojson_source.ts
@@ -256,20 +256,13 @@ class GeoJSONSource extends Evented implements Source {
             this._pendingLoads--;
 
             if (this._removed || (result && result.abandoned)) {
+                this.fire(new Event('dataabort', {dataType: 'source', sourceDataType}));
                 return;
             }
 
             let resourceTiming = null;
             if (result && result.resourceTiming && result.resourceTiming[this.id])
                 resourceTiming = result.resourceTiming[this.id].slice(0);
-            // Any `loadData` calls that piled up while we were processing
-            // this one will get coalesced into a single call when this
-            // 'coalesce' message is processed.
-            // We would self-send from the worker if we had access to its
-            // message queue. Waiting instead for the 'coalesce' to round-trip
-            // through the foreground just means we're throttling the worker
-            // to run at a little less than full-throttle.
-            this.actor.send(`${this.type}.coalesce`, {source: options.source}, null);
 
             if (err) {
                 this.fire(new ErrorEvent(err));

--- a/src/source/geojson_worker_source.test.ts
+++ b/src/source/geojson_worker_source.test.ts
@@ -237,29 +237,35 @@ describe('loadData', () => {
 
     test('abandons previous callbacks', done => {
         const worker = createWorker();
+        let firstCallbackHasRun = false;
 
         worker.loadData({source: 'source1', data: JSON.stringify(geoJson)} as LoadGeoJSONParameters, (err, result) => {
             expect(err).toBeNull();
             expect(result && result.abandoned).toBeTruthy();
+            firstCallbackHasRun = true;
         });
 
         worker.loadData({source: 'source1', data: JSON.stringify(geoJson)} as LoadGeoJSONParameters, (err, result) => {
             expect(err).toBeNull();
             expect(result && result.abandoned).toBeFalsy();
+            expect(firstCallbackHasRun).toBeTruthy();
             done();
         });
     });
 
     test('removeSource aborts callbacks', done => {
         const worker = createWorker();
+        let loadDataCallbackHasRun = false;
         worker.loadData({source: 'source1', data: JSON.stringify(geoJson)} as LoadGeoJSONParameters, (err, result) => {
             expect(err).toBeNull();
             expect(result && result.abandoned).toBeTruthy();
-            done();
+            loadDataCallbackHasRun = true;
         });
 
         worker.removeSource({source: 'source1'}, (err) => {
             expect(err).toBeFalsy();
+            expect(loadDataCallbackHasRun).toBeTruthy();
+            done();
         });
 
     });

--- a/src/ui/events.ts
+++ b/src/ui/events.ts
@@ -1395,7 +1395,7 @@ export type MapEvent =
     | 'style.load'
 
     /**
-     * Fired when a request for one of the map's sources' tiles is aborted.
+     * Fired when a request for one of the map's sources' data is aborted.
      * See {@link MapDataEvent} for more information.
      *
      * @event dataabort
@@ -1406,7 +1406,7 @@ export type MapEvent =
      * // Initialize the map
      * var map = new maplibregl.Map({ // map options });
      * // Set an event listener that fires
-     * // when a request for one of the map's sources' tiles is aborted.
+     * // when a request for one of the map's sources' data is aborted.
      * map.on('dataabort', function() {
      *   console.log('A dataabort event occurred.');
      * });
@@ -1414,7 +1414,7 @@ export type MapEvent =
     | 'dataabort'
 
     /**
-     * Fired when a request for one of the map's sources' tiles is aborted.
+     * Fired when a request for one of the map's sources' data is aborted.
      * See {@link MapDataEvent} for more information.
      *
      * @event sourcedataabort
@@ -1425,7 +1425,7 @@ export type MapEvent =
      * // Initialize the map
      * var map = new maplibregl.Map({ // map options });
      * // Set an event listener that fires
-     * // when a request for one of the map's sources' tiles is aborted.
+     * // when a request for one of the map's sources' data is aborted.
      * map.on('sourcedataabort', function() {
      *   console.log('A sourcedataabort event occurred.');
      * });


### PR DESCRIPTION
<changelog>Cancel pending GeoJSON requests when GeoJSONSource.setData() is called</changelog>

Currently, when `GeoJSONSource.setData()` is called with a new URL, the source waits for the previous URL to finish loading before issuing the request for the new URL. This PR proposes a solution where instead of waiting for the pending request to complete before issuing the new one, the pending request is canceled. The goal of this PR is to improve latency and avoid downloading unnecessary data.

## Launch Checklist

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Write tests for all new functionality.
 - [x] Document any changes to public APIs.
 - [x] Manually test the debug page.
 - [x] Add an entry inside this element for inclusion in the `maplibre-gl-js` changelog: `<changelog></changelog>`.