### PR TITLE
Fixes missing setTerrain method for benchmarks

### DIFF
--- a/test/bench/lib/tile_parser.ts
+++ b/test/bench/lib/tile_parser.ts
@@ -29,6 +29,8 @@ class StubMap extends Evented {
     getPixelRatio() {
         return devicePixelRatio;
     }
+
+    setTerrain() {}
 }
 
 function createStyle(styleJSON: StyleSpecification): Promise<Style> {


### PR DESCRIPTION
Fixes #1709 - benchmarks are broken.
I hope as this needs to be merged to main and then see that it creates the relevant file...
