### PR TITLE
when terrain is on render last layer correct, fixes #1124

### DIFF
--- a/src/render/render_to_texture.ts
+++ b/src/render/render_to_texture.ts
@@ -145,7 +145,7 @@ export default class RenderToTexture {
                 return true;
             }
 
-            if (isLastLayer) return true;
+            return this._renderToTexture[type];
         }
 
         return false;


### PR DESCRIPTION
Fixes the [GeoJSON label thing](https://github.com/maplibre/maplibre-gl-js/issues/1124), and i am pretty shure it is the correct fix for this, but we really need unit-tests for this. Anyone willed to help? I think it quite some work:

The Logic is (simplified):

* that all render-to-texture layers are collected in `this._stacks`, and rendered at once, because switching framebuffer for every layer is to slow.
* in `this._renderToTexture` is a list of layers which should render to texture
* the `RenderToTexture.renderLayer` returns `true` if the the current layer is rendered to texture, else `false`.

So tests should cover:

* create test stylesheets (or layer-arrays): one with a symbol-layer at the end, one with a render-to-texture-layer at end, or on the start, or symbol-layers in between of render-to-texture-layers,... there are a lot of different possibilities
* mock the whole render-logic, `prepareTerrain`, `drawTerrain`, `painter.renderLayer`, ...
* check the `_stacks` variable for correctness
* check the return value
* ...