### PR TITLE
Make sure coop-gesture overlay always on top

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### ✨ Features and improvements
 - *...Add new stuff here...*
 - Listen to webglcontextcreationerror event and give detailed debug info when it fails ([#1715](https://github.com/maplibre/maplibre-gl-js/pull/1715))
+- Make sure `cooperativeGestures` overlay is always "on top" (z-index) of map features ([#1753](https://github.com/maplibre/maplibre-gl-js/pull/1753))
 
 ### 🐞 Bug fixes
 - *...Add new stuff here...*

--- a/src/css/maplibre-gl.css
+++ b/src/css/maplibre-gl.css
@@ -789,6 +789,7 @@ a.maplibregl-ctrl-logo.maplibregl-compact {
     opacity: 0;
     pointer-events: none;
     transition: opacity 1s ease 1s;
+    z-index: 99999;
 }
 
 .maplibregl-cooperative-gesture-screen.maplibregl-show {


### PR DESCRIPTION
Add a high z-index to the `cooperativeGesture` overlay. 
This make sure that, e.g, popups in a map, always is below the overlay.

CooperativeGestures introduced in #1234 

### Before
![image](https://user-images.githubusercontent.com/68547893/196639950-36a8468b-cb80-40ee-bf46-da1cf1df07de.png)


### After
![image](https://user-images.githubusercontent.com/68547893/196639985-3b2b6ceb-fca8-4fe2-9dbc-628664319115.png)

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [x] Include before/after visuals or gifs if this PR includes visual changes.