### PR TITLE
Version with test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ### ✨ Features and improvements
 
 - *...Add new stuff here...*
-- 
+- Re-enable method to get library version. Either with `import {version} from 'maplibre-gl'`, or on a Map instance as `map.version`.
+
 ### 🐞 Bug fixes
 
 - *...Add new stuff here...*

--- a/build/rollup_plugins.ts
+++ b/build/rollup_plugins.ts
@@ -11,8 +11,6 @@ import strip from '@rollup/plugin-strip';
 import {Plugin} from 'rollup';
 import {importAssertionsPlugin} from 'rollup-plugin-import-assert';
 
-import {version} from '../package.json';
-
 // Common set of plugins/transformations shared across different rollup
 // builds (main maplibre bundle, style-spec package, benchmarks bundle)
 
@@ -33,9 +31,6 @@ export const plugins = (production: boolean): Plugin[] => [
         values: {
             '_token_stack:': ''
         }
-    }),
-    replace({
-        '__packageVersion': version,
     }),
     production && strip({
         sourceMap: true,

--- a/build/rollup_plugins.ts
+++ b/build/rollup_plugins.ts
@@ -11,6 +11,8 @@ import strip from '@rollup/plugin-strip';
 import {Plugin} from 'rollup';
 import {importAssertionsPlugin} from 'rollup-plugin-import-assert';
 
+import {version} from '../package.json';
+
 // Common set of plugins/transformations shared across different rollup
 // builds (main maplibre bundle, style-spec package, benchmarks bundle)
 
@@ -31,6 +33,9 @@ export const plugins = (production: boolean): Plugin[] => [
         values: {
             '_token_stack:': ''
         }
+    }),
+    replace({
+        '__packageVersion': version,
     }),
     production && strip({
         sourceMap: true,

--- a/package.json
+++ b/package.json
@@ -167,7 +167,7 @@
     "test-render": "node --loader ts-node/esm --experimental-specifier-resolution=node --max-old-space-size=2048 test/integration/render/render.test.ts",
     "test-query": "jest -c ./jest.config.e2e.ts --roots ./test/integration/query",
     "test-expression": "jest --roots ./test/integration/expression",
-    "test-unit": "jest  -c ./jest.config.ts --roots ./src",
+    "test-unit": "jest --roots ./src  -c ./jest.config.ts ",
     "codegen": "npm run generate-style-code && npm run generate-struct-arrays && npm run generate-style-spec && npm run generate-shaders && npm run generate-debug-index-file",
     "benchmark": "node --loader ts-node/esm --experimental-specifier-resolution=node test/bench/run-benchmarks.ts",
     "gl-stats": "node --loader ts-node/esm --experimental-specifier-resolution=node test/bench/gl-stats.ts",

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -4,4 +4,13 @@ describe('maplibre', () => {
     test('workerCount', () => {
         expect(typeof maplibre.workerCount === 'number').toBeTruthy();
     });
+
+    test('version', () => {
+        expect(typeof maplibre.version === 'string').toBeTruthy();
+
+        // Semver regex: https://gist.github.com/jhorsman/62eeea161a13b80e39f5249281e17c39
+        // Backslashes are doubled to escape them
+        const regexp = new RegExp('^([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*))?(?:\\+[0-9A-Za-z-]+)?$');
+        expect(regexp.test(maplibre.version)).toBeTruthy();
+    });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -100,6 +100,13 @@ const exported = {
     clearPrewarmedResources,
 
     /**
+     * Returns the package version of the library
+     */
+    get version(): string {
+        return '__packageVersion';
+    },
+
+    /**
      * Gets and sets the number of web workers instantiated on a page with GL JS maps.
      * By default, it is set to half the number of CPU cores (capped at 6).
      * Make sure to set this property before creating any map instances for it to have effect.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import assert from 'assert';
 import {supported} from '@mapbox/mapbox-gl-supported';
-
+import {version} from '../package.json';
 import Map from './ui/map';
 import NavigationControl from './ui/control/navigation_control';
 import GeolocateControl from './ui/control/geolocate_control';
@@ -104,7 +104,7 @@ const exported = {
      * @returns {string} Package version of the library
      */
     get version(): string {
-        return '__packageVersion';
+        return version;
     },
 
     /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import assert from 'assert';
 import {supported} from '@mapbox/mapbox-gl-supported';
-import {version} from '../package.json';
+import packageJSON from '../package.json' assert {type: 'json'};
 import Map from './ui/map';
 import NavigationControl from './ui/control/navigation_control';
 import GeolocateControl from './ui/control/geolocate_control';
@@ -35,6 +35,8 @@ import RasterDEMTileSource from './source/raster_dem_tile_source';
 import RasterTileSource from './source/raster_tile_source';
 import VectorTileSource from './source/vector_tile_source';
 import VideoSource from './source/video_source';
+
+const version = packageJSON.version;
 
 const exported = {
     supported,

--- a/src/index.ts
+++ b/src/index.ts
@@ -101,6 +101,7 @@ const exported = {
 
     /**
      * Returns the package version of the library
+     * @returns {string} Package version of the library
      */
     get version(): string {
         return '__packageVersion';

--- a/src/ui/map.test.ts
+++ b/src/ui/map.test.ts
@@ -40,6 +40,17 @@ afterEach(() => {
 
 describe('Map', () => {
 
+    test('version', () => {
+        const map = createMap({interactive: true, style: null});
+
+        expect(typeof map.version === 'string').toBeTruthy();
+
+        // Semver regex: https://gist.github.com/jhorsman/62eeea161a13b80e39f5249281e17c39
+        // Backslashes are doubled to escape them
+        const regexp = new RegExp('^([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*))?(?:\\+[0-9A-Za-z-]+)?$');
+        expect(regexp.test(map.version)).toBeTruthy();
+    });
+
     test('constructor', () => {
         const map = createMap({interactive: true, style: null});
         expect(map.getContainer()).toBeTruthy();

--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -1,7 +1,7 @@
 import {extend, bindAll, warnOnce, uniqueId, isImageBitmap} from '../util/util';
 import browser from '../util/browser';
 import DOM from '../util/dom';
-import {version} from '../../package.json';
+import packageJSON from '../../package.json' assert {type: 'json'};
 import {getImage, GetImageCallback, getJSON, ResourceType} from '../util/ajax';
 import {RequestManager} from '../util/request_manager';
 import Style from '../style/style';
@@ -58,6 +58,8 @@ import type {
 import {Callback} from '../types/callback';
 import type {ControlPosition, IControl} from './control/control';
 import type {MapGeoJSONFeature} from '../util/vectortile_to_geojson';
+
+const version = packageJSON.version;
 
 /* eslint-enable no-use-before-define */
 export type MapOptions = {

--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -524,6 +524,13 @@ class Map extends Camera {
     }
 
     /**
+     * Returns the package version of the library
+     */
+    get version(): string {
+        return '__packageVersion';
+    }
+
+    /**
      * Adds an {@link IControl} to the map, calling `control.onAdd(this)`.
      *
      * @param {IControl} control The {@link IControl} to add.

--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -1,6 +1,7 @@
 import {extend, bindAll, warnOnce, uniqueId, isImageBitmap} from '../util/util';
 import browser from '../util/browser';
 import DOM from '../util/dom';
+import {version} from '../../package.json';
 import {getImage, GetImageCallback, getJSON, ResourceType} from '../util/ajax';
 import {RequestManager} from '../util/request_manager';
 import Style from '../style/style';
@@ -521,13 +522,6 @@ class Map extends Camera {
     */
     _getMapId() {
         return this._mapId;
-    }
-
-    /**
-     * Returns the package version of the library
-     */
-    get version(): string {
-        return '__packageVersion';
     }
 
     /**
@@ -2931,6 +2925,14 @@ class Map extends Camera {
     // for cache browser tests
     _setCacheLimits(limit: number, checkThreshold: number) {
         setCacheLimits(limit, checkThreshold);
+    }
+
+    /**
+     * Returns the package version of the library
+     * @returns {string} Package version of the library
+     */
+    get version(): string {
+        return version;
     }
 }
 


### PR DESCRIPTION
Extension of #1459  towards resolving issues like this ( #1426)

Provides a way to get the package version, and add unit tests to make sure it's proper semver.

Because of compiler issues at the time this functionality was removed when we moved to typescript in [this PR](https://github.com/maplibre/maplibre-gl-js/pull/209), specifically in [this commit](https://github.com/maplibre/maplibre-gl-js/pull/209/commits/056a39635e8931388873008c23f7536d7ca670ce).