### PR TITLE
Fix raster source refreshing (#700)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - Dispose source resources on map style removal, it also fixes `cannot read properties of undefined (reading 'sourceCaches')` error (#1099).
 - Add MapGeoJSONFeature type as replacement for MapboxGeoJSONFeature. MapGeoJSONFeature type extends GeoJSONFeature type with layer, source, sourceLayer, and state properties (#1104).
+- Fix automatic refreshing of expired raster tiles (#1106)
 
 ## 2.1.8-pre.1
 

--- a/src/source/raster_tile_source.ts
+++ b/src/source/raster_tile_source.ts
@@ -105,7 +105,7 @@ class RasterTileSource extends Evented implements Source {
 
     loadTile(tile: Tile, callback: Callback<void>) {
         const url = tile.tileID.canonical.url(this.tiles, this.map.getPixelRatio(), this.scheme);
-        tile.request = getImage(this.map._requestManager.transformRequest(url, ResourceType.Tile), (err, img) => {
+        tile.request = getImage(this.map._requestManager.transformRequest(url, ResourceType.Tile), (err, img, expiry) => {
             delete tile.request;
 
             if (tile.aborted) {
@@ -115,9 +115,7 @@ class RasterTileSource extends Evented implements Source {
                 tile.state = 'errored';
                 callback(err);
             } else if (img) {
-                if (this.map._refreshExpiredTiles) tile.setExpiryData(img);
-                delete (img as any).cacheControl;
-                delete (img as any).expires;
+                if (this.map._refreshExpiredTiles) tile.setExpiryData(expiry);
 
                 const context = this.map.painter.context;
                 const gl = context.gl;

--- a/src/source/tile.ts
+++ b/src/source/tile.ts
@@ -33,6 +33,7 @@ import type {FilterSpecification} from '../style-spec/types.g';
 import type Point from '@mapbox/point-geometry';
 import {mat4} from 'gl-matrix';
 import type {VectorTileLayer} from '@mapbox/vector-tile';
+import {ExpiryData} from '../util/ajax';
 
 export type TileState = // Tile data is in the process of loading.
 'loading' | // Tile data has been loaded. Tile can be rendered.
@@ -340,7 +341,7 @@ class Tile {
         return this.imageAtlas && !!Object.keys(this.imageAtlas.patternPositions).length;
     }
 
-    setExpiryData(data: any) {
+    setExpiryData(data: ExpiryData) {
         const prior = this.expirationTime;
 
         if (data.cacheControl) {

--- a/src/source/vector_tile_worker_source.ts
+++ b/src/source/vector_tile_worker_source.ts
@@ -1,4 +1,4 @@
-import {getArrayBuffer} from '../util/ajax';
+import {ExpiryData, getArrayBuffer} from '../util/ajax';
 
 import vt from '@mapbox/vector-tile';
 import Protobuf from 'pbf';
@@ -21,10 +21,8 @@ import type {VectorTile} from '@mapbox/vector-tile';
 export type LoadVectorTileResult = {
     vectorTile: VectorTile;
     rawData: ArrayBuffer;
-    expires?: any;
-    cacheControl?: any;
     resourceTiming?: Array<PerformanceResourceTiming>;
-};
+} & ExpiryData;
 
 /**
  * @callback LoadVectorDataCallback

--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -1,7 +1,7 @@
 import {extend, bindAll, warnOnce, uniqueId, isImageBitmap} from '../util/util';
 import browser from '../util/browser';
 import DOM from '../util/dom';
-import {getImage, getJSON, ResourceType} from '../util/ajax';
+import {getImage, GetImageCallback, getJSON, ResourceType} from '../util/ajax';
 import {RequestManager} from '../util/request_manager';
 import Style from '../style/style';
 import EvaluationParameters from '../style/evaluation_parameters';
@@ -1836,7 +1836,7 @@ class Map extends Camera {
      *
      * @see [Add an icon to the map](https://maplibre.org/maplibre-gl-js-docs/example/add-image/)
      */
-    loadImage(url: string, callback: Callback<HTMLImageElement | ImageBitmap>) {
+    loadImage(url: string, callback: GetImageCallback) {
         getImage(this._requestManager.transformRequest(url, ResourceType.Image), callback);
     }
 

--- a/src/util/ajax.test.ts
+++ b/src/util/ajax.test.ts
@@ -182,13 +182,17 @@ describe('ajax', () => {
     test('getImage uses ImageBitmap when supported', done => {
         resetImageRequestQueue();
 
-        server.respondWith(request => request.respond(200, {'Content-Type': 'image/png'}, ''));
+        server.respondWith(request => request.respond(200, {'Content-Type': 'image/png',
+            'Cache-Control': 'cache',
+            'Expires': 'expires'}, ''));
 
         stubAjaxGetImage(() => Promise.resolve(new ImageBitmap()));
 
-        getImage({url: ''}, (err, img) => {
+        getImage({url: ''}, (err, img, expiry) => {
             if (err) done(err);
             expect(img).toBeInstanceOf(ImageBitmap);
+            expect(expiry.cacheControl).toBe('cache');
+            expect(expiry.expires).toBe('expires');
             done();
         });
 
@@ -198,13 +202,17 @@ describe('ajax', () => {
     test('getImage uses HTMLImageElement when ImageBitmap is not supported', done => {
         resetImageRequestQueue();
 
-        server.respondWith(request => request.respond(200, {'Content-Type': 'image/png'}, ''));
+        server.respondWith(request => request.respond(200, {'Content-Type': 'image/png',
+            'Cache-Control': 'cache',
+            'Expires': 'expires'}, ''));
 
         stubAjaxGetImage(undefined);
 
-        getImage({url: ''}, (err, img) => {
+        getImage({url: ''}, (err, img, expiry) => {
             if (err) done(`get image failed with error ${err.message}`);
             expect(img).toBeInstanceOf(HTMLImageElement);
+            expect(expiry.cacheControl).toBe('cache');
+            expect(expiry.expires).toBe('expires');
             done();
         });
 

--- a/src/util/ajax.ts
+++ b/src/util/ajax.ts
@@ -316,7 +316,7 @@ function sameOrigin(url) {
 
 const transparentPngUrl = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVQYV2NgAAIAAAUAAarVyFEAAAAASUVORK5CYII=';
 
-function arrayBufferToImage(data: ArrayBuffer, callback: (err?: Error | null, image?: HTMLImageElement | null) => void, cacheControl?: string | null, expires?: string | null) {
+function arrayBufferToImage(data: ArrayBuffer, callback: (err?: Error | null, image?: HTMLImageElement | null) => void) {
     const img: HTMLImageElement = new Image();
     img.onload = () => {
         callback(null, img);
@@ -329,8 +329,6 @@ function arrayBufferToImage(data: ArrayBuffer, callback: (err?: Error | null, im
     };
     img.onerror = () => callback(new Error('Could not load image. Please make sure to use a supported image type such as PNG or JPEG. Note that SVGs are not supported.'));
     const blob: Blob = new Blob([new Uint8Array(data)], {type: 'image/png'});
-    (img as any).cacheControl = cacheControl;
-    (img as any).expires = expires;
     img.src = data.byteLength ? URL.createObjectURL(blob) : transparentPngUrl;
 }
 
@@ -343,12 +341,14 @@ function arrayBufferToImageBitmap(data: ArrayBuffer, callback: (err?: Error | nu
     });
 }
 
-function arrayBufferToCanvasImageSource(data: ArrayBuffer, callback: (err?: Error | null, image?: CanvasImageSource | null) => void, cacheControl?: string | null, expires?: string | null) {
+export type ExpiryData = {cacheControl?: string | null; expires?: string | null};
+
+function arrayBufferToCanvasImageSource(data: ArrayBuffer, callback: Callback<CanvasImageSource>) {
     const imageBitmapSupported = typeof createImageBitmap === 'function';
     if (imageBitmapSupported) {
         arrayBufferToImageBitmap(data, callback);
     } else {
-        arrayBufferToImage(data, callback, cacheControl, expires);
+        arrayBufferToImage(data, callback);
     }
 }
 
@@ -359,9 +359,11 @@ export const resetImageRequestQueue = () => {
 };
 resetImageRequestQueue();
 
+export type GetImageCallback = (error?: Error | null, image?: HTMLImageElement | ImageBitmap | null, expiry?: ExpiryData | null) => void;
+
 export const getImage = function(
     requestParameters: RequestParameters,
-    callback: Callback<HTMLImageElement | ImageBitmap>
+    callback: GetImageCallback
 ): Cancelable {
     if (webpSupported.supported) {
         if (!requestParameters.headers) {
@@ -407,7 +409,14 @@ export const getImage = function(
         if (err) {
             callback(err);
         } else if (data) {
-            arrayBufferToCanvasImageSource(data, callback, cacheControl, expires);
+            const decoratedCallback = (imgErr?: Error | null, imgResult?: CanvasImageSource | null) => {
+                if (imgErr != null) {
+                    callback(imgErr);
+                } else if (imgResult != null) {
+                    callback(null, imgResult as (HTMLImageElement | ImageBitmap), {cacheControl, expires});
+                }
+            };
+            arrayBufferToCanvasImageSource(data, decoratedCallback);
         }
     });
 


### PR DESCRIPTION
Fixes expiry data on raster tiles fetched by browsers supporting offscreen canvas not getting automatically refreshed by mapbox.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [ ] ~Include before/after visuals or gifs if this PR includes visual changes.~
 - [x] Write tests for all new functionality.
 - [ ] ~Document any changes to public APIs.~
 - [ ] ~Post benchmark scores.~
 - [x] Manually test the debug page.
 - [x] Suggest a changelog category: bug
 - [x] Add an entry inside this element for inclusion in the `maplibre-gl-js` changelog: `<changelog>Fix automatic refreshing of expired raster tiles</changelog>`.
