### PR TITLE
Added typings for style-spec package

### DIFF
--- a/build/generate-typings.ts
+++ b/build/generate-typings.ts
@@ -16,7 +16,7 @@ fs.writeFileSync(outputFile, types);
 
 console.log('Finifhed bundling types for maplibre-gl starting style-spec');
 
-const outputPath = `./dist/style-spec`;
+const outputPath = './dist/style-spec';
 if (!fs.existsSync(outputPath)) {
     fs.mkdirSync(outputPath);
 }

--- a/build/generate-typings.ts
+++ b/build/generate-typings.ts
@@ -7,10 +7,20 @@ if (!fs.existsSync('dist')) {
 }
 
 console.log('Starting bundling types');
-const outputFile = './dist/maplibre-gl.d.ts';
+let outputFile = './dist/maplibre-gl.d.ts';
 childProcess.execSync(`dts-bundle-generator --umd-module-name=maplibregl -o ${outputFile} ./src/index.ts`);
 let types = fs.readFileSync(outputFile, 'utf8');
 // Classes are not exported but should be since this is exported as UMD - fixing...
 types = types.replace(/declare class/g, 'export declare class');
 fs.writeFileSync(outputFile, types);
+
+console.log('Finifhed bundling types for maplibre-gl starting style-spec');
+
+const outputPath = `./dist/style-spec`;
+if (!fs.existsSync(outputPath)) {
+    fs.mkdirSync(outputPath);
+}
+outputFile = `${outputPath}/index.d.ts`;
+childProcess.execSync(`dts-bundle-generator -o ${outputFile} ./src/style-spec/style-spec.ts`);
+
 console.log('Finished bundling types');

