### PR TITLE
Select better values for testing Transform precision

### DIFF
--- a/src/geo/transform.test.ts
+++ b/src/geo/transform.test.ts
@@ -342,7 +342,7 @@ describe('transform', () => {
     test('maintains high float precision when calculating matrices', () => {
 
         const transform = new Transform(0, 22, 0, 60, true);
-        transform.resize(200, 200);
+        transform.resize(200.25, 200.25);
         transform.zoom = 20.25;
         transform.pitch = 67.25;
         transform.center = new LngLat(0.0, 0.0);
@@ -350,6 +350,6 @@ describe('transform', () => {
 
         expect(transform.customLayerMatrix()[0].toString().length).toBeGreaterThan(10);
         expect(transform.glCoordMatrix[0].toString().length).toBeGreaterThan(10);
-        expect(transform.maxPitchScaleFactor()).toBeCloseTo(2.366025414864222, 10);
+        expect(transform.maxPitchScaleFactor()).toBeCloseTo(2.366025418080343, 10);
     });
 });


### PR DESCRIPTION
## Launch Checklist

Value previously used for Transform.width should have resulted in low decimal count result, despite returning a high decimal count value for some reason. This PR changes the Transform width to fractional value to more reliably induce high decimal count values to all the tested results.

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.