### PR TITLE
[feat] expose version identifiers

### DIFF
--- a/build/rollup_plugins.ts
+++ b/build/rollup_plugins.ts
@@ -11,6 +11,8 @@ import strip from '@rollup/plugin-strip';
 import {Plugin} from 'rollup';
 import {importAssertionsPlugin} from 'rollup-plugin-import-assert';
 
+import {version} from '../package.json';
+
 // Common set of plugins/transformations shared across different rollup
 // builds (main maplibre bundle, style-spec package, benchmarks bundle)
 
@@ -31,6 +33,9 @@ export const plugins = (production: boolean): Plugin[] => [
         values: {
             '_token_stack:': ''
         }
+    }),
+    replace({
+        '__packageVersion': version,
     }),
     production && strip({
         sourceMap: true,

--- a/src/index.ts
+++ b/src/index.ts
@@ -100,6 +100,13 @@ const exported = {
     clearPrewarmedResources,
 
     /**
+     * Returns the package version of the library
+     */
+    get version(): string {
+        return '__packageVersion';
+    },
+
+    /**
      * Gets and sets the number of web workers instantiated on a page with GL JS maps.
      * By default, it is set to half the number of CPU cores (capped at 6).
      * Make sure to set this property before creating any map instances for it to have effect.

--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -524,6 +524,13 @@ class Map extends Camera {
     }
 
     /**
+     * Returns the package version of the library
+     */
+    get version(): string {
+        return '__packageVersion';
+    }
+
+    /**
      * Adds an {@link IControl} to the map, calling `control.onAdd(this)`.
      *
      * @param {IControl} control The {@link IControl} to add.


### PR DESCRIPTION
Restore version identifiers that were removed in v2.0

After this PR it is possible to get the package version via

`import {version} from 'maplibre-gl';`

Or with a `Map` instance:

`map.version`

See discussion in #1426

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [ ] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Manually test the debug page.
 - [ ] Suggest a changelog category: bug/feature/docs/etc. or "skip changelog".
 - [ ] Add an entry inside this element for inclusion in the `maplibre-gl-js` changelog: `<changelog></changelog>`.
