### PR TITLE
allow usedForTerrain to show attribution

### DIFF
--- a/src/ui/control/attribution_control.ts
+++ b/src/ui/control/attribution_control.ts
@@ -131,7 +131,7 @@ class AttributionControl implements IControl {
         const sourceCaches = this._map.style.sourceCaches;
         for (const id in sourceCaches) {
             const sourceCache = sourceCaches[id];
-            if (sourceCache.used) {
+            if (sourceCache.used || sourceCache.usedForTerrain) {
                 const source = sourceCache.getSource();
                 if (source.attribution && attributions.indexOf(source.attribution) < 0) {
                     attributions.push(source.attribution);


### PR DESCRIPTION
This is a fix for attribution not showing for terrain, as mentioned in https://github.com/maplibre/maplibre-gl-js/issues/1513

When picking what layers should get attibution, the code right now checks if 'sourcecache.used' is true, but for terrain layers, this is false. terrain layers have their own 'sourcecache.usedForTerrain' that is used instead.

This PR allows 'sourcecache.usedForTerrain' to also trigger showing attribution, which allows attribution to show when terrain is in use.

I've made some test pages and examples on https://github.com/maplibre/maplibre-gl-js/issues/1513 , but you can see in this screenshot what the terrain layer looks like 
![image](https://user-images.githubusercontent.com/3792408/185618889-46d7ccd9-d0b4-4904-a1af-87f337dac124.png)


<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [ ] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [ ] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [ ] Manually test the debug page.
 - [ ] Suggest a changelog category: bug/feature/docs/etc. or "skip changelog".
 - [ ] Add an entry inside this element for inclusion in the `maplibre-gl-js` changelog: `<changelog></changelog>`.
