### PR TITLE
Adding `windows-latest` to OS matrix of CI build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,11 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{matrix.os}}
+  strategy:
+    matrix:
+      os: [ubuntu-latest, windows-latest]
+                
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,10 +8,11 @@ on:
 jobs:
   build:
     runs-on: ${{matrix.os}}
+
   strategy:
     matrix:
       os: [ubuntu-latest, windows-latest]
-                
+
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
This change attempts to add a CI build for the windows OS to reproduce errors that I've been encountering locally when running query/browser tests.


## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [ ] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [ ] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [ ] Manually test the debug page.
 - [ ] Suggest a changelog category: bug/feature/docs/etc. or "skip changelog".
 - [ ] Add an entry inside this element for inclusion in the `maplibre-gl-js` changelog: `<changelog></changelog>`.
