### PR TITLE
Use absolute paths in debug pages index file

### DIFF
--- a/build/generate-debug-index-file.ts
+++ b/build/generate-debug-index-file.ts
@@ -3,7 +3,7 @@ import fs from 'fs';
 
 const htmlFilesLinks = fs.readdirSync('test/debug-pages')
     .filter(f => f.endsWith('.html'))
-    .map(f => `    <a href='${f}'>${f}</a><br/>`)
+    .map(f => `    <a href='/test/debug-pages/${f}'>${f}</a><br/>`)
     .join('\n');
 
 fs.writeFileSync('test/debug-pages/index.html', `


### PR DESCRIPTION
## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

At the moment, going to http://localhost:9966/test/debug-pages without the trailing slash makes the links to the debug pages broken.

For example, one gets directed to http://localhost:9966/test/shield-rotation.html instead of http://localhost:9966/test/debug-pages/shield-rotation.html.

This pull request introduces absolute paths for the debug pages.

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [ ] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [ ] Manually test the debug page.
 - [ ] Suggest a changelog category: bug/feature/docs/etc. or "skip changelog".
 - [ ] Add an entry inside this element for inclusion in the `maplibre-gl-js` changelog: `<changelog></changelog>`.
