### PR TITLE
Fix headless benchmark execution especially on VM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### 🐞 Bug fixes
 - *...Add new stuff here...*
 - Add dev version for csp build ([#1730](https://github.com/maplibre/maplibre-gl-js/pull/1730))
+- Fix headless benchmark execution especially on VM ([#1732](https://github.com/maplibre/maplibre-gl-js/pull/1732))
 
 ## 3.0.0-pre.1
 


### PR DESCRIPTION
When working on VM (or various weak hardware), certain headless benchmark tests may fail to execute. Currently the execution just throws null exception and stops the rest. This fix ignores the failed ones and continue.
Cosmetic: one-line lambda and nested tertiary are difficult to set breakpoint and debug, so they are changed to if statements.

## Launch Checklist
 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Post benchmark scores.
 - [x] Add an entry to `CHANGELOG.md` under the `## main` section.
