### PR TITLE
Revert #1390

### DIFF
--- a/build/generate-style-spec.ts
+++ b/build/generate-style-spec.ts
@@ -48,7 +48,7 @@ function propertyType(property) {
     } else if (properties.supportsZoomExpression(property)) {
         return `PropertyValueSpecification<${baseType}>`;
     } else if (property.expression) {
-        return 'ExpressionSpecification';
+        return 'ExpressionSpecificationArray';
     } else {
         return baseType;
     }
@@ -128,152 +128,36 @@ export type ResolvedImageSpecification = string;
 
 export type PromoteIdSpecification = {[_: string]: string} | string;
 
-export type ExpressionInputType = string | number | boolean;
-
-export type CollatorExpressionSpecification = 
-    ['collator', {
-        'case-sensitive'?: boolean | ExpressionSpecification, 
-        'diacritic-sensitive'?: boolean | ExpressionSpecification, 
-        locale?: string | ExpressionSpecification}
-    ]; // collator
-
-export type InterpolationSpecification =
-    | ['linear'] 
-    | ['exponential', number | ExpressionSpecification] 
-    | ['cubic-bezier', number | ExpressionSpecification, number | ExpressionSpecification, number | ExpressionSpecification, number | ExpressionSpecification]
-    
-export type ExpressionSpecification = 
-    // types
-    | ['array', unknown | ExpressionSpecification] // array
-    | ['array', ExpressionInputType | ExpressionSpecification, unknown | ExpressionSpecification] // array
-    | ['array', ExpressionInputType | ExpressionSpecification, number | ExpressionSpecification, unknown | ExpressionSpecification] // array
-    | ['boolean', ...(unknown | ExpressionSpecification)[], unknown | ExpressionSpecification] // boolean
-    | CollatorExpressionSpecification
-    | ['format', ...(string | ['image', ExpressionSpecification] | ExpressionSpecification | {'font-scale'?: number | ExpressionSpecification, 'text-font'?: string[] | ExpressionSpecification, 'text-color': ColorSpecification | ExpressionSpecification})[]] // string
-    | ['image', unknown | ExpressionSpecification] // image
-    | ['literal', unknown]
-    | ['number', unknown | ExpressionSpecification, ...(unknown | ExpressionSpecification)[]] // number
-    | ['number-format', number | ExpressionSpecification, {'locale'?: string | ExpressionSpecification, 'currency'?: string | ExpressionSpecification, 'min-fraction-digits'?: number | ExpressionSpecification, 'max-fraction-digits'?: number | ExpressionSpecification}] // string
-    | ['object', unknown | ExpressionSpecification, ...(unknown | ExpressionSpecification)[]] // object
-    | ['string', unknown | ExpressionSpecification, ...(unknown | ExpressionSpecification)[]] // string
-    | ['to-boolean', unknown | ExpressionSpecification] // boolean
-    | ['to-color', unknown | ExpressionSpecification, ...(unknown | ExpressionSpecification)[]] // color
-    | ['to-number', unknown | ExpressionSpecification, ...(unknown | ExpressionSpecification)[]] // number
-    | ['to-string', unknown | ExpressionSpecification] // string
-    // feature data
-    | ['accumulated']
-    | ['feature-state', string]
-    | ['geometry-type'] // string
-    | ['id']
-    | ['line-progress'] // number
-    | ['properties'] // object
-    // lookup
-    | ['at', number | ExpressionSpecification, ExpressionSpecification]
-    | ['get', string | ExpressionSpecification, (Record<string, unknown> | ExpressionSpecification)?]
-    | ['has', string | ExpressionSpecification, (Record<string, unknown> | ExpressionSpecification)?]
-    | ['in', ExpressionInputType | ExpressionSpecification, ExpressionInputType | ExpressionSpecification]
-    | ['index-of', ExpressionInputType | ExpressionSpecification, ExpressionInputType | ExpressionSpecification] // number
-    | ['length', string | ExpressionSpecification]
-    | ['slice', string | ExpressionSpecification, number | ExpressionSpecification]
+export type FilterSpecificationInputType = string | number | boolean;
+export type FilterSpecification =
+    // Lookup
+    | ['at', number, (number |string)[]]
+    | ['get', string, Record<string, unknown>?]
+    | ['has', string, Record<string, unknown>?]
+    | ['in', ...FilterSpecificationInputType[], FilterSpecificationInputType | FilterSpecificationInputType[]]
+    | ['index-of', FilterSpecificationInputType, FilterSpecificationInputType | FilterSpecificationInputType[]]
+    | ['length', string | string[]]
+    | ['slice', string | string[], number]
     // Decision
