### PR TITLE
Fix gl-stats

### DIFF
--- a/test/bench/gl-stats.html
+++ b/test/bench/gl-stats.html
@@ -16,7 +16,7 @@ maplibregl.workerCount = 1;
 
 const map = new maplibregl.Map({
     container: document.getElementById('map'),
-    style: 'https://api.maptiler.com/maps/streets/style.json?key=get_a_key_at_maptiler_cloud',
+    style: 'https://api.maptiler.com/maps/streets/style.json?key=get_your_own_OpIi9ZULNHzrESv6T2vL',
     center: [-77.07842066675323, 38.890315130853566],
     zoom: 11
 });

--- a/test/bench/gl-stats.html
+++ b/test/bench/gl-stats.html
@@ -8,7 +8,7 @@
 let now = performance.now(); //eslint-disable-line prefer-const
 window.performance.now = () => now;
 </script>
-<script src="../dist/maplibre-gl.js"></script>
+<script src="/dist/maplibre-gl.js"></script>
 </head>
 <body style="margin: 0; padding: 0"><div id="map" style="width: 500px; height: 500px"></div></body>
 <script>

--- a/test/bench/gl-stats.ts
+++ b/test/bench/gl-stats.ts
@@ -3,12 +3,12 @@ import fs from 'fs';
 import zlib from 'zlib';
 import {execSync} from 'child_process';
 
-const maplibreGLJSSrc = fs.readFileSync('dist/maplibre-gl.js', 'utf8');
-const maplibreGLCSSSrc = fs.readFileSync('dist/maplibre-gl.css', 'utf8');
+const maplibreGLJSSrc = fs.readFileSync('dist/maplibre-gl.js');
+const maplibreGLCSSSrc = fs.readFileSync('dist/maplibre-gl.css');
 const benchSrc = fs.readFileSync('test/bench/gl-stats.html', 'utf8');
 
 const benchHTML = benchSrc
-    .replace(/<script src="..\/dist\/maplibre-gl.js"><\/script>/, `<script>${maplibreGLJSSrc}</script>`);
+    .replace('<script src="/dist\/maplibre-gl.js"></script>', `<script src="data:text/javascript;base64,${maplibreGLJSSrc.toString('base64')}"></script>`);
 
 function waitForConsole(page) {
     return new Promise((resolve) => {


### PR DESCRIPTION
Necessary fixes for opening http://localhost:9966/test/bench/gl-stats.html in the browser or running `npm run gl-stats` to work (its still necessary to edit gl-stats.html and provide your own maptiler api key).

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.