### PR TITLE
Partial source_cache invalidation from geojson_source

### DIFF
--- a/src/source/geojson_source.ts
+++ b/src/source/geojson_source.ts
@@ -295,7 +295,7 @@ class GeoJSONSource extends Evented implements Source {
                 return;
             }
 
-            const data: any = {dataType: 'source', invalidated: result.invalidated ? TileBitmask.deserialize(result.invalidated) : undefined};
+            const data: any = {dataType: 'source', invalidated: result?.invalidated ? TileBitmask.deserialize(result.invalidated) : undefined};
             if (this._collectResourceTiming && resourceTiming && resourceTiming.length > 0)
                 extend(data, {resourceTiming});
 

--- a/src/source/geojson_source.ts
+++ b/src/source/geojson_source.ts
@@ -13,6 +13,7 @@ import type Actor from '../util/actor';
 import type {Callback} from '../types/callback';
 import type {GeoJSONSourceSpecification, PromoteIdSpecification} from '../style-spec/types.g';
 import type {GeoJSONSourceDiff} from './geojson_source_diff';
+import {TileBitmask} from '../util/tile_bitmask';
 
 export type GeoJSONSourceOptions = GeoJSONSourceSpecification & {
     workerOptions?: any;
@@ -294,7 +295,7 @@ class GeoJSONSource extends Evented implements Source {
                 return;
             }
 
-            const data: any = {dataType: 'source'};
+            const data: any = {dataType: 'source', invalidated: result.invalidated ? TileBitmask.deserialize(result.invalidated) : undefined};
             if (this._collectResourceTiming && resourceTiming && resourceTiming.length > 0)
                 extend(data, {resourceTiming});
 

--- a/src/source/geojson_source_diff.ts
+++ b/src/source/geojson_source_diff.ts
@@ -173,6 +173,13 @@ function markInvalidated(updateable: Map<GeoJSONFeatureId, GeoJSON.Feature>, id:
     }
 
     const [minX, minY, maxX, maxY] = bbox;
+
+    // if the feature crosses the antimeridian, just give up and invalidate the world
+    if (minX < -180 || minY < -90 || maxX > 180 || maxY > 90) {
+        invalidated.mark(0, 0, 0);
+        return;
+    }
+
     let minTileX = convertToTileCoord(mercatorXfromLng(minX));
     let minTileY = convertToTileCoord(mercatorYfromLat(minY));
     let maxTileX = convertToTileCoord(mercatorXfromLng(maxX));

--- a/src/source/geojson_source_diff.ts
+++ b/src/source/geojson_source_diff.ts
@@ -1,3 +1,4 @@
+import { mercatorXfromLng, mercatorYfromLat } from '../geo/mercator_coordinate';
 import {TileBitmask} from '../util/tile_bitmask';
 
 export type GeoJSONFeatureId = number | string;
@@ -172,10 +173,10 @@ function markInvalidated(updateable: Map<GeoJSONFeatureId, GeoJSON.Feature>, id:
     }
 
     const [minX, minY, maxX, maxY] = bbox;
-    let minTileX = convertToTileCoord(minX);
-    let minTileY = convertToTileCoord(minY);
-    let maxTileX = convertToTileCoord(maxX);
-    let maxTileY = convertToTileCoord(maxY);
+    let minTileX = convertToTileCoord(mercatorXfromLng(minX));
+    let minTileY = convertToTileCoord(mercatorYfromLat(minY));
+    let maxTileX = convertToTileCoord(mercatorXfromLng(maxX));
+    let maxTileY = convertToTileCoord(mercatorYfromLat(maxY));
     let zoom = TileBitmask.MaxZoom;
     // zoom out here to avoid having to compact ancestors in the tile bitmask
     while (zoom > 0 && maxTileX > 2 + minTileX && maxTileY > 2 + minTileY) {
@@ -196,8 +197,8 @@ function convertToTileCoord(val: number): number {
     const result = Math.floor(val * TileBitmask.MaxZoomTiles);
     if (result < 0) {
         return 0;
-    } else if (result > TileBitmask.MaxZoomTiles) {
-        return TileBitmask.MaxZoomTiles;
+    } else if (result >= TileBitmask.MaxZoomTiles) {
+        return TileBitmask.MaxZoomTiles - 1;
     } else {
         return result;
     }

--- a/src/source/geojson_source_diff.ts
+++ b/src/source/geojson_source_diff.ts
@@ -1,4 +1,4 @@
-import { mercatorXfromLng, mercatorYfromLat } from '../geo/mercator_coordinate';
+import {mercatorXfromLng, mercatorYfromLat} from '../geo/mercator_coordinate';
 import {TileBitmask} from '../util/tile_bitmask';
 
 export type GeoJSONFeatureId = number | string;

--- a/src/ui/events.ts
+++ b/src/ui/events.ts
@@ -7,6 +7,7 @@ import {extend} from '../util/util';
 import type Map from './map';
 import type LngLat from '../geo/lng_lat';
 import {SourceSpecification} from '../style-spec/types.g';
+import { TileBitmask } from '../util/tile_bitmask';
 
 export type MapLayerMouseEvent = MapMouseEvent & { features?: GeoJSON.Feature[] };
 
@@ -48,6 +49,7 @@ export interface MapSourceDataEvent extends MapLibreEvent {
     sourceId: string;
     sourceDataType: MapSourceDataType;
     tile: any;
+    invalidated?: TileBitmask;
 }
 /**
  * `MapMouseEvent` is the event type for mouse-related map events.

--- a/src/ui/events.ts
+++ b/src/ui/events.ts
@@ -7,7 +7,7 @@ import {extend} from '../util/util';
 import type Map from './map';
 import type LngLat from '../geo/lng_lat';
 import {SourceSpecification} from '../style-spec/types.g';
-import { TileBitmask } from '../util/tile_bitmask';
+import {TileBitmask} from '../util/tile_bitmask';
 
 export type MapLayerMouseEvent = MapMouseEvent & { features?: GeoJSON.Feature[] };
 

--- a/src/util/tile_bitmask.test.ts
+++ b/src/util/tile_bitmask.test.ts
@@ -1,0 +1,36 @@
+import {CanonicalTileID} from '../source/tile_id';
+import {TileBitmask} from './tile_bitmask';
+
+describe('tile_bitmask', () => {
+    test('basic direct sets', done => {
+        const invalidated = new TileBitmask();
+        invalidated.mark(1, 0, 0);
+        expect(invalidated.isMarked(new CanonicalTileID(1, 0, 0))).toBeTruthy();
+        expect(invalidated.isMarked(new CanonicalTileID(0, 0, 0))).toBeTruthy();
+        expect(invalidated.isMarked(new CanonicalTileID(1, 1, 0))).toBeFalsy();
+        done();
+    });
+
+    test('basic direct sets survives serialization', done => {
+        const source = new TileBitmask();
+        source.mark(1, 0, 0);
+        const serialized = source.serialize();
+        const invalidated = TileBitmask.deserialize(serialized);
+
+        expect(invalidated.isMarked(new CanonicalTileID(1, 0, 0))).toBeTruthy();
+        expect(invalidated.isMarked(new CanonicalTileID(0, 0, 0))).toBeTruthy();
+        expect(invalidated.isMarked(new CanonicalTileID(1, 1, 0))).toBeFalsy();
+        done();
+    });
+
+    test('sets past max zoom', done => {
+        const source = new TileBitmask();
+        source.mark(8, 0, 0);
+        const serialized = source.serialize();
+        const invalidated = TileBitmask.deserialize(serialized);
+        expect(invalidated.isMarked(new CanonicalTileID(8, 0, 0))).toBeTruthy();
+        expect(invalidated.isMarked(new CanonicalTileID(7, 0, 0))).toBeTruthy();
+        expect(invalidated.isMarked(new CanonicalTileID(8, 4, 0))).toBeFalsy();
+        done();
+    });
+});

--- a/src/util/tile_bitmask.ts
+++ b/src/util/tile_bitmask.ts
@@ -1,0 +1,172 @@
+import {CanonicalTileID} from '../source/tile_id';
+
+const InvalidationTreeDepth = 7;
+
+function packTileCoord(zoom: number, x: number, y: number): number {
+    return (zoom << (2 * InvalidationTreeDepth)) | (x << InvalidationTreeDepth) | y;
+}
+
+function unpackTileCoord(coord: number): { zoom: number; x: number; y: number } {
+    const mask = (1 << InvalidationTreeDepth) - 1;
+    return {
+        zoom: coord >> (2 * InvalidationTreeDepth),
+        x: (coord >> InvalidationTreeDepth) & mask,
+        y: coord & mask,
+    };
+}
+
+enum Composition {
+    MIXED = 0,
+    MARKED = 1,
+}
+
+export type SerializedTileBitmask = Int32Array;
+
+/**
+ * Stores a mask of tile coordinates as a quadtree.
+ */
+export class TileBitmask {
+    /**
+     * Maximum zoom level tracked by this tree, inclusive.
+     */
+    public static readonly MaxZoom = InvalidationTreeDepth - 1;
+    /**
+     * Number of tiles along a single axis at the maximum zoom level.
+     */
+    public static readonly MaxZoomTiles = 1 << TileBitmask.MaxZoom;
+
+    private readonly tree: Map<number, Composition>;
+
+    constructor() {
+        this.tree = new Map<number, Composition>();
+    }
+
+    public isMarked(tileId: CanonicalTileID): boolean {
+        const {z: zoom, x, y} = tileId;
+        for (let z = 0; z <= TileBitmask.MaxZoom; z++) {
+            const zoomedX = x >> (zoom - z);
+            const zoomedY = y >> (zoom - z);
+            const composition = this.tree.get(packTileCoord(z, zoomedX, zoomedY));
+            if (composition == null) {
+                return false;
+            }
+            if (z === zoom || composition !== Composition.MIXED) {
+                return true;
+            }
+        }
+        throw new Error(`Invalid quadtree: Request for ${zoom} ${x} ${y} ran off the end of the tree`);
+    }
+
+    /**
+     * Clears all descendants of a tile from the tree.  This can be used after setting the composition of a tile
+     * to MARKED (since that implies that all descendants are also MARKED)
+     * @param zoom
+     * @param x
+     * @param y
+     */
+    private clearDescendants(zoom: number, x: number, y: number) {
+        if (zoom >= TileBitmask.MaxZoom) {
+            return;
+        }
+
+        const rootX = x << 1;
+        const rootY = y << 1;
+        for (let childX = rootX; childX <= rootX + 1; childX++) {
+            for (let childY = rootY; childY <= rootY + 1; childY++) {
+                if (this.tree.delete(packTileCoord(zoom + 1, childX, childY))) {
+                    this.clearDescendants(zoom + 1, childX, childY);
+                }
+            }
+        }
+    }
+
+    /**
+     * Used after marking a tile to compact the quadtree for the case where all 4 children of a tile are marked, by
+     * replacing the 4 marked children with a single marked parent.
+     * @param zoom
+     * @param x
+     * @param y
+     */
+    private compactAncestors(zoom: number, x: number, y: number) {
+        while (zoom > 0) {
+            const rootX = x & ~1;
+            const rootY = y & ~1;
+            // check that all siblings are marked
+            for (let siblingX = rootX; siblingX <= rootX + 1; siblingX++) {
+                for (let siblingY = rootY; siblingY <= rootY + 1; siblingY++) {
+                    const siblingComposition = this.tree.get(packTileCoord(zoom, siblingX, siblingY));
+                    if (siblingComposition !== Composition.MARKED) {
+                        return;
+                    }
+                }
+            }
+            // delete entries for all siblings
+            for (let siblingX = rootX; siblingX <= rootX + 1; siblingX++) {
+                for (let siblingY = rootY; siblingY <= rootY + 1; siblingY++) {
+                    this.tree.delete(packTileCoord(zoom, siblingX, siblingY));
+                }
+            }
+            // set parent as marked
+            zoom--;
+            x >>= 1;
+            y >>= 1;
+            this.tree.set(packTileCoord(zoom, x, y), Composition.MARKED);
+            // continue to visit the parent's parent
+        }
+    }
+
+    public mark(zoom: number, x: number, y: number) {
+        const insertZoom = Math.min(TileBitmask.MaxZoom, zoom);
+        for (let z = 0; z <= insertZoom; z++) {
+            const zoomedX = x >> (zoom - z);
+            const zoomedY = y >> (zoom - z);
+            const key = packTileCoord(z, zoomedX, zoomedY);
+            const composition = this.tree.get(key);
+            if (composition === Composition.MARKED) {
+                // subtree already marked so we can early exit
+                return;
+            }
+            if (z === insertZoom) {
+                this.tree.set(key, Composition.MARKED);
+                this.clearDescendants(z, zoomedX, zoomedY);
+                this.compactAncestors(z, zoomedX, zoomedY);
+                return;
+            }
+            if (composition !== Composition.MIXED) {
+                this.tree.set(key, Composition.MIXED);
+            }
+        }
+        throw new Error(`Invalid quadtree: Mark request for ${zoom} ${x} ${y} ran off the end of the tree`);
+    }
+
+    /**
+     * Slow debugging method that gets all definitively marked tiles.
+     */
+    public getMarkedTiles() {
+        const markedTiles = [];
+        for (const [key, val] of this.tree.entries()) {
+            if (val !== Composition.MARKED) {
+                continue;
+            }
+            markedTiles.push(unpackTileCoord(key));
+        }
+        return markedTiles;
+    }
+
+    public serialize(): SerializedTileBitmask {
+        const buffer = new Int32Array(this.tree.size);
+        let i = 0;
+        for (const [key, val] of this.tree.entries()) {
+            buffer[i++] = (key << 2) | val;
+        }
+        return buffer;
+    }
+
+    public static deserialize(ser: SerializedTileBitmask): TileBitmask {
+        const result = new TileBitmask();
+        for (const key of ser) {
+            result.tree.set(key >> 2, key & 3);
+        }
+        return result;
+    }
+}

--- a/src/util/tile_bitmask.ts
+++ b/src/util/tile_bitmask.ts
@@ -6,15 +6,6 @@ function packTileCoord(zoom: number, x: number, y: number): number {
     return (zoom << (2 * InvalidationTreeDepth)) | (x << InvalidationTreeDepth) | y;
 }
 
-function unpackTileCoord(coord: number): { zoom: number; x: number; y: number } {
-    const mask = (1 << InvalidationTreeDepth) - 1;
-    return {
-        zoom: coord >> (2 * InvalidationTreeDepth),
-        x: (coord >> InvalidationTreeDepth) & mask,
-        y: coord & mask,
-    };
-}
-
 enum Composition {
     MIXED = 0,
     MARKED = 1,
@@ -60,9 +51,9 @@ export class TileBitmask {
     /**
      * Clears all descendants of a tile from the tree.  This can be used after setting the composition of a tile
      * to MARKED (since that implies that all descendants are also MARKED)
-     * @param zoom
-     * @param x
-     * @param y
+     * @param zoom tile zoom
+     * @param x tile x
+     * @param y tile y
      */
     private clearDescendants(zoom: number, x: number, y: number) {
         if (zoom >= TileBitmask.MaxZoom) {
@@ -83,9 +74,9 @@ export class TileBitmask {
     /**
      * Used after marking a tile to compact the quadtree for the case where all 4 children of a tile are marked, by
      * replacing the 4 marked children with a single marked parent.
-     * @param zoom
-     * @param x
-     * @param y
+     * @param zoom tile zoom
+     * @param x tile x
+     * @param y tile y
      */
     private compactAncestors(zoom: number, x: number, y: number) {
         while (zoom > 0) {
@@ -137,20 +128,6 @@ export class TileBitmask {
             }
         }
         throw new Error(`Invalid quadtree: Mark request for ${zoom} ${x} ${y} ran off the end of the tree`);
-    }
-
-    /**
-     * Slow debugging method that gets all definitively marked tiles.
-     */
-    public getMarkedTiles() {
-        const markedTiles = [];
-        for (const [key, val] of this.tree.entries()) {
-            if (val !== Composition.MARKED) {
-                continue;
-            }
-            markedTiles.push(unpackTileCoord(key));
-        }
-        return markedTiles;
     }
 
     public serialize(): SerializedTileBitmask {


### PR DESCRIPTION
Follow-on work to #1236 which lets us skip recomputing tiles that we know have not changed.

Introduce TileBitmask which keeps track of the tiles that actually changed.
Consume TileBitmask in the geojson_worker_source to keep track of the changes we send through in a diff.
Pass this back to the main thread into source_cache to selectively invalidate tiles instead of hitting all of them.

How well this works depends on the usage patterns. For the geojson-update debug page it looked like we were able to skip invalidating individual tiles about 40% of the time at a zoomed out view, but about 85% of the time when we zoom in on a smaller area. The geographic distribution of updates may also impact how often we can skip invalidating our tiles.

Once we're happy with the approach I can go ahead and polish the rest of this with tests, changelog, etc.

![image](https://user-images.githubusercontent.com/24275386/200407315-6d9b4958-d803-4325-81c5-b6fea6376e77.png)

## Launch Checklist

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [x] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [x] Manually test the debug page.
 - [ ] Add an entry to `CHANGELOG.md` under the `## main` section.
