### PR TITLE
create a frame around render-to-texture tiles to avoid stiching on different zoomlevels

### DIFF
--- a/src/render/draw_terrain.ts
+++ b/src/render/draw_terrain.ts
@@ -64,59 +64,35 @@ function drawCoords(painter: Painter, terrain: Terrain) {
         program.draw(context, gl.TRIANGLES, depthMode, StencilMode.disabled, colorMode, CullFaceMode.backCCW, uniformValues, terrainData, 'terrain', mesh.vertexBuffer, mesh.indexBuffer, mesh.segments);
         terrain.coordsIndex.push(tile.tileID.key);
     }
-
     context.bindFramebuffer.set(null);
     context.viewport.set([0, 0, painter.width, painter.height]);
 }
 
-/**
- * Render, e.g. drape, a render-to-texture tile onto the 3d mesh on screen.
- * @param {Painter} painter - the painter
- * @param {Terrain} terrain - the source cache
- * @param {Tile} tile - the tile
- */
-function drawTerrain(painter: Painter, terrain: Terrain, tile: Tile) {
-    const context = painter.context;
-    const gl = context.gl;
-    const colorMode = painter.colorModeForRenderPass();
-    const depthMode = new DepthMode(gl.LEQUAL, DepthMode.ReadWrite, painter.depthRangeFor3D);
-    const program = painter.useProgram('terrain');
-    const mesh = terrain.getTerrainMesh();
-    const terrainData = terrain.getTerrainData(tile.tileID);
+function drawTerrain(painter: Painter, terrain: Terrain, tiles: Array<Tile>) {
+   const context = painter.context;
+   const gl = context.gl;
+   const colorMode = painter.colorModeForRenderPass();
+   const depthMode = new DepthMode(gl.LEQUAL, DepthMode.ReadWrite, painter.depthRangeFor3D);
+   const program = painter.useProgram('terrain');
+   const mesh = terrain.getTerrainMesh();
 
-    context.bindFramebuffer.set(null);
-    context.viewport.set([0, 0, painter.width, painter.height]);
-    context.activeTexture.set(gl.TEXTURE0);
-    gl.bindTexture(gl.TEXTURE_2D, terrain.getRTTFramebuffer().colorAttachment.get());
-    const posMatrix = painter.transform.calculatePosMatrix(tile.tileID.toUnwrapped());
-    const uniformValues = terrainUniformValues(posMatrix);
-    program.draw(context, gl.TRIANGLES, depthMode, StencilMode.disabled, colorMode, CullFaceMode.backCCW, uniformValues, terrainData, 'terrain', mesh.vertexBuffer, mesh.indexBuffer, mesh.segments);
-}
+   context.bindFramebuffer.set(null);
+   context.viewport.set([0, 0, painter.width, painter.height]);
 
-/**
- * prepare the render-to-texture tile.
- * E.g. creates the necessary textures and attach them to the render-to-texture-framebuffer.
- * @param {Painter} painter - the painter
- * @param {Terrain} terrain - the terrain
- * @param {Tile} tile - the tile
- * @param {number} stack number of a layer-groop. see painter.ts
- */
-function prepareTerrain(painter: Painter, terrain: Terrain, tile: Tile, stack: number) {
-    const context = painter.context;
-    const size = tile.tileSize * terrain.qualityFactor;
-    if (!tile.textures[stack]) {
-        tile.textures[stack] = painter.getTileTexture(size) || new Texture(context, {width: size, height: size, data: null}, context.gl.RGBA);
-        tile.textures[stack].bind(context.gl.LINEAR, context.gl.CLAMP_TO_EDGE);
-        if (stack === 0) terrain.sourceCache.renderHistory.unshift(tile.tileID.key);
-    }
-    const fb = terrain.getRTTFramebuffer();
-    fb.colorAttachment.set(tile.textures[stack].texture);
-    context.bindFramebuffer.set(fb.framebuffer);
-    context.viewport.set([0, 0, size, size]);
+   for (const tile of tiles) {
+       const texture = painter.rtt.getTexture(tile);
+       if (!texture) continue; // tile will be rendered later
+       const terrainData = terrain.getTerrainData(tile.tileID);
+       context.activeTexture.set(gl.TEXTURE0);
+       gl.bindTexture(gl.TEXTURE_2D, texture.texture);
+       const posMatrix = painter.transform.calculatePosMatrix(tile.tileID.toUnwrapped());
+       const uniformValues = terrainUniformValues(posMatrix);
+       program.draw(context, gl.TRIANGLES, depthMode, StencilMode.disabled, colorMode, CullFaceMode.backCCW, uniformValues, terrainData, 'terrain', mesh.vertexBuffer, mesh.indexBuffer, mesh.segments);
+   }
+
 }
 
 export {
-    prepareTerrain,
     drawTerrain,
     drawDepth,
     drawCoords

--- a/src/render/painter.ts
+++ b/src/render/painter.ts
@@ -85,6 +85,7 @@ type PainterOptions = {
 class Painter {
     context: Context;
     transform: Transform;
+    rtt: RenderToTexture;
     _tileTextures: {
         [_: number]: Array<Texture>;
     };
@@ -378,7 +379,6 @@ class Painter {
 
         const layerIds = this.style._order;
         const sourceCaches = this.style.sourceCaches;
-        const renderToTexture = this.style.map.terrain && new RenderToTexture(this);
 
         for (const id in sourceCaches) {
             const sourceCache = sourceCaches[id];
@@ -407,7 +407,8 @@ class Painter {
             }
         }
 
-        if (renderToTexture) {
+        if (this.rtt) {
+            this.rtt.initialize(this.style, this.transform.zoom);
             // this is disabled, because render-to-texture is rendering all layers from bottom to top.
             this.opaquePassCutoff = 0;
 
@@ -450,7 +451,7 @@ class Painter {
 
         // Opaque pass ===============================================
         // Draw opaque layers top-to-bottom first.
-        if (!renderToTexture) {
+        if (!this.rtt) {
             this.renderPass = 'opaque';
 
             for (this.currentLayer = layerIds.length - 1; this.currentLayer >= 0; this.currentLayer--) {
@@ -471,7 +472,7 @@ class Painter {
             const layer = this.style._layers[layerIds[this.currentLayer]];
             const sourceCache = sourceCaches[layer.source];
 
-            if (renderToTexture && renderToTexture.renderLayer(layer)) continue;
+            if (this.rtt && this.rtt.renderLayer(layer)) continue;
 
             // For symbol layers in the translucent pass, we add extra tiles to the renderable set
             // for cross-tile symbol fading. Symbol layers don't use tile clipping, so no need to render

--- a/src/render/render_to_texture.ts
+++ b/src/render/render_to_texture.ts
@@ -2,22 +2,109 @@ import Painter from './painter';
 import Tile from '../source/tile';
 import Color from '../style-spec/util/color';
 import {OverscaledTileID} from '../source/tile_id';
-import {prepareTerrain, drawTerrain} from './draw_terrain';
+import {drawTerrain} from './draw_terrain';
 import type StyleLayer from '../style/style_layer';
+import Framebuffer from '../gl/framebuffer';
+import Texture from './texture';
+import Context from '../gl/context';
+import Style from '../style/style';
+import Terrain from './terrain';
+
+// lookup table which layers should rendered to texture
+const LAYERS: { [keyof in StyleLayer['type']]?: boolean } = {
+   background: true,
+   fill: true,
+   line: true,
+   raster: true,
+   hillshade: true
+};
+
+const POOL_SIZE = 30; // must by divide by 2
+
+type PoolObject = {
+   id: number;
+   fbo: Framebuffer;
+   texture: Texture;
+   inUseTime: number;
+};
+
+export class RenderPool {
+    objs: Array<PoolObject>;
+    tileSize: number;
+    context: Context;
+
+    constructor(context: Context, tileSize: number) {
+        this.context = context;
+        this.tileSize = tileSize;
+        this.objs = [];
+    }
+
+    destruct() {
+        for (const obj of this.objs) {
+            obj.texture.destroy();
+            obj.fbo.destroy();
+        }
+    }
+
+    getObject(id: number): PoolObject {
+        return this.objs[id] && this.objs[id].inUseTime && this.objs[id];
+    }
+
+    useObject(id: number) {
+        if (this.objs[id]) this.objs[id].inUseTime = Date.now();
+    }
+
+    createObject(id: number): PoolObject {
+        const fbo = this.context.createFramebuffer(this.tileSize, this.tileSize, true);
+        const texture = new Texture(this.context, { width: this.tileSize, height: this.tileSize, data: null }, this.context.gl.RGBA);
+        texture.bind(this.context.gl.LINEAR, this.context.gl.CLAMP_TO_EDGE);
+        fbo.depthAttachment.set(this.context.createRenderbuffer(this.context.gl.DEPTH_COMPONENT16, this.tileSize, this.tileSize));
+        fbo.colorAttachment.set(texture.texture);
+        return { id: id, fbo: fbo, texture: texture, inUseTime: 0 };
+    }
+
+    isFull(): boolean {
+        if (this.objs.length < POOL_SIZE) return false;
+        for (const obj of this.objs)
+            if (!obj.inUseTime) return false;
+        return true;
+    }
+
+    getFreeObject(): PoolObject {
+        // check for free existing objects
+        for (let i = 0; i < this.objs.length; i++) {
+            if (!this.objs[i].inUseTime) {
+                this.useObject(i);
+                return this.objs[i];
+            }
+        }
+        if (!this.isFull()) {
+            const obj = this.createObject(this.objs.length);
+            this.useObject(obj.id);
+            this.objs.push(obj);
+            return obj;
+        }
+        return null;
+    }
+
+    freeObject(id: number) {
+        if (this.objs[id]) this.objs[id].inUseTime = 0;
+    }
+}
 
 /**
  * RenderToTexture
  */
 export default class RenderToTexture {
     painter: Painter;
-    // this object holds a lookup table which layers should rendered to texture
-    _renderToTexture: {[keyof in StyleLayer['type']]?: boolean};
+    terrain: Terrain;
+    pool: RenderPool;
     // coordsDescendingInv contains a list of all tiles which should be rendered for one render-to-texture tile
     // e.g. render 4 raster-tiles with size 256px to the 512px render-to-texture tile
-    _coordsDescendingInv: {[_: string]: {[_:string]: Array<OverscaledTileID>}} = {};
+    _coordsDescendingInv: {[_: string]: {[_:string]: Array<OverscaledTileID>}};
     // create a string representation of all to tiles rendered to render-to-texture tiles
     // this string representation is used to check if tile should be re-rendered.
-    _coordsDescendingInvStr: {[_: string]: {[_:string]: string}} = {};
+    _coordsDescendingInvStr: {[_: string]: {[_:string]: string}};
     // store for render-stacks
     // a render stack is a set of layers which should be rendered into one texture
     // every stylesheet can have multipe stacks. A new stack is created if layers which should
@@ -25,33 +112,51 @@ export default class RenderToTexture {
     _stacks: Array<Array<string>>;
     // remember the previous processed layer to check if a new stack is needed
     _prevType: string;
-    // create a lookup which tiles should rendered to texture
-    _rerender: {[_: string]: boolean};
     // a list of tiles that can potentially rendered
     _renderableTiles: Array<Tile>;
+    // a list of tiles that should be rendered to screen in the next render-call
+    _rttTiles: Array<Tile>;
+    // a list of all layer-ids which should be rendered
+    _renderableLayerIds: Array<string>;
 
-    constructor(painter: Painter) {
+    constructor(painter: Painter, terrain: Terrain) {
         this.painter = painter;
-        this._renderToTexture = {background: true, fill: true, line: true, raster: true};
-        this._coordsDescendingInv = {};
-        this._coordsDescendingInvStr = {};
-        this._stacks = [];
-        this._prevType = null;
-        this._rerender = {};
-        this._renderableTiles = painter.style.map.terrain.sourceCache.getRenderableTiles();
-        this._init();
+        this.terrain = terrain;
+        this.pool = new RenderPool(painter.context, terrain.sourceCache.tileSize * terrain.qualityFactor);
     }
 
-    _init() {
-        const style = this.painter.style;
-        const terrain = style.map.terrain;
+    destruct() {
+        this.pool.destruct();
+    }
 
-        // fill _coordsDescendingInv
+    getTexture(tile: Tile) {
+        const rtt = this.pool.getObject(tile.rtt[this._stacks.length - 1]);
+        return rtt && rtt.texture;
+    }
+
+    freeRttIds(ids: Array<number>) {
+        for (const id of ids) this.pool.freeObject(id);
+        for (const key in this.terrain.sourceCache._tiles) {
+            const tile = this.terrain.sourceCache._tiles[key];
+            for (let i = 0; i < tile.rtt.length; i++) {
+                if (!this.pool.getObject(tile.rtt[i])) tile.rtt[i] = null;
+            }
+        }
+    }
+
+    initialize(style: Style, zoom: number) {
+        this._stacks = [];
+        this._prevType = null;
+        this._rttTiles = [];
+        this._renderableTiles = this.terrain.sourceCache.getRenderableTiles();
+        this._renderableLayerIds = style._order.filter(id => !style._layers[id].isHidden(zoom));
+
+        this._coordsDescendingInv = {};
         for (const id in style.sourceCaches) {
             this._coordsDescendingInv[id] = {};
             const tileIDs = style.sourceCaches[id].getVisibleCoordinates();
             for (const tileID of tileIDs) {
-                const keys = terrain.sourceCache.getTerrainCoords(tileID);
+                const keys = this.terrain.sourceCache.getTerrainCoords(tileID);
                 for (const key in keys) {
                     if (!this._coordsDescendingInv[id][key]) this._coordsDescendingInv[id][key] = [];
                     this._coordsDescendingInv[id][key].push(keys[key]);
@@ -59,10 +164,10 @@ export default class RenderToTexture {
             }
         }
 
-        // fill _coordsDescendingInvStr
+        this._coordsDescendingInvStr = {};
         for (const id of style._order) {
             const layer = style._layers[id], source = layer.source;
-            if (this._renderToTexture[layer.type]) {
+            if (LAYERS[layer.type]) {
                 if (!this._coordsDescendingInvStr[source]) {
                     this._coordsDescendingInvStr[source] = {};
                     for (const key in this._coordsDescendingInv[source])
@@ -71,21 +176,19 @@ export default class RenderToTexture {
             }
         }
 
-        // remove cached textures
-        this._renderableTiles.forEach(tile => {
+        // check tiles to render
+        for (const tile of this._renderableTiles) {
             for (const source in this._coordsDescendingInvStr) {
                 // rerender if there are more coords to render than in the last rendering
                 const coords = this._coordsDescendingInvStr[source][tile.tileID.key];
-                if (coords && coords !== tile.textureCoords[source]) tile.clearTextures(this.painter);
-                // rerender if tile is marked for rerender
-                if (terrain.needsRerender(source, tile.tileID)) tile.clearTextures(this.painter);
+                if (coords && coords !== tile.rttCoords[source]) tile.rtt = [];
             }
-            this._rerender[tile.tileID.key] = !tile.textures.length;
-        });
-        terrain.clearRerenderCache();
-        terrain.sourceCache.removeOutdated(this.painter);
+        }
 
-        return this;
+        // free used rtt objs in pool
+        const inUse = {};
+        for (const id of this.terrain.sourceCache.getRttIds()) inUse[id] = true;
+        for (const obj of this.pool.objs) if (!inUse[obj.id]) this.pool.freeObject(obj.id);
     }
 
     /**
@@ -99,56 +202,58 @@ export default class RenderToTexture {
      * @returns {boolean} if true layer is rendered to texture, otherwise false
      */
     renderLayer(layer: StyleLayer): boolean {
+        if (layer.isHidden(this.painter.transform.zoom)) return false;
+
         const type = layer.type;
         const painter = this.painter;
-        const layerIds = painter.style._order;
-        const currentLayer = painter.currentLayer;
-        const isLastLayer = currentLayer + 1 === layerIds.length;
+        const isLastLayer = this._renderableLayerIds[this._renderableLayerIds.length - 1] === layer.id;
 
         // remember background, fill, line & raster layer to render into a stack
-        if (this._renderToTexture[type]) {
-            if (!this._prevType || !this._renderToTexture[this._prevType]) this._stacks.push([]);
+        if (LAYERS[type]) {
+            // create a new stack if previous layer was not rendered to texture (f.e. symbols)
+            if (!this._prevType || !LAYERS[this._prevType]) this._stacks.push([]);
+            // push current render-to-texture layer to render-stack
             this._prevType = type;
-            this._stacks[this._stacks.length - 1].push(layerIds[currentLayer]);
+            this._stacks[this._stacks.length - 1].push(layer.id);
             // rendering is done later, all in once
             if (!isLastLayer) return true;
         }
 
         // in case a stack is finished render all collected stack-layers into a texture
-        if (this._renderToTexture[this._prevType] || type === 'hillshade' || (this._renderToTexture[type] && isLastLayer)) {
+        if (LAYERS[this._prevType] || (LAYERS[type] && isLastLayer)) {
             this._prevType = type;
             const stack = this._stacks.length - 1, layers = this._stacks[stack] || [];
             for (const tile of this._renderableTiles) {
-                prepareTerrain(painter, painter.style.map.terrain, tile, stack);
-                if (this._rerender[tile.tileID.key]) {
-                    painter.context.clear({color: Color.transparent});
-                    for (let l = 0; l < layers.length; l++) {
-                        const layer = painter.style._layers[layers[l]];
-                        const coords = layer.source ? this._coordsDescendingInv[layer.source][tile.tileID.key] : [tile.tileID];
-                        painter._renderTileClippingMasks(layer, coords);
-                        painter.renderLayer(painter, painter.style.sourceCaches[layer.source], layer, coords);
-                        if (layer.source) tile.textureCoords[layer.source] = this._coordsDescendingInvStr[layer.source][tile.tileID.key];
-                    }
+                if (this.pool.getObject(tile.rtt[stack])) { // layer is rendered in an previous pass
+                    this._rttTiles.push(tile);
+                    this.pool.useObject(tile.rtt[stack]);
+                    continue;
                 }
-                drawTerrain(painter, painter.style.map.terrain, tile);
-            }
-
-            // the hillshading layer is a special case because it changes on every camera-movement
-            // so rerender it in any case.
-            if (type === 'hillshade') {
-                this._stacks.push([layerIds[currentLayer]]);
-                for (const tile of this._renderableTiles) {
-                    const coords = this._coordsDescendingInv[layer.source][tile.tileID.key];
-                    prepareTerrain(painter, painter.style.map.terrain, tile, this._stacks.length - 1);
-                    painter.context.clear({color: Color.transparent});
+                if (this.pool.isFull()) {
+                    drawTerrain(this.painter, this.terrain, this._rttTiles);
+                    this._rttTiles = [];
+                    // free the oldest 50% pool objects
+                    const rttIds = this.pool.objs.slice().sort((a, b) => b.inUseTime - a.inUseTime).map(obj => obj.id);
+                    this.freeRttIds(rttIds.slice(0, POOL_SIZE / 2));
+                }
+                this._rttTiles.push(tile);
+                const rtt = this.pool.getFreeObject();
+                tile.rtt[stack] = rtt.id;
+                painter.context.bindFramebuffer.set(rtt.fbo.framebuffer);
+                painter.context.viewport.set([0, 0, rtt.fbo.width, rtt.fbo.height]);
+                painter.context.clear({color: Color.transparent});
+                for (let l = 0; l < layers.length; l++) {
+                    const layer = painter.style._layers[layers[l]];
+                    const coords = layer.source ? this._coordsDescendingInv[layer.source][tile.tileID.key] : [tile.tileID];
                     painter._renderTileClippingMasks(layer, coords);
                     painter.renderLayer(painter, painter.style.sourceCaches[layer.source], layer, coords);
-                    drawTerrain(painter, painter.style.map.terrain, tile);
+                    if (layer.source) tile.rttCoords[layer.source] = this._coordsDescendingInvStr[layer.source][tile.tileID.key];
                 }
-                return true;
             }
+            drawTerrain(this.painter, this.terrain, this._rttTiles);
+            this._rttTiles = [];
 
-            return this._renderToTexture[type];
+            return LAYERS[type];
         }
 
         return false;

--- a/src/render/terrain.ts
+++ b/src/render/terrain.ts
@@ -107,13 +107,6 @@ export default class Terrain {
     // as of overzooming of raster-dem tiles in high zoomlevels, this cache contains
     // matrices to transform from vector-tile coords to raster-dem-tile coords.
     _demMatrixCache: {[_: string]: { matrix: mat4; coord: OverscaledTileID }};
-    // because of overzooming raster-dem tiles this cache holds the corresponding
-    // framebuffer-object to render tiles to texture
-    _rttFramebuffer: Framebuffer;
-    // loading raster-dem tiles foreach render-to-texture tile results in loading
-    // a lot of terrain-dem tiles with very low visual advantage. So with this setting
-    // remember all tiles which contains new data for a spezific source and tile-key.
-    _rerender: {[_: string]: {[_: number]: boolean}};
 
     constructor(style: Style, sourceCache: SourceCache, options: TerrainSpecification) {
         this.style = style;
@@ -126,7 +119,6 @@ export default class Terrain {
         this._demMatrixCache = {};
         this.coordsIndex = [];
         this._coordsTextureSize = 1024;
-        this.clearRerenderCache();
     }
 
     /**
@@ -152,25 +144,6 @@ export default class Terrain {
             elevation = mix(mix(tl, tr, coord[0] - c[0]), mix(bl, br, coord[0] - c[0]), coord[1] - c[1]);
         }
         return elevation;
-    }
-
-    rememberForRerender(source: string, tileID: OverscaledTileID) {
-        for (const key in this.sourceCache._tiles) {
-            const tile = this.sourceCache._tiles[key];
-            if (tile.tileID.equals(tileID) || tile.tileID.isChildOf(tileID)) {
-                if (source === this.sourceCache.sourceCache.id) tile.timeLoaded = Date.now();
-                this._rerender[source] = this._rerender[source] || {};
-                this._rerender[source][tile.tileID.key] = true;
-            }
-        }
-    }
-
-    needsRerender(source: string, tileID: OverscaledTileID) {
-        return this._rerender[source] && this._rerender[source][tileID.key];
-    }
-
-    clearRerenderCache() {
-        this._rerender = {};
     }
 
     /**
@@ -240,20 +213,6 @@ export default class Terrain {
             depthTexture: (this._fboDepthTexture || this._emptyDepthTexture).texture,
             tile: sourceTile
         };
-    }
-
-    /**
-     * create the render-to-texture framebuffer
-     * @returns {Framebuffer} - the frame buffer
-     */
-    getRTTFramebuffer() {
-        const painter = this.style.map.painter;
-        if (!this._rttFramebuffer) {
-            const size = this.sourceCache.tileSize * this.qualityFactor;
-            this._rttFramebuffer = painter.context.createFramebuffer(size, size, true);
-            this._rttFramebuffer.depthAttachment.set(painter.context.createRenderbuffer(painter.context.gl.DEPTH_COMPONENT16, size, size));
-        }
-        return this._rttFramebuffer;
     }
 
     /**

--- a/src/render/terrain.ts
+++ b/src/render/terrain.ts
@@ -317,6 +317,27 @@ export default class Terrain {
             indexArray.emplaceBack(x + y, meshSize + x + y + 1, meshSize + x + y + 2);
             indexArray.emplaceBack(x + y, meshSize + x + y + 2, x + y + 1);
         }
+        // add an extra frame around the mesh to avoid stiching on tile boundaries with different zoomlevels
+        // encode z-coordinate into x-coordinate by using x values outside EXTENT
+        // first code-block is for top-bottom frame and second for left-right frame
+        let offset = vertexArray.length, offset2 = offset + (meshSize + 1) * 2;
+        for (let y = 0; y <= 1; y++) for (let x = 0; x <= meshSize; x++) for (let z = 0; z <= 1; z++)
+            vertexArray.emplaceBack(x * delta + z * (EXTENT + 1), y * EXTENT);
+        for (let x = 0; x < meshSize * 2; x += 2) {
+            indexArray.emplaceBack(offset2 + x, offset2 + x + 1, offset2 + x + 3);
+            indexArray.emplaceBack(offset2 + x, offset2 + x + 3, offset2 + x + 2);
+            indexArray.emplaceBack(offset + x, offset + x + 3, offset + x + 1);
+            indexArray.emplaceBack(offset + x, offset + x + 2, offset + x + 3);
+        }
+        offset = vertexArray.length; offset2 = offset + (meshSize + 1) * 2;
+        for (let x = 0; x <= 1; x++) for (let y = 0; y <= meshSize; y++) for (let z = 0; z <= 1; z++)
+            vertexArray.emplaceBack(x * EXTENT + z * (EXTENT + 1), y * delta);
+        for (let y = 0; y < meshSize * 2; y += 2) {
+            indexArray.emplaceBack(offset + y, offset + y + 1, offset + y + 3);
+            indexArray.emplaceBack(offset + y, offset + y + 3, offset + y + 2);
+            indexArray.emplaceBack(offset2 + y, offset2 + y + 3, offset2 + y + 1);
+            indexArray.emplaceBack(offset2 + y, offset2 + y + 2, offset2 + y + 3);
+        }
         this._mesh = {
             indexBuffer: context.createIndexBuffer(indexArray),
             vertexBuffer: context.createVertexBuffer(vertexArray, posAttributes.members),

--- a/src/shaders/terrain.vertex.glsl
+++ b/src/shaders/terrain.vertex.glsl
@@ -6,7 +6,16 @@ varying vec2 v_texture_pos;
 varying float v_depth;
 
 void main() {
-    v_texture_pos = a_pos / 8192.0; // 8192.0 is the hardcoded vector-tiles coordinates resolution
-    gl_Position = u_matrix * vec4(a_pos, get_elevation(a_pos), 1.0);
+    float extent = 8192.0; // 8192.0 is the hardcoded vector-tiles coordinates resolution
+    vec2 pos = a_pos;
+    float ele = 0.0;
+    if (pos.x > extent) { // check for encoded z values when creating tile frame
+        pos.x -= extent - 1.0;
+        ele = -450.0;
+    } else {
+        ele = get_elevation(pos);
+    }
+    v_texture_pos = pos / extent;
+    gl_Position = u_matrix * vec4(pos, ele, 1.0);
     v_depth = gl_Position.z / gl_Position.w;
 }

--- a/src/source/terrain_source_cache.ts
+++ b/src/source/terrain_source_cache.ts
@@ -5,7 +5,6 @@ import {mat4} from 'gl-matrix';
 import {Evented} from '../util/evented';
 import type Transform from '../geo/transform';
 import type SourceCache from '../source/source_cache';
-import Painter from '../render/painter';
 import Terrain from '../render/terrain';
 
 /**
@@ -34,10 +33,6 @@ export default class TerrainSourceCache extends Evented {
     tileSize: number;
     // raster-dem tiles will load for performance the actualZoom - deltaZoom zoom-level.
     deltaZoom: number;
-    // each time a render-to-texture tile is rendered, its tileID.key is stored into this array
-    renderHistory: Array<string>;
-    // maximal size of render-history
-    renderHistorySize: number;
 
     constructor(sourceCache: SourceCache) {
         super();
@@ -45,12 +40,10 @@ export default class TerrainSourceCache extends Evented {
         this._tiles = {};
         this._renderableTilesKeys = [];
         this._sourceTileCache = {};
-        this.renderHistory = [];
         this.minzoom = 0;
         this.maxzoom = 22;
         this.tileSize = 512;
         this.deltaZoom = 1;
-        this.renderHistorySize = sourceCache._cache.max;
         sourceCache.usedForTerrain = true;
         sourceCache.tileSize = this.tileSize * 2 ** this.deltaZoom;
     }
@@ -58,11 +51,6 @@ export default class TerrainSourceCache extends Evented {
     destruct() {
         this.sourceCache.usedForTerrain = false;
         this.sourceCache.tileSize = null;
-        for (const key in this._tiles) {
-            const tile = this._tiles[key];
-            tile.textures.forEach(t => t.destroy());
-            tile.textures = [];
-        }
     }
 
     /**
@@ -75,6 +63,7 @@ export default class TerrainSourceCache extends Evented {
         this.sourceCache.update(transform, terrain);
         // create internal render-to-texture tiles for the current scene.
         this._renderableTilesKeys = [];
+        const keys = {};
         for (const tileID of transform.coveringTiles({
             tileSize: this.tileSize,
             minzoom: this.minzoom,
@@ -82,6 +71,7 @@ export default class TerrainSourceCache extends Evented {
             reparseOverscaled: false,
             terrain
         })) {
+            keys[tileID.key] = true;
             this._renderableTilesKeys.push(tileID.key);
             if (!this._tiles[tileID.key]) {
                 tileID.posMatrix = new Float64Array(16) as any;
@@ -89,30 +79,26 @@ export default class TerrainSourceCache extends Evented {
                 this._tiles[tileID.key] = new Tile(tileID, this.tileSize);
             }
         }
+        // free unused tiles
+        for (const key in this._tiles) {
+            if (!keys[key]) delete(this._tiles[key]);
+        }
     }
 
     /**
-     * This method should called before each render-to-texture step to free old cached tiles
-     * @param {Painter} painter - the painter
+     * get a list of all RttIds sorted by newest loaded tiles
+     * @param {TileID} tileID optional, handle only tiles which corresponds to tileID.
+     * @returns  {Array<number>} a list of rtt obj-ids
      */
-    removeOutdated(painter: Painter) {
-        // create lookuptable for actual needed tiles
-        const tileIDs = {};
-        // remove duplicates from renderHistory and chop to renderHistorySize
-        this.renderHistory = this.renderHistory.filter((i, p) => {
-            return this.renderHistory.indexOf(i) === p;
-        }).slice(0, this.renderHistorySize);
-        // fill lookuptable with current rendered tiles
-        for (const key of this._renderableTilesKeys) tileIDs[key] = true;
-        // fill lookuptable with most recent rendered tiles outside the viewport
-        for (const key of this.renderHistory) tileIDs[key] = true;
-        // free (GPU) memory from previously rendered not needed tiles
-        for (const key in this._tiles) {
-            if (!tileIDs[key]) {
-                this._tiles[key].clearTextures(painter);
-                delete this._tiles[key];
+    getRttIds(tileID?: OverscaledTileID): Array<number> {
+        let ids = [] as Array<number>;
+        let tiles = Object.values(this._tiles).sort((a, b) => b.timeAdded - a.timeAdded);
+        for (const tile of tiles) {
+            if (!tileID || tile.tileID.equals(tileID) || tile.tileID.isChildOf(tileID) || tileID.isChildOf(tile.tileID)) {
+                ids = ids.concat(tile.rtt);
             }
         }
+        return ids;
     }
 
     /**
@@ -200,6 +186,6 @@ export default class TerrainSourceCache extends Evented {
      * @returns {Array<Tile>} - the relevant tiles
      */
     tilesAfterTime(time = Date.now()): Array<Tile> {
-        return Object.values(this._tiles).filter(t => t.timeLoaded >= time);
+        return Object.values(this._tiles).filter(t => t.timeAdded >= time);
     }
 }

--- a/src/source/tile.ts
+++ b/src/source/tile.ts
@@ -65,7 +65,6 @@ class Tile {
     expiredRequestCount: number;
     state: TileState;
     timeAdded: any;
-    timeLoaded: any;
     fadeEndTime: any;
     collisionBoxArray: CollisionBoxArray;
     redoWhenDone: boolean;
@@ -93,8 +92,8 @@ class Tile {
     hasSymbolBuckets: boolean;
     hasRTLText: boolean;
     dependencies: any;
-    textures: Array<Texture>;
-    textureCoords: {[_: string]: string}; // remeber all coords rendered to textures
+    rtt: Array<number>;
+    rttCoords: {[_:string]: string};
 
     /**
      * @param {OverscaledTileID} tileID
@@ -112,8 +111,8 @@ class Tile {
         this.hasSymbolBuckets = false;
         this.hasRTLText = false;
         this.dependencies = {};
-        this.textures = [];
-        this.textureCoords = {};
+        this.rtt = [];
+        this.rttCoords = {};
 
         // Counts the number of times a response was already expired when
         // received. We're using this to add a delay when making a new request
@@ -138,10 +137,7 @@ class Tile {
 
     clearTextures(painter: any) {
         if (this.demTexture) painter.saveTileTexture(this.demTexture);
-        this.textures.forEach(t => painter.saveTileTexture(t));
         this.demTexture = null;
-        this.textures = [];
-        this.textureCoords = {};
     }
 
     /**

--- a/src/style/style.ts
+++ b/src/style/style.ts
@@ -56,12 +56,10 @@ import type {
     StyleSpecification,
     LightSpecification,
     SourceSpecification,
-    TerrainSpecification
 } from '../style-spec/types.g';
 import type {CustomLayerInterface} from './style_layer/custom_style_layer';
 import type {Validator} from './validate_style';
 import type {OverscaledTileID} from '../source/tile_id';
-import Terrain from '../render/terrain';
 
 const supportedDiffOperations = pick(diffOperations, [
     'addLayer',
@@ -172,7 +170,6 @@ class Style extends Evented {
     zoomHistory: ZoomHistory;
     _loaded: boolean;
     _rtlTextPluginCallback: (a: any) => any;
-    _terrainDataCallback: (e: any) => any;
     _changed: boolean;
     _updatedSources: {[_: string]: 'clear' | 'reload'};
     _updatedLayers: {[_: string]: true};
@@ -328,7 +325,7 @@ class Style extends Evented {
 
         this.light = new Light(this.stylesheet.light);
 
-        this.setTerrain(this.stylesheet.terrain);
+        this.map.setTerrain(this.stylesheet.terrain);
 
         this.fire(new Event('data', {dataType: 'style'}));
         this.fire(new Event('style.load'));
@@ -530,43 +527,6 @@ class Style extends Evented {
         this._updatedPaintProps = {};
 
         this._changedImages = {};
-    }
-
-    /**
-     * Loads a 3D terrain mesh, based on a "raster-dem" source.
-     * @param {TerrainSpecification} [options] Options object.
-     */
-    setTerrain(options?: TerrainSpecification) {
-        this._checkLoaded();
-
-        // clear event handlers
-        if (this._terrainDataCallback) this.off('data', this._terrainDataCallback);
-
-        // remove terrain
-        if (!options) {
-            if (this.map.terrain) this.map.terrain.sourceCache.destruct();
-            this.map.terrain = null;
-            this.map.transform.updateElevation(this.map.terrain);
-
-        // add terrain
-        } else {
-            const sourceCache = this.sourceCaches[options.source];
-            if (!sourceCache) throw new Error(`cannot load terrain, because there exists no source with ID: ${options.source}`);
-            this.map.terrain = new Terrain(this, sourceCache, options);
-            this.map.transform.updateElevation(this.map.terrain);
-            this._terrainDataCallback = e => {
-                if (!e.tile) return;
-                if (e.sourceId === options.source) {
-                    this.map.transform.updateElevation(this.map.terrain);
-                    this.map.terrain.rememberForRerender(e.sourceId, e.tile.tileID);
-                } else if (e.source.type === 'geojson') {
-                    this.map.terrain.rememberForRerender(e.sourceId, e.tile.tileID);
-                }
-            };
-            this.on('data', this._terrainDataCallback);
-        }
-
-        this.map.fire(new Event('terrain', {terrain: options}));
     }
 
     /**


### PR DESCRIPTION
This code fixes https://github.com/maplibre/maplibre-gl-js/issues/1602. Creating the frame (e.g. triangle-mesh) to dead-sea around the terrain-tile is not the smartest code, but it works. I dont think that this code has any impact on performance.

@birkskyum it would be great if you can make a render-test for this issue.