### PR TITLE
Transform._constrain handles bounds that cross the anti-meridian

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### 🐞 Bug fixes
 
 - *...Add new stuff here...*
+- Handle maxBounds which cross the meridian at longitude ±180° (#1298, #1299)
 - Hide arrow displayed in default `summary` styles on the attribution control ([#1258](https://github.com/maplibre/maplibre-gl-js/pull/1258))
 
 ## 2.2.0-pre.2

--- a/src/geo/transform.test.ts
+++ b/src/geo/transform.test.ts
@@ -109,19 +109,31 @@ describe('transform', () => {
         transform.zoom = 10;
         transform.resize(500, 500);
 
-        transform.lngRange = [175, -175];
-        transform.latRange = [-5, 5];
+        // equivalent ranges
+        const lngRanges: [number, number][] = [
+            [175, -175], [175, 185], [-185, -175], [-185, 185]
+        ];
 
-        transform.zoom = 0;
-        expect(transform.zoom).toBe(5.1357092861044045);
+        for (const lngRange of lngRanges) {
+            transform.lngRange = lngRange;
+            transform.latRange = [-5, 5];
 
-        transform.center = new LngLat(-50, -30);
-        expect(transform.center).toEqual(new LngLat(180, -0.0063583052861417855));
+            transform.zoom = 0;
+            expect(transform.zoom).toBe(5.1357092861044045);
 
-        transform.zoom = 10;
-        transform.center = new LngLat(-50, -30);
-        // eslint-disable-next-line no-loss-of-precision
-        expect(transform.center).toEqual(new LngLat(-175.17166137695312, -4.828969771321582));
+            transform.center = new LngLat(-50, -30);
+            expect(transform.center).toEqual(new LngLat(180, -0.0063583052861417855));
+
+            transform.zoom = 10;
+            transform.center = new LngLat(-50, -30);
+            expect(transform.center).toEqual(new LngLat(-175.171661376953125, -4.828969771321582));
+
+            transform.center = new LngLat(230, 0);
+            expect(transform.center).toEqual(new LngLat(-175.171661376953125, 0));
+
+            transform.center = new LngLat(130, 0);
+            expect(transform.center).toEqual(new LngLat(175.171661376953125, 0));
+        }
     });
 
     describe('coveringTiles', () => {

--- a/src/geo/transform.test.ts
+++ b/src/geo/transform.test.ts
@@ -93,7 +93,7 @@ describe('transform', () => {
         transform.latRange = [-5, 5];
 
         transform.zoom = 0;
-        expect(transform.zoom).toBe(5.135709286104402);
+        expect(transform.zoom).toBe(5.1357092861044045);
 
         transform.center = new LngLat(-50, -30);
         expect(transform.center).toEqual(new LngLat(0, -0.0063583052861417855));
@@ -101,6 +101,27 @@ describe('transform', () => {
         transform.zoom = 10;
         transform.center = new LngLat(-50, -30);
         expect(transform.center).toEqual(new LngLat(-4.828338623046875, -4.828969771321582));
+    });
+
+    test('lngRange can constrain zoom and center across meridian', () => {
+        const transform = new Transform(0, 22, 0, 60, true);
+        transform.center = new LngLat(180, 0);
+        transform.zoom = 10;
+        transform.resize(500, 500);
+
+        transform.lngRange = [175, -175];
+        transform.latRange = [-5, 5];
+
+        transform.zoom = 0;
+        expect(transform.zoom).toBe(5.1357092861044045);
+
+        transform.center = new LngLat(-50, -30);
+        expect(transform.center).toEqual(new LngLat(180, -0.0063583052861417855));
+
+        transform.zoom = 10;
+        transform.center = new LngLat(-50, -30);
+        // eslint-disable-next-line no-loss-of-precision
+        expect(transform.center).toEqual(new LngLat(-175.17166137695312, -4.828969771321582));
     });
 
     describe('coveringTiles', () => {

--- a/src/geo/transform.ts
+++ b/src/geo/transform.ts
@@ -766,8 +766,20 @@ class Transform {
 
         if (this.lngRange) {
             const lngRange = this.lngRange;
-            minX = mercatorXfromLng(lngRange[0]) * this.worldSize;
-            maxX = mercatorXfromLng(lngRange[1]) * this.worldSize;
+
+            minX = wrap(
+                mercatorXfromLng(lngRange[0]) * this.worldSize,
+                0,
+                this.worldSize
+            );
+            maxX = wrap(
+                mercatorXfromLng(lngRange[1]) * this.worldSize,
+                0,
+                this.worldSize
+            );
+
+            if (maxX < minX) maxX += this.worldSize;
+
             sx = maxX - minX < size.x ? size.x / (maxX - minX) : 0;
         }
 
@@ -795,7 +807,8 @@ class Transform {
         }
 
         if (this.lngRange) {
-            const x = point.x,
+            const centerX = (minX + maxX) / 2;
+            const x = wrap(point.x, centerX - this.worldSize / 2, centerX + this.worldSize / 2),
                 w2 = size.x / 2;
 
             if (x - w2 < minX) x2 = minX + w2;
@@ -806,7 +819,7 @@ class Transform {
         if (x2 !== undefined || y2 !== undefined) {
             this.center = this.unproject(new Point(
                 x2 !== undefined ? x2 : point.x,
-                y2 !== undefined ? y2 : point.y));
+                y2 !== undefined ? y2 : point.y)).wrap();
         }
 
         this._unmodified = unmodified;

--- a/src/geo/transform.ts
+++ b/src/geo/transform.ts
@@ -808,8 +808,8 @@ class Transform {
 
         if (this.lngRange) {
             const centerX = (minX + maxX) / 2;
-            const x = wrap(point.x, centerX - this.worldSize / 2, centerX + this.worldSize / 2),
-                w2 = size.x / 2;
+            const x = wrap(point.x, centerX - this.worldSize / 2, centerX + this.worldSize / 2);
+            const w2 = size.x / 2;
 
             if (x - w2 < minX) x2 = minX + w2;
             if (x + w2 > maxX) x2 = maxX - w2;

--- a/src/ui/map.test.ts
+++ b/src/ui/map.test.ts
@@ -227,7 +227,7 @@ describe('Map', () => {
             map.transform.lngRange = [-120, 140];
             map.transform.latRange = [-60, 80];
             map.transform.resize(600, 400);
-            expect(map.transform.zoom).toBe(0.6983039737971012);
+            expect(map.transform.zoom).toBe(0.6983039737971014);
             expect(map.transform.unmodified).toBeTruthy();
             map.setStyle(createStyle());
             map.on('style.load', () => {


### PR DESCRIPTION
_constrain uses 'wrap()' to adjust minX, maxX and point.x to the same range
so that valid 'east of' and 'west of' comparisons can be made

Fixes bug in issue #1298 

## Launch Checklist

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [x] Post benchmark scores.
 - [x ] Manually test the debug page.
 - [x] Suggest a changelog category: bug/feature/docs/etc. or "skip changelog".
 - [x] Add an entry inside this element for inclusion in the `maplibre-gl-js` changelog: `<changelog></changelog>`.
