### PR TITLE
Automatically merge dependabot semver patch and minor pull requests

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,21 +1,26 @@
 name: Dependabot auto-merge
 on: pull_request
 
-permissions:
-  contents: write
+permissions: write-all
 
 jobs:
   dependabot:
     runs-on: ubuntu-latest
     if: ${{ github.actor == 'dependabot[bot]' }}
     steps:
-      - name: Get metadata
+      - name: Dependabot metadata
         id: metadata
         uses: dependabot/fetch-metadata@v1.3.3
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Approve Dependabot PRs
+        if: ${{steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor'}}
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
       - name: Enable auto-merge for Dependabot PRs
-        if: ${{steps.metadata.outputs.update-type == 'version-update:semver-patch'}}
+        if: ${{steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor'}}
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}


### PR DESCRIPTION
Enables automatic approval and merging of pull requests from dependabot if they bump the minor or patch version of a package. Pull requests are only merged after a successful CI run.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [ ] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [ ] Manually test the debug page.
 - [ ] Suggest a changelog category: bug/feature/docs/etc. or "skip changelog".
 - [ ] Add an entry inside this element for inclusion in the `maplibre-gl-js` changelog: `<changelog></changelog>`.
