### PR TITLE
Use Node 16 for test-render

### DIFF
--- a/.github/workflows/test-render.yml
+++ b/.github/workflows/test-render.yml
@@ -11,10 +11,10 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v2
-      - name: Use Node.js 16.13 x64
+      - name: Use Node.js 16 x64
         uses: actions/setup-node@v2
         with:
-          node-version: 16.13
+          node-version: 16
           architecture: x64
       - run: npm ci
       - run: npm run build-dev

--- a/package.json
+++ b/package.json
@@ -162,7 +162,7 @@
     "test-symbol-shaping": "jest --roots ./test/integration/symbol-shaping",
     "test-style-spec": "jest --roots ./test/integration/style-spec",
     "test-browser": "jest -c ./jest.config.e2e.ts --roots ./test/integration/browser",
-    "test-render": "node --loader ts-node/esm --experimental-specifier-resolution=node --experimental-json-modules --max-old-space-size=2048 test/integration/render/render.test.ts",
+    "test-render": "node --loader ts-node/esm --experimental-specifier-resolution=node --max-old-space-size=2048 test/integration/render/render.test.ts",
     "test-query": "jest -c ./jest.config.e2e.ts --roots ./test/integration/query",
     "test-expression": "jest --roots ./test/integration/expression",
     "test-unit": "jest  -c ./jest.config.ts --roots ./src",


### PR DESCRIPTION
Render tests were using node 16.13, where all other tests are using latest node 16.x which maps to 16.16.

This allows the render tests to use Node 16.x as well.