### PR TITLE
Create pull request demo on GitHub Pages

### DIFF
--- a/.github/workflows/add-pr-demo.yml
+++ b/.github/workflows/add-pr-demo.yml
@@ -1,0 +1,49 @@
+name: Add PR Demo
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  add-pr-demo:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set-up node
+        uses: actions/setup-node@v2
+        with:
+          node-version: 16
+
+      - name: Build
+        run: |
+          npm ci
+          npm run build-prod
+          npm run build-csp
+          npm run build-dev
+          npm run build-css
+          npm run build-benchmarks
+          npm run generate-typings
+          cp test/integration/pr-demo/index.html dist/index.html
+
+      - name: Empty postinstall.js
+        run: |
+          echo "// empty in published package" > postinstall.js
+
+      - name: Write dist/package.json
+        run: |
+          echo "{ \"type\": \"commonjs\" }" > dist/package.json
+    
+      - name: Deploy
+        uses: JamesIves/github-pages-deploy-action@4.1.0
+        with:
+          branch: gh-pages
+          folder: dist
+          target-folder: pulls/${{ github.event.number }}
+
+      - name: Add comment
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: pr-demo
+          message: |
+            Uploaded [build output](https://github.com/wipfli/maplibre-gl-js/tree/gh-pages/pulls/${{ github.event.number }}) and created a [live demo](https://maplibre.org/maplibre-gl-js/pulls/${{ github.event.number }}).

--- a/.github/workflows/add-pr-demo.yml
+++ b/.github/workflows/add-pr-demo.yml
@@ -46,4 +46,4 @@ jobs:
         with:
           header: pr-demo
           message: |
-            Uploaded [build output](https://github.com/wipfli/maplibre-gl-js/tree/gh-pages/pulls/${{ github.event.number }}) and created a [live demo](https://maplibre.org/maplibre-gl-js/pulls/${{ github.event.number }}).
+            Uploaded [build output](https://github.com/maplibre/maplibre-gl-js/tree/gh-pages/pulls/${{ github.event.number }}) and created a [live demo](https://maplibre.org/maplibre-gl-js/pulls/${{ github.event.number }}).

--- a/.github/workflows/remove-pr-demo.yml
+++ b/.github/workflows/remove-pr-demo.yml
@@ -1,0 +1,29 @@
+name: Remove PR Demo
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  remove-pr-demo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: gh-pages
+
+    - name: Remove folder 
+      run: git rm -rf pulls/${{ github.event.number }}
+
+    - name: Commit and push
+      run: |
+        git config --global user.name 'bot'
+        git config --global user.email 'email@example.com'
+        git commit -am "Remove ${{ github.event.number }}"
+        git push
+    - name: Add comment
+      uses: marocchino/sticky-pull-request-comment@v2
+      with:
+        header: pr-demo
+        message: |
+          Removed build output and live demo.

--- a/test/integration/pr-demo/index.html
+++ b/test/integration/pr-demo/index.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8" />
+<title>Display a map</title>
+<meta name="viewport" content="initial-scale=1,maximum-scale=1,user-scalable=no" />
+<script src="maplibre-gl.js"></script>
+<link href="maplibre-gl.css" rel="stylesheet" />
+<style>
+	body { margin: 0; padding: 0; }
+	#map { position: absolute; top: 0; bottom: 0; width: 100%; }
+</style>
+</head>
+<body>
+<div id="map"></div>
+<script>
+new maplibregl.Map({
+    container: 'map',
+    style: 'https://demotiles.maplibre.org/style.json',
+    center: [0, 0],
+    zoom: 1
+});
+</script>
+
+</body>
+</html> 


### PR DESCRIPTION
This is a revival of #328 which builds the library automatically and deploys the build output file from the `dist/` folder to the gh-pages branch on pull request.

This is useful for stackblitz and jsbins where one can make an examples with the code from a pull request.

Build output will be available at https://maplibre.org/maplibre-gl-js/pulls/<pr-number>


## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [ ] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [ ] Manually test the debug page.
 - [ ] Suggest a changelog category: bug/feature/docs/etc. or "skip changelog".
 - [ ] Add an entry inside this element for inclusion in the `maplibre-gl-js` changelog: `<changelog></changelog>`.
