### PR TITLE
[TypeScript] fix: missing `touchmove` in MapTouchEvent["type"]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🐞 Bug fixes
 
-- *...Add new stuff here...*
+- Fix missing `touchmove` in `MapTouchEvent["type"]`
  
 ## 2.1.8-pre.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🐞 Bug fixes
 
-- Fix missing `touchmove` in `MapTouchEvent["type"] (#1131)`
+- Fix missing `touchmove` in `MapTouchEvent["type"]` (#1131)
  
 ## 2.1.8-pre.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🐞 Bug fixes
 
-- Fix missing `touchmove` in `MapTouchEvent["type"]`
+- Fix missing `touchmove` in `MapTouchEvent["type"] (#1131)`
  
 ## 2.1.8-pre.3
 

--- a/src/ui/events.ts
+++ b/src/ui/events.ts
@@ -141,7 +141,7 @@ export class MapTouchEvent extends Event implements MapLibreEvent<TouchEvent> {
     /**
      * The event type.
      */
-    type: 'touchstart' | 'touchend' | 'touchcancel';
+    type: 'touchstart' | 'touchmove' | 'touchend' | 'touchcancel';
 
     /**
      * The `Map` object that fired the event.


### PR DESCRIPTION
Accessing `MapTouchEvent`'s `type` property and comparing it to `"mousemove"` throws a TypeScript error. This PR fixes it.

Example:
```typescript
if (e.type === "touchmove") e.originalEvent.preventDefault();
```

The code above results in
```
This condition will always return 'false' since the types '"mousedown" | "mouseup" | "click" | "dblclick" | "mousemove" | "mouseover" | "mouseenter" | "mouseleave" | "mouseout" | "contextmenu" | "touchstart" | "touchend" | "touchcancel"' and '"touchmove"' have no overlap.
```

![Screenshot_20220329_163726](https://user-images.githubusercontent.com/9782236/160612740-7c10829e-84d0-4806-b503-27a3e08e5fda.png)

The event is already properly documented, nothing to do on that account.