### PR TITLE
Fix contextmenu on windows: do not trigger after rotate or pitch.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### 🐞 Bug fixes
 
 - *...Add new stuff here...*
+- No triggering of contextmenu after rotate, pitch, etc. also on Windows
 
 ## 2.3.1-pre.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 ### 🐞 Bug fixes
 
 - *...Add new stuff here...*
-- No triggering of contextmenu after rotate, pitch, etc. also on Windows
+- No triggering of contextmenu after rotate, pitch, etc. also on Windows ([#1537](https://github.com/maplibre/maplibre-gl-js/pull/1537))
 
 ## 2.3.1-pre.2
 

--- a/src/ui/handler/map_event.ts
+++ b/src/ui/handler/map_event.ts
@@ -104,6 +104,7 @@ export class MapEventHandler implements Handler {
 export class BlockableMapEventHandler {
     _map: Map;
     _delayContextMenu: boolean;
+    _ignoreContextMenu: boolean;
     _contextMenuEvent: MouseEvent;
 
     constructor(map: Map) {
@@ -112,6 +113,7 @@ export class BlockableMapEventHandler {
 
     reset() {
         this._delayContextMenu = false;
+        this._ignoreContextMenu = true;
         delete this._contextMenuEvent;
     }
 
@@ -122,6 +124,7 @@ export class BlockableMapEventHandler {
 
     mousedown() {
         this._delayContextMenu = true;
+        this._ignoreContextMenu = false;
     }
 
     mouseup() {
@@ -135,7 +138,7 @@ export class BlockableMapEventHandler {
         if (this._delayContextMenu) {
             // Mac: contextmenu fired on mousedown; we save it until mouseup for consistency's sake
             this._contextMenuEvent = e;
-        } else {
+        } else if (!this._ignoreContextMenu) {
             // Windows: contextmenu fired on mouseup, so fire event now
             this._map.fire(new MapMouseEvent(e.type, this._map, e));
         }

--- a/test/unit/lib/simulate_interaction.ts
+++ b/test/unit/lib/simulate_interaction.ts
@@ -48,7 +48,7 @@ events['dblclick'] = function (target, options) {
     };
 });
 
-['mouseup', 'mousedown', 'mouseover', 'mousemove', 'mouseout'].forEach((event) => {
+['mouseup', 'mousedown', 'mouseover', 'mousemove', 'mouseout', 'contextmenu'].forEach((event) => {
     events[event] = function (target, options) {
         options = Object.assign({bubbles: true}, options);
         const MouseEvent = window(target).MouseEvent;
@@ -98,6 +98,7 @@ interface EventsInterface {
     mouseover: Function;
     mousemove: Function;
     mouseout: Function;
+    contextmenu: Function;
     wheel: Function;
     mousewheel: Function;
     magicWheelZoomDelta: Number;


### PR DESCRIPTION
If something (e.g. rotate or pitch) resets the context menu handler, this is now also taken into account on Windows, where the browser contextmenu event is triggered after mouseup (and not after mousedown).

Fixes #1511.