### PR TITLE
Only use stale bot for pull requests

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -9,10 +9,8 @@ jobs:
     steps:
       - uses: actions/stale@v4
         with:
-          stale-issue-message: 'This issue is stale because it has been open 180 days with no activity. Remove stale label or comment or this will be closed in 30 days.'
           stale-pr-message: 'This PR is stale because it has been open 60 days with no activity. Remove stale label or comment or this will be closed in 30 days.'
-          close-issue-message: 'This issue was closed because it has been stalled for 30 days with no activity.'
           close-pr-message: 'This PR was closed because it has been stalled for 30 days with no activity.'
           days-before-pr-stale: 60
-          days-before-issue-stale: 180
+          days-before-issue-stale: -1
           days-before-close: 30


### PR DESCRIPTION
I think the stale bot is useful for reminding us about pull requests. With issues however, I find it disturbing that the bot closes issues after a certain time of inactivity. Especially if a person removed the stale label already once. This pull request configures stale bot to only care about pull requests.

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [ ] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [ ] Manually test the debug page.
 - [ ] Suggest a changelog category: bug/feature/docs/etc. or "skip changelog".
 - [ ] Add an entry inside this element for inclusion in the `maplibre-gl-js` changelog: `<changelog></changelog>`.
