### PR TITLE
Removes `_interpolationType`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 - *...Add new stuff here...*
 - Upgrade target from ES2017 to ES2019
+- Removed `_interpolationType` unused field (#264)
 
 ### 🐞 Bug fixes
 

--- a/src/style/style_layer/symbol_style_layer.ts
+++ b/src/style/style_layer/symbol_style_layer.ts
@@ -122,12 +122,11 @@ class SymbolStyleLayer extends StyleLayer {
             const styleExpression = new StyleExpression(override, overriden.property.specification);
             let expression = null;
             if (overriden.value.kind === 'constant' || overriden.value.kind === 'source') {
-                expression = (new ZoomConstantExpression('source', styleExpression) as SourceExpression);
+                expression = new ZoomConstantExpression('source', styleExpression) as SourceExpression;
             } else {
-                expression = (new ZoomDependentExpression('composite',
+                expression = new ZoomDependentExpression('composite',
                     styleExpression,
-                    overriden.value.zoomStops,
-                    (overriden.value as any)._interpolationType) as CompositeExpression);
+                    overriden.value.zoomStops);
             }
             this.paint._values[overridable] = new PossiblyEvaluatedPropertyValue(overriden.property,
                 expression,

--- a/src/style/style_layer/symbol_style_layer.ts
+++ b/src/style/style_layer/symbol_style_layer.ts
@@ -24,7 +24,7 @@ import type {BucketParameters} from '../../data/bucket';
 import type {SymbolLayoutProps, SymbolPaintProps} from './symbol_style_layer_properties.g';
 import type EvaluationParameters from '../evaluation_parameters';
 import type {LayerSpecification} from '../../style-spec/types.g';
-import type {Feature, SourceExpression, CompositeExpression} from '../../style-spec/expression';
+import type {Feature, SourceExpression} from '../../style-spec/expression';
 import type {Expression} from '../../style-spec/expression/expression';
 import type {CanonicalTileID} from '../../source/tile_id';
 import {FormattedType} from '../../style-spec/expression/types';


### PR DESCRIPTION
## Launch Checklist

Fixes #264 - removes `_interpolationType` which is not used and no set anywhere as far as I can understand...
