### PR TITLE
Use new unassert plugin

### DIFF
--- a/build/rollup_plugins.ts
+++ b/build/rollup_plugins.ts
@@ -3,7 +3,7 @@ import typescript from '@rollup/plugin-typescript';
 import resolve from '@rollup/plugin-node-resolve';
 import replace from '@rollup/plugin-replace';
 import commonjs from '@rollup/plugin-commonjs';
-import unassert from 'rollup-plugin-unassert';
+import {unassert} from 'unassert-rollup-plugin';
 import json from '@rollup/plugin-json';
 import {terser} from 'rollup-plugin-terser';
 import minifyStyleSpec from './rollup_plugin_minify_style_spec';

--- a/build/rollup_plugins.ts
+++ b/build/rollup_plugins.ts
@@ -3,7 +3,7 @@ import typescript from '@rollup/plugin-typescript';
 import resolve from '@rollup/plugin-node-resolve';
 import replace from '@rollup/plugin-replace';
 import commonjs from '@rollup/plugin-commonjs';
-import {unassert} from 'unassert-rollup-plugin';
+import unassert from 'unassert-rollup-plugin';
 import json from '@rollup/plugin-json';
 import {terser} from 'rollup-plugin-terser';
 import minifyStyleSpec from './rollup_plugin_minify_style_spec';

--- a/package-lock.json
+++ b/package-lock.json
@@ -129,7 +129,7 @@
         "ts-jest": "^28.0.7",
         "ts-node": "^10.9.1",
         "typescript": "^4.7.4",
-        "unassert-rollup-plugin": "^1.0.4"
+        "unassert-rollup-plugin": "^1.0.15"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -18462,9 +18462,9 @@
       }
     },
     "node_modules/unassert-rollup-plugin": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/unassert-rollup-plugin/-/unassert-rollup-plugin-1.0.4.tgz",
-      "integrity": "sha512-uGAZmTbi5Oz6G5/wXyoSTIrRXLNFJPaq+aORyKNXpgfCmFk4Wb7mNauWFZQug34naJqj6U0X8z4LBScqu3FczA==",
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/unassert-rollup-plugin/-/unassert-rollup-plugin-1.0.15.tgz",
+      "integrity": "sha512-nOmRAUuMboK7Ddd1MXNBdA1ckk5m8+K6FGIOYllVcisQ12QYLvkpFRzC/lKLCAXGsThShdYpAB7sIEZGRO8hFg==",
       "dev": true,
       "dependencies": {
         "@rollup/pluginutils": "^4.2.1",
@@ -18474,6 +18474,9 @@
         "escodegen": "^2.0.0",
         "multi-stage-sourcemap": "^0.3.1",
         "unassert": "^1.6.0"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/unassert-rollup-plugin/node_modules/@rollup/pluginutils": {
@@ -33704,9 +33707,9 @@
       }
     },
     "unassert-rollup-plugin": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/unassert-rollup-plugin/-/unassert-rollup-plugin-1.0.4.tgz",
-      "integrity": "sha512-uGAZmTbi5Oz6G5/wXyoSTIrRXLNFJPaq+aORyKNXpgfCmFk4Wb7mNauWFZQug34naJqj6U0X8z4LBScqu3FczA==",
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/unassert-rollup-plugin/-/unassert-rollup-plugin-1.0.15.tgz",
+      "integrity": "sha512-nOmRAUuMboK7Ddd1MXNBdA1ckk5m8+K6FGIOYllVcisQ12QYLvkpFRzC/lKLCAXGsThShdYpAB7sIEZGRO8hFg==",
       "dev": true,
       "requires": {
         "@rollup/pluginutils": "^4.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -129,7 +129,7 @@
         "ts-jest": "^28.0.7",
         "ts-node": "^10.9.1",
         "typescript": "^4.7.4",
-        "unassert-rollup-plugin": "^1.0.15"
+        "unassert-rollup-plugin": "^2.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -4281,26 +4281,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/call-matcher": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/call-matcher/-/call-matcher-2.0.0.tgz",
-      "integrity": "sha512-CIDC5wZZfZ2VjZu849WQckS58Z3pJXFfRaSjNjgo/q3in5zxkhTwVL83vttgtmvyLG7TuDlLlBya7SKP6CjDIA==",
-      "dev": true,
-      "dependencies": {
-        "deep-equal": "^1.0.0",
-        "espurify": "^2.0.0",
-        "estraverse": "^4.0.0"
-      }
-    },
-    "node_modules/call-matcher/node_modules/estraverse": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
-      "dev": true,
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -5620,23 +5600,6 @@
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
       "integrity": "sha512-Q6fKUPqnAHAyhiUgFU7BUzLiv0kd8saH9al7tnu5Q/okj6dnupxyTgFIBjVzJATdfIAm9NAsvXNzjaKa+bxVyA==",
       "dev": true
