### PR TITLE
Add sponsors with recurring donations to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,12 @@ Want an example? Have a look at the official [MapLibre GL JS Documentation](http
 
 Use MapLibre GL JS bindings for React (https://visgl.github.io/react-map-gl/docs/get-started/get-started#using-with-a-mapbox-gl-fork) and Angular (https://github.com/maplibre/ngx-maplibre-gl). Find more at [awesome-maplibre](https://github.com/maplibre/awesome-maplibre).
 
+### Sponsors
+
+We thank everyone who supported us financially in the past and special thanks to the people and organizations who support us with recurring dontations:  
+
+@jawg, @nekoyasan, @atierian, @photoprism, @kaplanlior, @francois2metz, @Schneider-Geo, @serghov, @ambientlight, @joschi77, @geoffhill, @jasongodev
+
 ### Roadmap
 
 This project's initial plans are outlined in the [Roadmap](https://github.com/maplibre/maplibre-gl-js/projects/2) project. The primary goal is consistency and continued bug fixes and maintenance as we advance. 


### PR DESCRIPTION
As discussed in the governing board and announced on open collective, we would like to mention all sponsors who support us with recurring donations in the README. We can put the name, github handle, and if desired a company name.

@nyurik do you think the wording makes sense? 

Suggestions welcome on formulating this better. The point is just to say thanks to people and orgs who support us...

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [ ] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [ ] Manually test the debug page.
 - [ ] Suggest a changelog category: bug/feature/docs/etc. or "skip changelog".
 - [ ] Add an entry inside this element for inclusion in the `maplibre-gl-js` changelog: `<changelog></changelog>`.
