### PR TITLE
Accept LngLatLike input for method extend

### DIFF
--- a/src/geo/lng_lat.ts
+++ b/src/geo/lng_lat.ts
@@ -148,6 +148,10 @@ class LngLat {
         }
         throw new Error('`LngLatLike` argument must be specified as a LngLat instance, an object {lng: <lng>, lat: <lat>}, an object {lon: <lng>, lat: <lat>}, or an array of [<lng>, <lat>]');
     }
+
+    static isLngLatLikeObject(input: LngLatLike) {
+        return typeof input === 'object' && input.lng || input.lon && input.lat
+    }
 }
 
 /**

--- a/src/geo/lng_lat_bounds.ts
+++ b/src/geo/lng_lat_bounds.ts
@@ -69,6 +69,8 @@ class LngLatBounds {
             ne = this._ne;
         let sw2, ne2;
 
+        if (!obj) return this;
+ 
         if (obj instanceof LngLat) {
             sw2 = obj;
             ne2 = obj;
@@ -84,10 +86,11 @@ class LngLatBounds {
                 if (obj.length === 4 || (obj as any[]).every(Array.isArray)) {
                     const lngLatBoundsObj = (obj as any as LngLatBoundsLike);
                     return this.extend(LngLatBounds.convert(lngLatBoundsObj));
-                } else {
-                    const lngLatObj = (obj as any as LngLatLike);
-                    return this.extend(LngLat.convert(lngLatObj));
                 }
+            }
+            else {
+                const lngLatObj = (obj as any as LngLatLike);
+                return this.extend(LngLat.convert(lngLatObj));
             }
             return this;
         }


### PR DESCRIPTION
Hey there before proceeding I would like to discuss the expected behaviour to prevent double work.

Problem: Currently if you've got a LngLatBounds and want to extend it with a LngLatLike or LngLatBoundsLike it will fail (not extend the given bounds) in certain cases (obj with lng/lat or lon/lat properties).

Do we want to keep the typing and add more checks to the extend method or is the typing wrong and we only want to accept LngLat | LngLatBounds


Example:
LngLat.convert({lng: 1, lat: 2}).toBounds().extend({lng: 2, lat: 3}) returns LngLatBound with [[1,2], [1,2]] I would expect [[1,2], [2,3]]