### PR TITLE
Fix GeoJSONSource appearing to never finish loading when calling its setData method immediately after adding it to a Map due to it not firing a metadata data event (#1693)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - *...Add new stuff here...*
 
 ### 🐞 Bug fixes
+- Fix `GeoJSONSource` appearing to never finish loading when calling its `setData` method immediately after adding it to a `Map` due to it not firing a `metadata` `data` event ([#1693](https://github.com/maplibre/maplibre-gl-js/issues/1693))
 - *...Add new stuff here...*
 
 ## 3.0.0-pre.0

--- a/src/source/geojson_source.test.ts
+++ b/src/source/geojson_source.test.ts
@@ -305,6 +305,24 @@ describe('GeoJSONSource#update', () => {
         source.load();
     });
 
+    test('fires metadata data event even when initial request is aborted', done => {
+        let requestCount = 0;
+        const mockDispatcher = wrapDispatcher({
+            send(message, args, callback) {
+                setTimeout(() => callback(null, {abandoned: requestCount++ === 0}));
+            }
+        });
+
+        const source = new GeoJSONSource('id', {data: {}} as GeoJSONSourceOptions, mockDispatcher, undefined);
+
+        source.on('data', e => {
+            if (e.sourceDataType === 'metadata') done();
+        });
+
+        source.load();
+        source.setData({} as GeoJSON.GeoJSON);
+    });
+
     test('fires "error"', done => {
         const mockDispatcher = wrapDispatcher({
             send(message, args, callback) {

--- a/src/source/geojson_source.ts
+++ b/src/source/geojson_source.ts
@@ -12,7 +12,6 @@ import type Tile from './tile';
 import type Actor from '../util/actor';
 import type {Callback} from '../types/callback';
 import type {GeoJSONSourceSpecification, PromoteIdSpecification} from '../style-spec/types.g';
-import type {MapSourceDataType} from '../ui/events';
 import type {GeoJSONSourceDiff} from './geojson_source_diff';
 
 export type GeoJSONSourceOptions = GeoJSONSourceSpecification & {


### PR DESCRIPTION
<changelog>Fix `GeoJSONSource` appearing to never finish loading when calling its `setData` method immediately after adding it to a `Map` due to it not firing a `metadata` `data` event</changelog>

## Launch Checklist

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Write tests for all new functionality.
 - [x] Add an entry inside this element for inclusion in the `maplibre-gl-js` changelog: `<changelog></changelog>`.
