### PR TITLE
Update target from ES2017 to ES2019

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,12 @@
 ### ✨ Features and improvements
 
 - *...Add new stuff here...*
+- Upgrade target from ES2017 to ES2019
 
 ### 🐞 Bug fixes
 
 - *...Add new stuff here...*
-
+  
 ## 2.3.1-pre.1
 
 ### ✨ Features and improvements

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,7 @@
     "skipLibCheck": false,
     "sourceMap": true,
     "strict": false,
-    "target": "es2017",
+    "target": "ES2019",
     "lib": [
       "ESNext",
       "DOM",


### PR DESCRIPTION
Modern browsers have come a long way, and so have our codebase, and we might as well start leveraging that. [ES2019 is well supported]( https://caniuse.com/sr_es10), and [your browser](https://www.whatismybrowser.com/detect/ecma-script-version) is probably ahead of that, and we were previously blocked from moving towards it because of lacking support by the SWC / Jest setup we had for unit-test.