### PR TITLE
Release-2.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,11 @@
 
 - *...Add new stuff here...*
 - 
-## 2.2.2
+## 2.3.0
 
-### 🐞 Bug fixes
+### ✨ Features and improvements
 
-- Fix method to get library version. Either with `import {version} from 'maplibre-gl'`, or on a Map instance as `map.version`.
+- Re-enable method to get library version. Either with `import {version} from 'maplibre-gl'`, or on a Map instance as `map.version`.
 
 ## 2.2.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,19 @@
 ## main
 
+
 ### ✨ Features and improvements
 
 - *...Add new stuff here...*
-- Re-enable method to get library version. Either with `import {version} from 'maplibre-gl'`, or on a Map instance as `map.version`.
-
+- 
 ### 🐞 Bug fixes
 
 - *...Add new stuff here...*
+- 
+## 2.2.2
+
+### 🐞 Bug fixes
+
+- Fix method to get library version. Either with `import {version} from 'maplibre-gl'`, or on a Map instance as `map.version`.
 
 ## 2.2.1
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "maplibre-gl",
-  "version": "2.2.2",
+  "version": "2.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "maplibre-gl",
-      "version": "2.2.2",
+      "version": "2.3.0",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "maplibre-gl",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "maplibre-gl",
-      "version": "2.2.1",
+      "version": "2.2.2",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "maplibre-gl",
   "description": "BSD licensed community fork of mapbox-gl, a WebGL interactive maps library",
-  "version": "2.2.2",
+  "version": "2.3.0",
   "main": "dist/maplibre-gl.js",
   "style": "dist/maplibre-gl.css",
   "license": "BSD-3-Clause",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "maplibre-gl",
   "description": "BSD licensed community fork of mapbox-gl, a WebGL interactive maps library",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "main": "dist/maplibre-gl.js",
   "style": "dist/maplibre-gl.css",
   "license": "BSD-3-Clause",


### PR DESCRIPTION
Adds a getter method to retrieve the package version. We lost this ability in the migration to typescript.