### PR TITLE
Remove coverage action again...

### DIFF
--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -31,12 +31,5 @@ jobs:
           node-version: ${{ matrix.node_version }}
           architecture: ${{ matrix.architecture }}
       - run: npm ci
-      - uses: ArtiomTr/jest-coverage-report-action@v2
-        id: coverage
-        with:
-          output: report-markdown
-          annotations: none
-          test-script: xvfb-run -s "-ac -screen 0 1280x1024x24" npm run test-unit-ci            
-      - uses: marocchino/sticky-pull-request-comment@v2
-        with:
-          message: ${{ steps.coverage.outputs.report }}
+      - run: xvfb-run -s "-ac -screen 0 1280x1024x24" npm run test-unit-ci
+

--- a/package.json
+++ b/package.json
@@ -166,7 +166,7 @@
     "test-query": "jest -c ./jest.config.e2e.ts --roots ./test/integration/query",
     "test-expression": "jest --roots ./test/integration/expression",
     "test-unit": "jest --roots ./src  -c ./jest.config.ts ",
-    "test-unit-ci": "jest --roots ./src  -c ./jest.config.ts --ci --coverage --testLocationInResults --json --outputFile=report.json",
+    "test-unit-ci": "jest --roots ./src  -c ./jest.config.ts --ci --coverage --testLocationInResults",
     "codegen": "npm run generate-style-code && npm run generate-struct-arrays && npm run generate-style-spec && npm run generate-shaders && npm run generate-debug-index-file",
     "benchmark": "node --loader ts-node/esm --experimental-specifier-resolution=node test/bench/run-benchmarks.ts",
     "gl-stats": "node --loader ts-node/esm --experimental-specifier-resolution=node test/bench/gl-stats.ts",


### PR DESCRIPTION
Seems like the coverage action is still problematic when running on a fork PR.
See here:
https://github.com/ArtiomTr/jest-coverage-report-action/issues/313#issuecomment-1239627404

In order to allow PRs to pass unit tests I'm reverting this.
Once the linked issue is solved we can try to introduce code coverage again...