### PR TITLE
Fix/improve expression type

### DIFF
--- a/build/generate-style-spec.ts
+++ b/build/generate-style-spec.ts
@@ -187,30 +187,26 @@ export type ExpressionSpecification =
     | ['any', ...(boolean | ExpressionSpecification)[]] // boolean
     | ['case', boolean | ExpressionSpecification, ExpressionInputType | ExpressionSpecification, 
         ...(boolean | ExpressionInputType | ExpressionSpecification)[], ExpressionInputType | ExpressionSpecification]
-    | ['coalesce', ExpressionInputType | ExpressionSpecification, ExpressionInputType | ExpressionSpecification, 
-        ...(ExpressionInputType | ExpressionSpecification)[]]
+    | ['coalesce', ...(ExpressionInputType | ExpressionSpecification)[]] // at least two inputs required
     | ['match', ExpressionInputType | ExpressionSpecification, 
         ExpressionInputType | ExpressionInputType[], ExpressionInputType | ExpressionSpecification, 
         ...(ExpressionInputType | ExpressionInputType[] | ExpressionSpecification)[], // repeated as above
         ExpressionInputType]
     | ['within', unknown | ExpressionSpecification]
     // Ramps, scales, curves
-    | ['interpolate', InterpolationSpecification, 
-        number | ExpressionSpecification, ...(number | ExpressionInputType | ExpressionSpecification)[]]
-    | ['interpolate-hcl', InterpolationSpecification,
-        number | ExpressionSpecification, number | ExpressionSpecification, ExpressionInputType | ExpressionSpecification, 
-        ...(number | ColorSpecification | ExpressionSpecification)[]]
-    | ['interpolate-lab', InterpolationSpecification,
-        number | ExpressionSpecification, number | ExpressionSpecification, ExpressionInputType | ExpressionSpecification, 
-        ...(number | ColorSpecification | ExpressionSpecification)[]]
-    | ['step', number | ExpressionSpecification, number | ExpressionSpecification, ExpressionInputType | ExpressionSpecification, 
-        ...(number | ExpressionInputType | ExpressionSpecification)[]]
+    | ['interpolate', InterpolationSpecification, number | ExpressionSpecification, 
+        ...(number | number[] | ColorSpecification)[]] // alternating number and number | number[] | ColorSpecification
+    | ['interpolate-hcl', InterpolationSpecification, number | ExpressionSpecification, 
+        ...(number | ColorSpecification)[]] // alternating number and ColorSpecificaton
+    | ['interpolate-lab', InterpolationSpecification, number | ExpressionSpecification, 
+        ...(number | ColorSpecification)[]] // alternating number and ColorSpecification
+    | ['step', number | ExpressionSpecification, ExpressionInputType | ExpressionSpecification,
+        ...(number | ExpressionInputType | ExpressionSpecification)[]] // alternating number and ExpressionInputType | ExpressionSpecification
     // Variable binding
     | ['let', string, ExpressionInputType | ExpressionSpecification, ...(string | ExpressionInputType | ExpressionSpecification)[]]
     | ['var', string]
     // String
-    | ['concat', ExpressionInputType | ExpressionSpecification, ExpressionInputType | ExpressionSpecification, 
-        ...(ExpressionInputType | ExpressionSpecification)[]] // string
+    | ['concat', ...(ExpressionInputType | ExpressionSpecification)[]] // at least two inputs required -> string
     | ['downcase', string | ExpressionSpecification] // string
     | ['is-supported-script', string | ExpressionSpecification] // boolean
     | ['resolved-locale', CollatorExpressionSpecification] // string
@@ -225,7 +221,7 @@ export type ExpressionSpecification =
     | ['/', number | ExpressionSpecification, number | ExpressionSpecification] // number
     | ['%', number | ExpressionSpecification, number | ExpressionSpecification] // number
     | ['^', number | ExpressionSpecification, number | ExpressionSpecification] // number