-    },
-    "node_modules/deep-equal": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
-      "integrity": "sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==",
-      "dev": true,
-      "dependencies": {
-        "is-arguments": "^1.0.4",
-        "is-date-object": "^1.0.1",
-        "is-regex": "^1.0.4",
-        "object-is": "^1.0.1",
-        "object-keys": "^1.1.1",
-        "regexp.prototype.flags": "^1.2.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
     },
     "node_modules/deep-extend": {
       "version": "0.6.0",
@@ -7040,12 +7003,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/espurify": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/espurify/-/espurify-2.1.1.tgz",
-      "integrity": "sha512-zttWvnkhcDyGOhSH4vO2qCBILpdCMv/MX8lp4cqgRkQoDRGK2oZxi2GfWhlP2dIXmk7BaKeOTuzbHhyC68o8XQ==",
-      "dev": true
     },
     "node_modules/esquery": {
       "version": "1.4.0",
@@ -13806,22 +13763,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/object-is": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
-      "integrity": "sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==",
-      "dev": true,
-      "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/object-keys": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
@@ -18447,24 +18388,18 @@
       }
     },
     "node_modules/unassert": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/unassert/-/unassert-1.6.0.tgz",
-      "integrity": "sha512-GoMtWTwGSxSFuRD0NKmbjlx3VJkgvSogzDzMPpJXYmBZv6MIWButsyMqEYhMx3NI4osXACcZA9mXiBteXyJtRw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unassert/-/unassert-2.0.0.tgz",
+      "integrity": "sha512-45E+m8zz+utoQPxkkXAsKPrtjE0GzEbMwzmrcM4inlPhcOxIJRwE+AVxkZfgIWTR3gWG2Daxa7mHFRUwMUfyzg==",
       "dev": true,
       "dependencies": {
-        "acorn": "^7.0.0",
-        "call-matcher": "^2.0.0",
-        "deep-equal": "^1.0.0",
-        "espurify": "^2.0.1",
-        "estraverse": "^4.1.0",
-        "esutils": "^2.0.2",
-        "object-assign": "^4.1.0"
+        "estraverse": "^5.0.0"
       }
     },
     "node_modules/unassert-rollup-plugin": {
-      "version": "1.0.15",
-      "resolved": "https://registry.npmjs.org/unassert-rollup-plugin/-/unassert-rollup-plugin-1.0.15.tgz",
-      "integrity": "sha512-nOmRAUuMboK7Ddd1MXNBdA1ckk5m8+K6FGIOYllVcisQ12QYLvkpFRzC/lKLCAXGsThShdYpAB7sIEZGRO8hFg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unassert-rollup-plugin/-/unassert-rollup-plugin-2.0.0.tgz",
+      "integrity": "sha512-c/bTvUd71Kiz0OUV3Agaf9zo2co43gw0JjWrXNoXxuM6WapxbHk/gMa/EAApwOJCqpvvo8jry4L9B22hHuqSmQ==",
       "dev": true,
       "dependencies": {
         "@rollup/pluginutils": "^4.2.1",
@@ -18473,7 +18408,7 @@
         "convert-source-map": "^1.8.0",
         "escodegen": "^2.0.0",
         "multi-stage-sourcemap": "^0.3.1",
-        "unassert": "^1.6.0"
+        "unassert": "^2.0.0"
       },
       "engines": {
         "node": ">=16"
@@ -18506,27 +18441,6 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true
-    },
-    "node_modules/unassert/node_modules/acorn": {
-      "version": "7.4.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
-      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
-      "dev": true,
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/unassert/node_modules/estraverse": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
-      "dev": true,
-      "engines": {
-        "node": ">=4.0"
-      }
     },
     "node_modules/unbox-primitive": {
       "version": "1.0.2",
@@ -23064,25 +22978,6 @@
         "get-intrinsic": "^1.0.2"
       }
     },
