### PR TITLE
Update ExpressionInputType to accept null values

### DIFF
--- a/build/generate-style-spec.ts
+++ b/build/generate-style-spec.ts
@@ -128,7 +128,7 @@ export type ResolvedImageSpecification = string;
 
 export type PromoteIdSpecification = {[_: string]: string} | string;
 
-export type ExpressionInputType = string | number | boolean;
+export type ExpressionInputType = string | number | boolean | null;
 
 export type CollatorExpressionSpecification = 
     ['collator', {


### PR DESCRIPTION
Should `ExpressionInputType` allow null values? Right now, below code raises ts type error:

```js
'line-color': [
              'case',
              ['==', ['get', 'color'], null],
              PATH_DEFAULT_COLOR,
              ['get', 'color'],
            ],
```

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [ ] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [ ] Briefly describe the changes in this PR.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [ ] Manually test the debug page.
 - [ ] Suggest a changelog category: bug/feature/docs/etc. or "skip changelog".
 - [ ] Add an entry inside this element for inclusion in the `maplibre-gl-js` changelog: `<changelog></changelog>`.
