### PR TITLE
Added missing style-spec typings to publish

### DIFF
--- a/.github/workflows/publish-style-spec.yml
+++ b/.github/workflows/publish-style-spec.yml
@@ -30,6 +30,7 @@ jobs:
       - name: Build style spec
         run: |
           npm run build-style-spec
+          npm run generate-typings
           cp -r dist/style-spec/* src/style-spec/dist
       
       - name: Check version and publish

--- a/src/style-spec/CHANGELOG.md
+++ b/src/style-spec/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 17.0.1
 
-* Generated typings file as not created in the build process and was added in this version
+* Generated typings file as not created in the build process and was added in this version [#1470](https://github.com/maplibre/maplibre-gl-js/pull/1470)
 
 ## 17.0.0
 

--- a/src/style-spec/CHANGELOG.md
+++ b/src/style-spec/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 17.0.1
+
+* Generated typings file as not created in the build process and was added in this version
+
 ## 17.0.0
 
 ### Breaking changes

--- a/src/style-spec/package.json
+++ b/src/style-spec/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@maplibre/maplibre-gl-style-spec",
   "description": "a specification for maplibre gl styles",
-  "version": "17.0.0",
+  "version": "17.0.1",
   "author": "MapLibre",
   "keywords": [
     "mapbox",


### PR DESCRIPTION
## Launch Checklist

Related to #1107 #1116 #1468
This basically adds the missing step in the publish CI script which I assumed happens automatically but apparently it was a wrong assumption as the only thing that runs in the post install is the code generation that is needed in order to build the package but the type generation is not part of it.
My bad :-(
