### PR TITLE
Return a promise from once in case a listener is not provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## main
 
 ### ✨ Features and improvements
-- Return a promise from `once` method to allow easier usage of async/await in this case
+- Return a promise from `once` method to allow easier usage of async/await in this case ([#1690(https://github.com/maplibre/maplibre-gl-js/pull/1690)) @HarelM
 - *...Add new stuff here...*
 
 ### 🐞 Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,15 @@
 ## main
 
 ### ✨ Features and improvements
+- Return a promise from `once` method to allow easier usage of async/await in this case
+- *...Add new stuff here...*
 
 ### 🐞 Bug fixes
-
+- *...Add new stuff here...*
 ## 3.0.0-pre.0
 
 ### ✨ Features and improvements
 
-- *...Add new stuff here...*
 - Add map.getCameraTargetElevation() ([#1558](https://github.com/maplibre/maplibre-gl-js/pull/1558))
 - Add `freezeElevation` to `AnimationOptions` to allow smooth camera movement in 3D ([#1514](https://github.com/maplibre/maplibre-gl-js/pull/1514), [#1492](https://github.com/maplibre/maplibre-gl-js/issues/1492))
 - [Breaking] Remove deprecated mapboxgl css classes ([#1575](https://github.com/maplibre/maplibre-gl-js/pull/1575))
@@ -21,7 +22,6 @@
 - [Breaking] Make geojson data source a required field to align with the docs ([#1396](https://github.com/maplibre/maplibre-gl-js/issue/1396))
 - Fix showTileBoundaries to show the first vector source [#1395](https://github.com/maplibre/maplibre-gl-js/pull/1395)
 - Fix `match` expression type ([#1631](https://github.com/maplibre/maplibre-gl-js/pull/1631))
-- *...Add new stuff here...*
 
 ## 2.4.0
 

--- a/src/source/geojson_source.test.ts
+++ b/src/source/geojson_source.test.ts
@@ -71,15 +71,14 @@ describe('GeoJSONSource#setData', () => {
         expect(source.setData({} as GeoJSON.GeoJSON)).toBe(source);
     });
 
-    test('fires "data" event', done => {
+    test('fires "data" event', async () => {
         const source = createSource();
-        source.once('data', () => {
-            source.once('data', () => {
-                done();
-            });
-            source.setData({} as GeoJSON.GeoJSON);
-        });
+        const loadPromise = source.once('data');
         source.load();
+        await loadPromise;
+        const setDataPromise = source.once('data');
+        source.setData({} as GeoJSON.GeoJSON);
+        await setDataPromise;
     });
 
     test('fires "dataloading" event', done => {
@@ -119,35 +118,32 @@ describe('GeoJSONSource#setData', () => {
         source.setData('http://localhost/nonexistent');
     });
 
-    test('only marks source as loaded when there are no pending loads', done => {
+    test('only marks source as loaded when there are no pending loads', async () => {
         const source = createSource();
-        source.once('data', () => {
-            expect(source.loaded()).toBeFalsy();
-            source.once('data', () => {
-                expect(source.loaded()).toBeTruthy();
-                done();
-            });
-        });
+        const setDataPromise = source.once('data');
         source.setData({} as GeoJSON.GeoJSON);
         source.setData({} as GeoJSON.GeoJSON);
+        await setDataPromise;
+        expect(source.loaded()).toBeFalsy();
+        const setDataPromise2 = source.once('data');
+        await setDataPromise2;
+        expect(source.loaded()).toBeTruthy();
     });
 
-    test('marks source as not loaded before firing "dataloading" event', done => {
+    test('marks source as not loaded before firing "dataloading" event', async () => {
         const source = createSource();
-        source.once('dataloading', () => {
-            expect(source.loaded()).toBeFalsy();
-            done();
-        });
+        const setDataPromise = source.once('dataloading');
         source.setData({} as GeoJSON.GeoJSON);
+        await setDataPromise;
+        expect(source.loaded()).toBeFalsy();
     });
 
-    test('marks source as loaded before firing "data" event', done => {
+    test('marks source as loaded before firing "data" event', async () => {
         const source = createSource();
-        source.once('data', () => {
-            expect(source.loaded()).toBeTruthy();
-            done();
-        });
+        const dataPromise = source.once('data');
         source.setData({} as GeoJSON.GeoJSON);
+        await dataPromise;
+        expect(source.loaded()).toBeTruthy();
     });
 
     test('marks source as loaded before firing "dataabort" event', done => {

--- a/src/source/source_cache.test.ts
+++ b/src/source/source_cache.test.ts
@@ -336,7 +336,7 @@ describe('SourceCache#removeTile', () => {
         sourceCache._addTile(tileID);
     });
 
-    test('fires dataabort event', done => {
+    test('fires dataabort event', async () => {
         const sourceCache = createSourceCache({
             loadTile() {
                 // Do not call back in order to make sure the tile is removed before it is loaded.
@@ -344,13 +344,12 @@ describe('SourceCache#removeTile', () => {
         });
         const tileID = new OverscaledTileID(0, 0, 0, 0, 0);
         const tile = sourceCache._addTile(tileID);
-        sourceCache.once('dataabort', event => {
-            expect(event.dataType).toBe('source');
-            expect(event.tile).toBe(tile);
-            expect(event.coord).toBe(tileID);
-            done();
-        });
+        const abortPromise = sourceCache.once('dataabort');
         sourceCache._removeTile(tileID.key);
+        const event = await abortPromise;
+        expect(event.dataType).toBe('source');
+        expect(event.tile).toBe(tile);
+        expect(event.coord).toBe(tileID);
     });
 
     test('does not fire dataabort event when the tile has already been loaded', () => {

--- a/src/source/vector_tile_source.test.ts
+++ b/src/source/vector_tile_source.test.ts
@@ -344,14 +344,12 @@ describe('VectorTileSource', () => {
         });
     });
 
-    test('setTiles only clears the cache once the TileJSON has reloaded', done => {
+    test('setTiles only clears the cache once the TileJSON has reloaded', async () => {
         const clearTiles = jest.fn();
         const source = createSource({tiles: ['http://example.com/{z}/{x}/{y}.pbf']}, undefined, clearTiles);
         source.setTiles(['http://example2.com/{z}/{x}/{y}.pbf']);
         expect(clearTiles.mock.calls).toHaveLength(0);
-        source.once('data', () => {
-            expect(clearTiles.mock.calls).toHaveLength(1);
-            done();
-        });
+        await source.once('data');
+        expect(clearTiles.mock.calls).toHaveLength(1);
     });
 });

--- a/src/style/style.test.ts
+++ b/src/style/style.test.ts
@@ -691,15 +691,16 @@ describe('Style#addSource', () => {
         });
     });
 
-    test('fires "data" event', done => {
+    test('fires "data" event', async () => {
         const style = createStyle();
         style.loadJSON(createStyleJSON());
         const source = createSource();
-        style.once('data', () => { done(); });
+        let dataPriomse = style.once('data');
         style.on('style.load', () => {
             style.addSource('source-id', source);
             style.update({} as EvaluationParameters);
         });
+        await dataPriomse;
     });
 
     test('throws on duplicates', done => {
@@ -765,16 +766,17 @@ describe('Style#removeSource', () => {
         expect(() => style.removeSource('source-id')).toThrow(/load/i);
     });
 
-    test('fires "data" event', done => {
+    test('fires "data" event', async () => {
         const style = new Style(getStubMap());
         style.loadJSON(createStyleJSON());
         const source = createSource();
-        style.once('data', () => { done(); });
+        let dataPriomse = style.once('data');
         style.on('style.load', () => {
             style.addSource('source-id', source);
             style.removeSource('source-id');
             style.update({} as EvaluationParameters);
         });
+        await dataPriomse;
     });
 
     test('clears tiles', done => {
@@ -1081,17 +1083,18 @@ describe('Style#addLayer', () => {
 
     });
 
-    test('fires "data" event', done => {
+    test('fires "data" event', async () => {
         const style = new Style(getStubMap());
         style.loadJSON(createStyleJSON());
         const layer = {id: 'background', type: 'background'} as LayerSpecification;
 
-        style.once('data', () => { done(); });
+        let dataPriomse = style.once('data');
 
         style.on('style.load', () => {
             style.addLayer(layer);
             style.update({} as EvaluationParameters);
         });
+        await dataPriomse;
     });
 
     test('emits error on duplicates', done => {
@@ -1207,18 +1210,20 @@ describe('Style#removeLayer', () => {
         expect(() => style.removeLayer('background')).toThrow(/load/i);
     });
 
-    test('fires "data" event', done => {
+    test('fires "data" event', async () => {
         const style = new Style(getStubMap());
         style.loadJSON(createStyleJSON());
         const layer = {id: 'background', type: 'background'} as LayerSpecification;
 
-        style.once('data', () => { done(); });
+        let dataPriomse = style.once('data');
 
         style.on('style.load', () => {
             style.addLayer(layer);
             style.removeLayer('background');
             style.update({} as EvaluationParameters);
         });
+
+        await dataPriomse;
     });
 
     test('tears down layer event forwarding', done => {
@@ -1305,18 +1310,18 @@ describe('Style#moveLayer', () => {
         expect(() => style.moveLayer('background')).toThrow(/load/i);
     });
 
-    test('fires "data" event', done => {
+    test('fires "data" event', async () => {
         const style = new Style(getStubMap());
         style.loadJSON(createStyleJSON());
         const layer = {id: 'background', type: 'background'} as LayerSpecification;
 
-        style.once('data', () => { done(); });
-
+        let dataPriomse = style.once('data');
         style.on('style.load', () => {
             style.addLayer(layer);
             style.moveLayer('background');
             style.update({} as EvaluationParameters);
         });
+        await dataPriomse;
     });
 
     test('fires an error on non-existence', done => {

--- a/src/style/style.test.ts
+++ b/src/style/style.test.ts
@@ -695,12 +695,12 @@ describe('Style#addSource', () => {
         const style = createStyle();
         style.loadJSON(createStyleJSON());
         const source = createSource();
-        const dataPriomse = style.once('data');
+        const dataPromise = style.once('data');
         style.on('style.load', () => {
             style.addSource('source-id', source);
             style.update({} as EvaluationParameters);
         });
-        await dataPriomse;
+        await dataPromise;
     });
 
     test('throws on duplicates', done => {
@@ -770,13 +770,13 @@ describe('Style#removeSource', () => {
         const style = new Style(getStubMap());
         style.loadJSON(createStyleJSON());
         const source = createSource();
-        const dataPriomse = style.once('data');
+        const dataPromise = style.once('data');
         style.on('style.load', () => {
             style.addSource('source-id', source);
             style.removeSource('source-id');
             style.update({} as EvaluationParameters);
         });
-        await dataPriomse;
+        await dataPromise;
     });
 
     test('clears tiles', done => {
@@ -1088,13 +1088,13 @@ describe('Style#addLayer', () => {
         style.loadJSON(createStyleJSON());
         const layer = {id: 'background', type: 'background'} as LayerSpecification;
 
-        const dataPriomse = style.once('data');
+        const dataPromise = style.once('data');
 
         style.on('style.load', () => {
             style.addLayer(layer);
             style.update({} as EvaluationParameters);
         });
-        await dataPriomse;
+        await dataPromise;
     });
 
     test('emits error on duplicates', done => {
@@ -1215,7 +1215,7 @@ describe('Style#removeLayer', () => {
         style.loadJSON(createStyleJSON());
         const layer = {id: 'background', type: 'background'} as LayerSpecification;
 
-        const dataPriomse = style.once('data');
+        const dataPromise = style.once('data');
 
         style.on('style.load', () => {
             style.addLayer(layer);
@@ -1223,7 +1223,7 @@ describe('Style#removeLayer', () => {
             style.update({} as EvaluationParameters);
         });
 
-        await dataPriomse;
+        await dataPromise;
     });
 
     test('tears down layer event forwarding', done => {
@@ -1315,13 +1315,13 @@ describe('Style#moveLayer', () => {
         style.loadJSON(createStyleJSON());
         const layer = {id: 'background', type: 'background'} as LayerSpecification;
 
-        const dataPriomse = style.once('data');
+        const dataPromise = style.once('data');
         style.on('style.load', () => {
             style.addLayer(layer);
             style.moveLayer('background');
             style.update({} as EvaluationParameters);
         });
-        await dataPriomse;
+        await dataPromise;
     });
 
     test('fires an error on non-existence', done => {

--- a/src/style/style.test.ts
+++ b/src/style/style.test.ts
@@ -695,7 +695,7 @@ describe('Style#addSource', () => {
         const style = createStyle();
         style.loadJSON(createStyleJSON());
         const source = createSource();
-        let dataPriomse = style.once('data');
+        const dataPriomse = style.once('data');
         style.on('style.load', () => {
             style.addSource('source-id', source);
             style.update({} as EvaluationParameters);
@@ -770,7 +770,7 @@ describe('Style#removeSource', () => {
         const style = new Style(getStubMap());
         style.loadJSON(createStyleJSON());
         const source = createSource();
-        let dataPriomse = style.once('data');
+        const dataPriomse = style.once('data');
         style.on('style.load', () => {
             style.addSource('source-id', source);
             style.removeSource('source-id');
@@ -1088,7 +1088,7 @@ describe('Style#addLayer', () => {
         style.loadJSON(createStyleJSON());
         const layer = {id: 'background', type: 'background'} as LayerSpecification;
 
-        let dataPriomse = style.once('data');
+        const dataPriomse = style.once('data');
 
         style.on('style.load', () => {
             style.addLayer(layer);
@@ -1215,7 +1215,7 @@ describe('Style#removeLayer', () => {
         style.loadJSON(createStyleJSON());
         const layer = {id: 'background', type: 'background'} as LayerSpecification;
 
-        let dataPriomse = style.once('data');
+        const dataPriomse = style.once('data');
 
         style.on('style.load', () => {
             style.addLayer(layer);
@@ -1315,7 +1315,7 @@ describe('Style#moveLayer', () => {
         style.loadJSON(createStyleJSON());
         const layer = {id: 'background', type: 'background'} as LayerSpecification;
 
-        let dataPriomse = style.once('data');
+        const dataPriomse = style.once('data');
         style.on('style.load', () => {
             style.addLayer(layer);
             style.moveLayer('background');

--- a/src/ui/control/geolocate_control.test.ts
+++ b/src/ui/control/geolocate_control.test.ts
@@ -124,7 +124,7 @@ describe('GeolocateControl with no options', () => {
 
         const click = new window.Event('click');
 
-        let moveEndPromise = map.once('moveend');
+        const moveEndPromise = map.once('moveend');
         geolocate._geolocateButton.dispatchEvent(click);
         geolocation.send({latitude: 10, longitude: 20, accuracy: 1});
         await moveEndPromise;
@@ -152,7 +152,7 @@ describe('GeolocateControl with no options', () => {
 
         const click = new window.Event('click');
 
-        let moveEndPromise = map.once('moveend');
+        const moveEndPromise = map.once('moveend');
         geolocate._geolocateButton.dispatchEvent(click);
         geolocation.send({latitude: 10, longitude: 20, accuracy: 1});
         await moveEndPromise;
@@ -172,7 +172,7 @@ describe('GeolocateControl with no options', () => {
 
         const click = new window.Event('click');
 
-        let moveEndPromise = map.once('moveend');
+        const moveEndPromise = map.once('moveend');
         geolocate._geolocateButton.dispatchEvent(click);
         geolocation.send({latitude: 10, longitude: 20, accuracy: 1000});
         await moveEndPromise;
@@ -319,7 +319,7 @@ describe('GeolocateControl with no options', () => {
 
         const click = new window.Event('click');
 
-        let promise = geolocate.once('trackuserlocationstart');
+        const promise = geolocate.once('trackuserlocationstart');
         geolocate._geolocateButton.dispatchEvent(click);
         await promise;
         expect(map.getCenter()).toEqual({lng: 0, lat: 0});
@@ -333,7 +333,7 @@ describe('GeolocateControl with no options', () => {
 
         const click = new window.Event('click');
 
-        let geolocatePromise = geolocate.once('geolocate');
+        const geolocatePromise = geolocate.once('geolocate');
         geolocate._geolocateButton.dispatchEvent(click);
         geolocation.send({latitude: 10, longitude: 20, accuracy: 30, timestamp: 40});
         await geolocatePromise;
@@ -350,7 +350,7 @@ describe('GeolocateControl with no options', () => {
 
         const click = new window.Event('click');
 
-        let geolocatePromise = geolocate.once('geolocate');
+        const geolocatePromise = geolocate.once('geolocate');
         geolocate._geolocateButton.dispatchEvent(click);
         geolocation.send({latitude: 10, longitude: 20, accuracy: 30, timestamp: 40});
         await geolocatePromise;
@@ -371,14 +371,14 @@ describe('GeolocateControl with no options', () => {
 
         const click = new window.Event('click');
 
-        let geolocatePromise = geolocate.once('geolocate');
+        const geolocatePromise = geolocate.once('geolocate');
         geolocate._geolocateButton.dispatchEvent(click);
         geolocation.send({latitude: 10, longitude: 20, accuracy: 700});
         await geolocatePromise;
         map.jumpTo({
             center: [10, 20]
         });
-        let zoomendPromise = map.once('zoomend');
+        const zoomendPromise = map.once('zoomend');
         map.zoomTo(10, {duration: 0});
         await zoomendPromise;
         expect(!geolocate._circleElement.style.width).toBeTruthy();
@@ -393,7 +393,7 @@ describe('GeolocateControl with no options', () => {
 
         const click = new window.Event('click');
 
-        let geolocatePromise = geolocate.once('geolocate');
+        const geolocatePromise = geolocate.once('geolocate');
         geolocate._geolocateButton.dispatchEvent(click);
         geolocation.send({latitude: 10, longitude: 20, accuracy: 700});
         await geolocatePromise;
@@ -422,14 +422,14 @@ describe('GeolocateControl with no options', () => {
 
         const click = new window.Event('click');
 
-        let geolocatePromise = geolocate.once('geolocate');
+        const geolocatePromise = geolocate.once('geolocate');
         geolocate._geolocateButton.dispatchEvent(click);
         geolocation.send({latitude: 10, longitude: 20, accuracy: 700});
         await geolocatePromise;
         map.jumpTo({
             center: [10, 20]
         });
-        let zoomendPromise = map.once('zoomend');
+        const zoomendPromise = map.once('zoomend');
         map.zoomTo(10, {duration: 0});
         await zoomendPromise;
         expect(geolocate._circleElement.style.width).toBeTruthy();

--- a/src/ui/map.test.ts
+++ b/src/ui/map.test.ts
@@ -567,7 +567,7 @@ describe('Map', () => {
 
     });
 
-    test('#moveLayer', done => {
+    test('#moveLayer', async () => {
         const map = createMap({
             style: extend(createStyle(), {
                 sources: {
@@ -592,15 +592,13 @@ describe('Map', () => {
             })
         });
 
-        map.once('render', () => {
-            map.moveLayer('layerId1', 'layerId2');
-            expect(map.getLayer('layerId1').id).toBe('layerId1');
-            expect(map.getLayer('layerId2').id).toBe('layerId2');
-            done();
-        });
+        await map.once('render');
+        map.moveLayer('layerId1', 'layerId2');
+        expect(map.getLayer('layerId1').id).toBe('layerId1');
+        expect(map.getLayer('layerId2').id).toBe('layerId2');
     });
 
-    test('#getLayer', done => {
+    test('#getLayer', async () => {
         const layer = {
             id: 'layerId',
             type: 'circle',
@@ -621,13 +619,11 @@ describe('Map', () => {
             })
         });
 
-        map.once('render', () => {
-            const mapLayer = map.getLayer('layerId');
-            expect(mapLayer.id).toBe(layer.id);
-            expect(mapLayer.type).toBe(layer.type);
-            expect(mapLayer.source).toBe(layer.source);
-            done();
-        });
+        await map.once('render');
+        const mapLayer = map.getLayer('layerId');
+        expect(mapLayer.id).toBe(layer.id);
+        expect(mapLayer.type).toBe(layer.type);
+        expect(mapLayer.source).toBe(layer.source);
     });
 
     describe('#resize', () => {
@@ -1055,14 +1051,14 @@ describe('Map', () => {
         canvas.dispatchEvent(new window.Event('webglcontextlost'));
     });
 
-    test('#redraw', done => {
+    test('#redraw', async () => {
         const map = createMap();
 
-        map.once('idle', () => {
-            map.once('render', () => done());
+        await map.once('idle');
+        let renderPromise = map.once('render');
 
-            map.redraw();
-        });
+        map.redraw();
+        await renderPromise;
     });
 
     test('#addControl', () => {
@@ -1308,7 +1304,7 @@ describe('Map', () => {
             });
         });
 
-        test('fires a data event', done => {
+        test('fires a data event', async () => {
             // background layers do not have a source
             const map = createMap({
                 style: {
@@ -1324,15 +1320,11 @@ describe('Map', () => {
                 }
             });
 
-            map.once('style.load', () => {
-                map.once('data', (e) => {
-                    if (e.dataType === 'style') {
-                        done();
-                    }
-                });
-
-                map.setLayoutProperty('background', 'visibility', 'visible');
-            });
+            await map.once('style.load');
+            let dataPromise = map.once('data');
+            map.setLayoutProperty('background', 'visibility', 'visible');
+            let e = await dataPromise;
+            expect(e.dataType).toBe('style');
         });
 
         test('sets visibility on background layer', done => {
@@ -2020,17 +2012,14 @@ describe('Map', () => {
         });
     });
 
-    test('no idle event during move', done => {
+    test('no idle event during move', async () => {
         const style = createStyle();
         const map = createMap({style, fadeDuration: 0});
-        map.once('idle', () => {
-            map.zoomTo(0.5, {duration: 100});
-            expect(map.isMoving()).toBeTruthy();
-            map.once('idle', () => {
-                expect(!map.isMoving()).toBeTruthy();
-                done();
-            });
-        });
+        await map.once('idle');
+        map.zoomTo(0.5, {duration: 100});
+        expect(map.isMoving()).toBeTruthy();
+        await map.once('idle');
+        expect(map.isMoving()).toBeFalsy();
     });
 
     test('#removeLayer restores Map#loaded() to true', done => {
@@ -2226,10 +2215,11 @@ describe('Map', () => {
         expect(map.painter.height).toBe(1024);
     });
 
-    test('fires sourcedataabort event on dataabort event', done => {
+    test('fires sourcedataabort event on dataabort event', async () => {
         const map = createMap();
-        map.once('sourcedataabort', () => done());
+        let sourcePromise = map.once('sourcedataabort');
         map.fire(new Event('dataabort'));
+        await sourcePromise;
     });
 
     describe('getCameraTargetElevation', () => {

--- a/src/ui/map.test.ts
+++ b/src/ui/map.test.ts
@@ -1055,7 +1055,7 @@ describe('Map', () => {
         const map = createMap();
 
         await map.once('idle');
-        let renderPromise = map.once('render');
+        const renderPromise = map.once('render');
 
         map.redraw();
         await renderPromise;
@@ -1321,9 +1321,9 @@ describe('Map', () => {
             });
 
             await map.once('style.load');
-            let dataPromise = map.once('data');
+            const dataPromise = map.once('data');
             map.setLayoutProperty('background', 'visibility', 'visible');
-            let e = await dataPromise;
+            const e = await dataPromise;
             expect(e.dataType).toBe('style');
         });
 
@@ -2217,7 +2217,7 @@ describe('Map', () => {
 
     test('fires sourcedataabort event on dataabort event', async () => {
         const map = createMap();
-        let sourcePromise = map.once('sourcedataabort');
+        const sourcePromise = map.once('sourcedataabort');
         map.fire(new Event('dataabort'));
         await sourcePromise;
     });

--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -1165,16 +1165,16 @@ class Map extends Camera {
      * feature in this layer will trigger the listener. The event will have a `features` property containing
      * an array of the matching features.
      * @param {Function} listener The function to be called when the event is fired.
-     * @returns {Map} `this`
+     * @returns {Map | Promise} `this` if listener is provided, promise otherwise to allow easier usage of async/await
      */
     once<T extends keyof MapLayerEventType>(
         type: T,
         layer: string,
-        listener: (ev: MapLayerEventType[T] & Object) => void,
-    ): this;
-    once<T extends keyof MapEventType>(type: T, listener: (ev: MapEventType[T] & Object) => void): this;
-    once(type: MapEvent | string, listener: Listener): this;
-    once(type: MapEvent | string, layerIdOrListener: string | Listener, listener?: Listener): this {
+        listener?: (ev: MapLayerEventType[T] & Object) => void,
+    ): this | Promise<MapLayerEventType[T] & Object>;
+    once<T extends keyof MapEventType>(type: T, listener?: (ev: MapEventType[T] & Object) => void): this | Promise<any>;
+    once(type: MapEvent | string, listener?: Listener): this | Promise<any>;
+    once(type: MapEvent | string, layerIdOrListener: string | Listener, listener?: Listener): this | Promise<any> {
 
         if (listener === undefined) {
             return super.once(type, layerIdOrListener as Listener);

--- a/src/ui/map/requestRenderFrame.test.ts
+++ b/src/ui/map/requestRenderFrame.test.ts
@@ -16,26 +16,22 @@ describe('requestRenderFrame', () => {
         map.remove();
     });
 
-    test('Map#_requestRenderFrame queues a task for the next render frame', done => {
+    test('Map#_requestRenderFrame queues a task for the next render frame', async () => {
         const map = createMap();
         const cb = jest.fn();
         map._requestRenderFrame(cb);
-        map.once('render', () => {
-            expect(cb).toHaveBeenCalledTimes(1);
-            map.remove();
-            done();
-        });
+        await map.once('render');
+        expect(cb).toHaveBeenCalledTimes(1);
+        map.remove();
     });
 
-    test('Map#_cancelRenderFrame cancels a queued task', done => {
+    test('Map#_cancelRenderFrame cancels a queued task', async () => {
         const map = createMap();
         const cb = jest.fn();
         const id = map._requestRenderFrame(cb);
         map._cancelRenderFrame(id);
-        map.once('render', () => {
-            expect(cb).toHaveBeenCalledTimes(0);
-            map.remove();
-            done();
-        });
+        await map.once('render');
+        expect(cb).toHaveBeenCalledTimes(0);
+        map.remove();
     });
 });

--- a/src/util/evented.test.ts
+++ b/src/util/evented.test.ts
@@ -22,6 +22,16 @@ describe('Evented', () => {
 
     });
 
+    test('returns a promise when no listener is provided to "once" method', async () => {
+        const evented = new Evented();
+        const promise = evented.once('a');
+        evented.fire(new Event('a'));
+        evented.fire(new Event('a'));
+        await promise;
+        expect(evented.listens('a')).toBeFalsy();
+
+    });
+
     test('passes data to listeners', () => {
         const evented = new Evented();
         evented.on('a', (data) => {

--- a/src/util/evented.ts
+++ b/src/util/evented.ts
@@ -90,9 +90,12 @@ export class Evented {
      *
      * @param {string} type The event type to listen for.
      * @param {Function} listener The function to be called when the event is fired the first time.
-     * @returns {Object} `this`
+     * @returns {Object} `this` or a promise if a listener is not provided
      */
-    once(type: string, listener: Listener) {
+    once(type: string, listener?: Listener): this | Promise<any> {
+        if (!listener) {
+            return new Promise((resolve) => this.once(type, resolve));
+        }
         this._oneTimeListeners = this._oneTimeListeners || {};
         _addEventListener(type, listener, this._oneTimeListeners);
 


### PR DESCRIPTION
## Launch Checklist

I've added the ability to get a promise from the `once` method when not sending a listener.
This doesn't break the API but extends it.
I've changed some tests to show the that it is more readable (for me at least).

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Write tests for all new functionality.
 - [x] Document any changes to public APIs.
 - [x] Add an entry inside this element for inclusion in the `maplibre-gl-js` changelog: `<changelog></changelog>`.
