### PR TITLE
Remove import asserts

### DIFF
--- a/src/style-spec/reference/latest.ts
+++ b/src/style-spec/reference/latest.ts
@@ -1,3 +1,3 @@
 
-import spec from './v8.json' assert {type: 'json'};
+import spec from './v8.json';
 export default spec as any;

--- a/src/style-spec/style-spec.ts
+++ b/src/style-spec/style-spec.ts
@@ -63,7 +63,7 @@ export type StylePropertySpecification = {
     default?: number | Array<number>;
 };
 
-import v8Spec from './reference/v8.json' assert {type: 'json'};
+import v8Spec from './reference/v8.json';
 const v8 = v8Spec as any;
 import latest from './reference/latest';
 import format from './format';


### PR DESCRIPTION
The documentation website is stuck on version v2.1.9 of MapLibre GL JS and does currently not build with the latest version v2.3.0.

This pull request removes two import assert statements which let's us build the docs website again in https://github.com/maplibre/maplibre-gl-js-docs/pull/230.

@birkskyum let me know if I am missing something...

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [ ] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [ ] Manually test the debug page.
 - [ ] Suggest a changelog category: bug/feature/docs/etc. or "skip changelog".
 - [ ] Add an entry inside this element for inclusion in the `maplibre-gl-js` changelog: `<changelog></changelog>`.
