### PR TITLE
Remove unminified production build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,6 @@ jobs:
           architecture: x64
       - run: npm ci
       - run: npm run generate-typings
-      - run: npm run build-prod-min
       - run: npm run build-prod
       - run: npm run build-csp
       - run: npm run build-dev

--- a/.github/workflows/publish-style-spec.yml
+++ b/.github/workflows/publish-style-spec.yml
@@ -24,7 +24,7 @@ jobs:
       
       - name: Build GL JS
         run: |
-          npm run build-prod-min
+          npm run build-prod
           npm run build-css
       
       - name: Build style spec

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,6 @@ jobs:
 
       - name: Build
         run: |
-          npm run build-prod-min
           npm run build-prod
           npm run build-csp
           npm run build-dev

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,7 +107,7 @@ A standalone build allows you to turn the contents of this repository into `mapl
 
 To create a standalone build, run
 ```bash
-npm run build-prod-min
+npm run build-prod
 npm run build-css
 ```
 

--- a/build/readme.md
+++ b/build/readme.md
@@ -8,7 +8,7 @@ The bundeling process can be split into several steps:
 `npm run build-css`
 This command will compile the css code and create the css file.
 
-`npm run build-prod` or `npm run build-prod-min` or `npm run build-dev`
+`npm run build-prod` and `npm run build-dev`
 These commands will use rollup to bundle the code. This is where the magic happens and uses some files in this folder.
 
 `banner.ts` is used to create a banner at the beginning of the output file

--- a/build/rollup_plugins.ts
+++ b/build/rollup_plugins.ts
@@ -17,7 +17,7 @@ export const nodeResolve = resolve({
     preferBuiltins: false
 });
 
-export const plugins = (minified: boolean, production: boolean): Plugin[] => [
+export const plugins = (production: boolean): Plugin[] => [
     minifyStyleSpec(),
     json(),
     // https://github.com/zaach/jison/issues/351
@@ -29,20 +29,20 @@ export const plugins = (minified: boolean, production: boolean): Plugin[] => [
             '_token_stack:': ''
         }
     }),
-    production ? strip({
+    production && strip({
         sourceMap: true,
         functions: ['PerformanceUtils.*', 'Debug.*']
-    }) : false,
-    minified ? terser({
+    }),
+    production && terser({
         compress: {
             // eslint-disable-next-line camelcase
             pure_getters: true,
             passes: 3
         }
-    }) : false,
-    production ? unassert({
+    }),
+    production && unassert({
         include: ['**/*'], // by default, unassert only includes .js files
-    }) : false,
+    }),
     nodeResolve,
     typescript(),
     commonjs({

--- a/package.json
+++ b/package.json
@@ -142,7 +142,6 @@
     "build-dev": "rollup --configPlugin @rollup/plugin-typescript -c --environment BUILD:dev",
     "watch-dev": "rollup --configPlugin @rollup/plugin-typescript -c --environment BUILD:dev --watch",
     "build-prod": "rollup --configPlugin @rollup/plugin-typescript -c --environment BUILD:production",
-    "build-prod-min": "rollup --configPlugin @rollup/plugin-typescript -c --environment BUILD:production,MINIFY:true",
     "build-csp": "rollup --configPlugin @rollup/plugin-typescript -c rollup.config.csp.ts",
     "build-css": "postcss -o dist/maplibre-gl.css src/css/maplibre-gl.css",
     "build-style-spec": "rollup --configPlugin @rollup/plugin-typescript -c rollup.config.style-spec.ts && rollup --configPlugin @rollup/plugin-typescript -c rollup.config.style-spec.ts --environment esm",

--- a/rollup.config.csp.ts
+++ b/rollup.config.csp.ts
@@ -16,7 +16,7 @@ const config = (input: InputOption, file: string, format: ModuleFormat): RollupO
         banner
     },
     treeshake: true,
-    plugins: plugins(true, true)
+    plugins: plugins(true)
 });
 
 export default [

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -4,12 +4,9 @@ import {plugins} from './build/rollup_plugins';
 import banner from './build/banner';
 import {RollupOptions} from 'rollup';
 
-const {BUILD, MINIFY} = process.env;
-const minified = MINIFY === 'true';
+const {BUILD} = process.env;
 const production = BUILD === 'production';
-const outputFile =
-    !production ? 'dist/maplibre-gl-dev.js' :
-        minified ? 'dist/maplibre-gl.js' : 'dist/maplibre-gl-unminified.js';
+const outputFile = production ? 'dist/maplibre-gl.js' : 'dist/maplibre-gl-dev.js';
 
 const config: RollupOptions[] = [{
     // Before rollup you should run build-tsc to transpile from typescript to javascript (except when running rollup in watch mode)
@@ -28,7 +25,7 @@ const config: RollupOptions[] = [{
         chunkFileNames: 'shared.js'
     },
     treeshake: production,
-    plugins: plugins(minified, production)
+    plugins: plugins(production)
 }, {
     // Next, bundle together the three "chunks" produced in the previous pass
     // into a single, final bundle. See rollup/bundle_prelude.js and

--- a/test/bench/README.md
+++ b/test/bench/README.md
@@ -31,7 +31,7 @@ By default, the style benchmark page will run its benchmarks against `https://ap
 
 ## Generating gl statistics
 
-Build minimized production maplibre-gl-js with `npm run build-prod-min`.
+Build minimized production maplibre-gl-js with `npm run build-prod`.
 
 Gather and output gl statistics from headless chromium with `npm run gl-stats`. The results are output to the terminal and saved in data.json.gz.
 

--- a/test/bench/rollup_config_benchmarks.ts
+++ b/test/bench/rollup_config_benchmarks.ts
@@ -26,7 +26,7 @@ const replaceConfig = {
     'process.env.NODE_ENV': JSON.stringify('production')
 };
 
-const allPlugins = plugins(true, true).concat(replace(replaceConfig));
+const allPlugins = plugins(true).concat(replace(replaceConfig));
 const intro = fs.readFileSync('rollup/bundle_prelude.js', 'utf8');
 
 const splitConfig = (name: string): RollupOptions[] => [{


### PR DESCRIPTION
The unminified production target isn't tested, and seems somewhat useless, so I suggest we tidy up the build pipeline by removing it.

This way `npm run build-prod` can also be assigned to make the actual production build, which seems more intuitive.