### PR TITLE
Add regex for Windows full path so test-build can pass

### DIFF
--- a/test/build/style-spec.test.ts
+++ b/test/build/style-spec.test.ts
@@ -21,7 +21,7 @@ describe('@maplibre/maplibre-gl-style-spec npm package', () => {
                     const slashOrDot: boolean = /^[\/\.]/.test(id);
 
                     // Windows (path could start with drive letter: for example c:\)
-                    const windowsFullPath: boolean = /^[a-zA-Z]:\\/.test(id);
+                    const windowsFullPath: boolean = /^[c-zC-Z]:\\/.test(id);
                     
                     if (
                         slashOrDot ||

--- a/test/build/style-spec.test.ts
+++ b/test/build/style-spec.test.ts
@@ -16,8 +16,16 @@ describe('@maplibre/maplibre-gl-style-spec npm package', () => {
             plugins: [{
                 name: 'test-checker',
                 resolveId: (id, importer) => {
+
+                    // linux (path starts with slash or dot)
+                    const slashOrDot: boolean = /^[\/\.]/.test(id);
+
+                    // Windows (path could start with drive letter: for example c:\)
+                    const windowsFullPath: boolean = /^[a-zA-Z]:\\/.test(id);
+                    
                     if (
-                        /^[\/\.]/.test(id) ||
+                        slashOrDot ||
+                        windowsFullPath ||
                         isBuiltin(id) ||
                         /node_modules/.test(importer)
                     ) {

--- a/test/build/style-spec.test.ts
+++ b/test/build/style-spec.test.ts
@@ -22,7 +22,7 @@ describe('@maplibre/maplibre-gl-style-spec npm package', () => {
 
                     // Windows (path could start with drive letter: for example c:\)
                     const windowsFullPath: boolean = /^[c-zC-Z]:\\/.test(id);
-                    
+
                     if (
                         slashOrDot ||
                         windowsFullPath ||


### PR DESCRIPTION
Very simple fix.
Currently "test-build" does not pass on windows because regex tests fail for full path string starting with "c:\".