-    "call-matcher": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/call-matcher/-/call-matcher-2.0.0.tgz",
-      "integrity": "sha512-CIDC5wZZfZ2VjZu849WQckS58Z3pJXFfRaSjNjgo/q3in5zxkhTwVL83vttgtmvyLG7TuDlLlBya7SKP6CjDIA==",
-      "dev": true,
-      "requires": {
-        "deep-equal": "^1.0.0",
-        "espurify": "^2.0.0",
-        "estraverse": "^4.0.0"
-      },
-      "dependencies": {
-        "estraverse": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-          "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
-          "dev": true
-        }
-      }
-    },
     "callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -24099,20 +23994,6 @@
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
       "integrity": "sha512-Q6fKUPqnAHAyhiUgFU7BUzLiv0kd8saH9al7tnu5Q/okj6dnupxyTgFIBjVzJATdfIAm9NAsvXNzjaKa+bxVyA==",
       "dev": true
-    },
-    "deep-equal": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
-      "integrity": "sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==",
-      "dev": true,
-      "requires": {
-        "is-arguments": "^1.0.4",
-        "is-date-object": "^1.0.1",
-        "is-regex": "^1.0.4",
-        "object-is": "^1.0.1",
-        "object-keys": "^1.1.1",
-        "regexp.prototype.flags": "^1.2.0"
-      }
     },
     "deep-extend": {
       "version": "0.6.0",
@@ -25167,12 +25048,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "dev": true
-    },
-    "espurify": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/espurify/-/espurify-2.1.1.tgz",
-      "integrity": "sha512-zttWvnkhcDyGOhSH4vO2qCBILpdCMv/MX8lp4cqgRkQoDRGK2oZxi2GfWhlP2dIXmk7BaKeOTuzbHhyC68o8XQ==",
       "dev": true
     },
     "esquery": {
@@ -30241,16 +30116,6 @@
       "integrity": "sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==",
       "dev": true
     },
-    "object-is": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
-      "integrity": "sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3"
-      }
-    },
     "object-keys": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
@@ -33678,38 +33543,18 @@
       "dev": true
     },
     "unassert": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/unassert/-/unassert-1.6.0.tgz",
