### PR TITLE
Remove coverage action

### DIFF
--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -31,8 +31,4 @@ jobs:
           node-version: ${{ matrix.node_version }}
           architecture: ${{ matrix.architecture }}
       - run: npm ci
-      - uses: ArtiomTr/jest-coverage-report-action@v2
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          annotations: none
-          test-script: xvfb-run -s "-ac -screen 0 1280x1024x24" npm run test-unit-ci
+      - run: xvfb-run -s "-ac -screen 0 1280x1024x24" npm run test-unit-ci

--- a/package.json
+++ b/package.json
@@ -167,7 +167,7 @@
     "test-query": "jest -c ./jest.config.e2e.ts --roots ./test/integration/query",
     "test-expression": "jest --roots ./test/integration/expression",
     "test-unit": "jest --roots ./src  -c ./jest.config.ts ",
-    "test-unit-ci": "jest --roots ./src  -c ./jest.config.ts --ci --json --coverage --testLocationInResults --outputFile=report.json",
+    "test-unit-ci": "jest --roots ./src  -c ./jest.config.ts --ci --coverage --testLocationInResults",
     "codegen": "npm run generate-style-code && npm run generate-struct-arrays && npm run generate-style-spec && npm run generate-shaders && npm run generate-debug-index-file",
     "benchmark": "node --loader ts-node/esm --experimental-specifier-resolution=node test/bench/run-benchmarks.ts",
     "gl-stats": "node --loader ts-node/esm --experimental-specifier-resolution=node test/bench/gl-stats.ts",


### PR DESCRIPTION
Fixes #1581 - Removes the github action to add coverage and add the coverage report to the console log of the CI machine.
It's far from ideal but at least can be used to some extent...