### PR TITLE
In query tests, fixing up the glob sync path so it works on Windows

### DIFF
--- a/build/generate-query-test-fixtures.ts
+++ b/build/generate-query-test-fixtures.ts
@@ -26,9 +26,10 @@ function generateFixtureJson(rootDirectory: string, suiteDirectory: string, outp
     const imagePaths = globs[1];
     //Extract the filedata into a flat dictionary
     const allFiles = {};
-    let allPaths = glob.sync(jsonPaths);
+    // Using replace() to fixup Windows paths so they are compatible with glob sync.
+    let allPaths = glob.sync(jsonPaths.replace(/\\/g, '/'));
     if (includeImages) {
-        allPaths = allPaths.concat(glob.sync(imagePaths));
+        allPaths = allPaths.concat(glob.sync(imagePaths.replace(/\\/g, '/')));
     }
 
     //A Set that stores test names that are malformed so they can be removed later


### PR DESCRIPTION
I found another case where glob.sync was failing, leading to the query tests not working on Windows.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [ ] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [ ] Manually test the debug page.
 - [ ] Suggest a changelog category: bug/feature/docs/etc. or "skip changelog".
 - [ ] Add an entry inside this element for inclusion in the `maplibre-gl-js` changelog: `<changelog></changelog>`.
