### PR TITLE
Disable cooperative gestures in fullscreen

### DIFF
--- a/src/ui/handler/scroll_zoom.ts
+++ b/src/ui/handler/scroll_zoom.ts
@@ -148,7 +148,7 @@ class ScrollZoomHandler {
 
     wheel(e: WheelEvent) {
         if (!this.isEnabled()) return;
-        if (this._map._cooperativeGestures) {
+        if (this._map._cooperativeGestures && document.fullscreenElement == null) {
             if (this._map._metaPress) {
                 e.preventDefault();
             } else {

--- a/src/ui/handler/touch_zoom_rotate.ts
+++ b/src/ui/handler/touch_zoom_rotate.ts
@@ -234,7 +234,7 @@ export class TouchPitchHandler extends TwoTouchHandler {
 
     _move(points: [Point, Point], center: Point, e: TouchEvent) {
         // If cooperative gestures is enabled, we need a 3-finger minimum for this gesture to register
-        if (this._map._cooperativeGestures && this._currentTouchCount < 3) {
+        if (this._map._cooperativeGestures && document.fullscreenElement == null && this._currentTouchCount < 3) {
             return;
         }
 

--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -2523,7 +2523,7 @@ class Map extends Camera {
     }
 
     _onCooperativeGesture(event: any, metaPress, touches) {
-        if (!metaPress && touches < 2) {
+        if (document.fullscreenElement == null && !metaPress && touches < 2) {
             // Alert user how to scroll/pan
             this._cooperativeGesturesScreen.classList.add('maplibregl-show');
             setTimeout(() => {


### PR DESCRIPTION
Don't use cooperative gestures when in fullscreen
This is achieved basically by replacing all the if (this._map._cooperativeGestures)... with if (this._map._cooperativeGestures && document.fullscreenElement == null)... in various places.

changelog:
<changelog>`cooperativeGestures` are automatically disabled in fullscreen mode, since there is no need to prevent inadvertent scrolling/panning</changelog>

suggested changelog category: feature

## Launch Checklist

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [ ] Manually test the debug page.
 - [x] Suggest a changelog category: bug/feature/docs/etc. or "skip changelog".
 - [ ] Add an entry inside this element for inclusion in the `maplibre-gl-js` changelog: `<changelog></changelog>`.
