### PR TITLE
Short-circuit the rendering of fully transparent symbol tiles.

### DIFF
--- a/src/data/bucket/symbol_bucket.ts
+++ b/src/data/bucket/symbol_bucket.ts
@@ -175,6 +175,7 @@ export class SymbolBuffers {
 
     opacityVertexArray: SymbolOpacityArray;
     opacityVertexBuffer: VertexBuffer;
+    hasVisibleVertices: boolean;
 
     collisionVertexArray: CollisionVertexArray;
     collisionVertexBuffer: VertexBuffer;
@@ -188,6 +189,7 @@ export class SymbolBuffers {
         this.segments = new SegmentVector();
         this.dynamicLayoutVertexArray = new SymbolDynamicLayoutArray();
         this.opacityVertexArray = new SymbolOpacityArray();
+        this.hasVisibleVertices = false;
         this.placedSymbolArray = new PlacedSymbolArray();
     }
 

--- a/src/render/draw_symbol.test.ts
+++ b/src/render/draw_symbol.test.ts
@@ -71,7 +71,8 @@ describe('drawSymbol', () => {
             },
             segments: {
                 get: () => [1]
-            }
+            },
+            hasVisibleVertices: true
         } as any;
         bucketMock.iconSizeData = {
             kind: 'constant',
@@ -132,7 +133,8 @@ describe('drawSymbol', () => {
             },
             segments: {
                 get: () => [1]
-            }
+            },
+            hasVisibleVertices: true
         } as any;
         bucketMock.iconSizeData = {
             kind: 'constant',

--- a/src/render/draw_symbol.ts
+++ b/src/render/draw_symbol.ts
@@ -291,7 +291,7 @@ function drawLayerSymbols(
         const bucket = tile.getBucket(layer) as SymbolBucket;
         if (!bucket) continue;
         const buffers = isText ? bucket.text : bucket.icon;
-        if (!buffers || !buffers.segments.get().length) continue;
+        if (!buffers || !buffers.segments.get().length || !buffers.hasVisibleVertices) continue;
         const programConfiguration = buffers.programConfigurations.get(layer.id);
 
         const isSDF = isText || bucket.sdfIcons;

--- a/src/symbol/placement.ts
+++ b/src/symbol/placement.ts
@@ -946,8 +946,14 @@ export class Placement {
     updateBucketOpacities(bucket: SymbolBucket, seenCrossTileIDs: {
         [k in string | number]: boolean;
     }, collisionBoxArray?: CollisionBoxArray | null) {
-        if (bucket.hasTextData()) bucket.text.opacityVertexArray.clear();
-        if (bucket.hasIconData()) bucket.icon.opacityVertexArray.clear();
+        if (bucket.hasTextData()) {
+            bucket.text.opacityVertexArray.clear();
+            bucket.text.hasVisibleVertices = false;
+        }
+        if (bucket.hasIconData()) {
+            bucket.icon.opacityVertexArray.clear();
+            bucket.icon.hasVisibleVertices = false;
+        }
         if (bucket.hasIconCollisionBoxData()) bucket.iconCollisionBox.collisionVertexArray.clear();
         if (bucket.hasTextCollisionBoxData()) bucket.textCollisionBox.collisionVertexArray.clear();
 
@@ -976,6 +982,7 @@ export class Placement {
             for (let i = 0; i < numVertices / 4; i++) {
                 iconOrText.opacityVertexArray.emplaceBack(opacity);
             }
+            iconOrText.hasVisibleVertices = iconOrText.hasVisibleVertices || (opacity !== PACKED_HIDDEN_OPACITY);
         };
 
         for (let s = 0; s < bucket.symbolInstances.length; s++) {


### PR DESCRIPTION
When there are large clusters of colliding symbolic icons and labels, many of them are culled by being set fully transparent but their geometry is still rendered. In some cases, entire tiles full of symbols can be made transparent but are still rendered. This change looks for those fully transparent symbol tiles and avoids rendering them at all which can greatly reduce GL context commands (including draws). For example, for Bing Maps in downtown Seattle at LOD 17 the total number of rendering commands can be reduced by 20-25% with this change.

## Launch Checklist

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to [related issues](https://github.com/maplibre/maplibre-gl-js/issues/96).
 - [ ] (n/a) Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] (n/a) Write tests for all new functionality.
 - [ ] (n/a) Document any changes to public APIs.
 - [x] Post benchmark scores. 
 ![benchmark result](https://raw.githubusercontent.com/AdamSzofranMSFT/maplibre-gl-js/users/AdamSzofranMSFT/PR-data/users/AdamSzofranMSFT/LayerSymbolWithSortKey-benchmark-1376b12.png)
 - [x] Manually test the debug page.
 - [ ] Add an entry to `CHANGELOG.md` under the `## main` section.
