### PR TITLE
Release 2.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,18 @@
 ## main
 
-
 ### ✨ Features and improvements
 
 - *...Add new stuff here...*
-- Add map.getCameraTargetElevation() (#1558)
 
 ### 🐞 Bug fixes
 
 - *...Add new stuff here...*
+
+## 2.5.0
+
+### ✨ Features and improvements
+
+- Add map.getCameraTargetElevation() (#1558)
 
 ## 2.4.0
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "maplibre-gl",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "maplibre-gl",
-      "version": "2.4.0",
+      "version": "2.5.0",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "maplibre-gl",
   "description": "BSD licensed community fork of mapbox-gl, a WebGL interactive maps library",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "main": "dist/maplibre-gl.js",
   "style": "dist/maplibre-gl.css",
   "license": "BSD-3-Clause",


### PR DESCRIPTION
New getter to i.e. improve deck.gl compatibility with 3d terrain.

- Add map.getCameraTargetElevation() (#1558)