### PR TITLE
set threshold to deactivate pan-inertia

### DIFF
--- a/src/ui/handler_inertia.ts
+++ b/src/ui/handler_inertia.ts
@@ -92,7 +92,7 @@ export default class HandlerInertia {
             if (settings.panDelta) {
                 deltas.pan._add(settings.panDelta);
                 const panDistance = ((settings.panDelta as Point).x ** 2 + (settings.panDelta as Point).y ** 2) ** 0.5;
-                if  (panDistance < 3) deltas.pan = new Point(0, 0) // the number is a threshold to kill inertia, in xy-distance
+                if  (panDistance < 3) deltas.pan = new Point(0, 0); // the number is a threshold to kill inertia, in xy-distance
             }
         }
 

--- a/src/ui/handler_inertia.ts
+++ b/src/ui/handler_inertia.ts
@@ -89,14 +89,12 @@ export default class HandlerInertia {
             deltas.pitch += settings.pitchDelta || 0;
             if (settings.around) deltas.around = settings.around;
             if (settings.pinchAround) deltas.pinchAround = settings.pinchAround;
-            if (settings.panDelta) {
-                deltas.pan._add(settings.panDelta);
-                const panDistance = ((settings.panDelta as Point).x ** 2 + (settings.panDelta as Point).y ** 2) ** 0.5;
-                if  (panDistance < 3) deltas.pan = new Point(0, 0); // the number is a threshold to kill inertia, in xy-distance
-            }
         }
+        
 
         const lastEntry = this._inertiaBuffer[this._inertiaBuffer.length - 1];
+        if (lastEntry.settings.panDelta) deltas.pan._add(lastEntry.settings.panDelta.mult(10)); // the number of mult is magnifier for panDelta
+
         const duration = (lastEntry.time - this._inertiaBuffer[0].time);
 
         const easeOptions = {} as any;

--- a/src/ui/handler_inertia.ts
+++ b/src/ui/handler_inertia.ts
@@ -87,9 +87,13 @@ export default class HandlerInertia {
             deltas.zoom += settings.zoomDelta || 0;
             deltas.bearing += settings.bearingDelta || 0;
             deltas.pitch += settings.pitchDelta || 0;
-            if (settings.panDelta) deltas.pan._add(settings.panDelta);
             if (settings.around) deltas.around = settings.around;
             if (settings.pinchAround) deltas.pinchAround = settings.pinchAround;
+            if (settings.panDelta) {
+                deltas.pan._add(settings.panDelta);
+                const panDistance = ((settings.panDelta as Point).x ** 2 + (settings.panDelta as Point).y ** 2) ** 0.5;
+                if  (panDistance < 3) deltas.pan = new Point(0, 0) // the number is a threshold to kill inertia, in xy-distance
+            }
         }
 
         const lastEntry = this._inertiaBuffer[this._inertiaBuffer.length - 1];


### PR DESCRIPTION
may close #1303 (under discussion)

## current behavior

- `Map-Pan` with mouse-dragging, <b>stop drag</b> and then release mousedown, pan-inertia will be activate despite mouse-drag stopped once.

## improve

- When mouse-dragging stop once in series of dragging, it is better pan-inertia is killed.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [ ] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [ ] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [ ] Manually test the debug page.
 - [ ] Suggest a changelog category: bug/feature/docs/etc. or "skip changelog".
 - [ ] Add an entry inside this element for inclusion in the `maplibre-gl-js` changelog: `<changelog></changelog>`.
