### PR TITLE
Remove jest from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,5 @@ updates:
       interval: "monthly"
     ignore:
       - dependency-name: "documentation"
-      - dependency-name: "jest"
-      - dependency-name: "@types/jest"
       - dependency-name: "ts-node"
     open-pull-requests-limit: 20


### PR DESCRIPTION
Now that jest is up to date, dependabot can manage it again.