### PR TITLE
Fix glob path so render tests can run on Windows

### DIFF
--- a/test/integration/render/render.test.ts
+++ b/test/integration/render/render.test.ts
@@ -3,6 +3,7 @@ import './mock_browser_for_node';
 import canvas from 'canvas';
 import path, {dirname} from 'path';
 import fs from 'fs';
+import isWindows from 'is-windows';
 import {PNG} from 'pngjs';
 import pixelmatch from 'pixelmatch';
 import {fileURLToPath} from 'url';
@@ -155,7 +156,11 @@ function compareRenderResults(directory: string, testData: TestData, data: Uint8
     actualImg.data = data as any;
 
     // there may be multiple expected images, covering different platforms
-    const expectedPaths = glob.sync(path.join(dir, 'expected*.png'));
+    let globPattern = path.join(dir, 'expected*.png');
+    if (isWindows()) {
+        globPattern = globPattern.replace(/\\/g, '/');
+    }
+    const expectedPaths = glob.sync(globPattern);
 
     if (!process.env.UPDATE && expectedPaths.length === 0) {
         throw new Error('No expected*.png files found; did you mean to run tests with UPDATE=true?');

--- a/test/integration/render/render.test.ts
+++ b/test/integration/render/render.test.ts
@@ -3,7 +3,6 @@ import './mock_browser_for_node';
 import canvas from 'canvas';
 import path, {dirname} from 'path';
 import fs from 'fs';
-import isWindows from 'is-windows';
 import {PNG} from 'pngjs';
 import pixelmatch from 'pixelmatch';
 import {fileURLToPath} from 'url';
@@ -157,9 +156,7 @@ function compareRenderResults(directory: string, testData: TestData, data: Uint8
 
     // there may be multiple expected images, covering different platforms
     let globPattern = path.join(dir, 'expected*.png');
-    if (isWindows()) {
-        globPattern = globPattern.replace(/\\/g, '/');
-    }
+    globPattern = globPattern.replace(/\\/g, '/'); // ensure a Windows path is converted to a glob compatible pattern.
     const expectedPaths = glob.sync(globPattern);
 
     if (!process.env.UPDATE && expectedPaths.length === 0) {
@@ -253,7 +250,8 @@ function mockXhr() {
 function getTestStyles(options: RenderOptions, directory: string): StyleWithTestData[] {
     const tests = options.tests || [];
 
-    const sequence = glob.sync('**/style.json', {cwd: directory})
+    const globCwd = directory.replace(/\\/g, '/'); // ensure a Windows path is converted to a glob compatible pattern.
+    const sequence = glob.sync('**/style.json', {cwd: globCwd})
         .map(fixture => {
             const id = path.dirname(fixture);
             const style = JSON.parse(fs.readFileSync(path.join(directory, fixture), 'utf8')) as StyleWithTestData;


### PR DESCRIPTION
I was unable to run the render tests on a Windows machine because none of the expected PNG files were being found. It turned out to be due to the backslashes in the path being created to find the PNG files. The backslashes mess up the glob pattern. This change applies the suggested fix by the fast-glob library, to replace '\\' with '/' on Windows.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [ ] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [ ] Manually test the debug page.
 - [ ] Suggest a changelog category: bug/feature/docs/etc. or "skip changelog".
 - [ ] Add an entry inside this element for inclusion in the `maplibre-gl-js` changelog: `<changelog></changelog>`.
