### PR TITLE
Fix test fails on Windows 11 platform: "test-render custom-layer-js/depth" and "test-render custom-layer-js/null-island"

### DIFF
--- a/test/integration/render/custom_layer_implementations.ts
+++ b/test/integration/render/custom_layer_implementations.ts
@@ -37,7 +37,7 @@ class NullIsland {
     }
 
     render(gl, matrix) {
-        const vertexArray = new Float32Array([ 0.5, 0.5, 0.0 ]);
+        const vertexArray = new Float32Array([0.5, 0.5, 0.0]);
         gl.useProgram(this.program);
         const vertexBuffer = gl.createBuffer();
         gl.bindBuffer(gl.ARRAY_BUFFER, vertexBuffer);

--- a/test/integration/render/custom_layer_implementations.ts
+++ b/test/integration/render/custom_layer_implementations.ts
@@ -11,9 +11,10 @@ class NullIsland {
 
     onAdd(map, gl: WebGLRenderingContext) {
         const vertexSource = `
+        attribute vec3 aPos;
         uniform mat4 u_matrix;
         void main() {
-            gl_Position = u_matrix * vec4(0.5, 0.5, 0.0, 1.0);
+            gl_Position = u_matrix * vec4(aPos, 1.0);
             gl_PointSize = 20.0;
         }`;
 
@@ -36,7 +37,14 @@ class NullIsland {
     }
 
     render(gl, matrix) {
+        const vertexArray = new Float32Array([ 0.5, 0.5, 0.0 ]);
         gl.useProgram(this.program);
+        const vertexBuffer = gl.createBuffer();
+        gl.bindBuffer(gl.ARRAY_BUFFER, vertexBuffer);
+        gl.bufferData(gl.ARRAY_BUFFER, vertexArray, gl.STATIC_DRAW);
+        const posAttrib = gl.getAttribLocation(this.program, 'aPos');
+        gl.enableVertexAttribArray(posAttrib);
+        gl.vertexAttribPointer(posAttrib, 3, gl.FLOAT, false, 0, 0);
         gl.uniformMatrix4fv(gl.getUniformLocation(this.program, 'u_matrix'), false, matrix);
         gl.drawArrays(gl.POINTS, 0, 1);
     }


### PR DESCRIPTION
<changelog>
The following 2 tests fail on Windows platform but pass on Linux.

1. test-render custom-layer-js/depth
2. test-render custom-layer-js/null-island

Possibly resulted by a bug/optimization results to WebGL Shaders from headless-gl/Chrome Angle(WebGL simulator for Node.js).

We found a same purpose fix in test-render custom-layer-js/tent-3d, and ported from there.

Have verified that the 2 tests can pass both on Windows 11 and WSL.
</changelog>

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [X] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [X] Briefly describe the changes in this PR.
 - [ ] Link to related issues.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [ ] Manually test the debug page.
 - [ ] Add an entry to `CHANGELOG.md` under the `## main` section.