-    | ['!', boolean | ExpressionSpecification] // boolean
-    | ['!=', ExpressionInputType | ExpressionSpecification, ExpressionInputType | ExpressionSpecification, CollatorExpressionSpecification?] // boolean
-    | ['<', ExpressionInputType | ExpressionSpecification, ExpressionInputType | ExpressionSpecification, CollatorExpressionSpecification?] // boolean
-    | ['<=', ExpressionInputType | ExpressionSpecification, ExpressionInputType | ExpressionSpecification, CollatorExpressionSpecification?] // boolean
-    | ['==', ExpressionInputType | ExpressionSpecification, ExpressionInputType | ExpressionSpecification, CollatorExpressionSpecification?] // boolean
-    | ['>', ExpressionInputType | ExpressionSpecification, ExpressionInputType | ExpressionSpecification, CollatorExpressionSpecification?] // boolean
-    | ['>=', ExpressionInputType | ExpressionSpecification, ExpressionInputType | ExpressionSpecification, CollatorExpressionSpecification?] // boolean
-    | ['all', ...(boolean | ExpressionSpecification)[]] // boolean
-    | ['any', ...(boolean | ExpressionSpecification)[]] // boolean
-    | ['case', boolean | ExpressionSpecification, ExpressionInputType | ExpressionSpecification, 
-        ...(boolean | ExpressionInputType | ExpressionSpecification)[], ExpressionInputType | ExpressionSpecification]
-    | ['coalesce', ExpressionInputType | ExpressionSpecification, ExpressionInputType | ExpressionSpecification, 
-        ...(ExpressionInputType | ExpressionSpecification)[]]
-    | ['match', ExpressionInputType | ExpressionSpecification, 
-        ExpressionInputType | ExpressionInputType[], ExpressionInputType | ExpressionSpecification, 
-        ...(ExpressionInputType | ExpressionInputType[] | ExpressionSpecification)[], // repeated as above
-        ExpressionInputType]
-    | ['within', unknown | ExpressionSpecification]
-    // Ramps, scales, curves
-    | ['interpolate', InterpolationSpecification, 
-        number | ExpressionSpecification, number | ExpressionSpecification, ExpressionInputType | ExpressionSpecification, 
-        ...(number | ExpressionInputType | ExpressionSpecification)[]]
-    | ['interpolate-hcl', InterpolationSpecification,
-        number | ExpressionSpecification, number | ExpressionSpecification, ExpressionInputType | ExpressionSpecification, 
-        ...(number | ColorSpecification | ExpressionSpecification)[]]
-    | ['interpolate-lab', InterpolationSpecification,
-        number | ExpressionSpecification, number | ExpressionSpecification, ExpressionInputType | ExpressionSpecification, 
-        ...(number | ColorSpecification | ExpressionSpecification)[]]
-    | ['step', number | ExpressionSpecification, number | ExpressionSpecification, ExpressionInputType | ExpressionSpecification, 
-        ...(number | ExpressionInputType | ExpressionSpecification)[]]
-    // Variable binding
-    | ['let', string, ExpressionInputType | ExpressionSpecification, ...(string | ExpressionInputType | ExpressionSpecification)[]]
-    | ['var', string]
-    // String
-    | ['concat', ExpressionInputType | ExpressionSpecification, ExpressionInputType | ExpressionSpecification, 
-        ...(ExpressionInputType | ExpressionSpecification)[]] // string
-    | ['downcase', string | ExpressionSpecification] // string
-    | ['is-supported-script', string | ExpressionSpecification] // boolean
-    | ['resolved-locale', CollatorExpressionSpecification] // string
-    | ['upcase', string | ExpressionSpecification] // string
-    // Color
-    | ['rgb', number | ExpressionSpecification, number | ExpressionSpecification, number | ExpressionSpecification] // color
-    | ['rgba', number | ExpressionSpecification, number | ExpressionSpecification, number | ExpressionSpecification, number | ExpressionSpecification]
-    | ['to-rgba', ColorSpecification | ExpressionSpecification]
-    // Math
-    | ['-', number | ExpressionSpecification, (number | ExpressionSpecification)?] // number
-    | ['*', number | ExpressionSpecification, number | ExpressionSpecification, ...(number | ExpressionSpecification)[]] // number
-    | ['/', number | ExpressionSpecification, number | ExpressionSpecification] // number
-    | ['%', number | ExpressionSpecification, number | ExpressionSpecification] // number
-    | ['^', number | ExpressionSpecification, number | ExpressionSpecification] // number
-    | ['+', number | ExpressionSpecification, number | ExpressionSpecification, ...(number | ExpressionSpecification)[]] // number
-    | ['abs', number | ExpressionSpecification] // number
-    | ['acos', number | ExpressionSpecification] // number
-    | ['asin', number | ExpressionSpecification] // number
-    | ['atan', number | ExpressionSpecification] // number
-    | ['ceil', number | ExpressionSpecification] // number
-    | ['cos', number | ExpressionSpecification] // number
-    | ['distance', Record<string, unknown> | ExpressionSpecification] // number
-    | ['ExpressionSpecification'] // number
-    | ['floor', number | ExpressionSpecification] // number
-    | ['ln', number | ExpressionSpecification] // number
-    | ['ln2'] // number
-    | ['log10', number | ExpressionSpecification] // number
-    | ['log2', number | ExpressionSpecification] // number
-    | ['max', number | ExpressionSpecification, ...(number | ExpressionSpecification)[]] // number
-    | ['min', number | ExpressionSpecification, ...(number | ExpressionSpecification)[]] // number
-    | ['pi'] // number
-    | ['round', number | ExpressionSpecification] // number
-    | ['sin', number | ExpressionSpecification] // number
-    | ['sqrt', number | ExpressionSpecification] // number
-    | ['tan', number | ExpressionSpecification] // number
-    // Zoom
-    | ['zoom'] // number
-    // Heatmap
-    | ['heatmap-density'] // number
-
-export type ExpressionFilterSpecification = boolean | ExpressionSpecification
-
-export type LegacyFilterSpecification =
-    // Existential
-    | ['has', string]
-    | ['!has', string]
-    // Comparison
-    | ['==', string, string | number | boolean]
-    | ['!=', string, string | number | boolean]
-    | ['>', string, string | number | boolean]
-    | ['>=', string, string | number | boolean]
-    | ['<', string, string | number | boolean]
-    | ['<=', string, string | number | boolean]
-    // Set membership
-    | ['in', string, ...(string | number | boolean)[]]
-    | ['!in', string, ...(string | number | boolean)[]]
-    // Combining
-    | ['all', ...LegacyFilterSpecification[]]
-    | ['any', ...LegacyFilterSpecification[]]
-    | ['none', ...LegacyFilterSpecification[]]
-
-export type FilterSpecification = ExpressionFilterSpecification | LegacyFilterSpecification
+    | ['!', FilterSpecification]
+    | ['!=', string | FilterSpecification, FilterSpecificationInputType]
+    | ['<', string | FilterSpecification, FilterSpecificationInputType]
+    | ['<=', string | FilterSpecification, FilterSpecificationInputType]
+    | ['==', string | FilterSpecification, FilterSpecificationInputType]
+    | ['>', string | FilterSpecification, FilterSpecificationInputType]
+    | ['>=', string | FilterSpecification, FilterSpecificationInputType]
+    | ["all", ...FilterSpecification[], FilterSpecificationInputType]
+    | ["any", ...FilterSpecification[], FilterSpecificationInputType]
+    | ["case", ...FilterSpecification[], FilterSpecificationInputType]
+    | ["coalesce", ...FilterSpecification[], FilterSpecificationInputType]
+    | ["match", ...FilterSpecification[], FilterSpecificationInputType]
+    | ["within", ...FilterSpecification[], FilterSpecificationInputType]
+    // Used in convert.ts
+    | ["!in", ...FilterSpecification[], FilterSpecificationInputType]
+    | ["!has", ...FilterSpecification[], FilterSpecificationInputType]
+    | ["none", ...FilterSpecification[], FilterSpecificationInputType]
+    // Fallbak for others
+    | Array<string | FilterSpecification>
 
 export type TransitionSpecification = {
     duration?: number,
@@ -297,17 +181,19 @@ export type CompositeFunctionSpecification<T> =
     | { type: 'interval',    stops: Array<[{zoom: number, value: number}, T]>, property: string, default?: T }
     | { type: 'categorical', stops: Array<[{zoom: number, value: string | number | boolean}, T]>, property: string, default?: T };
 
+export type ExpressionSpecificationArray = Array<unknown>;
+
 export type PropertyValueSpecification<T> =
       T
     | CameraFunctionSpecification<T>
-    | ExpressionSpecification;
+    | ExpressionSpecificationArray;
 
 export type DataDrivenPropertyValueSpecification<T> =
       T
     | CameraFunctionSpecification<T>
     | SourceFunctionSpecification<T>
     | CompositeFunctionSpecification<T>
-    | ExpressionSpecification;
+    | ExpressionSpecificationArray;
 
 ${objectDeclaration('StyleSpecification', spec.$root)}
 

--- a/src/data/bucket/fill_bucket.test.ts
+++ b/src/data/bucket/fill_bucket.test.ts
@@ -55,7 +55,6 @@ test('FillBucket segmentation', () => {
         id: 'test',
         type: 'fill',
         layout: {},
-        source: 'source',
         paint: {
             'fill-color': ['to-color', ['get', 'foo'], '#000']
         }

--- a/src/style-spec/feature_filter/convert.ts
+++ b/src/style-spec/feature_filter/convert.ts
@@ -1,8 +1,17 @@
 import {isExpressionFilter} from './index';
 
-import type {ExpressionFilterSpecification, ExpressionInputType, ExpressionSpecification, FilterSpecification, LegacyFilterSpecification} from '../types.g';
+import type {FilterSpecification} from '../types.g';
 
-type ExpectedTypes = {[_: string]: ExpressionInputType};
+type ExpectedTypes = {[_: string]: 'string' | 'number' | 'boolean'};
+
+/**
+ * Convert the given legacy filter to (the JSON representation of) an
+ * equivalent expression
+ * @private
+ */
+export default function convertFilter(filter: FilterSpecification): unknown {
+    return _convertFilter(filter, {});
+}
 
 /*
  * Convert the given filter to an expression, storing the expected types for
@@ -52,58 +61,51 @@ type ExpectedTypes = {[_: string]: ExpressionInputType};
  * false (legacy filter semantics) are equivalent: they cause the filter to
  * produce a `false` result.
  */
-export default function convertFilter(filter: FilterSpecification, expectedTypes: ExpectedTypes = {}): ExpressionFilterSpecification {
-    if (isExpressionFilter(filter)) return filter;
+function _convertFilter(filter: FilterSpecification, expectedTypes: ExpectedTypes): unknown {
+    if (isExpressionFilter(filter)) { return filter; }
+
     if (!filter) return true;
+    const op = filter[0];
+    if (filter.length <= 1) return (op !== 'any');
 
-    const legacyFilter = filter as LegacyFilterSpecification;
-    const legacyOp = legacyFilter[0];
-    if (filter.length <= 1) return (legacyOp !== 'any');
+    let converted;
 
-    switch (legacyOp) {
-        case '==':
-        case '!=':
-        case '<':
-        case '>':
-        case '<=':
-        case '>=': {
-            const [, property, value] = filter;
-            return convertComparisonOp(property as string, value, legacyOp, expectedTypes);
-        }
-        case 'any': {
-            const [, ...conditions] = legacyFilter;
-            const children = conditions.map((f: LegacyFilterSpecification) => {
-                const types = {};
-                const child = convertFilter(f, types);
-                const typechecks = runtimeTypeChecks(types);
-                return typechecks === true ? child : ['case', typechecks, child, false] as ExpressionSpecification;
-            });
-            return ['any', ...children];
-        }
-        case 'all': {
-            const [, ...conditions] = legacyFilter;
-            const children = conditions.map(f => convertFilter(f, expectedTypes));
-            return children.length > 1 ? ['all', ...children] : children[0];
-        }
-        case 'none': {
-            const [, ...conditions] = legacyFilter;
-            return ['!', convertFilter(['any', ...conditions], {})];
-        }
-        case 'in': {
-            const [, property, ...values] = legacyFilter;
-            return convertInOp(property, values);
-        }
-        case '!in': {
-            const [, property, ...values] = legacyFilter;
-            return convertInOp(property, values, true);
-        }
-        case 'has':
-            return convertHasOp(legacyFilter[1]);
-        case '!has':
-            return ['!', convertHasOp(legacyFilter[1])];
-        default:
-            return true;
+    if (
+        op === '==' ||
+        op === '!=' ||
+        op === '<' ||
+        op === '>' ||
+        op === '<=' ||
+        op === '>='
+    ) {
+        const [, property, value] = filter;
+        converted = convertComparisonOp(property as string, value, op, expectedTypes);
+    } else if (op === 'any') {
+        const children = (filter).slice(1).map((f: FilterSpecification) => {
+            const types = {};
+            const child = _convertFilter(f, types);
+            const typechecks = runtimeTypeChecks(types);
+            return typechecks === true ? child : ['case', typechecks, child, false];
+        });
+        return ['any'].concat(children as string[]);
+    } else if (op === 'all') {
+        const children = (filter).slice(1).map(f => _convertFilter(f as FilterSpecification, expectedTypes));
+        return children.length > 1 ? ['all'].concat(children as string[]) : [].concat(...children);
+    } else if (op === 'none') {
+        return ['!', _convertFilter(['any'].concat(filter.slice(1) as string[]) as string[], {})];
+    } else if (op === 'in') {
+        converted = convertInOp(filter[1] as string, filter.slice(2));
+    } else if (op === '!in') {
+        converted = convertInOp(filter[1] as string, filter.slice(2), true);
+    } else if (op === 'has') {
+        converted = convertHasOp(filter[1] as string);
+    } else if (op === '!has') {
+        converted = ['!', convertHasOp(filter[1] as string)];
+    } else {
+        converted = true;
     }
+
+    return converted;
 }
 
 // Given a set of feature properties and an expected type for each one,
@@ -114,7 +116,7 @@ export default function convertFilter(filter: FilterSpecification, expectedTypes
 //   ['==', ['typeof', ['get', 'name'], 'string']],
 //   ['==', ['typeof', ['get', 'population'], 'number]]
 // ]
-function runtimeTypeChecks(expectedTypes: ExpectedTypes): ExpressionFilterSpecification {
+function runtimeTypeChecks(expectedTypes: ExpectedTypes) {
     const conditions = [];
     for (const property in expectedTypes) {
         const get = property === '$id' ? ['id'] : ['get', property];
@@ -122,13 +124,13 @@ function runtimeTypeChecks(expectedTypes: ExpectedTypes): ExpressionFilterSpecif
     }
     if (conditions.length === 0) return true;
     if (conditions.length === 1) return conditions[0];
-    return ['all', ...conditions];
+    return ['all'].concat(conditions);
 }
 
-function convertComparisonOp(property: string, value: any, op: string, expectedTypes?: ExpectedTypes | null): ExpressionFilterSpecification {
+function convertComparisonOp(property: string, value: any, op: string, expectedTypes?: ExpectedTypes | null) {
     let get;
     if (property === '$type') {
-        return [op, ['geometry-type'], value] as ExpressionFilterSpecification;
+        return [op, ['geometry-type'], value];
     } else if (property === '$id') {
         get = ['id'];
     } else {
@@ -154,13 +156,13 @@ function convertComparisonOp(property: string, value: any, op: string, expectedT
         ];
     }
 
-    return [op, get, value] as ExpressionFilterSpecification;
+    return [op, get, value];
 }
 
-function convertInOp(property: string, values: Array<any>, negate = false): ExpressionFilterSpecification {
+function convertInOp(property: string, values: Array<any>, negate = false) {
     if (values.length === 0) return negate;
 
-    let get: ExpressionSpecification;
+    let get;
     if (property === '$type') {
         get = ['geometry-type'];
     } else if (property === '$id') {
@@ -188,14 +190,12 @@ function convertInOp(property: string, values: Array<any>, negate = false): Expr
         return ['match', get, uniqueValues, !negate, negate];
     }
 
-    if (negate) {
-        return ['all', ...values.map(v => ['!=', get, v] as ExpressionSpecification)];
-    } else {
-        return ['any', ...values.map(v => ['==', get, v] as ExpressionSpecification)];
-    }
+    return [ negate ? 'all' : 'any' as any].concat(
+        values.map(v => [negate ? '!=' : '==', get, v])
+    );
 }
 
-function convertHasOp(property: string): ExpressionFilterSpecification {
+function convertHasOp(property: string) {
     if (property === '$type') {
         return true;
     } else if (property === '$id') {

--- a/src/style-spec/feature_filter/feature_filter.test.ts
+++ b/src/style-spec/feature_filter/feature_filter.test.ts
@@ -5,39 +5,10 @@ import Point from '@mapbox/point-geometry';
 import MercatorCoordinate from '../../geo/mercator_coordinate';
 import EXTENT from '../../data/extent';
 import {CanonicalTileID} from '../../source/tile_id';
-import {ExpressionFilterSpecification, FilterSpecification} from '../types.g';
+import {FilterSpecification} from '../types.g';
 import {Feature} from '../expression';
 
 describe('filter', () => {
-    test('exprssions transpilation test', () => {
-        function compileTimeCheck(_: ExpressionFilterSpecification) {
-            expect(true).toBeTruthy();
-        }
-        compileTimeCheck(['any']);
-        compileTimeCheck(['at', 2, ['array', 1, 2, 3]]);
-        compileTimeCheck(['case', ['has', 'color'], ['get', 'color'], 'white']);
-        compileTimeCheck(['case', ['all', ['has', 'point_count'], ['<', ['get', 'point_count'], 3]], ['get', 'cluster_routes'], '']);
-        compileTimeCheck(['interpolate', ['linear'], ['get', 'point_count'], 2, 18.0, 10, 24.0]);
-        compileTimeCheck(['case', ['has', 'point_count'], ['interpolate', ['linear'], ['get', 'point_count'], 2, 18.0, 10, 24.0], 12.0]);
-        compileTimeCheck([
-            'case',
-            ['has', 'point_count'], ['interpolate', ['linear'], ['get', 'point_count'], 2, '#ccc', 10, '#444'],
-            ['has', 'priorityValue'], ['interpolate', ['linear'], ['get', 'priorityValue'], 0, '#ff9', 1, '#f66'],
-            '#fcaf3e'
-        ]);
-        compileTimeCheck([
-            'case',
-            ['==', ['get', 'CAPITAL'], 1], 'city-capital',
-            ['>=', ['get', 'POPULATION'], 1000000], 'city-1M',
-            ['>=', ['get', 'POPULATION'], 500000], 'city-500k',
-            ['>=', ['get', 'POPULATION'], 100000], 'city-100k',
-            'city'
-        ]);
-        compileTimeCheck(['match', ['get', 'TYPE'], ['TARGETPOINT:HOSPITAL'], true, false]);
-        compileTimeCheck(['match', ['get', 'TYPE'], ['ADIZ', 'AMA', 'AWY', 'CLASS', 'NO-FIR', 'OCA', 'OTA', 'P', 'RAS', 'RCA', 'UTA', 'UTA-P'], true, false]);
-        compileTimeCheck(['==', ['get', 'MILITARYAIRPORT'], 1]);
-    });
-
     test('expression, zoom', () => {
         const f = createFilter(['>=', ['number', ['get', 'x']], ['zoom']]).filter;
         expect(f({zoom: 1}, {properties: {x: 0}} as any as Feature)).toBe(false);
@@ -79,18 +50,6 @@ describe('filter', () => {
         expect(createFilter(['any', true]).filter(undefined, undefined)).toBe(true);
         expect(createFilter(['any', true, false]).filter(undefined, undefined)).toBe(true);
         expect(createFilter(['any', false, false]).filter(undefined, undefined)).toBe(false);
-    });
-
-    test('expression, literal', () => {
-        expect(createFilter(['literal', true]).filter(undefined, undefined)).toBe(true);
-        expect(createFilter(['literal', false]).filter(undefined, undefined)).toBe(false);
-    });
-
-    test('expression, match', () => {
-        const match = createFilter(['match', ['get', 'x'], ['a', 'b', 'c'], true, false]).filter;
-        expect(match(undefined, {properties: {x: 'a'}} as any as Feature)).toBe(true);
-        expect(match(undefined, {properties: {x: 'c'}} as any as Feature)).toBe(true);
-        expect(match(undefined, {properties: {x: 'd'}} as any as Feature)).toBe(false);
     });
 
     test('expression, type error', () => {
@@ -220,14 +179,14 @@ describe('convert legacy filters to expressions', () => {
                 ['LineString', 'Point', 'Polygon'],
                 true,
                 false
-            ],
+            ] as FilterSpecification,
             [
                 'match',
                 ['get', 'type'],
                 ['island'],
                 true,
                 false
-            ]
+            ] as FilterSpecification
         ];
 
         const converted = convertFilter(filter);

--- a/src/style-spec/feature_filter/index.ts
+++ b/src/style-spec/feature_filter/index.ts
@@ -2,7 +2,6 @@ import {createExpression} from '../expression';
 import type {GlobalProperties, Feature} from '../expression';
 import type {CanonicalTileID} from '../../source/tile_id';
 import {StylePropertySpecification} from '../style-spec';
-import {ExpressionFilterSpecification} from '../types.g';
 
 type FilterExpression = (
     globalProperties: GlobalProperties,
@@ -18,7 +17,7 @@ export type FeatureFilter = {
 export default createFilter;
 export {isExpressionFilter};
 
-function isExpressionFilter(filter: any): filter is ExpressionFilterSpecification {
+function isExpressionFilter(filter: any) {
     if (filter === true || filter === false) {
         return true;
     }

--- a/src/style-spec/migrate/expressions.ts
+++ b/src/style-spec/migrate/expressions.ts
@@ -15,7 +15,7 @@ export default function expressions(style: StyleSpecification) {
 
     eachLayer(style, (layer: LayerSpecification & { filter?: FilterSpecification }) => {
         if (layer.filter) {
-            layer.filter = convertFilter(layer.filter);
+            layer.filter = (convertFilter(layer.filter) as any);
         }
     });
 

--- a/src/style/light.test.ts
+++ b/src/style/light.test.ts
@@ -77,7 +77,7 @@ describe('Light#setLight', () => {
         const light = new Light({});
 
         const lightSpy = jest.spyOn(light, '_validate');
-        light.setLight({color: [999]} as any, {validate: false});
+        light.setLight({color: [999]}, {validate: false});
         light.updateTransitions({transition: false} as any as TransitionParameters);
         light.recalculate({zoom: 16, zoomHistory: {}, now: 10} as EvaluationParameters);
 


### PR DESCRIPTION
This pull request reverts #1390 which broke the typings, see #1462 

Would it make sense to temporarily revert #1390 such that our NPM package is not broken?

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [ ] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [ ] Manually test the debug page.
 - [ ] Suggest a changelog category: bug/feature/docs/etc. or "skip changelog".
 - [ ] Add an entry inside this element for inclusion in the `maplibre-gl-js` changelog: `<changelog></changelog>`.
