### PR TITLE
Use async/await for more readable code.

### DIFF
--- a/test/bench/benchmarks/filter_evaluate.ts
+++ b/test/bench/benchmarks/filter_evaluate.ts
@@ -8,32 +8,31 @@ import filters from '../data/filters.json';
 export default class FilterEvaluate extends Benchmark {
     layers: any[];
 
-    setup() {
-        return fetch('/bench/data/785.vector.pbf')
-            .then(response => response.arrayBuffer())
-            .then(data => {
-                const tile = new VectorTile(new Pbf(data));
+    async setup() {
+        const response = await fetch('/bench/data/785.vector.pbf');
+        const data = await response.arrayBuffer();
+        const tile = new VectorTile(new Pbf(data));
 
-                this.layers = [];
-                for (const name in tile.layers) {
-                    const layer = tile.layers[name];
-                    if (!layer.length) continue;
+        this.layers = [];
+        for (const name in tile.layers) {
+            const layer = tile.layers[name];
+            if (!layer.length)
+                continue;
 
-                    const features = [];
-                    for (let j = 0; j < layer.length; j++) {
-                        features.push(layer.feature(j));
-                    }
+            const features = [];
+            for (let j = 0; j < layer.length; j++) {
+                features.push(layer.feature(j));
+            }
 
-                    const layerFilters = [];
-                    for (const filter of filters) {
-                        if (filter.layer === name) {
-                            layerFilters.push(createFilter(filter.filter));
-                        }
-                    }
-
-                    this.layers.push({features, filters: layerFilters});
+            const layerFilters = [];
+            for (const filter of filters) {
+                if (filter.layer === name) {
+                    layerFilters.push(createFilter(filter.filter));
                 }
-            });
+            }
+
+            this.layers.push({features, filters: layerFilters});
+        }
     }
 
     bench() {

--- a/test/bench/benchmarks/hillshade_load.ts
+++ b/test/bench/benchmarks/hillshade_load.ts
@@ -36,16 +36,15 @@ export default class HillshadeLoad extends Benchmark {
         };
     }
 
-    bench() {
-        return createMap({
+    async bench() {
+        const map = await createMap({
             width: 1024,
             height: 1024,
             style: this.style,
             stubRender: false,
             showMap: true,
             idle: true
-        }).then((map) => {
-            map.remove();
         });
+        map.remove();
     }
 }

--- a/test/bench/benchmarks/layers.ts
+++ b/test/bench/benchmarks/layers.ts
@@ -21,18 +21,18 @@ export class LayerBenchmark extends Benchmark {
     layerStyle: any;
     map: any;
 
-    setup() {
-        return createMap({
-            zoom: 16,
-            width,
-            height,
-            center: [-77.032194, 38.912753],
-            style: this.layerStyle
-        }).then(map => {
-            this.map = map;
-        }).catch(error => {
+    async setup() {
+        try {
+            this.map = await createMap({
+                zoom: 16,
+                width,
+                height,
+                center: [-77.032194, 38.912753],
+                style: this.layerStyle
+            });
+        } catch (error) {
             console.error(error);
-        });
+        }
     }
 
     bench() {
@@ -110,44 +110,42 @@ export class LayerFillExtrusion extends LayerBenchmark {
 }
 
 export class LayerHeatmap extends LayerBenchmark {
-    setup() {
-        return fetch('/bench/data/naturalearth-land.json')
-            .then(response => response.json())
-            .then(data => {
-                this.layerStyle = Object.assign({}, style, {
-                    sources: {
-                        'heatmap': {
-                            'type': 'geojson',
-                            data,
-                            'maxzoom': 23
-                        }
+    async setup() {
+        const response = await fetch('/bench/data/naturalearth-land.json');
+        const data = await response.json();
+        this.layerStyle = Object.assign({}, style, {
+            sources: {
+                'heatmap': {
+                    'type': 'geojson',
+                    data,
+                    'maxzoom': 23
+                }
+            },
+            layers: generateLayers({
+                'id': 'layer',
+                'type': 'heatmap',
+                'source': 'heatmap',
+                'paint': {
+                    'heatmap-radius': 50,
+                    'heatmap-weight': {
+                        'stops': [[0, 0.5], [4, 2]]
                     },
-                    layers: generateLayers({
-                        'id': 'layer',
-                        'type': 'heatmap',
-                        'source': 'heatmap',
-                        'paint': {
-                            'heatmap-radius': 50,
-                            'heatmap-weight': {
-                                'stops': [[0, 0.5], [4, 2]]
-                            },
-                            'heatmap-intensity': 0.9,
-                            'heatmap-color': [
-                                'interpolate',
-                                ['linear'],
-                                ['heatmap-density'],
-                                0, 'rgba(0, 0, 255, 0)',
-                                0.1, 'royalblue',
-                                0.3, 'cyan',
-                                0.5, 'lime',
-                                0.7, 'yellow',
-                                1, 'red'
-                            ]
-                        }
-                    })
-                });
+                    'heatmap-intensity': 0.9,
+                    'heatmap-color': [
+                        'interpolate',
+                        ['linear'],
+                        ['heatmap-density'],
+                        0, 'rgba(0, 0, 255, 0)',
+                        0.1, 'royalblue',
+                        0.3, 'cyan',
+                        0.5, 'lime',
+                        0.7, 'yellow',
+                        1, 'red'
+                    ]
+                }
             })
-            .then(() => super.setup());
+        });
+        await super.setup();
     }
 }
 

--- a/test/bench/benchmarks/map_idle.ts
+++ b/test/bench/benchmarks/map_idle.ts
@@ -18,16 +18,17 @@ export default class MapIdle extends Benchmark {
     /**
      * Waits for map's idle event before returning.
      */
-    async createMap(): Promise<void> {
-        return createMap({
-            idle: true,
-            center: [-77.032194, 38.912753],
-            zoom: 15
-        })
-            .then(map => map.remove())
-            .catch(error => {
-                console.error(error);
+    async createMap() {
+        try {
+            const map = await createMap({
+                idle: true,
+                center: [-77.032194, 38.912753],
+                zoom: 15
             });
+            map.remove();
+        } catch (error) {
+            console.error(error);
+        }
     }
 
     setup(): Promise<void> {

--- a/test/bench/benchmarks/map_load.ts
+++ b/test/bench/benchmarks/map_load.ts
@@ -7,17 +7,18 @@ import createMap from '../lib/create_map';
  * using an empty style with no sources or layers.
  */
 export default class MapLoad extends Benchmark {
-    bench() {
-        return createMap({
-            style: {
-                version: 8,
-                sources: {},
-                layers: []
-            }
-        })
-            .then(map => map.remove())
-            .catch(error => {
-                console.error(error);
+    async bench() {
+        try {
+            const map = await createMap({
+                style: {
+                    version: 8,
+                    sources: {},
+                    layers: []
+                }
             });
+            map.remove();
+        } catch (error) {
+            console.error(error);
+        }
     }
 }

--- a/test/bench/benchmarks/paint.ts
+++ b/test/bench/benchmarks/paint.ts
@@ -16,22 +16,20 @@ export default class Paint extends Benchmark {
         this.locations = locations;
     }
 
-    setup(): Promise<void> {
-        return Promise.all(this.locations.map(location => {
-            return createMap({
-                zoom: location.zoom,
-                width,
-                height,
-                center: location.center,
-                style: this.style
-            });
-        }))
-            .then(maps => {
-                this.maps = maps;
-            })
-            .catch(error => {
-                console.error(error);
-            });
+    async setup() {
+        try {
+            this.maps = await Promise.all(this.locations.map(location => {
+                return createMap({
+                    zoom: location.zoom,
+                    width,
+                    height,
+                    center: location.center,
+                    style: this.style
+                });
+            }));
+        } catch (error) {
+            console.error(error);
+        }
     }
 
     bench() {

--- a/test/bench/benchmarks/paint_states.ts
+++ b/test/bench/benchmarks/paint_states.ts
@@ -1,5 +1,5 @@
 
-import style from '../data/empty.json';
+import emptystyle from '../data/empty.json';
 import Benchmark from '../lib/benchmark';
 import createMap from '../lib/create_map';
 
@@ -27,41 +27,37 @@ export default class PaintStates extends Benchmark {
         this.center = center;
     }
 
-    setup() {
-        return fetch('/bench/data/naturalearth-land.json')
-            .then(response => response.json())
-            .then(data => {
-                this.numFeatures = data.features.length;
-                return Object.assign({}, style, {
-                    sources: {'land': {'type': 'geojson', data, 'maxzoom': 23}},
-                    layers: generateLayers({
-                        'id': 'layer',
-                        'type': 'fill',
-                        'source': 'land',
-                        'paint': {
-                            'fill-color': [
-                                'case',
-                                ['boolean', ['feature-state', 'bench'], false],
-                                ['rgb', 21, 210, 210],
-                                ['rgb', 233, 233, 233]
-                            ]
-                        }
-                    })
-                });
+    async setup() {
+        const response = await fetch('/bench/data/naturalearth-land.json');
+        const data = await response.json();
+        this.numFeatures = data.features.length;
+        const style = Object.assign({}, emptystyle, {
+            sources: {'land': {'type': 'geojson', data, 'maxzoom': 23}},
+            layers: generateLayers({
+                'id': 'layer',
+                'type': 'fill',
+                'source': 'land',
+                'paint': {
+                    'fill-color': [
+                        'case',
+                        ['boolean', ['feature-state', 'bench'], false],
+                        ['rgb', 21, 210, 210],
+                        ['rgb', 233, 233, 233]
+                    ]
+                }
             })
-            .then((style) => {
-                return createMap({
-                    zoom,
-                    width,
-                    height,
-                    center: this.center,
-                    style
-                }).then(map => {
-                    this.map = map;
-                }).catch(error => {
-                    console.error(error);
-                });
+        });
+        try {
+            this.map = await createMap({
+                zoom,
+                width,
+                height,
+                center: this.center,
+                style
             });
+        } catch (error) {
+            console.error(error);
+        }
     }
 
     bench() {

--- a/test/bench/benchmarks/placement.ts
+++ b/test/bench/benchmarks/placement.ts
@@ -16,23 +16,21 @@ export default class Paint extends Benchmark {
         this.locations = locations;
     }
 
-    setup(): Promise<void> {
-        return Promise.all(this.locations.map(location => {
-            return createMap({
-                zoom: location.zoom,
-                width,
-                height,
-                center: location.center,
-                style: this.style,
-                idle: true
-            });
-        }))
-            .then(maps => {
-                this.maps = maps;
-            })
-            .catch(error => {
-                console.error(error);
-            });
+    async setup() {
+        try {
+            this.maps = await Promise.all(this.locations.map(location => {
+                return createMap({
+                    zoom: location.zoom,
+                    width,
+                    height,
+                    center: location.center,
+                    style: this.style,
+                    idle: true
+                });
+            }));
+        } catch (error) {
+            console.error(error);
+        }
     }
 
     bench() {

--- a/test/bench/benchmarks/query_box.ts
+++ b/test/bench/benchmarks/query_box.ts
@@ -17,22 +17,20 @@ export default class QueryBox extends Benchmark {
         this.locations = locations;
     }
 
-    setup(): Promise<void> {
-        return Promise.all(this.locations.map(location => {
-            return createMap({
-                zoom: location.zoom,
-                width,
-                height,
-                center: location.center,
-                style: this.style
-            });
-        }))
-            .then(maps => {
-                this.maps = maps;
-            })
-            .catch(error => {
-                console.error(error);
-            });
+    async setup() {
+        try {
+            this.maps = await Promise.all(this.locations.map(location => {
+                return createMap({
+                    zoom: location.zoom,
+                    width,
+                    height,
+                    center: location.center,
+                    style: this.style
+                });
+            }));
+        } catch (error) {
+            console.error(error);
+        }
     }
 
     bench() {

--- a/test/bench/benchmarks/query_point.ts
+++ b/test/bench/benchmarks/query_point.ts
@@ -31,22 +31,20 @@ export default class QueryPoint extends Benchmark {
         this.locations = locations;
     }
 
-    setup(): Promise<void> {
-        return Promise.all(this.locations.map(location => {
-            return createMap({
-                zoom: location.zoom,
-                width,
-                height,
-                center: location.center,
-                style: this.style
-            });
-        }))
-            .then(maps => {
-                this.maps = maps;
-            })
-            .catch(error => {
-                console.error(error);
-            });
+    async setup() {
+        try {
+            this.maps = await Promise.all(this.locations.map(location => {
+                return createMap({
+                    zoom: location.zoom,
+                    width,
+                    height,
+                    center: location.center,
+                    style: this.style
+                });
+            }));
+        } catch (error) {
+            console.error(error);
+        }
     }
 
     bench() {

--- a/test/bench/benchmarks/remove_paint_state.ts
+++ b/test/bench/benchmarks/remove_paint_state.ts
@@ -1,5 +1,5 @@
 
-import style from '../data/empty.json';
+import emptystyle from '../data/empty.json';
 import Benchmark from '../lib/benchmark';
 import createMap from '../lib/create_map';
 
@@ -27,42 +27,37 @@ class RemovePaintState extends Benchmark {
         this.center = center;
     }
 
-    setup() {
-        return fetch('/bench/data/naturalearth-land.json')
-            .then(response => response.json())
-            .then(data => {
-                this.numFeatures = data.features.length;
-                return Object.assign({}, style, {
-                    sources: {'land': {'type': 'geojson', data, 'maxzoom': 23}},
-                    layers: generateLayers({
-                        'id': 'layer',
-                        'type': 'fill',
-                        'source': 'land',
-                        'paint': {
-                            'fill-color': [
-                                'case',
-                                ['boolean', ['feature-state', 'bench'], false],
-                                ['rgb', 21, 210, 210],
-                                ['rgb', 233, 233, 233]
-                            ]
-                        }
-                    })
-                });
+    async setup() {
+        const response = await fetch('/bench/data/naturalearth-land.json');
+        const data = await response.json();
+        this.numFeatures = data.features.length;
+        const style = Object.assign({}, emptystyle, {
+            sources: {'land': {'type': 'geojson', data, 'maxzoom': 23}},
+            layers: generateLayers({
+                'id': 'layer',
+                'type': 'fill',
+                'source': 'land',
+                'paint': {
+                    'fill-color': [
+                        'case',
+                        ['boolean', ['feature-state', 'bench'], false],
+                        ['rgb', 21, 210, 210],
+                        ['rgb', 233, 233, 233]
+                    ]
+                }
             })
-            .then((style) => {
-                return createMap({
-                    zoom,
-                    width,
-                    height,
-                    center: this.center,
-                    style
-                }).then(map => {
-                    this.map = map;
-                })
-                    .catch(error => {
-                        console.error(error);
-                    });
+        });
+        try {
+            this.map = await createMap({
+                zoom,
+                width,
+                height,
+                center: this.center,
+                style
             });
+        } catch (error) {
+            console.error(error);
+        }
     }
 
     bench() {

--- a/test/bench/benchmarks/style_layer_create.ts
+++ b/test/bench/benchmarks/style_layer_create.ts
@@ -13,9 +13,9 @@ export default class StyleLayerCreate extends Benchmark {
         this.style = style;
     }
 
-    setup(): Promise<void> {
-        return fetchStyle(this.style)
-            .then(json => { this.layers = deref(json.layers); });
+    async setup() {
+        const json = await fetchStyle(this.style);
+        this.layers = deref(json.layers);
     }
 
     bench() {

--- a/test/bench/benchmarks/style_validate.ts
+++ b/test/bench/benchmarks/style_validate.ts
@@ -12,9 +12,8 @@ export default class StyleValidate extends Benchmark {
         this.style = style;
     }
 
-    setup(): Promise<void> {
-        return fetchStyle(this.style)
-            .then(json => { this.json = json; });
+    async setup() {
+        this.json = await fetchStyle(this.style);
     }
 
     bench() {

--- a/test/bench/benchmarks/worker_transfer.ts
+++ b/test/bench/benchmarks/worker_transfer.ts
@@ -17,7 +17,7 @@ export default class WorkerTransfer extends Benchmark {
         this.style = style;
     }
 
-    setup(): Promise<void> {
+    async setup(): Promise<void> {
         const src = `
         onmessage = (e) => {
             postMessage(e.data);
@@ -33,23 +33,16 @@ export default class WorkerTransfer extends Benchmark {
             new OverscaledTileID(13, 0, 13, 2412, 3079)
         ];
 
-        return fetchStyle(this.style)
-            .then((styleJSON) => {
-                this.parser = new TileParser(styleJSON, 'openmaptiles');
-                return this.parser.setup();
-            })
-            .then(() => {
-                return Promise.all(tileIDs.map(tileID => this.parser.fetchTile(tileID)));
-            })
-            .then((tiles) => {
-                return Promise.all(tiles.map(tile => this.parser.parseTile(tile)));
-            }).then((tileResults) => {
-                const payload = tileResults
-                    .concat(Object.values(this.parser.icons))
-                    .concat(Object.values(this.parser.glyphs)).map((obj) => serialize(obj, []));
-                this.payloadJSON = payload.map(barePayload);
-                this.payloadTiles = payload.slice(0, tileResults.length);
-            });
+        const styleJSON = await fetchStyle(this.style);
+        this.parser = new TileParser(styleJSON, 'openmaptiles');
+        await this.parser.setup();
+        const tiles = await Promise.all(tileIDs.map(tileID => this.parser.fetchTile(tileID)));
+        const tileResults = await Promise.all(tiles.map(tile => this.parser.parseTile(tile)));
+        const payload = tileResults
+            .concat(Object.values(this.parser.icons))
+            .concat(Object.values(this.parser.glyphs)).map((obj) => serialize(obj, []));
+        this.payloadJSON = payload.map(barePayload);
+        this.payloadTiles = payload.slice(0, tileResults.length);
     }
 
     sendPayload(obj: any): Promise<void> {
@@ -59,22 +52,16 @@ export default class WorkerTransfer extends Benchmark {
         });
     }
 
-    bench(): Promise<void> {
-        let promise: Promise<void> = Promise.resolve();
-
+    async bench(): Promise<void> {
         // benchmark sending raw JSON payload
         for (const obj of this.payloadJSON) {
-            promise = promise.then(() => {
-                return this.sendPayload(obj);
-            });
+            await this.sendPayload(obj);
         }
 
-        return promise.then(() => {
-            // benchmark deserializing full tile payload because it happens on the main thread
-            for (const obj of this.payloadTiles) {
-                deserialize(obj);
-            }
-        });
+        // benchmark deserializing full tile payload because it happens on the main thread
+        for (const obj of this.payloadTiles) {
+            deserialize(obj);
+        }
     }
 }
 


### PR DESCRIPTION
I refactored most benchmarks to use async await as I consider that style more readable. I can change the remaining benchmarks too for consistency but there the difference is very minor. I'm assuming browser compatibility is less of an issue with the benchmark code.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 