### PR TITLE
fix: contraint zoom >= 0

### DIFF
--- a/src/geo/transform.ts
+++ b/src/geo/transform.ts
@@ -196,7 +196,7 @@ class Transform {
 
     get zoom(): number { return this._zoom; }
     set zoom(zoom: number) {
-        const z = Math.min(Math.max(zoom, this.minZoom), this.maxZoom);
+        const z = Math.min(Math.max(zoom, this.minZoom, 0), this.maxZoom);
         if (this._zoom === z) return;
         this._unmodified = false;
         this._zoom = z;


### PR DESCRIPTION
MapLibre allows negative zoom. Putting a constraint that zoom always must be greater than 0.

Example http://localhost:9966/test/debug-pages/terrain-osm.html#-0.07/0/32.8

If we add this constraint and test the example, the zoom will change to 0

Also, this will fix issue #1650 