-      "integrity": "sha512-GoMtWTwGSxSFuRD0NKmbjlx3VJkgvSogzDzMPpJXYmBZv6MIWButsyMqEYhMx3NI4osXACcZA9mXiBteXyJtRw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unassert/-/unassert-2.0.0.tgz",
+      "integrity": "sha512-45E+m8zz+utoQPxkkXAsKPrtjE0GzEbMwzmrcM4inlPhcOxIJRwE+AVxkZfgIWTR3gWG2Daxa7mHFRUwMUfyzg==",
       "dev": true,
       "requires": {
-        "acorn": "^7.0.0",
-        "call-matcher": "^2.0.0",
-        "deep-equal": "^1.0.0",
-        "espurify": "^2.0.1",
-        "estraverse": "^4.1.0",
-        "esutils": "^2.0.2",
-        "object-assign": "^4.1.0"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "7.4.1",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
-          "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
-          "dev": true
-        },
-        "estraverse": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-          "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
-          "dev": true
-        }
+        "estraverse": "^5.0.0"
       }
     },
     "unassert-rollup-plugin": {
-      "version": "1.0.15",
-      "resolved": "https://registry.npmjs.org/unassert-rollup-plugin/-/unassert-rollup-plugin-1.0.15.tgz",
-      "integrity": "sha512-nOmRAUuMboK7Ddd1MXNBdA1ckk5m8+K6FGIOYllVcisQ12QYLvkpFRzC/lKLCAXGsThShdYpAB7sIEZGRO8hFg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unassert-rollup-plugin/-/unassert-rollup-plugin-2.0.0.tgz",
+      "integrity": "sha512-c/bTvUd71Kiz0OUV3Agaf9zo2co43gw0JjWrXNoXxuM6WapxbHk/gMa/EAApwOJCqpvvo8jry4L9B22hHuqSmQ==",
       "dev": true,
       "requires": {
         "@rollup/pluginutils": "^4.2.1",
@@ -33718,7 +33563,7 @@
         "convert-source-map": "^1.8.0",
         "escodegen": "^2.0.0",
         "multi-stage-sourcemap": "^0.3.1",
-        "unassert": "^1.6.0"
+        "unassert": "^2.0.0"
       },
       "dependencies": {
         "@rollup/pluginutils": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -119,7 +119,6 @@
         "rollup-plugin-import-assert": "^2.1.0",
         "rollup-plugin-sourcemaps": "^0.6.3",
         "rollup-plugin-terser": "^7.0.2",
-        "rollup-plugin-unassert": "git://github.com/birkskyum/rollup-plugin-unassert.git#94c2fc4992b8bf008da4d85e814d90e291367303",
         "rw": "^1.3.3",
         "semver": "^7.3.7",
         "shuffle-seed": "^1.1.6",
@@ -129,7 +128,8 @@
         "stylelint-config-standard": "^26.0.0",
         "ts-jest": "^28.0.7",
         "ts-node": "^10.9.1",
-        "typescript": "^4.7.4"
+        "typescript": "^4.7.4",
+        "unassert-rollup-plugin": "^1.0.4"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -16420,50 +16420,6 @@
         "node": ">= 10.13.0"
       }
     },
-    "node_modules/rollup-plugin-unassert": {
-      "version": "0.4.0",
-      "resolved": "git+ssh://git@github.com/birkskyum/rollup-plugin-unassert.git#94c2fc4992b8bf008da4d85e814d90e291367303",
-      "integrity": "sha512-61t2JP3xnNDvpgVQMJCWw+BQxT0EytcCVyqdUP1xaNPcJjZpOiC/5LrKngRvQ3ZMY0e4iDcDtYBHMYK9/ot89w==",
-      "dev": true,
-      "license": "Beerware",
-      "dependencies": {
-        "@rollup/pluginutils": "^4.2.1",
-        "acorn": "^8.8.0",
-        "acorn-import-assertions": "^1.8.0",
-        "convert-source-map": "^1.8.0",
-        "escodegen": "^2.0.0",
-        "multi-stage-sourcemap": "^0.3.1",
-        "unassert": "^1.6.0"
-      }
-    },
-    "node_modules/rollup-plugin-unassert/node_modules/@rollup/pluginutils": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.2.1.tgz",
-      "integrity": "sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==",
-      "dev": true,
-      "dependencies": {
-        "estree-walker": "^2.0.1",
-        "picomatch": "^2.2.2"
-      },
-      "engines": {
-        "node": ">= 8.0.0"
-      }
-    },
-    "node_modules/rollup-plugin-unassert/node_modules/convert-source-map": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.8.0.tgz",
-      "integrity": "sha512-+OQdjP49zViI/6i7nIJpA8rAl4sV/JdPfU9nZs3VqOwGIgizICvuN2ru6fMd+4llL0tar18UYJXfZ/TWtmhUjA==",
-      "dev": true,
-      "dependencies": {
-        "safe-buffer": "~5.1.1"
-      }
-    },
-    "node_modules/rollup-plugin-unassert/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true
-    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -18504,6 +18460,49 @@
         "esutils": "^2.0.2",
         "object-assign": "^4.1.0"
       }
