### PR TITLE
map.setStyle's transformStyle option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Add map.getCameraTargetElevation() (#1558)
 - Add `freezeElevation` to `AnimationOptions` to allow smooth camera movement in 3D (#1514, #1492)
 - [Breaking] Remove deprecated mapboxgl css classes (#1575)
+- Add map.setStyle's transformStyle option (#1632)
 
 ### 🐞 Bug fixes
 

--- a/src/style/style.test.ts
+++ b/src/style/style.test.ts
@@ -395,6 +395,48 @@ describe('Style#loadJSON', () => {
             done();
         });
     });
+
+    test('applies transformStyle function', (done) => {
+        const previousStyle = createStyleJSON({
+            sources: {
+                base: {
+                    type: 'geojson',
+                    data: {type: 'FeatureCollection', features: []}
+                }
+            },
+            layers: [{
+                id: 'layerId0',
+                type: 'circle',
+                source: 'base'
+            }, {
+                id: 'layerId1',
+                type: 'circle',
+                source: 'base'
+            }]
+        });
+
+        const style = new Style(getStubMap());
+        style.loadJSON(createStyleJSON(), {
+            transformStyle: (prevStyle, nextStyle) => ({
+                ...nextStyle,
+                sources: {
+                    ...nextStyle.sources,
+                    base: prevStyle.sources.base
+                },
+                layers: [
+                    ...nextStyle.layers,
+                    prevStyle.layers[0]
+                ]
+            })
+        }, previousStyle);
+
+        style.on('style.load', () => {
+            expect('base' in style.stylesheet.sources).toBeTruthy();
+            expect(style.stylesheet.layers[0].id).toBe(previousStyle.layers[0].id);
+            expect(style.stylesheet.layers).toHaveLength(1);
+            done();
+        });
+    })
 });
 
 describe('Style#_remove', () => {
@@ -579,6 +621,52 @@ describe('Style#setState', () => {
             expect(mockGeoJSONSourceSetData).toHaveBeenCalledWith(geoJSONSourceData);
             expect(didChange).toBeTruthy();
             expect(style.stylesheet).toEqual(nextState);
+            done();
+        });
+    });
+
+    test('updates stylesheet according to applied transformStyle function', done => {
+        const initialState = createStyleJSON({
+            sources: {
+                base: {
+                    type: 'geojson',
+                    data: {type: 'FeatureCollection', features: []}
+                }
+            },
+            layers: [{
+                id: 'layerId0',
+                type: 'circle',
+                source: 'base'
+            }, {
+                id: 'layerId1',
+                type: 'circle',
+                source: 'base'
+            }]
+        });
+
+        const nextState = createStyleJSON();
+        const style = new Style(getStubMap());
+        style.loadJSON(initialState);
+
+        style.on('style.load', () => {
+            const didChange = style.setState(nextState, {
+                transformStyle: (prevStyle, nextStyle) => ({
+                    ...nextStyle,
+                    sources: {
+                        ...nextStyle.sources,
+                        base: prevStyle.sources.base
+                    },
+                    layers: [
+                        ...nextStyle.layers,
+                        prevStyle.layers[0]
+                    ]
+                })
+            })
+
+            expect(didChange).toBeTruthy();
+            expect('base' in style.stylesheet.sources).toBeTruthy();
+            expect(style.stylesheet.layers[0].id).toBe(initialState.layers[0].id);
+            expect(style.stylesheet.layers).toHaveLength(1);
             done();
         });
     });

--- a/src/style/style.test.ts
+++ b/src/style/style.test.ts
@@ -436,7 +436,7 @@ describe('Style#loadJSON', () => {
             expect(style.stylesheet.layers).toHaveLength(1);
             done();
         });
-    })
+    });
 });
 
 describe('Style#_remove', () => {
@@ -661,7 +661,7 @@ describe('Style#setState', () => {
                         prevStyle.layers[0]
                     ]
                 })
-            })
+            });
 
             expect(didChange).toBeTruthy();
             expect('base' in style.stylesheet.sources).toBeTruthy();

