### PR TITLE
Handle empty 20x raster tile response as empty tile.

### DIFF
--- a/src/source/raster_tile_source.ts
+++ b/src/source/raster_tile_source.ts
@@ -136,6 +136,14 @@ class RasterTileSource extends Evented implements Source {
                 cacheEntryPossiblyAdded(this.dispatcher);
 
                 callback(null);
+            } else {
+                if (this.map._refreshExpiredTiles) tile.setExpiryData(expiry);
+
+                tile.state = 'empty';
+
+                cacheEntryPossiblyAdded(this.dispatcher);
+
+                callback(new Error('204 No Content: Empty tile'));
             }
         });
     }

--- a/src/source/tile.ts
+++ b/src/source/tile.ts
@@ -40,8 +40,9 @@ export type TileState = // Tile data is in the process of loading.
 'loaded' | // Tile data has been loaded and is being updated. Tile can be rendered.
 'reloading' | // Tile data has been deleted.
 'unloaded' | // Tile data was not loaded because of an error.
-'errored' | 'expired';  /* Tile data was previously loaded, but has expired per its
-                   * HTTP headers and is in the process of refreshing. */
+'errored' | // error during loading
+'expired' | // Tile data was previously loaded, but has expired per its HTTP headers and is in the process of refreshing.
+'empty'; // No tile data available
 
 /**
  * A tile object is the combination of a Coordinate, which defines

--- a/src/util/ajax.ts
+++ b/src/util/ajax.ts
@@ -411,11 +411,16 @@ export const getImage = function(
             const decoratedCallback = (imgErr?: Error | null, imgResult?: CanvasImageSource | null) => {
                 if (imgErr != null) {
                     callback(imgErr);
-                } else if (imgResult != null) {
-                    callback(null, imgResult as (HTMLImageElement | ImageBitmap), {cacheControl, expires});
+                } else {
+                    callback(null, imgResult as (HTMLImageElement | ImageBitmap | null), {cacheControl, expires});
                 }
             };
-            arrayBufferToCanvasImageSource(data, decoratedCallback);
+            if (data.byteLength === 0) {
+                // no data - probably was 204 response
+                decoratedCallback(null, null);
+            } else {
+                arrayBufferToCanvasImageSource(data, decoratedCallback);
+            }
         }
     });
 


### PR DESCRIPTION
getImage (ajax.ts) now returns a null image, if there is no content (ArrayBuffer with length 0).
Raster source loadTile will store such an image as a tile with the new status 'empty' (to avoid loading it again, if there are cache headers).

See also #1579.