### PR TITLE
merge_lines to merge on all multi(linestring/polygon) components

### DIFF
--- a/src/symbol/merge_lines.ts
+++ b/src/symbol/merge_lines.ts
@@ -1,38 +1,34 @@
+import Point from '@mapbox/point-geometry';
 import type {SymbolFeature} from '../data/bucket/symbol_bucket';
 
 export default function mergeLines(features: Array<SymbolFeature>): Array<SymbolFeature> {
-    const leftIndex: {[_: string]: number} = {};
-    const rightIndex: {[_: string]: number} = {};
-    const mergedFeatures = [];
-    let mergedIndex = 0;
-
-    function add(k) {
-        mergedFeatures.push(features[k]);
-        mergedIndex++;
-    }
-
+    const leftIndex: {[_: string]: [number, number]} = {};
+    const rightIndex: {[_: string]: [number, number]} = {};
+    // merged subcomponents per each feature
+    const mergedComponents: { [_: number]: { [_: number]: Point[] | null }} = [];
+    const noTextFeatures: SymbolFeature[] = [];
     function mergeFromRight(leftKey: string, rightKey: string, geom) {
-        const i = rightIndex[leftKey];
+        const [i, j] = rightIndex[leftKey];
         delete rightIndex[leftKey];
-        rightIndex[rightKey] = i;
+        rightIndex[rightKey] = [i, j];
 
-        mergedFeatures[i].geometry[0].pop();
-        mergedFeatures[i].geometry[0] = mergedFeatures[i].geometry[0].concat(geom[0]);
-        return i;
+        mergedComponents[i][j].pop();
+        mergedComponents[i][j] = mergedComponents[i][j].concat(geom);
+        return [i, j];
     }
 
     function mergeFromLeft(leftKey: string, rightKey: string, geom) {
-        const i = leftIndex[rightKey];
+        const [i, j] = leftIndex[rightKey];
         delete leftIndex[rightKey];
-        leftIndex[leftKey] = i;
+        leftIndex[leftKey] = [i, j];
 
-        mergedFeatures[i].geometry[0].shift();
-        mergedFeatures[i].geometry[0] = geom[0].concat(mergedFeatures[i].geometry[0]);
-        return i;
+        mergedComponents[i][j].shift();
+        mergedComponents[i][j] = geom.concat(mergedComponents[i][j]);
+        return [i, j];
     }
 
     function getKey(text, geom, onRight?) {
-        const point = onRight ? geom[0][geom[0].length - 1] : geom[0][0];
+        const point = onRight ? geom[geom.length - 1] : geom[0];
         return `${text}:${point.x}:${point.y}`;
     }
 
@@ -42,39 +38,55 @@ export default function mergeLines(features: Array<SymbolFeature>): Array<Symbol
         const text = feature.text ? feature.text.toString() : null;
 
         if (!text) {
-            add(k);
+            noTextFeatures.push(feature);
             continue;
         }
 
-        const leftKey = getKey(text, geom),
-            rightKey = getKey(text, geom, true);
+        for (let c = 0; c < geom.length; c++) {
+            const comp = geom[c];
+            // ensure l-to-r orientation of each segment
+            if (comp[0].x > comp[comp.length - 1].x) {
+                comp.reverse();
+            }
+            const leftKey = getKey(text, comp),
+                rightKey = getKey(text, comp, true);
+            if ((leftKey in rightIndex) && (rightKey in leftIndex) && (rightIndex[leftKey] !== leftIndex[rightKey])) {
+                // found lines with the same text adjacent to both ends of the current line, merge all three
+                const [w, z] = mergeFromLeft(leftKey, rightKey, comp);
+                const [i, j] = mergeFromRight(leftKey, rightKey, mergedComponents[w][z]);
 
-        if ((leftKey in rightIndex) && (rightKey in leftIndex) && (rightIndex[leftKey] !== leftIndex[rightKey])) {
-            // found lines with the same text adjacent to both ends of the current line, merge all three
-            const j = mergeFromLeft(leftKey, rightKey, geom);
-            const i = mergeFromRight(leftKey, rightKey, mergedFeatures[j].geometry);
+                delete leftIndex[leftKey];
+                delete rightIndex[rightKey];
 
-            delete leftIndex[leftKey];
-            delete rightIndex[rightKey];
-
-            rightIndex[getKey(text, mergedFeatures[i].geometry, true)] = i;
-            mergedFeatures[j].geometry = null;
-
-        } else if (leftKey in rightIndex) {
-            // found mergeable line adjacent to the start of the current line, merge
-            mergeFromRight(leftKey, rightKey, geom);
-
-        } else if (rightKey in leftIndex) {
-            // found mergeable line adjacent to the end of the current line, merge
-            mergeFromLeft(leftKey, rightKey, geom);
-
-        } else {
-            // no adjacent lines, add as a new item
-            add(k);
-            leftIndex[leftKey] = mergedIndex - 1;
-            rightIndex[rightKey] = mergedIndex - 1;
+                rightIndex[getKey(text, mergedComponents[i][j], true)] = [i, j];
+                mergedComponents[w][z] = null;
+            } else if (leftKey in rightIndex) {
+                // found mergeable line adjacent to the start of the current line, merge
+                mergeFromRight(leftKey, rightKey, comp);
+            } else if (rightKey in leftIndex) {
+                // found mergeable line adjacent to the end of the current line, merge
+                mergeFromLeft(leftKey, rightKey, comp);
+            } else {
+                // no adjacent lines, add as a new item
+                const featureComponents = mergedComponents[k] || {};
+                featureComponents[c] = comp;
+                leftIndex[leftKey] = [k, c];
+                rightIndex[rightKey] = [k, c];
+                mergedComponents[k] = featureComponents;
+            }
         }
     }
 
-    return mergedFeatures.filter((f) => f.geometry);
+    return [
+        ...noTextFeatures,
+        ...Object.keys(mergedComponents)
+            // filter out features with empty geometry
+            .map(featureIdx => {
+                const mergedGeometry = Object.values(mergedComponents[+featureIdx]).filter(component => component !== null);
+                const feature = features[+featureIdx];
+                feature.geometry = mergedGeometry;
+                return mergedGeometry.length > 0 ? feature : null;
+            })
+            .filter(feature => feature !== null)
+    ];
 }


### PR DESCRIPTION
When symbol buckets with `line` symbol-placement are populated, a line merging algorithm is used to merge individual line segments. This later helps during the determination of anchors as anchors are considered per each symbol feature.

For now, the 'first' (LineString or Polygon or first linestring/polygon of MultiLineString/MultiPolygon) geometry primitives are considered in merge: https://github.com/maplibre/maplibre-gl-js/blob/0f5b68a236c7664e2b98aa386f251065bcd569e4/src/symbol/merge_lines.ts#L35

This PR changes that and considers all components for merge. This helps to increase a chance of producing anchors in usecases when road geometry in tiles consist of MultiLineStrings with each component shorter then expected glyph length.

Example:
![image](https://user-images.githubusercontent.com/14032724/170527056-47634f57-d8eb-4b22-8da3-9e27bc18d0f5.png)

when merged - a text symbol can then be placed across what originally is a MultiLineString:

![image](https://user-images.githubusercontent.com/14032724/170527244-862892ea-001c-4c45-9423-d7008dcfdedb.png)



## Launch Checklist

 - [X] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [X] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [ ] Manually test the debug page.
 - [ ] Suggest a changelog category: bug/feature/docs/etc. or "skip changelog".
 - [ ] Add an entry inside this element for inclusion in the `maplibre-gl-js` changelog: `<changelog></changelog>`.
