### PR TITLE
Remove elevationOffset and fix below sea-level clipping

### DIFF
--- a/src/geo/transform.test.ts
+++ b/src/geo/transform.test.ts
@@ -403,8 +403,15 @@ describe('transform', () => {
         transform.recalculateZoom(null);
         expect(transform.zoom).toBe(14.127997275621933);
         expect(transform.elevation).toBe(400);
+
         expect(transform._center.lng).toBe(10.00000000000071);
         expect(transform._center.lat).toBe(50.00000000000017);
+
+        // expect new zoom because of elevation change to point below sea level
+        transform.getElevation = () => -200;
+        transform.recalculateZoom(null);
+        expect(transform.zoom).toBe(13.773740316343467);
+        expect(transform.elevation).toBe(-200);
     });
 
     test('pointCoordinate with terrain when returning null should fall back to 2D', () => {

--- a/src/geo/transform.ts
+++ b/src/geo/transform.ts
@@ -866,7 +866,7 @@ class Transform {
 
         // Add a bit extra to avoid precision problems when a fragment's distance is exactly `furthestDistance`
         // Provide a max to give a buffer for points below the sea level
-        const farZ = Math.max(Math.min(furthestDistance, furthestDistanceHorizon) * 1.01, 4000);
+        const farZ = Math.min(furthestDistance, furthestDistanceHorizon) * 1.01;
 
         // The larger the value of nearZ is
         // - the more depth precision is available for features (good)

--- a/src/geo/transform.ts
+++ b/src/geo/transform.ts
@@ -845,9 +845,8 @@ class Transform {
 
         // Calculate the camera to sea-level distance in pixel in respect of terrain
         // In case of negative elevation (e.g. the dead see) use the lower plane for calculation
-        const elevationInPixelSpaceNonAbsolute = this._elevation * this._pixelPerMeter / Math.cos(this._pitch);
-        this.cameraToSeaLevelDistance = this.cameraToCenterDistance + elevationInPixelSpaceNonAbsolute;
-        const lowestPlane = elevationInPixelSpaceNonAbsolute > 0 ? this.cameraToSeaLevelDistance : this.cameraToSeaLevelDistance - elevationInPixelSpaceNonAbsolute;
+        this.cameraToSeaLevelDistance = this.cameraToCenterDistance + this._elevation * this._pixelPerMeter / Math.cos(this._pitch);
+        const lowestPlane = this._elevation < 0 ? this.cameraToCenterDistance : this.cameraToSeaLevelDistance;
 
         // Find the distance from the center point [width/2 + offset.x, height/2 + offset.y] to the
         // center top point [width/2 + offset.x, 0] in Z units, using the law of sines.

--- a/src/geo/transform.ts
+++ b/src/geo/transform.ts
@@ -847,10 +847,8 @@ class Transform {
         // In case of negative elevation (e.g. the dead see) use the lower plane for calculation
         const elevationInPixelSpaceNonAbsolute = this._elevation * this._pixelPerMeter / Math.cos(this._pitch);
         this.cameraToSeaLevelDistance = this.cameraToCenterDistance + elevationInPixelSpaceNonAbsolute;
-        const lowestPlane = elevationInPixelSpaceNonAbsolute > 0 
-            ? this.cameraToSeaLevelDistance
-            : this.cameraToSeaLevelDistance - elevationInPixelSpaceNonAbsolute;
-        
+        const lowestPlane = elevationInPixelSpaceNonAbsolute > 0 ? this.cameraToSeaLevelDistance : this.cameraToSeaLevelDistance - elevationInPixelSpaceNonAbsolute;
+
         // Find the distance from the center point [width/2 + offset.x, height/2 + offset.y] to the
         // center top point [width/2 + offset.x, 0] in Z units, using the law of sines.
         // 1 Z unit is equivalent to 1 horizontal px at the center of the map

--- a/src/geo/transform.ts
+++ b/src/geo/transform.ts
@@ -865,7 +865,8 @@ class Transform {
         const furthestDistanceHorizon = Math.cos(Math.PI / 2 - this._pitch) * topHalfSurfaceDistanceHorizon + this.cameraToSeaLevelDistance;
 
         // Add a bit extra to avoid precision problems when a fragment's distance is exactly `furthestDistance`
-        const farZ = Math.min(furthestDistance, furthestDistanceHorizon) * 1.01;
+        // Provide a max to give a buffer for points below the sea level
+        const farZ = Math.max(Math.min(furthestDistance, furthestDistanceHorizon) * 1.01, 4000);
 
         // The larger the value of nearZ is
         // - the more depth precision is available for features (good)

--- a/src/render/program/terrain_program.ts
+++ b/src/render/program/terrain_program.ts
@@ -14,7 +14,6 @@ export type TerrainPreludeUniformsType = {
     'u_terrain_dim': Uniform1f;
     'u_terrain_matrix': UniformMatrix4f;
     'u_terrain_unpack': Uniform4f;
-    'u_terrain_offset': Uniform1f;
     'u_terrain_exaggeration': Uniform1f;
 };
 
@@ -39,7 +38,6 @@ const terrainPreludeUniforms = (context: Context, locations: UniformLocations): 
     'u_terrain_dim': new Uniform1f(context, locations.u_terrain_dim),
     'u_terrain_matrix': new UniformMatrix4f(context, locations.u_terrain_matrix),
     'u_terrain_unpack': new Uniform4f(context, locations.u_terrain_unpack),
-    'u_terrain_offset': new Uniform1f(context, locations.u_terrain_offset),
     'u_terrain_exaggeration': new Uniform1f(context, locations.u_terrain_exaggeration)
 });
 

--- a/src/render/terrain.test.ts
+++ b/src/render/terrain.test.ts
@@ -84,7 +84,7 @@ describe('Terrain', () => {
         const terrain = new Terrain(
             style,
             sourceCache,
-            {exaggeration: 2, elevationOffset: 50} as any as TerrainSpecification,
+            {exaggeration: 2} as any as TerrainSpecification,
         );
 
         terrain.sourceCache._tiles[tileID.key] = tile;
@@ -113,7 +113,7 @@ describe('Terrain', () => {
         const terrain = new Terrain(
             style,
             sourceCache,
-            {exaggeration: 2, elevationOffset: 50} as any as TerrainSpecification,
+            {exaggeration: 2} as any as TerrainSpecification,
         );
 
         const minMaxNoTile = terrain.getMinMaxElevation(tileID);
@@ -145,7 +145,7 @@ describe('Terrain', () => {
         const terrain = new Terrain(
             style,
             sourceCache,
-            {exaggeration: 2, elevationOffset: 50} as any as TerrainSpecification,
+            {exaggeration: 2} as any as TerrainSpecification,
         );
         const minMaxNoDEM = terrain.getMinMaxElevation(tileID);
 

--- a/src/render/terrain.test.ts
+++ b/src/render/terrain.test.ts
@@ -90,8 +90,8 @@ describe('Terrain', () => {
         terrain.sourceCache._tiles[tileID.key] = tile;
         const {minElevation, maxElevation} = terrain.getMinMaxElevation(tileID);
 
-        expect(minElevation).toBe(100);
-        expect(maxElevation).toBe(300);
+        expect(minElevation).toBe(0);
+        expect(maxElevation).toBe(200);
     });
 
     test('Return null elevation values when no tile', () => {

--- a/src/render/terrain.ts
+++ b/src/render/terrain.ts
@@ -26,7 +26,6 @@ export type TerrainData = {
     'u_terrain_dim': number;
     'u_terrain_matrix': mat4;
     'u_terrain_unpack': number[];
-    'u_terrain_offset': number;
     'u_terrain_exaggeration': number;
     texture: WebGLTexture;
     depthTexture: WebGLTexture;
@@ -78,8 +77,6 @@ export default class Terrain {
     meshSize: number;
     // multiplicator for the elevation. Used to make terrain more "extrem".
     exaggeration: number;
-    // defines the global offset of putting negative elevations (e.g. dead-sea) into positive values.
-    elevationOffset: number;
     // to not see pixels in the render-to-texture tiles it is good to render them bigger
     // this number is the multiplicator (must be a power of 2) for the current tileSize.
     // So to get good results with not too much memory footprint a value of 2 should be fine.
@@ -120,7 +117,6 @@ export default class Terrain {
         this.sourceCache = new TerrainSourceCache(sourceCache);
         this.options = options;
         this.exaggeration = typeof options.exaggeration === 'number' ? options.exaggeration : 1.0;
-        this.elevationOffset = typeof options.elevationOffset === 'number' ? options.elevationOffset : 450; // ~ dead-sea
         this.qualityFactor = 2;
         this.meshSize = 128;
         this._demMatrixCache = {};
@@ -138,7 +134,7 @@ export default class Terrain {
      * @returns {number} - the elevation
      */
     getDEMElevation(tileID: OverscaledTileID, x: number, y: number, extent: number = EXTENT): number {
-        if (!(x >= 0 && x < extent && y >= 0 && y < extent)) return this.elevationOffset;
+        if (!(x >= 0 && x < extent && y >= 0 && y < extent)) throw Error('Not fulfilled: !(x >= 0 && x < extent && y >= 0 && y < extent)');
         let elevation = 0;
         const terrain = this.getTerrainData(tileID);
         if (terrain.tile && terrain.tile.dem) {
@@ -174,7 +170,7 @@ export default class Terrain {
     }
 
     /**
-     * get the Elevation for given coordinate in respect of elevationOffset and exaggeration.
+     * get the Elevation for given coordinate in respect of exaggeration.
      * @param {OverscaledTileID} tileID - the tile id
      * @param {number} x between 0 .. EXTENT
      * @param {number} y between 0 .. EXTENT
@@ -182,7 +178,7 @@ export default class Terrain {
      * @returns {number} - the elevation
      */
     getElevation(tileID: OverscaledTileID, x: number, y: number, extent: number = EXTENT): number {
-        return (this.getDEMElevation(tileID, x, y, extent) + this.elevationOffset) * this.exaggeration;
+        return this.getDEMElevation(tileID, x, y, extent) * this.exaggeration;
     }
 
     /**
@@ -234,7 +230,6 @@ export default class Terrain {
             'u_terrain_dim': sourceTile && sourceTile.dem && sourceTile.dem.dim || 1,
             'u_terrain_matrix': matrixKey ? this._demMatrixCache[tileID.key].matrix : this._emptyDemMatrix,
             'u_terrain_unpack': sourceTile && sourceTile.dem && sourceTile.dem.getUnpackVector() || this._emptyDemUnpack,
-            'u_terrain_offset': this.elevationOffset,
             'u_terrain_exaggeration': this.exaggeration,
             texture: (sourceTile && sourceTile.demTexture || this._emptyDemTexture).texture,
             depthTexture: (this._fboDepthTexture || this._emptyDepthTexture).texture,
@@ -367,19 +362,19 @@ export default class Terrain {
     }
 
     /**
-     * Get the minimum and maximum elevation contained in a tile. This includes any elevation offset
-     * and exaggeration included in the terrain.
+     * Get the minimum and maximum elevation contained in a tile. This includes any
+     * exaggeration included in the terrain.
      *
      * @param tileID Id of the tile to be used as a source for the min/max elevation
      * @returns {Object} Minimum and maximum elevation found in the tile, including the terrain's
-     * elevation offset and exaggeration
+     * exaggeration
      */
     getMinMaxElevation(tileID: OverscaledTileID): {minElevation: number | null; maxElevation: number | null} {
         const tile = this.getTerrainData(tileID).tile;
         const minMax = {minElevation: null, maxElevation: null};
         if (tile && tile.dem) {
-            minMax.minElevation = (tile.dem.min + this.elevationOffset) * this.exaggeration;
-            minMax.maxElevation = (tile.dem.max + this.elevationOffset) * this.exaggeration;
+            minMax.minElevation = tile.dem.min * this.exaggeration;
+            minMax.maxElevation = tile.dem.max * this.exaggeration;
         }
         return minMax;
     }

--- a/src/render/terrain.ts
+++ b/src/render/terrain.ts
@@ -134,7 +134,7 @@ export default class Terrain {
      * @returns {number} - the elevation
      */
     getDEMElevation(tileID: OverscaledTileID, x: number, y: number, extent: number = EXTENT): number {
-        if (!(x >= 0 && x < extent && y >= 0 && y < extent)) throw Error('Not fulfilled: !(x >= 0 && x < extent && y >= 0 && y < extent)');
+        if (!(x >= 0 && x < extent && y >= 0 && y < extent)) return 0;
         let elevation = 0;
         const terrain = this.getTerrainData(tileID);
         if (terrain.tile && terrain.tile.dem) {

--- a/src/shaders/_prelude.vertex.glsl
+++ b/src/shaders/_prelude.vertex.glsl
@@ -79,7 +79,6 @@ uniform sampler2D u_terrain;
 uniform float u_terrain_dim;
 uniform mat4 u_terrain_matrix;
 uniform vec4 u_terrain_unpack;
-uniform float u_terrain_offset;
 uniform float u_terrain_exaggeration;
 uniform highp sampler2D u_depth;
 #endif
@@ -142,7 +141,7 @@ float get_elevation(vec2 pos) {
         float bl = ele(c + vec2(0.0, d));
         float br = ele(c + vec2(d, d));
         float elevation = mix(mix(tl, tr, f.x), mix(bl, br, f.x), f.y);
-        return (elevation + u_terrain_offset) * u_terrain_exaggeration;
+        return elevation * u_terrain_exaggeration;
     #else
         return 0.0;
     #endif

--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -62,8 +62,7 @@
       "doc": "The terrain configuration.",
       "example": {
         "source": "raster-dem-source",
-        "exaggeration": 0.5,
-        "elevationOffset": 100
+        "exaggeration": 0.5
       }
     },
     "sources": {
@@ -3838,16 +3837,6 @@
       "minimum": 0,
       "doc": "The exaggeration of the terrain - how high it will look.",
       "default": 1.0,
-      "sdk-support": {
-        "basic functionality": {
-          "js": "2.2.0"
-        }
-      }
-    },
-    "elevationOffset": {
-      "type": "number",
-      "doc": "The elevation offset.",
-      "default": 450,
       "sdk-support": {
         "basic functionality": {
           "js": "2.2.0"

--- a/src/style-spec/validate/validate_terrain.test.ts
+++ b/src/style-spec/validate/validate_terrain.test.ts
@@ -26,7 +26,7 @@ describe('Validate Terrain', () => {
     });
 
     test('Should return errors according to spec violations', () => {
-        const errors = validateTerrain({value: {source: 1 as any, exaggeration: {} as any, elevationOffset: 'ex2' as any}, styleSpec: v8, style: {} as any});
+        const errors = validateTerrain({value: {source: 1 as any, exaggeration: {} as any}, styleSpec: v8, style: {} as any});
         expect(errors).toHaveLength(3);
         expect(errors[0].message).toContain('number');
         expect(errors[0].message).toContain('string');
@@ -36,11 +36,10 @@ describe('Validate Terrain', () => {
         expect(errors[1].message).toContain('exaggeration');
         expect(errors[2].message).toContain('number');
         expect(errors[2].message).toContain('string');
-        expect(errors[2].message).toContain('elevationOffset');
     });
 
     test('Should pass if everything is according to spec', () => {
-        const errors = validateTerrain({value: {source: 'source-id', elevationOffset: 1, exaggeration: 0.2}, styleSpec: v8, style: {} as any});
+        const errors = validateTerrain({value: {source: 'source-id', exaggeration: 0.2}, styleSpec: v8, style: {} as any});
         expect(errors).toHaveLength(0);
     });
 });

--- a/src/style-spec/validate/validate_terrain.test.ts
+++ b/src/style-spec/validate/validate_terrain.test.ts
@@ -27,15 +27,13 @@ describe('Validate Terrain', () => {
 
     test('Should return errors according to spec violations', () => {
         const errors = validateTerrain({value: {source: 1 as any, exaggeration: {} as any}, styleSpec: v8, style: {} as any});
-        expect(errors).toHaveLength(3);
+        expect(errors).toHaveLength(2);
         expect(errors[0].message).toContain('number');
         expect(errors[0].message).toContain('string');
         expect(errors[0].message).toContain('source');
         expect(errors[1].message).toContain('number');
         expect(errors[1].message).toContain('object');
         expect(errors[1].message).toContain('exaggeration');
-        expect(errors[2].message).toContain('number');
-        expect(errors[2].message).toContain('string');
     });
 
     test('Should pass if everything is according to spec', () => {

--- a/src/ui/control/terrain_control.ts
+++ b/src/ui/control/terrain_control.ts
@@ -12,7 +12,6 @@ import type {TerrainSpecification} from '../../style-spec/types.g';
  * @param {Object} [options]
  * @param {string} [options.id] The ID of the raster-dem source to use.
  * @param {Object} [options.options]
- * @param {number} [options.options.elevationOffset]
  * @param {number} [options.options.exaggeration]
  * @example
  * var map = new maplibregl.Map({TerrainControl: false})

--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -2947,7 +2947,7 @@ class Map extends Camera {
     /**
      * Returns the elevation for the point where the camera is looking.
      * This value corresponds to:
-     * ("meters above sea level" + "elevation offset (style-spec v8 defualts to 450 m)") * "exaggeration"
+     * "meters above sea level" * "exaggeration"
      * @returns {number} * The elevation.
      */
     getCameraTargetElevation(): number {

--- a/test/debug-pages/terrain-satellite.html
+++ b/test/debug-pages/terrain-satellite.html
@@ -58,7 +58,6 @@
               terrain: {
                   source: 'terrainSource',
                   exaggeration: 1,
-                  elevationOffset: 0,
               },
           },
           maxZoom: 18,

--- a/test/integration/render/tests/terrain/default/style.json
+++ b/test/integration/render/tests/terrain/default/style.json
@@ -42,7 +42,6 @@
   ],
   "terrain": {
     "source": "terrain",
-    "exaggeration": 2,
-    "elevationOffset": 2000
+    "exaggeration": 2
   }
 }

--- a/test/integration/style-spec/tests/terrain.input.json
+++ b/test/integration/style-spec/tests/terrain.input.json
@@ -11,7 +11,6 @@
   "layers": [],
   "terrain": {
     "source": 123,
-    "exaggeration": "2",
-    "elevationOffset": "50"
+    "exaggeration": "2"
   }
 }

--- a/test/integration/style-spec/tests/terrain.output.json
+++ b/test/integration/style-spec/tests/terrain.output.json
@@ -6,9 +6,5 @@
   {
     "message": "exaggeration: number expected, string found",
     "line": 14
-  },
-  {
-    "message": "elevationOffset: number expected, string found",
-    "line": 15
   }
 ]


### PR DESCRIPTION
The first two commits just remove the elevation offset.

We have a ~450 elevation offset to move lakes below sea level to places above sea level. It's a workaroud, and it should be removed.