### PR TITLE
Minor optimization for primitive size selection

### DIFF
--- a/src/render/program.ts
+++ b/src/render/program.ts
@@ -175,12 +175,16 @@ class Program<Us extends UniformBindings> {
         }
 
         let primitiveSize = 0;
-        if (drawMode === gl.LINES) {
-            primitiveSize = 2;
-        } else if (drawMode === gl.TRIANGLES) {
-            primitiveSize = 3;
-        } else if (drawMode === gl.LINE_STRIP) {
-            primitiveSize = 1;
+        switch (drawMode) {
+            case gl.LINES:
+                primitiveSize = 2;
+                break;
+            case gl.TRIANGLES:
+                primitiveSize = 3;
+                break;
+            case gl.LINE_STRIP:
+                primitiveSize = 1;
+                break;
         }
 
         for (const segment of segments.get()) {

--- a/src/render/program.ts
+++ b/src/render/program.ts
@@ -174,11 +174,14 @@ class Program<Us extends UniformBindings> {
             configuration.setUniforms(context, this.binderUniforms, currentProperties, {zoom: (zoom as any)});
         }
 
-        const primitiveSize = {
-            [gl.LINES]: 2,
-            [gl.TRIANGLES]: 3,
-            [gl.LINE_STRIP]: 1
-        }[drawMode];
+        let primitiveSize = 0;
+        if (drawMode === gl.LINES) {
+            primitiveSize = 2;
+        } else if (drawMode === gl.TRIANGLES) {
+            primitiveSize = 3;
+        } else if (drawMode === gl.LINE_STRIP) {
+            primitiveSize = 1;
+        }
 
         for (const segment of segments.get()) {
             const vaos = segment.vaos || (segment.vaos = {});


### PR DESCRIPTION
I'm looking at ways to speedup shader compilation (unrelated to this change) and found this snippet of code in the `draw` function which seemed inefficient.

Some benchmarking showed that the previous primitive size selection (which uses an object, etc.) is about 3x slower in Chromium browsers than a switch statement. It also is apparently a lot slower in Firefox, but I don't know how much credence to give the results I got on Firefox.

It's probably in micro-optimization territory either way, but it's a simple change.

https://www.measurethat.net/Benchmarks/Show/20441/0/if-else-vs-switch-vs-object-2

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [ ] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [x] Manually test the debug page.
 - [ ] Suggest a changelog category: bug/feature/docs/etc. or "skip changelog".
 - [ ] Add an entry inside this element for inclusion in the `maplibre-gl-js` changelog: `<changelog></changelog>`.
