### PR TITLE
Automatically keep package.json and lock-file in sync

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,7 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 20
+    versioning-strategy: increase
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
Every once in a while when the lockfile is way ahead of package.json, we manually go in and update the package.json.

Dependabot can actually update the package.json too so they don't get out of sync, simply by setting the `versioning-strategy: increase`

https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file