### PR TITLE
Add unit test for calculating min/max elevation

### DIFF
--- a/src/geo/transform.test.ts
+++ b/src/geo/transform.test.ts
@@ -4,6 +4,8 @@ import LngLat from './lng_lat';
 import {OverscaledTileID, CanonicalTileID} from '../source/tile_id';
 import {fixedLngLat, fixedCoord} from '../../test/unit/lib/fixed';
 import type Terrain from '../render/terrain';
+import type DEMData from '../data/dem_data';
+import Tile from '../source/tile';
 
 describe('transform', () => {
     test('creates a transform', () => {
@@ -407,4 +409,21 @@ describe('transform', () => {
         expect(transform.getBounds().getNorthWest().toArray()).toStrictEqual(transform.pointLocation(new Point(0, top)).toArray());
     });
 
+    test('Calculate tile minimum and maximum elevation', () => {
+        const transform = new Transform(0, 22, 0, 85, true);
+        const tile = {
+            dem: {
+                min: 0,
+                max: 100,
+            } as any as DEMData
+        } as any as Tile;
+        const terrain = {
+            exaggeration: 2,
+            elevationOffset: 50,
+        } as any as Terrain;
+        const {minElevation, maxElevation} = transform.getMinMaxElevation(tile, terrain);
+
+        expect(minElevation).toBe(100);
+        expect(maxElevation).toBe(300);
+    });
 });

--- a/src/geo/transform.test.ts
+++ b/src/geo/transform.test.ts
@@ -4,8 +4,6 @@ import LngLat from './lng_lat';
 import {OverscaledTileID, CanonicalTileID} from '../source/tile_id';
 import {fixedLngLat, fixedCoord} from '../../test/unit/lib/fixed';
 import type Terrain from '../render/terrain';
-import type DEMData from '../data/dem_data';
-import Tile from '../source/tile';
 
 describe('transform', () => {
     test('creates a transform', () => {
@@ -409,21 +407,4 @@ describe('transform', () => {
         expect(transform.getBounds().getNorthWest().toArray()).toStrictEqual(transform.pointLocation(new Point(0, top)).toArray());
     });
 
-    test('Calculate tile minimum and maximum elevation', () => {
-        const transform = new Transform(0, 22, 0, 85, true);
-        const tile = {
-            dem: {
-                min: 0,
-                max: 100,
-            } as any as DEMData
-        } as any as Tile;
-        const terrain = {
-            exaggeration: 2,
-            elevationOffset: 50,
-        } as any as Terrain;
-        const {minElevation, maxElevation} = transform.getTileMinMaxElevation(tile, terrain);
-
-        expect(minElevation).toBe(100);
-        expect(maxElevation).toBe(300);
-    });
 });

--- a/src/geo/transform.test.ts
+++ b/src/geo/transform.test.ts
@@ -421,7 +421,7 @@ describe('transform', () => {
             exaggeration: 2,
             elevationOffset: 50,
         } as any as Terrain;
-        const {minElevation, maxElevation} = transform.getMinMaxElevation(tile, terrain);
+        const {minElevation, maxElevation} = transform.getTileMinMaxElevation(tile, terrain);
 
         expect(minElevation).toBe(100);
         expect(maxElevation).toBe(300);

--- a/src/geo/transform.ts
+++ b/src/geo/transform.ts
@@ -12,6 +12,7 @@ import EdgeInsets from './edge_insets';
 import {UnwrappedTileID, OverscaledTileID, CanonicalTileID} from '../source/tile_id';
 import type {PaddingOptions} from './edge_insets';
 import Terrain from '../render/terrain';
+import Tile from '../source/tile';
 
 /**
  * A single transform, generally used for a single tile to be
@@ -441,8 +442,7 @@ class Transform {
                     const tile = options.terrain.getTerrainData(tileID).tile;
                     let minElevation = this.elevation, maxElevation = this.elevation;
                     if (tile && tile.dem) {
-                        minElevation = (tile.dem.min + options.terrain.elevationOffset) * options.terrain.exaggeration;
-                        maxElevation = (tile.dem.max + options.terrain.elevationOffset) * options.terrain.exaggeration;
+                        ({minElevation, maxElevation} = this.getTileMinMaxElevation(tile, options.terrain));
                     }
                     quadrant = new Aabb(
                         [quadrant.min[0], quadrant.min[1], minElevation] as vec3,
@@ -454,6 +454,22 @@ class Transform {
         }
 
         return result.sort((a, b) => a.distanceSq - b.distanceSq).map(a => a.tileID);
+    }
+
+    /**
+     * Get the minimum and maximum elevation contained in a tile. This includes any elevation offset
+     * and exaggeration in the provided terrain configuration.
+     *
+     * @param tile Tile instance
+     * @param terrain Terrain configuration
+     * @returns {Object} Minimum and maximum elevation found in the tile, including the terrain's
+     * elevation offset and exaggeration
+     */
+    getTileMinMaxElevation(tile: Tile, terrain: Terrain): {minElevation: number; maxElevation: number} {
+        return {
+            minElevation: (tile.dem.min + terrain.elevationOffset) * terrain.exaggeration,
+            maxElevation: (tile.dem.max + terrain.elevationOffset) * terrain.exaggeration,
+        };
     }
 
     resize(width: number, height: number) {

--- a/src/geo/transform.ts
+++ b/src/geo/transform.ts
@@ -438,8 +438,7 @@ class Transform {
                 let quadrant = it.aabb.quadrant(i);
                 if (options.terrain) {
                     const tileID = new OverscaledTileID(childZ, it.wrap, childZ, childX, childY);
-                    const tile = options.terrain.getTerrainData(tileID).tile;
-                    const minMax = options.terrain.getMinMaxElevation(tile);
+                    const minMax = options.terrain.getMinMaxElevation(tileID);
                     const minElevation = minMax.minElevation ?? this.elevation;
                     const maxElevation = minMax.maxElevation ?? this.elevation;
                     quadrant = new Aabb(

--- a/src/geo/transform.ts
+++ b/src/geo/transform.ts
@@ -12,7 +12,6 @@ import EdgeInsets from './edge_insets';
 import {UnwrappedTileID, OverscaledTileID, CanonicalTileID} from '../source/tile_id';
 import type {PaddingOptions} from './edge_insets';
 import Terrain from '../render/terrain';
-import Tile from '../source/tile';
 
 /**
  * A single transform, generally used for a single tile to be
@@ -440,10 +439,9 @@ class Transform {
                 if (options.terrain) {
                     const tileID = new OverscaledTileID(childZ, it.wrap, childZ, childX, childY);
                     const tile = options.terrain.getTerrainData(tileID).tile;
-                    let minElevation = this.elevation, maxElevation = this.elevation;
-                    if (tile && tile.dem) {
-                        ({minElevation, maxElevation} = this.getTileMinMaxElevation(tile, options.terrain));
-                    }
+                    const minMax = options.terrain.getMinMaxElevation(tile);
+                    const minElevation = minMax.minElevation ?? this.elevation;
+                    const maxElevation = minMax.maxElevation ?? this.elevation;
                     quadrant = new Aabb(
                         [quadrant.min[0], quadrant.min[1], minElevation] as vec3,
                         [quadrant.max[0], quadrant.max[1], maxElevation] as vec3
@@ -454,22 +452,6 @@ class Transform {
         }
 
         return result.sort((a, b) => a.distanceSq - b.distanceSq).map(a => a.tileID);
-    }
-
-    /**
-     * Get the minimum and maximum elevation contained in a tile. This includes any elevation offset
-     * and exaggeration in the provided terrain configuration.
-     *
-     * @param tile Tile instance
-     * @param terrain Terrain configuration
-     * @returns {Object} Minimum and maximum elevation found in the tile, including the terrain's
-     * elevation offset and exaggeration
-     */
-    getTileMinMaxElevation(tile: Tile, terrain: Terrain): {minElevation: number; maxElevation: number} {
-        return {
-            minElevation: (tile.dem.min + terrain.elevationOffset) * terrain.exaggeration,
-            maxElevation: (tile.dem.max + terrain.elevationOffset) * terrain.exaggeration,
-        };
     }
 
     resize(width: number, height: number) {

--- a/src/render/terrain.test.ts
+++ b/src/render/terrain.test.ts
@@ -7,6 +7,7 @@ import Texture from './texture';
 import type Style from '../style/style';
 import type SourceCache from '../source/source_cache';
 import type TerrainSourceCache from '../source/terrain_source_cache';
+import {OverscaledTileID} from '../source/tile_id';
 import type {TerrainSpecification} from '../style-spec/types.g';
 import type DEMData from '../data/dem_data';
 import Tile from '../source/tile';
@@ -54,31 +55,96 @@ describe('Terrain', () => {
     });
 
     test('Calculate tile minimum and maximum elevation', () => {
+        const tileID = new OverscaledTileID(5, 0, 5, 17, 11);
+        const tile = new Tile(tileID, 256);
+        tile.dem = {
+            min: 0,
+            max: 100,
+            getPixels: () => new RGBAImage({width: 1, height: 1}, new Uint8Array(1 * 4)),
+            getUnpackVector: () => [6553.6, 25.6, 0.1, 10000.0],
+        } as any as DEMData;
+        const style = {
+            map: {
+                painter: {
+                    context: new Context(gl(1, 1)),
+                    width: 1,
+                    height: 1,
+                    getTileTexture: () => null
+                }
+            }
+        } as any as Style;
+        const sourceCache = {
+            _source: {maxzoom: 12},
+            getTileByID: () => {
+                return tile;
+            },
+        } as any as SourceCache;
         const terrain = new Terrain(
-            {} as any as Style,
-            {} as any as SourceCache,
+            style,
+            sourceCache,
             {exaggeration: 2, elevationOffset: 50} as any as TerrainSpecification,
         );
-        const tile = {dem: {min: 0, max: 100} as any as DEMData} as any as Tile;
-        const {minElevation, maxElevation} = terrain.getMinMaxElevation(tile);
+
+        terrain.sourceCache._tiles[tileID.key] = tile;
+        const {minElevation, maxElevation} = terrain.getMinMaxElevation(tileID);
 
         expect(minElevation).toBe(100);
         expect(maxElevation).toBe(300);
     });
 
-    test('Return null elevation values when no tile or DEM', () => {
+    test('Return null elevation values when no tile', () => {
+        const tileID = new OverscaledTileID(5, 0, 5, 17, 11);
+        const style = {
+            map: {
+                painter: {
+                    context: new Context(gl(1, 1)),
+                    width: 1,
+                    height: 1,
+                }
+            }
+        } as any as Style;
+        const sourceCache = {
+            _source: {maxzoom: 12},
+            getTileByID: () => null,
+        } as any as SourceCache;
         const terrain = new Terrain(
-            {} as any as Style,
-            {} as any as SourceCache,
+            style,
+            sourceCache,
             {exaggeration: 2, elevationOffset: 50} as any as TerrainSpecification,
         );
-        const tile = {dem: null as any as DEMData} as any as Tile;
 
-        const minMaxNoTile = terrain.getMinMaxElevation(null as any as Tile);
-        const minMaxNoDEM = terrain.getMinMaxElevation(tile);
+        const minMaxNoTile = terrain.getMinMaxElevation(tileID);
 
         expect(minMaxNoTile.minElevation).toBeNull();
         expect(minMaxNoTile.maxElevation).toBeNull();
+    });
+
+    test('Return null elevation values when no DEM', () => {
+        const tileID = new OverscaledTileID(5, 0, 5, 17, 11);
+        const tile = new Tile(tileID, 256);
+        tile.dem = null as any as DEMData;
+        const style = {
+            map: {
+                painter: {
+                    context: new Context(gl(1, 1)),
+                    width: 1,
+                    height: 1,
+                }
+            }
+        } as any as Style;
+        const sourceCache = {
+            _source: {maxzoom: 12},
+            getTileByID: () => {
+                return tile;
+            },
+        } as any as SourceCache;
+        const terrain = new Terrain(
+            style,
+            sourceCache,
+            {exaggeration: 2, elevationOffset: 50} as any as TerrainSpecification,
+        );
+        const minMaxNoDEM = terrain.getMinMaxElevation(tileID);
+
         expect(minMaxNoDEM.minElevation).toBeNull();
         expect(minMaxNoDEM.maxElevation).toBeNull();
     });

--- a/src/render/terrain.test.ts
+++ b/src/render/terrain.test.ts
@@ -8,6 +8,8 @@ import type Style from '../style/style';
 import type SourceCache from '../source/source_cache';
 import type TerrainSourceCache from '../source/terrain_source_cache';
 import type {TerrainSpecification} from '../style-spec/types.g';
+import type DEMData from '../data/dem_data';
+import Tile from '../source/tile';
 
 describe('Terrain', () => {
     test('pointCoordiate should not return null', () => {
@@ -49,5 +51,35 @@ describe('Terrain', () => {
         const coordinate = terrain.pointCoordinate(new Point(0, 0));
 
         expect(coordinate).not.toBeNull();
+    });
+
+    test('Calculate tile minimum and maximum elevation', () => {
+        const terrain = new Terrain(
+            {} as any as Style,
+            {} as any as SourceCache,
+            {exaggeration: 2, elevationOffset: 50} as any as TerrainSpecification,
+        );
+        const tile = {dem: {min: 0, max: 100} as any as DEMData} as any as Tile;
+        const {minElevation, maxElevation} = terrain.getMinMaxElevation(tile);
+
+        expect(minElevation).toBe(100);
+        expect(maxElevation).toBe(300);
+    });
+
+    test('Return null elevation values when no tile or DEM', () => {
+        const terrain = new Terrain(
+            {} as any as Style,
+            {} as any as SourceCache,
+            {exaggeration: 2, elevationOffset: 50} as any as TerrainSpecification,
+        );
+        const tile = {dem: null as any as DEMData} as any as Tile;
+
+        const minMaxNoTile = terrain.getMinMaxElevation(null as any as Tile);
+        const minMaxNoDEM = terrain.getMinMaxElevation(tile);
+
+        expect(minMaxNoTile.minElevation).toBeNull();
+        expect(minMaxNoTile.maxElevation).toBeNull();
+        expect(minMaxNoDEM.minElevation).toBeNull();
+        expect(minMaxNoDEM.maxElevation).toBeNull();
     });
 });

--- a/src/render/terrain.ts
+++ b/src/render/terrain.ts
@@ -370,11 +370,12 @@ export default class Terrain {
      * Get the minimum and maximum elevation contained in a tile. This includes any elevation offset
      * and exaggeration included in the terrain.
      *
-     * @param tile The tile used as a source for the min/max elevation
+     * @param tileID Id of the tile to be used as a source for the min/max elevation
      * @returns {Object} Minimum and maximum elevation found in the tile, including the terrain's
      * elevation offset and exaggeration
      */
-    getMinMaxElevation(tile: Tile): {minElevation: number | null; maxElevation: number | null} {
+    getMinMaxElevation(tileID: OverscaledTileID): {minElevation: number | null; maxElevation: number | null} {
+        const tile = this.getTerrainData(tileID).tile;
         const minMax = {minElevation: null, maxElevation: null};
         if (tile && tile.dem) {
             minMax.minElevation = (tile.dem.min + this.elevationOffset) * this.exaggeration;

--- a/src/render/terrain.ts
+++ b/src/render/terrain.ts
@@ -366,4 +366,21 @@ export default class Terrain {
         return this._mesh;
     }
 
+    /**
+     * Get the minimum and maximum elevation contained in a tile. This includes any elevation offset
+     * and exaggeration included in the terrain.
+     *
+     * @param tile The tile used as a source for the min/max elevation
+     * @returns {Object} Minimum and maximum elevation found in the tile, including the terrain's
+     * elevation offset and exaggeration
+     */
+    getMinMaxElevation(tile: Tile): {minElevation: number | null; maxElevation: number | null} {
+        const minMax = {minElevation: null, maxElevation: null};
+        if (tile && tile.dem) {
+            minMax.minElevation = (tile.dem.min + this.elevationOffset) * this.exaggeration;
+            minMax.maxElevation = (tile.dem.max + this.elevationOffset) * this.exaggeration;
+        }
+        return minMax;
+    }
+
 }


### PR DESCRIPTION
This is a pull request on top of PR #1300. It adds a unit test for that PR's bug fix to [`Transform.coveringTiles()`](https://github.com/maplibre/maplibre-gl-js/blob/577f200072b9a55ce9b841bc04a21cde7603e01c/src/geo/transform.ts#L334). The affected code has been pulled out into a separate method, `Transform.getTileMinMaxElevation()`, so that it can be tested in isolation. (That method should probably be on [`DEMData`](https://github.com/maplibre/maplibre-gl-js/blob/main/src/data/dem_data.ts), but time has run away from me.)

This test fails on `main` but passes on the `covering_tiles_3d` branch.
