### PR TITLE
Fix: use correct location for mouse events of line layer with line-offset (#1108)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,9 @@
 - *...Add new stuff here...*
 
 ### 🐞 Bug fixes
-- *...Add new stuff here...*
 
+- Use correct location for mouse events of line layer with line-offset (#1108).
+- *...Add new stuff here...*
 
 ## 2.1.8-pre.2
 

--- a/src/style/query_utils.test.ts
+++ b/src/style/query_utils.test.ts
@@ -1,0 +1,107 @@
+import Point from '@mapbox/point-geometry';
+
+import {offsetLine} from './query_utils';
+
+const defaultPrecision = 10;
+
+const closeTo = (expected, precision = defaultPrecision) => ({
+    asymmetricMatch: (actual) => Math.abs(expected - actual) < Math.pow(10, -precision) / 2
+});
+
+describe('offsetLine', () => {
+    test('line two points east', () => {
+        const line = [
+            new Point(0, 0),
+            new Point(1, 0)
+        ];
+        const offset = 1;
+
+        expect(offsetLine([line], offset)).toEqual([[
+            new Point(0, 1),
+            new Point(1, 1)
+        ]]);
+    });
+
+    test('line two points west', () => {
+        const line = [
+            new Point(10, 10),
+            new Point(5, 10)
+        ];
+        const offset = 2;
+
+        expect(offsetLine([line], offset)).toEqual([[
+            new Point(10, 8),
+            new Point(5, 8)
+        ]]);
+    });
+
+    test('line two points south', () => {
+        const line = [
+            new Point(0, -1),
+            new Point(0, 1)
+        ];
+        const offset = 1;
+
+        expect(offsetLine([line], offset)).toEqual([[
+            new Point(-1, -1),
+            new Point(-1, 1)
+        ]]);
+    });
+
+    test('line three points north', () => {
+        const line = [
+            new Point(0, 1),
+            new Point(0, 0),
+            new Point(0, -1)
+        ];
+        const offset = 1;
+
+        expect(offsetLine([line], offset)).toEqual([[
+            new Point(1, 1),
+            new Point(1, 0),
+            new Point(1, -1)
+        ]]);
+    });
+
+    test('line three points north east', () => {
+        const line = [
+            new Point(-1, 1),
+            new Point(0, 0),
+            new Point(1, -1)
+        ];
+        const offset = Math.sqrt(2);
+
+        expect(offsetLine([line], offset)).toEqual([[
+            {
+                x: closeTo(0),
+                y: closeTo(2)
+            },
+            {
+                x: closeTo(1),
+                y: closeTo(1)
+            },
+            {
+                x: closeTo(2),
+                y: closeTo(0)
+            }
+        ]]);
+    });
+
+    test('ring five points square', () => {
+        const ring = [
+            new Point(0, 0),
+            new Point(10, 0),
+            new Point(10, -10),
+            new Point(0, -10),
+            new Point(0, 0)
+        ];
+        const offset = 2;
+        expect(offsetLine([ring], offset)).toEqual([[
+            new Point(0, 2),
+            new Point(12, 2),
+            new Point(12, -12),
+            new Point(-2, -12),
+            new Point(-2, 0)
+        ]]);
+    });
+});

--- a/src/style/query_utils.ts
+++ b/src/style/query_utils.ts
@@ -58,7 +58,9 @@ export function offsetLine(rings, offset) {
             const extrude = aToB._add(bToC)._unit();
 
             const cosHalfAngle = extrude.x * bToC.x + extrude.y * bToC.y;
-            extrude._mult(1 / cosHalfAngle);
+            if (cosHalfAngle !== 0) {
+                extrude._mult(1 / cosHalfAngle);
+            }
 
             newRing.push(extrude._mult(offset)._add(b));
         }

--- a/src/style/query_utils.ts
+++ b/src/style/query_utils.ts
@@ -43,3 +43,26 @@ export function translate(queryGeometry: Array<Point>,
     }
     return translated;
 }
+
+export function offsetLine(rings, offset) {
+    const newRings = [];
+    for (let k = 0; k < rings.length; k++) {
+        const ring = rings[k];
+        const newRing = [];
+        for (let i = 0; i < ring.length; i++) {
+            const a = ring[i - 1];
+            const b = ring[i];
+            const c = ring[i + 1];
+            const aToB = i === 0 ? new Point(0, 0) : b.sub(a)._unit()._perp();
+            const bToC = i === ring.length - 1 ? new Point(0, 0) : c.sub(b)._unit()._perp();
+            const extrude = aToB._add(bToC)._unit();
+
+            const cosHalfAngle = extrude.x * bToC.x + extrude.y * bToC.y;
+            extrude._mult(1 / cosHalfAngle);
+
+            newRing.push(extrude._mult(offset)._add(b));
+        }
+        newRings.push(newRing);
+    }
+    return newRings;
+}

--- a/src/style/query_utils.ts
+++ b/src/style/query_utils.ts
@@ -44,17 +44,17 @@ export function translate(queryGeometry: Array<Point>,
     return translated;
 }
 
-export function offsetLine(rings, offset) {
-    const newRings = [];
-    for (let k = 0; k < rings.length; k++) {
-        const ring = rings[k];
-        const newRing = [];
-        for (let i = 0; i < ring.length; i++) {
-            const a = ring[i - 1];
-            const b = ring[i];
-            const c = ring[i + 1];
-            const aToB = i === 0 ? new Point(0, 0) : b.sub(a)._unit()._perp();
-            const bToC = i === ring.length - 1 ? new Point(0, 0) : c.sub(b)._unit()._perp();
+export function offsetLine(rings: Array<Array<Point>>, offset: number) {
+    const newRings: Array<Array<Point>> = [];
+    for (let ringIndex = 0; ringIndex < rings.length; ringIndex++) {
+        const ring = rings[ringIndex];
+        const newRing: Array<Point> = [];
+        for (let index = 0; index < ring.length; index++) {
+            const a = ring[index - 1];
+            const b = ring[index];
+            const c = ring[index + 1];
+            const aToB = index === 0 ? new Point(0, 0) : b.sub(a)._unit()._perp();
+            const bToC = index === ring.length - 1 ? new Point(0, 0) : c.sub(b)._unit()._perp();
             const extrude = aToB._add(bToC)._unit();
 
             const cosHalfAngle = extrude.x * bToC.x + extrude.y * bToC.y;

--- a/src/style/style_layer/line_style_layer.ts
+++ b/src/style/style_layer/line_style_layer.ts
@@ -128,7 +128,6 @@ function getLineWidth(lineWidth, lineGapWidth) {
 
 function offsetLine(rings, offset) {
     const newRings = [];
-    const zero = new Point(0, 0);
     for (let k = 0; k < rings.length; k++) {
         const ring = rings[k];
         const newRing = [];
@@ -136,8 +135,8 @@ function offsetLine(rings, offset) {
             const a = ring[i - 1];
             const b = ring[i];
             const c = ring[i + 1];
-            const aToB = i === 0 ? zero : b.sub(a)._unit()._perp();
-            const bToC = i === ring.length - 1 ? zero : c.sub(b)._unit()._perp();
+            const aToB = i === 0 ? new Point(0, 0) : b.sub(a)._unit()._perp();
+            const bToC = i === ring.length - 1 ? new Point(0, 0) : c.sub(b)._unit()._perp();
             const extrude = aToB._add(bToC)._unit();
 
             const cosHalfAngle = extrude.x * bToC.x + extrude.y * bToC.y;

--- a/src/style/style_layer/line_style_layer.ts
+++ b/src/style/style_layer/line_style_layer.ts
@@ -3,7 +3,7 @@ import Point from '@mapbox/point-geometry';
 import StyleLayer from '../style_layer';
 import LineBucket from '../../data/bucket/line_bucket';
 import {polygonIntersectsBufferedMultiLine} from '../../util/intersection_tests';
-import {getMaximumPaintValue, translateDistance, translate} from '../query_utils';
+import {getMaximumPaintValue, translateDistance, translate, offsetLine} from '../query_utils';
 import properties, {LineLayoutPropsPossiblyEvaluated, LinePaintPropsPossiblyEvaluated} from './line_style_layer_properties.g';
 import {extend} from '../../util/util';
 import EvaluationParameters from '../evaluation_parameters';
@@ -124,27 +124,4 @@ function getLineWidth(lineWidth, lineGapWidth) {
     } else {
         return lineWidth;
     }
-}
-
-function offsetLine(rings, offset) {
-    const newRings = [];
-    for (let k = 0; k < rings.length; k++) {
-        const ring = rings[k];
-        const newRing = [];
-        for (let i = 0; i < ring.length; i++) {
-            const a = ring[i - 1];
-            const b = ring[i];
-            const c = ring[i + 1];
-            const aToB = i === 0 ? new Point(0, 0) : b.sub(a)._unit()._perp();
-            const bToC = i === ring.length - 1 ? new Point(0, 0) : c.sub(b)._unit()._perp();
-            const extrude = aToB._add(bToC)._unit();
-
-            const cosHalfAngle = extrude.x * bToC.x + extrude.y * bToC.y;
-            extrude._mult(1 / cosHalfAngle);
-
-            newRing.push(extrude._mult(offset)._add(b));
-        }
-        newRings.push(newRing);
-    }
-    return newRings;
 }


### PR DESCRIPTION
### Changelog category

bug

### Changelog

<changelog>Use correct location for mouse events of line layer with line-offset (#1108)</changelog>.

### Technical description

The `offsetLine` function uses a `ring` array that contains instances of the class `Point` from `@mapbox/point-geometry`. Methods of the `Point` class that are prefixed with `_` adjust the instance of the `Point` class in place, i.e. no new instance is created and the current instance is mutated as a side effect and returned. This goes wrong when the `zero` variable is reused.

In the solution of this pull request the `zero` variable is removed and new instances of the `Point` class are created when needed.

### Backport from Mapbox project?

This fixes #1108 using a similar solution as in https://github.com/jack9ye/mapbox-gl-js/commit/ad2df2df734d26c85b9daa81c76eca9dc4f4508d, which is referred to in https://github.com/mapbox/mapbox-gl-js/issues/9419. The code is different, but the solution is very similar.

I guess that does not count as a backport, but I'm not totally sure. Please confirm.

Update: I checked what Mapbox GL JS version jack9ye uses for his proposed solution and unfortunately that is v2.2.0. However, all the code that is visible in https://github.com/jack9ye/mapbox-gl-js/commit/ad2df2df734d26c85b9daa81c76eca9dc4f4508d has not changed since v1.14.0-dev. Furthermore, the solution of this pull request will typically create 2 new `Point` objects per ring and the solution of https://github.com/jack9ye/mapbox-gl-js/commit/ad2df2df734d26c85b9daa81c76eca9dc4f4508d will create 3.

### Tasks

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Include before/after visuals or gifs if this PR includes visual changes.
     - No visual change, only a change in behavior.
 - [x] Write tests for all new functionality.
 - [x] Document any changes to public APIs.
     - No change to public APIs.
 - [ ] Post benchmark scores.
 - [x] Manually test the debug page.
 - [x] Suggest a changelog category: bug/feature/docs/etc. or "skip changelog".
 - [x] Add an entry inside this element for inclusion in the `maplibre-gl-js` changelog.
