### PR TITLE
reset attrib summary element styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 ### 🐞 Bug fixes
 
 - *...Add new stuff here...*
-- Hide arrow displayed in default `summary` styles on the attribution control
+- Hide arrow displayed in default `summary` styles on the attribution control ([#1258](https://github.com/maplibre/maplibre-gl-js/pull/1258))
 
 ## 2.2.0-pre.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### 🐞 Bug fixes
 
 - *...Add new stuff here...*
+- Hide arrow displayed in default `summary` styles on the attribution control
 
 ## 2.2.0-pre.2
 

--- a/src/css/maplibre-gl.css
+++ b/src/css/maplibre-gl.css
@@ -580,6 +580,15 @@ a.mapboxgl-ctrl-logo.mapboxgl-compact {
         border: 0;
     }
 
+    .maplibregl-ctrl-attrib summary.maplibregl-ctrl-attrib-button {
+        appearance: none;
+        list-style: none;
+    }
+
+    .maplibregl-ctrl-attrib summary.maplibregl-ctrl-attrib-button::-webkit-details-marker {
+        display: none;
+    }
+
     .maplibregl-ctrl-top-left .maplibregl-ctrl-attrib-button,
     .maplibregl-ctrl-bottom-left .maplibregl-ctrl-attrib-button,
     .mapboxgl-ctrl-top-left .mapboxgl-ctrl-attrib-button,


### PR DESCRIPTION
## Launch Checklist

Overrides the default styles for `summary` elements on the attribution control. This is currently showing on iOS Safari, but overriding the styles hides it. It looks like this popped up as a result of changing the elements in #557.

Let me know if I can make any changes to this, thanks!

Before:

![IMG_5131](https://user-images.githubusercontent.com/8291663/171026883-82fdfae5-ada7-4fa7-b9de-4da92484c26e.jpg)

After:

![IMG_5132](https://user-images.githubusercontent.com/8291663/171026885-4a922129-16a5-42df-a389-21e756616360.jpg)

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Suggest a changelog category: bug/feature/docs/etc. or "skip changelog".
 - [x] Add an entry inside this element for inclusion in the `maplibre-gl-js` changelog: `<changelog></changelog>`.
