### PR TITLE
Set navigationOptions as optional in NavigationControl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### ✨ Features and improvements
 - *...Add new stuff here...*
+- NavigationControlOptions is now optional when creating an instance of NavigationControl ([#1754](https://github.com/maplibre/maplibre-gl-js/issues/1754))
 - Listen to webglcontextcreationerror event and give detailed debug info when it fails ([#1715](https://github.com/maplibre/maplibre-gl-js/pull/1715))
 - Make sure `cooperativeGestures` overlay is always "on top" (z-index) of map features ([#1753](https://github.com/maplibre/maplibre-gl-js/pull/1753))
 

--- a/src/ui/control/navigation_control.test.ts
+++ b/src/ui/control/navigation_control.test.ts
@@ -1,0 +1,58 @@
+import {createMap as globalCreateMap, setWebGlContext, setPerformance} from '../../util/test/util';
+import NavigationControl from './navigation_control';
+
+function createMap() {
+    return globalCreateMap({
+        style: {
+            version: 8,
+            owner: 'mapblibre',
+            id: 'demotiles',
+        }
+    });
+}
+
+let map;
+
+beforeEach(() => {
+    setWebGlContext();
+    setPerformance();
+    map = createMap();
+});
+
+afterEach(() => {
+    map.remove();
+});
+
+describe('NavigationControl', () => {
+    test('appears in the top-right', () => {
+        map.addControl(new NavigationControl());
+
+        expect(
+            map.getContainer().querySelectorAll('.maplibregl-ctrl-top-right > .maplibregl-ctrl')
+        ).toHaveLength(1);
+    });
+
+    test('contains zoom in button', () => {
+        map.addControl(new NavigationControl());
+
+        expect(
+            map.getContainer().querySelectorAll('.maplibregl-ctrl-zoom-in')
+        ).toHaveLength(1);
+    });
+
+    test('contains zoom out button', () => {
+        map.addControl(new NavigationControl());
+
+        expect(
+            map.getContainer().querySelectorAll('.maplibregl-ctrl-zoom-out')
+        ).toHaveLength(1);
+    });
+
+    test('contains compass button', () => {
+        map.addControl(new NavigationControl());
+
+        expect(
+            map.getContainer().querySelectorAll('.maplibregl-ctrl-compass')
+        ).toHaveLength(1);
+    });
+});

--- a/src/ui/control/navigation_control.ts
+++ b/src/ui/control/navigation_control.ts
@@ -43,7 +43,7 @@ class NavigationControl implements IControl {
     _compassIcon: HTMLElement;
     _handler: MouseRotateWrapper;
 
-    constructor(options: NavigationOptions) {
+    constructor(options?: NavigationOptions) {
         this.options = extend({}, defaultOptions, options);
 
         this._container = DOM.create('div', 'maplibregl-ctrl maplibregl-ctrl-group');


### PR DESCRIPTION
This fix the #1754. The `NavigationControl` constructor should receive options as optional, this avoid to instantiate the class passing an empty object.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [ ] Manually test the debug page.
 - [x] Add an entry to `CHANGELOG.md` under the `## main` section.
