### PR TITLE
Fix Fork PR annotations error

### DIFF
--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -35,7 +35,7 @@ jobs:
         id: coverage
         with:
           output: report-markdown
-          annotations: coverage
+          annotations: ${{ github.event.pull_request.head.repo.full_name == github.event.repository.name && 'coverage' || 'none' }}
           test-script: xvfb-run -s "-ac -screen 0 1280x1024x24" npm run test-unit-ci            
       - uses: marocchino/sticky-pull-request-comment@v2
         with:


### PR DESCRIPTION
## Launch Checklist

Hopefully this should remove annotations from fork PRs so that test-unit will pass.
This is not ideal, but at least it should report some relevant coverage in the PR comment, I hope.
Worst case, we can always remove it :-)
