### PR TITLE
fix: unchecked event still will be listened in debug/events.html

### DIFF
--- a/debug/chinese.html
+++ b/debug/chinese.html
@@ -40,7 +40,7 @@ map.addControl(new maplibregl.NavigationControl());
 map.on('load', function () {
     map.addSource('points', {
         'type': 'geojson',
-        'data': '/test/integration/data/chinese.geojson'
+        'data': '../test/integration/assets/data/chinese.geojson'
     });
 
     map.addLayer({

--- a/debug/events.html
+++ b/debug/events.html
@@ -147,17 +147,19 @@ function blurMap(val) {
     node.classList[val ? 'add' : 'remove']('blur');
 }
 
-function checkEvent(type, checked) {
-    map.off(type);
-    if (!checked) return;
-    map.on(type, function(data) {
-        var e = (data && data.originalEvent) || {};
-        var dbg =
-            (typeof data.point !== 'undefined' ? ' point = ' + JSON.stringify(data.point) : '') +
-            (typeof e.button !== 'undefined' ? ' button = ' + e.button : '');
+var logEvent = function (data) {
+    var e = (data && data.originalEvent) || {};
+    var dbg =
+        (typeof data.point !== 'undefined' ? ' point = ' + JSON.stringify(data.point) : '') +
+        (typeof e.button !== 'undefined' ? ' button = ' + e.button : '');
 
-        console.log(type + ': ' + dbg);
-    });
+    console.log(data.type + ': ' + dbg);
+};
+
+function checkEvent(type, checked) {
+    map.off(type, logEvent);
+    if (!checked) return;
+    map.on(type, logEvent);
 }
 
 // Which map events do we want to observe?


### PR DESCRIPTION
Fix a bug in debug/events.html. The unchecked events that uncheck after checking still will be listened because 'map.off' should have 2nd param([listener](https://maplibre.org/maplibre-gl-js-docs/api/map/#map#off ))

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Manually test the debug page.
 - [x] Suggest a changelog category: bug/feature/docs/etc. or "skip changelog".