+    },
+    "node_modules/unassert-rollup-plugin": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/unassert-rollup-plugin/-/unassert-rollup-plugin-1.0.4.tgz",
+      "integrity": "sha512-uGAZmTbi5Oz6G5/wXyoSTIrRXLNFJPaq+aORyKNXpgfCmFk4Wb7mNauWFZQug34naJqj6U0X8z4LBScqu3FczA==",
+      "dev": true,
+      "dependencies": {
+        "@rollup/pluginutils": "^4.2.1",
+        "acorn": "^8.8.0",
+        "acorn-import-assertions": "^1.8.0",
+        "convert-source-map": "^1.8.0",
+        "escodegen": "^2.0.0",
+        "multi-stage-sourcemap": "^0.3.1",
+        "unassert": "^1.6.0"
+      }
+    },
+    "node_modules/unassert-rollup-plugin/node_modules/@rollup/pluginutils": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.2.1.tgz",
+      "integrity": "sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==",
+      "dev": true,
+      "dependencies": {
+        "estree-walker": "^2.0.1",
+        "picomatch": "^2.2.2"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
+    "node_modules/unassert-rollup-plugin/node_modules/convert-source-map": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.8.0.tgz",
+      "integrity": "sha512-+OQdjP49zViI/6i7nIJpA8rAl4sV/JdPfU9nZs3VqOwGIgizICvuN2ru6fMd+4llL0tar18UYJXfZ/TWtmhUjA==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "~5.1.1"
+      }
+    },
+    "node_modules/unassert-rollup-plugin/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
     },
     "node_modules/unassert/node_modules/acorn": {
       "version": "7.4.1",
@@ -32119,48 +32118,6 @@
         }
       }
     },
-    "rollup-plugin-unassert": {
-      "version": "git+ssh://git@github.com/birkskyum/rollup-plugin-unassert.git#94c2fc4992b8bf008da4d85e814d90e291367303",
-      "integrity": "sha512-61t2JP3xnNDvpgVQMJCWw+BQxT0EytcCVyqdUP1xaNPcJjZpOiC/5LrKngRvQ3ZMY0e4iDcDtYBHMYK9/ot89w==",
-      "dev": true,
-      "from": "rollup-plugin-unassert@git://github.com/birkskyum/rollup-plugin-unassert.git#94c2fc4992b8bf008da4d85e814d90e291367303",
-      "requires": {
-        "@rollup/pluginutils": "^4.2.1",
-        "acorn": "^8.8.0",
-        "acorn-import-assertions": "^1.8.0",
-        "convert-source-map": "^1.8.0",
-        "escodegen": "^2.0.0",
-        "multi-stage-sourcemap": "^0.3.1",
-        "unassert": "^1.6.0"
-      },
-      "dependencies": {
-        "@rollup/pluginutils": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.2.1.tgz",
-          "integrity": "sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==",
-          "dev": true,
-          "requires": {
-            "estree-walker": "^2.0.1",
-            "picomatch": "^2.2.2"
-          }
-        },
-        "convert-source-map": {
-          "version": "1.8.0",
-          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.8.0.tgz",
-          "integrity": "sha512-+OQdjP49zViI/6i7nIJpA8rAl4sV/JdPfU9nZs3VqOwGIgizICvuN2ru6fMd+4llL0tar18UYJXfZ/TWtmhUjA==",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "~5.1.1"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true
-        }
-      }
-    },
     "run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -33742,6 +33699,48 @@
           "version": "4.3.0",
           "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
           "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+          "dev": true
