### PR TITLE
Extend style swap options with stylePatch side-effect

### DIFF
--- a/src/style-spec/diff.ts
+++ b/src/style-spec/diff.ts
@@ -14,6 +14,11 @@ const operations = {
     addLayer: 'addLayer',
 
     /*
+     * { command: 'moveLayer', args: ['layerId, 'beforeLayerId']}
+     */
+    moveLayer: 'moveLayer',
+
+    /*
      * { command: 'removeLayer', args: ['layerId'] }
      */
     removeLayer: 'removeLayer',

--- a/src/style/style.ts
+++ b/src/style/style.ts
@@ -447,6 +447,7 @@ class Style extends Evented {
 
             for (const id in this._updatedPaintProps) {
                 this._layers[id].updateTransitions(parameters);
+                this._serializedLayers[id] = this._layers[id].serialize();
             }
 
             this.light.updateTransitions(parameters);
@@ -995,6 +996,7 @@ class Style extends Evented {
         if (deepEqual(layer.getLayoutProperty(name), value)) return;
 
         layer.setLayoutProperty(name, value, options);
+        this._serializedLayers[layerId] = layer.serialize();
         this._updateLayer(layer);
     }
 


### PR DESCRIPTION
## Launch Checklist

1. extends the style swap options (previously as `{ diff?: boolean }`) with an optional `stylePatch` function that allows performing a side effect during style switching: after a style is fetched but before it is committed to the map state. This allows to support a range of functionalities when incoming style requires modification based on external state or when previous style carries certain 'state' that needs to be carried over to a new style gracefully (without causing unnecessary visual transitions if changes are applied after a style change)  

2. adds layer serialization on layout or paint property changes: previously serialized version of the layer was not updated when its paint or layout properties were changed. (maplibre keeps two copies of layers internally, a list of serialized layers and a list of 'live' layers that need to be evaluated against the current feature state (and other things) before they are used for rendering.)

original author: @mbelt

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [ ] Manually test the debug page.
 - [ ] Suggest a changelog category: bug/feature/docs/etc. or "skip changelog".
 - [ ] Add an entry inside this element for inclusion in the `maplibre-gl-js` changelog: `<changelog></changelog>`.