--- a/src/style-spec/CHANGELOG.md
+++ b/src/style-spec/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 16.2.0
+
+### ✨ Features and improvements
+* Added typescript typings [1468](https://github.com/maplibre/maplibre-gl-js/pull/1468)
+
 ## 16.1.0
 
 ### ✨ Features and improvements

--- a/src/style-spec/CHANGELOG.md
+++ b/src/style-spec/CHANGELOG.md
@@ -1,7 +1,8 @@
-## 16.2.0
+## 17.0.0
 
-### ✨ Features and improvements
-* Added typescript typings [1468](https://github.com/maplibre/maplibre-gl-js/pull/1468)
+### Breaking changes
+
+* Renamed `ParsingError` to `ExpressionParsingError` as there were two with the same name and added typescript typings [1468](https://github.com/maplibre/maplibre-gl-js/pull/1468)
 
 ## 16.1.0
 

--- a/src/style-spec/expression/index.ts
+++ b/src/style-spec/expression/index.ts
@@ -1,7 +1,7 @@
 import assert from 'assert';
 
 import extend from '../util/extend';
-import ParsingError from './parsing_error';
+import ExpressionParsingError from './parsing_error';
 import ParsingContext from './parsing_context';
 import EvaluationContext from './evaluation_context';
 import CompoundExpression from './compound_expression';
@@ -135,7 +135,7 @@ export function isExpression(expression: unknown) {
  *
  * @private
  */
-export function createExpression(expression: unknown, propertySpec?: StylePropertySpecification | null): Result<StyleExpression, Array<ParsingError>> {
+export function createExpression(expression: unknown, propertySpec?: StylePropertySpecification | null): Result<StyleExpression, Array<ExpressionParsingError>> {
     const parser = new ParsingContext(definitions, [], propertySpec ? getExpectedType(propertySpec) : undefined);
 
     // For string-valued properties, coerce to string at the top level rather than asserting.
@@ -287,7 +287,7 @@ export type CompositeExpression = {
 
 export type StylePropertyExpression = ConstantExpression | SourceExpression | CameraExpression | CompositeExpression;
 
-export function createPropertyExpression(expressionInput: unknown, propertySpec: StylePropertySpecification): Result<StylePropertyExpression, Array<ParsingError>> {
+export function createPropertyExpression(expressionInput: unknown, propertySpec: StylePropertySpecification): Result<StylePropertyExpression, Array<ExpressionParsingError>> {
     const expression = createExpression(expressionInput, propertySpec);
     if (expression.result === 'error') {
         return expression;
@@ -297,21 +297,21 @@ export function createPropertyExpression(expressionInput: unknown, propertySpec:
 
     const isFeatureConstant = isConstant.isFeatureConstant(parsed);
     if (!isFeatureConstant && !supportsPropertyExpression(propertySpec)) {
-        return error([new ParsingError('', 'data expressions not supported')]);
+        return error([new ExpressionParsingError('', 'data expressions not supported')]);
     }
 
     const isZoomConstant = isConstant.isGlobalPropertyConstant(parsed, ['zoom']);
     if (!isZoomConstant && !supportsZoomExpression(propertySpec)) {
-        return error([new ParsingError('', 'zoom expressions not supported')]);
+        return error([new ExpressionParsingError('', 'zoom expressions not supported')]);
     }
 
     const zoomCurve = findZoomCurve(parsed);
     if (!zoomCurve && !isZoomConstant) {
-        return error([new ParsingError('', '"zoom" expression may only be used as input to a top-level "step" or "interpolate" expression.')]);
-    } else if (zoomCurve instanceof ParsingError) {
+        return error([new ExpressionParsingError('', '"zoom" expression may only be used as input to a top-level "step" or "interpolate" expression.')]);
+    } else if (zoomCurve instanceof ExpressionParsingError) {
         return error([zoomCurve]);
     } else if (zoomCurve instanceof Interpolate && !supportsInterpolation(propertySpec)) {
-        return error([new ParsingError('', '"interpolate" expressions cannot be used with this property')]);
+        return error([new ExpressionParsingError('', '"interpolate" expressions cannot be used with this property')]);
     }
 
     if (!zoomCurve) {
@@ -394,7 +394,7 @@ export function normalizePropertyExpression<T>(
 // Zoom-dependent expressions may only use ["zoom"] as the input to a top-level "step" or "interpolate"
 // expression (collectively referred to as a "curve"). The curve may be wrapped in one or more "let" or
 // "coalesce" expressions.
-function findZoomCurve(expression: Expression): Step | Interpolate | ParsingError | null {
+function findZoomCurve(expression: Expression): Step | Interpolate | ExpressionParsingError | null {
     let result = null;
     if (expression instanceof Let) {
         result = findZoomCurve(expression.result);
@@ -414,18 +414,18 @@ function findZoomCurve(expression: Expression): Step | Interpolate | ParsingErro
         result = expression;
     }
 
-    if (result instanceof ParsingError) {
+    if (result instanceof ExpressionParsingError) {
         return result;
     }
 
     expression.eachChild((child) => {
         const childResult = findZoomCurve(child);
-        if (childResult instanceof ParsingError) {
+        if (childResult instanceof ExpressionParsingError) {
             result = childResult;
         } else if (!result && childResult) {
-            result = new ParsingError('', '"zoom" expression may only be used as input to a top-level "step" or "interpolate" expression.');
+            result = new ExpressionParsingError('', '"zoom" expression may only be used as input to a top-level "step" or "interpolate" expression.');
         } else if (result && childResult && result !== childResult) {
-            result = new ParsingError('', 'Only one zoom-based "step" or "interpolate" subexpression may be used in an expression.');
+            result = new ExpressionParsingError('', 'Only one zoom-based "step" or "interpolate" subexpression may be used in an expression.');
         }
     });
 

--- a/src/style-spec/expression/parsing_context.ts
+++ b/src/style-spec/expression/parsing_context.ts
@@ -1,6 +1,6 @@
 import Scope from './scope';
 import {checkSubtype} from './types';
-import ParsingError from './parsing_error';
+import ExpressionParsingError from './parsing_error';
 import Literal from './definitions/literal';
 import Assertion from './definitions/assertion';
 import Coercion from './definitions/coercion';
@@ -23,7 +23,7 @@ class ParsingContext {
     path: Array<number>;
     key: string;
     scope: Scope;
-    errors: Array<ParsingError>;
+    errors: Array<ExpressionParsingError>;
 
     // The expected type of this expression. Provided only to allow Expression
     // implementations to infer argument types: Expression#parse() need not
@@ -36,7 +36,7 @@ class ParsingContext {
         path: Array<number> = [],
         expectedType?: Type | null,
         scope: Scope = new Scope(),
-        errors: Array<ParsingError> = []
+        errors: Array<ExpressionParsingError> = []
     ) {
         this.registry = registry;
         this.path = path;
@@ -183,7 +183,7 @@ class ParsingContext {
      */
     error(error: string, ...keys: Array<number>) {
         const key = `${this.key}${keys.map(k => `[${k}]`).join('')}`;
-        this.errors.push(new ParsingError(key, error));
+        this.errors.push(new ExpressionParsingError(key, error));
     }
 
     /**

--- a/src/style-spec/expression/parsing_error.ts
+++ b/src/style-spec/expression/parsing_error.ts
@@ -1,4 +1,4 @@
-class ParsingError extends Error {
+class ExpressionParsingError extends Error {
     key: string;
     message: string;
     constructor(key: string, message: string) {
@@ -8,4 +8,4 @@ class ParsingError extends Error {
     }
 }
 
-export default ParsingError;
+export default ExpressionParsingError;

--- a/src/style-spec/package.json
+++ b/src/style-spec/package.json
@@ -14,6 +14,7 @@
   "license": "ISC",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
   "type": "module",
   "scripts": {
   },

--- a/src/style-spec/package.json
+++ b/src/style-spec/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@maplibre/maplibre-gl-style-spec",
   "description": "a specification for maplibre gl styles",
-  "version": "16.1.0",
+  "version": "16.2.0",
   "author": "MapLibre",
   "keywords": [
     "mapbox",

--- a/src/style-spec/package.json
+++ b/src/style-spec/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@maplibre/maplibre-gl-style-spec",
   "description": "a specification for maplibre gl styles",
-  "version": "16.2.0",
+  "version": "17.0.0",
   "author": "MapLibre",
   "keywords": [
     "mapbox",


### PR DESCRIPTION
## Launch Checklist

See discussion here: #1116
This fixes #1107
Basically this adds typings to the style-spec pacakge.
I don't use it so this need better testing, but I think it's better than nothing...
@achou11 feel free to review this and see if it works as expected.

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality.
 - [x] Document any changes to public APIs.
 - [x] Post benchmark scores.
 - [x] Manually test the debug page.
 - [x] Suggest a changelog category: bug/feature/docs/etc. or "skip changelog".
 - [x] Add an entry inside this element for inclusion in the `maplibre-gl-js` changelog: `<changelog></changelog>`.
