### PR TITLE
bump rollup-plugin-import-assert to fix sourcemaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 - Fix headless benchmark execution especially on VM ([#1732](https://github.com/maplibre/maplibre-gl-js/pull/1732))
 - fix issue [#860](https://github.com/maplibre/maplibre-gl-js/issues/860) fill-pattern with pixelRatio > 1 is now switched correctly at runtime. ([#1765](https://github.com/maplibre/maplibre-gl-js/pull/1765))
 - Fix the exception that would be thrown on `map.setStyle` when it is passed with transformStyle option and map is initialized without an initial style. ([#1824](https://github.com/maplibre/maplibre-gl-js/pull/1824))
+- fix issue [#1582](https://github.com/maplibre/maplibre-gl-js/issues/1582) source maps are now properly generated
+
 ## 3.0.0-pre.1
 
 ### ✨ Features and improvements

--- a/package-lock.json
+++ b/package-lock.json
@@ -115,7 +115,7 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "rollup": "^2.79.1",
-        "rollup-plugin-import-assert": "^2.1.0",
+        "rollup-plugin-import-assert": "^2.1.3",
         "rollup-plugin-sourcemaps": "^0.6.3",
         "rollup-plugin-terser": "^7.0.2",
         "rw": "^1.3.3",
@@ -14309,9 +14309,9 @@
       }
     },
     "node_modules/rollup-plugin-import-assert": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-import-assert/-/rollup-plugin-import-assert-2.1.0.tgz",
-      "integrity": "sha512-+wb5BTdsZgbhVsshKuJzm30OCbwwlESLik74xs3oNfyOMDcEsiuQIwvRqabU0IM/NkgIRcgaB5Jd3fpRbMAc1w==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-import-assert/-/rollup-plugin-import-assert-2.1.3.tgz",
+      "integrity": "sha512-VWqxMWoJSoX9ZwzigYXWMN6iwNInwnK72FZ500eYTh91VtusZohMdTBm0h+xfnxAQUtuJiKv1dCRMSuwL5bo7Q==",
       "dev": true,
       "dependencies": {
         "string-to-template-literal": "^0.2.2"
@@ -27370,9 +27370,9 @@
       }
     },
     "rollup-plugin-import-assert": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-import-assert/-/rollup-plugin-import-assert-2.1.0.tgz",
-      "integrity": "sha512-+wb5BTdsZgbhVsshKuJzm30OCbwwlESLik74xs3oNfyOMDcEsiuQIwvRqabU0IM/NkgIRcgaB5Jd3fpRbMAc1w==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-import-assert/-/rollup-plugin-import-assert-2.1.3.tgz",
+      "integrity": "sha512-VWqxMWoJSoX9ZwzigYXWMN6iwNInwnK72FZ500eYTh91VtusZohMdTBm0h+xfnxAQUtuJiKv1dCRMSuwL5bo7Q==",
       "dev": true,
       "requires": {
         "string-to-template-literal": "^0.2.2"

--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "rollup": "^2.79.1",
-    "rollup-plugin-import-assert": "^2.1.0",
+    "rollup-plugin-import-assert": "^2.1.3",
     "rollup-plugin-sourcemaps": "^0.6.3",
     "rollup-plugin-terser": "^7.0.2",
     "rw": "^1.3.3",


### PR DESCRIPTION
This PR just bumps `rollup-plugin-import-assert` to fix the sourcemaps. Fix was in this PR: https://github.com/calebdwilliams/rollup-plugin-import-assert/pull/8

Fixes #1582

Note: the release that includes the change doesn't include in the built distribution, so keeping it in draft until that's fixed. Context here: https://github.com/calebdwilliams/rollup-plugin-import-assert/pull/8#issuecomment-1292847070

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [ ] Manually test the debug page.
 - [ ] Add an entry to `CHANGELOG.md` under the `## main` section.
