### PR TITLE
Fixes another issue with expression typings

### DIFF
--- a/build/generate-style-spec.ts
+++ b/build/generate-style-spec.ts
@@ -203,7 +203,7 @@ export type ExpressionSpecification =
     | ['interpolate-lab', InterpolationSpecification,
         number | ExpressionSpecification, number | ExpressionSpecification, ExpressionInputType | ExpressionSpecification, 
         ...(number | ColorSpecification | ExpressionSpecification)[]]
-    | ['step', number | ExpressionSpecification, number | ExpressionSpecification, ExpressionInputType | ExpressionSpecification, 
+    | ['step', number | ExpressionSpecification, ExpressionInputType | ExpressionSpecification, 
         ...(number | ExpressionInputType | ExpressionSpecification)[]]
     // Variable binding
     | ['let', string, ExpressionInputType | ExpressionSpecification, ...(string | ExpressionInputType | ExpressionSpecification)[]]

--- a/src/style-spec/feature_filter/feature_filter.test.ts
+++ b/src/style-spec/feature_filter/feature_filter.test.ts
@@ -43,6 +43,7 @@ describe('filter', () => {
             ['line-progress'],
             ...colorStops
         ]);
+        compileTimeCheck(['step', ['get', 'point_count'], '#df2d43', 50, '#df2d43', 200, '#df2d43']);
     });
 
     test('expression, zoom', () => {


### PR DESCRIPTION
## Launch Checklist

Fix more expressions typings
See here: https://github.com/maplibre/maplibre-gl-js/issues/1380#issuecomment-1216634886
Basically another type that is either too strict or has a typo, I'm not sure unfortunately...
@cns-solutions-admin feel free to review - this is the third PR with fixes to this and I still feel there are not enough tests for this, if you have more expressions to add to the test file please do so.
@hheexx if you have more types in your project that can be added to the changed test file, so I can have more tests to make sure at least all your cases are covered, please share then here before this is merged.

