### PR TITLE
Add type check to typescript definition generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - 
 ### 🐞 Bug fixes
 
+- Fix types generation and make sure they run as part of the CI (#1462)
 - *...Add new stuff here...*
 
 ## 2.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - 
 ### 🐞 Bug fixes
 
-- Fix types generation and make sure they run as part of the CI (#1462)
+- Fix types generation and make sure they run as part of the CI (#1462, #1465)
 - *...Add new stuff here...*
 
 ## 2.2.0

--- a/build/generate-typings.ts
+++ b/build/generate-typings.ts
@@ -8,7 +8,7 @@ if (!fs.existsSync('dist')) {
 
 console.log('Starting bundling types');
 const outputFile = './dist/maplibre-gl.d.ts';
-childProcess.execSync(`dts-bundle-generator --no-check --umd-module-name=maplibregl -o ${outputFile} ./src/index.ts`);
+childProcess.execSync(`dts-bundle-generator --umd-module-name=maplibregl -o ${outputFile} ./src/index.ts`);
 let types = fs.readFileSync(outputFile, 'utf8');
 // Classes are not exported but should be since this is exported as UMD - fixing...
 types = types.replace(/declare class/g, 'export declare class');

--- a/src/source/worker.ts
+++ b/src/source/worker.ts
@@ -266,10 +266,11 @@ export default class Worker {
         enforceCacheSizeLimit(limit);
     }
 }
-
 /* global self, WorkerGlobalScope */
+// @ts-ignore
 if (typeof WorkerGlobalScope !== 'undefined' &&
     typeof self !== 'undefined' &&
+    // @ts-ignore
     self instanceof WorkerGlobalScope) {
     (self as any).worker = new Worker(self as any);
 }

--- a/src/source/worker.ts
+++ b/src/source/worker.ts
@@ -267,7 +267,7 @@ export default class Worker {
         enforceCacheSizeLimit(limit);
     }
 }
-/* global self, WorkerGlobalScope */
+
 if (isWorker()) {
     (self as any).worker = new Worker(self as any);
 }

--- a/src/source/worker.ts
+++ b/src/source/worker.ts
@@ -7,6 +7,7 @@ import GeoJSONWorkerSource from './geojson_worker_source';
 import assert from 'assert';
 import {plugin as globalRTLTextPlugin} from './rtl_text_plugin';
 import {enforceCacheSizeLimit} from '../util/tile_request_cache';
+import {isWorker} from '../util/util';
 
 import type {
     WorkerSource,
@@ -267,10 +268,6 @@ export default class Worker {
     }
 }
 /* global self, WorkerGlobalScope */
-// @ts-ignore
-if (typeof WorkerGlobalScope !== 'undefined' &&
-    typeof self !== 'undefined' &&
-    // @ts-ignore
-    self instanceof WorkerGlobalScope) {
+if (isWorker()) {
     (self as any).worker = new Worker(self as any);
 }

--- a/src/style-spec/reference/latest.ts
+++ b/src/style-spec/reference/latest.ts
@@ -1,3 +1,3 @@
 
 import spec from './v8.json' assert {type: 'json'};
-export default spec;
+export default spec as any;

--- a/src/style-spec/style-spec.ts
+++ b/src/style-spec/style-spec.ts
@@ -1,7 +1,7 @@
 type ExpressionType = 'data-driven' | 'cross-faded' | 'cross-faded-data-driven' | 'color-ramp' | 'data-constant' | 'constant';
 type ExpressionParameters = Array<'zoom' | 'feature' | 'feature-state' | 'heatmap-density' | 'line-progress'>;
 
-type ExpressionSpecification = {
+type ExpressionSpecificationDefinition = {
     interpolated: boolean;
     parameters: ExpressionParameters;
 };
@@ -9,33 +9,33 @@ type ExpressionSpecification = {
 export type StylePropertySpecification = {
     type: 'number';
     'property-type': ExpressionType;
-    expression?: ExpressionSpecification;
+    expression?: ExpressionSpecificationDefinition;
     transition: boolean;
     default?: number;
 } | {
     type: 'string';
     'property-type': ExpressionType;
-    expression?: ExpressionSpecification;
+    expression?: ExpressionSpecificationDefinition;
     transition: boolean;
     default?: string;
     tokens?: boolean;
 } | {
     type: 'boolean';
     'property-type': ExpressionType;
-    expression?: ExpressionSpecification;
+    expression?: ExpressionSpecificationDefinition;
     transition: boolean;
     default?: boolean;
 } | {
     type: 'enum';
     'property-type': ExpressionType;
-    expression?: ExpressionSpecification;
+    expression?: ExpressionSpecificationDefinition;
     values: {[_: string]: {}};
     transition: boolean;
     default?: string;
 } | {
     type: 'color';
     'property-type': ExpressionType;
-    expression?: ExpressionSpecification;
+    expression?: ExpressionSpecificationDefinition;
     transition: boolean;
     default?: string;
     overridable: boolean;
@@ -43,7 +43,7 @@ export type StylePropertySpecification = {
     type: 'array';
     value: 'number';
     'property-type': ExpressionType;
-    expression?: ExpressionSpecification;
+    expression?: ExpressionSpecificationDefinition;
     length?: number;
     transition: boolean;
     default?: Array<number>;
@@ -51,19 +51,20 @@ export type StylePropertySpecification = {
     type: 'array';
     value: 'string';
     'property-type': ExpressionType;
-    expression?: ExpressionSpecification;
+    expression?: ExpressionSpecificationDefinition;
     length?: number;
     transition: boolean;
     default?: Array<string>;
 } | {
     type: 'padding';
     'property-type': ExpressionType;
-    expression?: ExpressionSpecification;
+    expression?: ExpressionSpecificationDefinition;
     transition: boolean;
     default?: number | Array<number>;
 };
 
-import v8 from './reference/v8.json';
+import v8Spec from './reference/v8.json' assert {type: 'json'};
+let v8 = v8Spec as any;
 import latest from './reference/latest';
 import format from './format';
 import migrate from './migrate';

--- a/src/style-spec/style-spec.ts
+++ b/src/style-spec/style-spec.ts
@@ -64,7 +64,7 @@ export type StylePropertySpecification = {
 };
 
 import v8Spec from './reference/v8.json' assert {type: 'json'};
-let v8 = v8Spec as any;
+const v8 = v8Spec as any;
 import latest from './reference/latest';
 import format from './format';
 import migrate from './migrate';

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -384,7 +384,6 @@ export function sphericalToCartesian([r, azimuthal, polar]: [number, number, num
     };
 }
 
-/* global self, WorkerGlobalScope */
 /**
  *  Returns true if the when run in the web-worker context.
  *

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -392,8 +392,8 @@ export function sphericalToCartesian([r, azimuthal, polar]: [number, number, num
  * @returns {boolean}
  */
 export function isWorker(): boolean {
-    return typeof WorkerGlobalScope !== 'undefined' && typeof self !== 'undefined' &&
-           self instanceof WorkerGlobalScope;
+    // @ts-ignore
+    return typeof WorkerGlobalScope !== 'undefined' && typeof self !== 'undefined' && self instanceof WorkerGlobalScope;
 }
 
 /**

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,15 +11,14 @@
     "module": "esnext",
     "moduleResolution": "Node",
     "resolveJsonModule": true,
-    "skipLibCheck": true,
+    "skipLibCheck": false,
     "sourceMap": true,
     "strict": false,
     "target": "es2017",
     "lib": [
       "ESNext",
       "DOM",
-      "DOM.Iterable",
-      "WebWorker"
+      "DOM.Iterable"
     ],
     "types": ["node", "jest", "geojson", "offscreencanvas"]
   },


### PR DESCRIPTION
## Launch Checklist

Fixes #1462 

This PR is to make sure that the type generation fails with this new build configuration.
This should not be merged as is, but rather use this branch to fix the typings.
The problem is that there are two `ExpressionSpecification` defined in the code now, and the type generation fails.
In the past I ignored the problem that it was exposing due to conflict between DOM and WebWroker.
I have now fixed the issues using `@ts-ignore` in the places where web worker types are used.
If you have a better idea how to fix/improve this let me know.
cc: @birkskyum @wipfli 