+        }
+      }
+    },
+    "unassert-rollup-plugin": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/unassert-rollup-plugin/-/unassert-rollup-plugin-1.0.4.tgz",
+      "integrity": "sha512-uGAZmTbi5Oz6G5/wXyoSTIrRXLNFJPaq+aORyKNXpgfCmFk4Wb7mNauWFZQug34naJqj6U0X8z4LBScqu3FczA==",
+      "dev": true,
+      "requires": {
+        "@rollup/pluginutils": "^4.2.1",
+        "acorn": "^8.8.0",
+        "acorn-import-assertions": "^1.8.0",
+        "convert-source-map": "^1.8.0",
+        "escodegen": "^2.0.0",
+        "multi-stage-sourcemap": "^0.3.1",
+        "unassert": "^1.6.0"
+      },
+      "dependencies": {
+        "@rollup/pluginutils": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.2.1.tgz",
+          "integrity": "sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==",
+          "dev": true,
+          "requires": {
+            "estree-walker": "^2.0.1",
+            "picomatch": "^2.2.2"
+          }
+        },
+        "convert-source-map": {
+          "version": "1.8.0",
+          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.8.0.tgz",
+          "integrity": "sha512-+OQdjP49zViI/6i7nIJpA8rAl4sV/JdPfU9nZs3VqOwGIgizICvuN2ru6fMd+4llL0tar18UYJXfZ/TWtmhUjA==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -121,7 +121,6 @@
     "rollup-plugin-import-assert": "^2.1.0",
     "rollup-plugin-sourcemaps": "^0.6.3",
     "rollup-plugin-terser": "^7.0.2",
-    "unassert-rollup-plugin": "^1.0.4",
     "rw": "^1.3.3",
     "semver": "^7.3.7",
     "shuffle-seed": "^1.1.6",
@@ -131,7 +130,8 @@
     "stylelint-config-standard": "^26.0.0",
     "ts-jest": "^28.0.7",
     "ts-node": "^10.9.1",
-    "typescript": "^4.7.4"
+    "typescript": "^4.7.4",
+    "unassert-rollup-plugin": "^1.0.15"
   },
   "scripts": {
     "generate-shaders": "node --loader ts-node/esm --experimental-specifier-resolution=node build/generate-shaders.ts",

--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
     "ts-jest": "^28.0.7",
     "ts-node": "^10.9.1",
     "typescript": "^4.7.4",
-    "unassert-rollup-plugin": "^1.0.15"
+    "unassert-rollup-plugin": "^2.0.0"
   },
   "scripts": {
     "generate-shaders": "node --loader ts-node/esm --experimental-specifier-resolution=node build/generate-shaders.ts",

--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "rollup-plugin-import-assert": "^2.1.0",
     "rollup-plugin-sourcemaps": "^0.6.3",
     "rollup-plugin-terser": "^7.0.2",
-    "rollup-plugin-unassert": "git://github.com/birkskyum/rollup-plugin-unassert.git#94c2fc4992b8bf008da4d85e814d90e291367303",
+    "unassert-rollup-plugin": "^1.0.4",
     "rw": "^1.3.3",
     "semver": "^7.3.7",
     "shuffle-seed": "^1.1.6",

--- a/rollup.config.style-spec.ts
+++ b/rollup.config.style-spec.ts
@@ -1,7 +1,7 @@
 import path, {dirname} from 'path';
 import replace from '@rollup/plugin-replace';
 import commonjs from '@rollup/plugin-commonjs';
-import unassert from 'rollup-plugin-unassert';
+import {unassert} from 'unassert-rollup-plugin';
 import json from '@rollup/plugin-json';
 import {fileURLToPath, pathToFileURL} from 'url';
 import {RollupOptions} from 'rollup';

--- a/rollup.config.style-spec.ts
+++ b/rollup.config.style-spec.ts
@@ -1,7 +1,7 @@
 import path, {dirname} from 'path';
 import replace from '@rollup/plugin-replace';
 import commonjs from '@rollup/plugin-commonjs';
-import {unassert} from 'unassert-rollup-plugin';
+import unassert from 'unassert-rollup-plugin';
 import json from '@rollup/plugin-json';
 import {fileURLToPath, pathToFileURL} from 'url';
 import {RollupOptions} from 'rollup';


### PR DESCRIPTION
Replace the rollup plugin for unassert with an improved version that compared to the old one:
* is written in typescript
* has node 18 compatibility
* is 20 times faster due to unassert 2.0.0 rather than 1.6.0
* has updated dependencies