### PR TITLE
Only remove terrain if `this.map.transform` exists

### DIFF
--- a/src/style/style.ts
+++ b/src/style/style.ts
@@ -500,6 +500,8 @@ class Style extends Evented {
         // remove terrain
         if (!options) {
             this.terrain = null;
+            console.log('this.map is', this.map);
+            console.log('this.map.transform is', this.map.transform);
             this.map.transform?.updateElevation(this.terrain);
 
         // add terrain

--- a/src/style/style.ts
+++ b/src/style/style.ts
@@ -500,7 +500,7 @@ class Style extends Evented {
         // remove terrain
         if (!options) {
             this.terrain = null;
-            this.map.transform.updateElevation(this.terrain);
+            this.map.transform?.updateElevation(this.terrain);
 
         // add terrain
         } else {

--- a/test/bench/versions/index.html
+++ b/test/bench/versions/index.html
@@ -27,9 +27,8 @@
                     const responseJson = await response.json();
                     versions = [responseJson['tag_name'], 'main'];
                 }
-                console.log(`Comparing versions: ${versions}`);
-                const versionsScripts = versions.map(v => `https://maplibre.org/maplibre-gl-js/benchmarks/${v}/benchmarks_generated.js`)
-                    .concat('/bench/versions/benchmarks_generated.js');
+                //console.log(`Comparing versions: ${versions}`);
+                const versionsScripts = ['/bench/versions/benchmarks_generated.js'];
                 for (const script of versionsScripts) {
                     await loadScript(script);
                 }


### PR DESCRIPTION
## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

Fixes #1254

I wonder if there are other places where we have to be more careful that `this.map.transform` actually exists.

And should I add a unit test for this?

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [ ] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [ ] Manually test the debug page.
 - [ ] Suggest a changelog category: bug/feature/docs/etc. or "skip changelog".
 - [ ] Add an entry inside this element for inclusion in the `maplibre-gl-js` changelog: `<changelog></changelog>`.
