### PR TITLE
Add new map option refreshServerErrorTiles 

### DIFF
--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -108,6 +108,7 @@ export type MapOptions = {
     style: StyleSpecification | string;
     pitchWithRotate?: boolean;
     pixelRatio?: number;
+    refreshServerErrorTiles?: number;
 };
 
 export type GestureOptions = {
@@ -174,7 +175,8 @@ const defaultOptions = {
     localIdeographFontFamily: 'sans-serif',
     transformRequest: null,
     fadeDuration: 300,
-    crossSourceCollisions: true
+    crossSourceCollisions: true,
+    refreshServerErrorTiles: 0,
 } as CompleteMapOptions;
 
 /**
@@ -311,6 +313,7 @@ class Map extends Camera {
     _failIfMajorPerformanceCaveat: boolean;
     _antialias: boolean;
     _refreshExpiredTiles: boolean;
+    _refreshServerErrorTiles: number;
     _hash: Hash;
     _delegatedListeners: any;
     _fadeDuration: number;
@@ -409,6 +412,7 @@ class Map extends Camera {
         this._trackResize = options.trackResize;
         this._bearingSnap = options.bearingSnap;
         this._refreshExpiredTiles = options.refreshExpiredTiles;
+        this._refreshServerErrorTiles = options.refreshServerErrorTiles;
         this._fadeDuration = options.fadeDuration;
         this._crossSourceCollisions = options.crossSourceCollisions;
         this._crossFadingFactor = 1;


### PR DESCRIPTION
which is the number of milliseconds to wait before retrying tiles that caused server errors

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [ ] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [ ] Briefly describe the changes in this PR.
 - [ ] Link to related issues.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [ ] Manually test the debug page.
 - [ ] Add an entry to `CHANGELOG.md` under the `## main` section.