-    | ['+', number | ExpressionSpecification, number | ExpressionSpecification, ...(number | ExpressionSpecification)[]] // number
+    | ['+', ...(number | ExpressionSpecification)[]] // at least two inputs required -> number
     | ['abs', number | ExpressionSpecification] // number
     | ['acos', number | ExpressionSpecification] // number
     | ['asin', number | ExpressionSpecification] // number

--- a/src/style-spec/feature_filter/feature_filter.test.ts
+++ b/src/style-spec/feature_filter/feature_filter.test.ts
@@ -9,7 +9,7 @@ import {ExpressionFilterSpecification, ExpressionInputType, ExpressionSpecificat
 import {Feature} from '../expression';
 
 describe('filter', () => {
-    test('exprssions transpilation test', () => {
+    test('expressions transpilation test', () => {
         function compileTimeCheck(_: ExpressionFilterSpecification) {
             expect(true).toBeTruthy();
         }
@@ -37,15 +37,17 @@ describe('filter', () => {
         compileTimeCheck(['match', ['get', 'TYPE'], ['ADIZ', 'AMA', 'AWY', 'CLASS', 'NO-FIR', 'OCA', 'OTA', 'P', 'RAS', 'RCA', 'UTA', 'UTA-P'], true, false]);
         compileTimeCheck(['==', ['get', 'MILITARYAIRPORT'], 1]);
         compileTimeCheck(['interpolate', ['linear'], ['line-progress'], 0, 10, 0.5, 100, 1, 1000]); // number output
-        compileTimeCheck(['interpolate', ['linear'], ['line-progress'], 0, 'red', 0.5, 'green', 1, 'blue']);
+        compileTimeCheck(['interpolate', ['linear'], ['line-progress'], 0, 'red', 0.5, 'green', 1, 'blue']); // color output
         compileTimeCheck(['interpolate', ['linear'], ['line-progress'], 0, [10, 20, 30], 0.5, [20, 30, 40], 1, [30, 40, 80]]); // number array output!
         compileTimeCheck(['interpolate-hcl', ['linear'], ['line-progress'], 0, 'red', 0.5, 'green', 1, 'blue']);
         compileTimeCheck(['interpolate-lab', ['linear'], ['line-progress'], 0, 'red', 0.5, 'green', 1, 'blue']);
         compileTimeCheck(['step', ['get', 'point_count'], '#df2d43', 50, '#df2d43', 200, '#df2d43']);
+        compileTimeCheck(['step', ['get', 'point_count'], 20, 50, 30, 200, 40]);
+        compileTimeCheck(['step', ['get', 'point_count'], 0.6, 50, 0.7, 200, 0.8]);
 
         // checks, where parts of the expression are injected from constants
         // as in most cases the styling is read from JSON, these are rather optional tests.
-        // due to typescript infering rather broad types, this is only possible in few places without specifying a type for the constant.
+        // due to typescript inferring rather broad types, this is only possible in few places without specifying a type for the constant.
         const colorStops = [0, 'red', 0.5, 'green', 1, 'blue'];
         compileTimeCheck([
             'interpolate',
@@ -65,8 +67,7 @@ describe('filter', () => {
             ['line-progress'],
             ...colorStops
         ]);
-        const firstOutput = '#df2d43';
-        const steps = [50, '#df2d43', 200, '#df2d43'];
+        const [firstOutput, ...steps] = ['#df2d43', 50, '#df2d43', 200, '#df2d43'];
         compileTimeCheck(['step', ['get', 'point_count'], firstOutput, ...steps]);
         const strings = ['first', 'second', 'third'];
         compileTimeCheck(['concat', ...strings]);

--- a/src/style-spec/feature_filter/feature_filter.test.ts
+++ b/src/style-spec/feature_filter/feature_filter.test.ts
@@ -5,7 +5,7 @@ import Point from '@mapbox/point-geometry';
 import MercatorCoordinate from '../../geo/mercator_coordinate';
 import EXTENT from '../../data/extent';
 import {CanonicalTileID} from '../../source/tile_id';
-import {ExpressionFilterSpecification, FilterSpecification} from '../types.g';
+import {ExpressionFilterSpecification, ExpressionInputType, ExpressionSpecification, FilterSpecification} from '../types.g';
 import {Feature} from '../expression';
 
 describe('filter', () => {
@@ -36,6 +36,16 @@ describe('filter', () => {
         compileTimeCheck(['match', ['get', 'TYPE'], ['TARGETPOINT:HOSPITAL'], true, false]);
         compileTimeCheck(['match', ['get', 'TYPE'], ['ADIZ', 'AMA', 'AWY', 'CLASS', 'NO-FIR', 'OCA', 'OTA', 'P', 'RAS', 'RCA', 'UTA', 'UTA-P'], true, false]);
         compileTimeCheck(['==', ['get', 'MILITARYAIRPORT'], 1]);
+        compileTimeCheck(['interpolate', ['linear'], ['line-progress'], 0, 10, 0.5, 100, 1, 1000]); // number output
+        compileTimeCheck(['interpolate', ['linear'], ['line-progress'], 0, 'red', 0.5, 'green', 1, 'blue']);
+        compileTimeCheck(['interpolate', ['linear'], ['line-progress'], 0, [10, 20, 30], 0.5, [20, 30, 40], 1, [30, 40, 80]]); // number array output!
+        compileTimeCheck(['interpolate-hcl', ['linear'], ['line-progress'], 0, 'red', 0.5, 'green', 1, 'blue']);
+        compileTimeCheck(['interpolate-lab', ['linear'], ['line-progress'], 0, 'red', 0.5, 'green', 1, 'blue']);
+        compileTimeCheck(['step', ['get', 'point_count'], '#df2d43', 50, '#df2d43', 200, '#df2d43']);
+
+        // checks, where parts of the expression are injected from constants
+        // as in most cases the styling is read from JSON, these are rather optional tests.
+        // due to typescript infering rather broad types, this is only possible in few places without specifying a type for the constant.
         const colorStops = [0, 'red', 0.5, 'green', 1, 'blue'];
         compileTimeCheck([
             'interpolate',
@@ -43,6 +53,25 @@ describe('filter', () => {
             ['line-progress'],
             ...colorStops
         ]);
+        compileTimeCheck([
+            'interpolate-hcl',
+            ['linear'],
+            ['line-progress'],
+            ...colorStops
+        ]);
+        compileTimeCheck([
+            'interpolate-lab',
+            ['linear'],
+            ['line-progress'],
+            ...colorStops
+        ]);
+        const firstOutput = '#df2d43';
+        const steps = [50, '#df2d43', 200, '#df2d43'];
+        compileTimeCheck(['step', ['get', 'point_count'], firstOutput, ...steps]);
+        const strings = ['first', 'second', 'third'];
+        compileTimeCheck(['concat', ...strings]);
+        const values: (ExpressionInputType | ExpressionSpecification)[] = [['get', 'name'], ['get', 'code'], 'NONE']; // type is necessary!
+        compileTimeCheck(['coalesce', ...values]);
     });
 
     test('expression, zoom', () => {


### PR DESCRIPTION
Fixes interpolate typing: allow number arrays, but no expressions (see https://github.com/maplibre/maplibre-gl-js/issues/1380#issuecomment-1212845168)
Also fixes interpolate-hcl/interpolate-lab.
Fix step typing (same as https://github.com/maplibre/maplibre-gl-js/pull/1509)
Simplify +, concat, coalesce typings (like done for the interpolate types)

Separates tests for expressions per se and tests for expressions with injected constants. 
In most cases this would require typing the constant due to typescript inferring rather broad types, but for some simple cases it is possible.