--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -1413,11 +1413,40 @@ class Map extends Camera {
      *   In these ranges, font settings from the map's style will be ignored, except for font-weight keywords (light/regular/medium/bold).
      *   Set to `false`, to enable font settings from the map's style for these glyph ranges.
      *   Forces a full update.
+     * @param {TransformStyleFunction} [options.stylePatch=undefined] A style patch function
+     *   that will perform a side-effect after a style is fetched but before it is committed to the map state. Refer to {@link TransformStyleFunction}.
      * @returns {Map} `this`
      *
      * @example
      * map.setStyle("https://demotiles.maplibre.org/style.json");
      *
+     * map.setStyle('https://demotiles.maplibre.org/style.json', {
+     *   transformStyle: (previousStyle, nextStyle) => ({
+     *       ...nextStyle,
+     *       sources: {
+     *           ...nextStyle.sources,
+     *           // copy a source from previous style
+     *           'osm': previousStyle.sources.osm
+     *       },
+     *       layers: [
+     *           // background layer
+     *           nextStyle.layers[0],
+     *           // copy a layer from previous style
+     *           previousStyle.layers[0],
+     *           // other layers from the next style
+     *           ...nextStyle.layers.slice(1).map(layer => {
+     *               // hide the layers we don't need from demotiles style
+     *               if (layer.id.startsWith('geolines')) {
+     *                   layer.layout = {...layer.layout || {}, visibility: 'none'};
+     *               // filter out US polygons
+     *               } else if (layer.id.startsWith('coastline') || layer.id.startsWith('countries')) {
+     *                   layer.filter = ['!=', ['get', 'ADM0_A3'], 'USA'];
+     *               }
+     *               return layer;
+     *           })
+     *       ]
+     *   })
+     * });
      */
     setStyle(style: StyleSpecification | string | null, options?: StyleSwapOptions & StyleOptions & StyleOptions) {
         options = extend({}, {localIdeographFontFamily: this._localIdeographFontFamily}, options);

--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -4,7 +4,7 @@ import DOM from '../util/dom';
 import packageJSON from '../../package.json' assert {type: 'json'};
 import {getImage, GetImageCallback, getJSON, ResourceType} from '../util/ajax';
 import {RequestManager} from '../util/request_manager';
-import Style from '../style/style';
+import Style, {StyleSwapOptions} from '../style/style';
 import EvaluationParameters from '../style/evaluation_parameters';
 import Painter from '../render/painter';
 import Transform from '../geo/transform';
@@ -1419,9 +1419,7 @@ class Map extends Camera {
      * map.setStyle("https://demotiles.maplibre.org/style.json");
      *
      */
-    setStyle(style: StyleSpecification | string | null, options?: {
-        diff?: boolean;
-    } & StyleOptions) {
+    setStyle(style: StyleSpecification | string | null, options?: StyleSwapOptions & StyleOptions & StyleOptions) {
         options = extend({}, {localIdeographFontFamily: this._localIdeographFontFamily}, options);
 
         if ((options.diff !== false && options.localIdeographFontFamily === this._localIdeographFontFamily) && this.style && style) {
@@ -1458,9 +1456,14 @@ class Map extends Camera {
         return str;
     }
 
-    _updateStyle(style: StyleSpecification | string | null,  options?: {
-        diff?: boolean;
-    } & StyleOptions) {
+    _updateStyle(style: StyleSpecification | string | null, options?: StyleSwapOptions & StyleOptions) {
+        // transformStyle relies on having previous style serialized, if it is not loaded yet, delay _updateStyle until previous style is loaded
+        if (options.transformStyle && !this.style._loaded) {
+            this.style.once('style.load', () => this._updateStyle(style, options));
+            return;
+        }
+
+        const previousStyle = this.style && options.transformStyle ? this.style.serialize() : undefined;
         if (this.style) {
             this.style.setEventedParent(null);
             this.style._remove();
@@ -1476,9 +1479,9 @@ class Map extends Camera {
         this.style.setEventedParent(this, {style: this.style});
 
         if (typeof style === 'string') {
-            this.style.loadURL(style);
+            this.style.loadURL(style, options, previousStyle);
         } else {
-            this.style.loadJSON(style);
+            this.style.loadJSON(style, options, previousStyle);
         }
 
         return this;
@@ -1492,9 +1495,7 @@ class Map extends Camera {
         }
     }
 
-    _diffStyle(style: StyleSpecification | string,  options?: {
-        diff?: boolean;
-    } & StyleOptions) {
+    _diffStyle(style: StyleSpecification | string, options?: StyleSwapOptions & StyleOptions) {
         if (typeof style === 'string') {
             const url = style;
             const request = this._requestManager.transformRequest(url, ResourceType.Style);
@@ -1510,11 +1511,9 @@ class Map extends Camera {
         }
     }
 
-    _updateDiff(style: StyleSpecification,  options?: {
-        diff?: boolean;
-    } & StyleOptions) {
+    _updateDiff(style: StyleSpecification, options?: StyleSwapOptions & StyleOptions) {
         try {
-            if (this.style.setState(style)) {
+            if (this.style.setState(style, options)) {
                 this._update(true);
             }
         } catch (e) {

--- a/test/debug-pages/transform-style.html
+++ b/test/debug-pages/transform-style.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>MapLibre GL JS debug page</title>
+    <meta charset='utf-8'>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel='stylesheet' href='../../dist/maplibre-gl.css' />
+    <style>
+        body { margin: 0; padding: 0; }
+        html, body, #map { height: 100%; }
+    </style>
+</head>
+
+<body>
+<div id='map'></div>
+
+<script src='../../dist/maplibre-gl-dev.js'></script>
+<script>
+
+const style = {
+    version: 8,
+    sources: {
+        osm: {
+            type: 'raster',
+            tiles: [
+                'https://tile.openstreetmap.org/{z}/{x}/{y}.png'
+            ],
+            tileSize: 256
+        },
+
+    },
+    layers: [{
+        id: 'osm',
+        type: 'raster',
+        source: 'osm',
+        minzoom: 0,
+        maxzoom: 19
+    }]
+};
+
+const map = new maplibregl.Map({
+    container: 'map',
+    zoom: 12.5,
+    center: [-77.01866, 38.888],
+    style,
+    hash: true
+});
+
+map.setStyle('https://demotiles.maplibre.org/style.json', {
+    // transformStyle can be used to compose a desired style representation on runtime before the style gets applied to map
+    // based on the previous style and the style that is being set.
+    // this can be handy when previous and incoming style need to be combined in a certain way
+    // or a partial visual state needs to move from one style to another
+    //
+    // let's use the hypothetical example when we want to show the countries shown in different colours (demotiles)
+    // while for US we display the original OSM basemap
+    transformStyle: (previousStyle, nextStyle) => ({
+        ...nextStyle,
+        sources: {
+            ...nextStyle.sources,
+            // preserve the OSM basemap from original style, place it above the background layer (below the next level above background)
+            'osm': previousStyle.sources.osm
+        },
+        layers: [
+            // background layer
+            nextStyle.layers[0],
+            // osm layer
+            previousStyle.layers[0],
+            // other layers from the next style
+            ...nextStyle.layers.slice(1).map(layer => {
+                // hide the layers we don't need from demotiles style
+                if (layer.id.startsWith('geolines')) {
+                    layer.layout = {...layer.layout || {}, visibility: 'none'};
+                // filter out US polygons
+                } else if (layer.id.startsWith('coastline') || layer.id.startsWith('countries')) {
+                    layer.filter = ['!=', ['get', 'ADM0_A3'], 'USA'];
+                }
+                return layer;
+            })
+        ]
+    })
+});
+
+</script>
+</body>
+</html>


### PR DESCRIPTION
Adds support to generic `transformStyle` convenience style transformer function that allows to modify a style after it is fetched but before it is committed to the map state. 

This allows to support a range of functionalities when incoming style requires modification based on external state or when previous style carries certain 'state' that needs to be carried over to a new style gracefully (without causing unnecessary visual transitions if changes are applied after a style change).

Impact to existing behaviour: **None**
This is a simple alternative to https://github.com/maplibre/maplibre-gl-js/pull/1238.

## Overview

Map's `setStyle()` and Style's `loadURL()` and `loadJSON()` options now may take an additional transformStyle function, which is exposed with a following signature:

```ts
transformStyle?: (previousStyle: StyleSpecification, nextStyle: StyleSpecification) => StyleSpecification
```

It is a simple function that constructs resulting style that will be applied to the map from previous style and the style that was passed to `setStyle()`.

**Implementation**:
1. transformStyle will be called prior to style validation of `style.setState() and style._load()`
2. When setStyle is passed with tranformStyle and previous style is still loading, `map._updateStyle` will wait until previous style is resolved.

## Hypothetical Example

The map is intialized with the simple raster basemap, set a new style while showing the previous raster basemap for a specific region (US).

```
const style = {
    version: 8,
    sources: {
        osm: {
            type: 'raster',
            tiles: [
                'https://tile.openstreetmap.org/{z}/{x}/{y}.png'
            ],
            tileSize: 256
        },

    },
    layers: [{
        id: 'osm',
        type: 'raster',
        source: 'osm',
        minzoom: 0,
        maxzoom: 19
    }]
};

const map = new maplibregl.Map({
    container: 'map',
    style,
    hash: true
});

map.setStyle('https://demotiles.maplibre.org/style.json', {
    transformStyle: (previousStyle, nextStyle) => ({
        ...nextStyle,
        sources: {
            ...nextStyle.sources,
            // copy a source from previous style
            osm: previousStyle.sources.osm
        },
        layers: [
            // background layer
            nextStyle.layers[0],
            // copy a layer from previous style
            previousStyle.layers[0],
            // other layers from the next style
            ...nextStyle.layers.slice(1).map(layer => {
                // filter out US polygons
                if (layer.id.startsWith('coastline') || layer.id.startsWith('countries')) {
                    layer.filter = ['!=', ['get', 'ADM0_A3'], 'USA'];
                }
                return layer;
            })
        ]
    })
});
```

## Why?

Without `transformStyle`, if we would want to transform the incoming style that will be fetched from URL, we would need to fetch it separately, apply the transformation and set json style, this would add additional unnecessary boilerplate.

## Launch Checklist

 - [X] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [X] Briefly describe the changes in this PR.
 - [X] Write tests for all new functionality.
 - [X] Document any changes to public APIs.
 - [X] Manually test the debug page.
 - [X] Suggest a changelog category: feature
 - [X] Add an entry inside this element for inclusion in the `maplibre-gl-js` changelog: `<changelog></changelog>`.
