### PR TITLE
Release 2.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,28 +5,39 @@
 
 - *...Add new stuff here...*
 
-- Upgrade target from ES2017 to ES2019
-- Removed `_interpolationType` unused field (#264)
-- Added calculateCameraOptionsFromTo to camera [#1427](https://github.com/maplibre/maplibre-gl-js/pull/1427)
-
 ### 🐞 Bug fixes
 
 - *...Add new stuff here...*
-- Fix attribution not being displayed for terrain ([#1516](https://github.com/maplibre/maplibre-gl-js/pull/1516))
-- No triggering of contextmenu after rotate, pitch, etc. also on Windows ([#1537](https://github.com/maplibre/maplibre-gl-js/pull/1537))
+
+## 2.4.0
+
+### ✨ Features and improvements
+- Added calculateCameraOptionsFromTo to camera (#1427)
+- Improve expression types (#1510)
+- Improve performance for primitive size selection (#1508)
+- Upgrade target from ES2017 to ES2019 (#1499)
+- Improve error handling (#1485)
+- Removed `_interpolationType` unused field (#264)
+
+### 🐞 Bug fixes
+- Fix query tests on windows (#1506)
+- Fix attribution not being displayed for terrain (#1516)
+- No triggering of contextmenu after rotate, pitch, etc. also on Windows (#1537)
 
 ## 2.3.1-pre.2
 
 ### ✨ Features and improvements
-- Improve expression types ([#1510](https://github.com/maplibre/maplibre-gl-js/pull/1510))
-- Improve performance for primitive size selection ([#1508](https://github.com/maplibre/maplibre-gl-js/pull/1508))
-- Fix query tests on windows ([#1506](https://github.com/maplibre/maplibre-gl-js/pull/1506))
-- Upgrade target from ES2017 to ES2019 ([#1499](https://github.com/maplibre/maplibre-gl-js/pull/1499))
+- Improve expression types (#1510)
+- Improve performance for primitive size selection (#1508)
+- Upgrade target from ES2017 to ES2019 (#1499)
+
+### 🐞 Bug fixes
+- Fix query tests on windows (#1506)
 
 ## 2.3.1-pre.1
 
 ### ✨ Features and improvements
-- Improve error handling ([#1485](https://github.com/maplibre/maplibre-gl-js/pull/1485))
+- Improve error handling (#1485)
 
 ## 2.3.0
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "maplibre-gl",
-  "version": "2.3.1-pre.2",
+  "version": "2.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "maplibre-gl",
-      "version": "2.3.1-pre.2",
+      "version": "2.3.1",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "maplibre-gl",
-  "version": "2.3.1",
+  "version": "2.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "maplibre-gl",
-      "version": "2.3.1",
+      "version": "2.4.0",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "maplibre-gl",
   "description": "BSD licensed community fork of mapbox-gl, a WebGL interactive maps library",
-  "version": "2.3.1",
+  "version": "2.4.0",
   "main": "dist/maplibre-gl.js",
   "style": "dist/maplibre-gl.css",
   "license": "BSD-3-Clause",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "maplibre-gl",
   "description": "BSD licensed community fork of mapbox-gl, a WebGL interactive maps library",
-  "version": "2.3.1-pre.2",
+  "version": "2.3.1",
   "main": "dist/maplibre-gl.js",
   "style": "dist/maplibre-gl.css",
   "license": "BSD-3-Clause",


### PR DESCRIPTION
After two pre-releases with nothing indicating the introduction of a bug, and some added camera options a 2.4.0 feature release seems appropriate even though #1514 is still underway to improve the camera movement.

## 2.4.0

### ✨ Features and improvements
- Added calculateCameraOptionsFromTo to camera (#1427)
- Improve expression types (#1510)
- Improve performance for primitive size selection (#1508)
- Upgrade target from ES2017 to ES2019 (#1499)
- Improve error handling (#1485)
- Removed `_interpolationType` unused field (#264)

### 🐞 Bug fixes
- Fix query tests on windows (#1506)
- Fix attribution not being displayed for terrain (#1516)
- No triggering of contextmenu after rotate, pitch, etc. also on Windows (#1537)
