### PR TITLE
Use willReadFrequently optimization hint on 2D canvases.

### DIFF
--- a/src/source/raster_dem_tile_worker_source.ts
+++ b/src/source/raster_dem_tile_worker_source.ts
@@ -33,7 +33,7 @@ class RasterDEMTileWorkerSource {
         if (!this.offscreenCanvas || !this.offscreenCanvasContext) {
             // Dem tiles are typically 256x256
             this.offscreenCanvas = new OffscreenCanvas(imgBitmap.width, imgBitmap.height);
-            this.offscreenCanvasContext = this.offscreenCanvas.getContext('2d');
+            this.offscreenCanvasContext = this.offscreenCanvas.getContext('2d', {willReadFrequently: true});
         }
 
         this.offscreenCanvas.width = imgBitmap.width;

--- a/src/util/browser.ts
+++ b/src/util/browser.ts
@@ -25,7 +25,7 @@ const exported = {
 
     getImageData(img: CanvasImageSource, padding: number = 0): ImageData {
         const canvas = window.document.createElement('canvas');
-        const context = canvas.getContext('2d');
+        const context = canvas.getContext('2d', {willReadFrequently: true});
         if (!context) {
             throw new Error('failed to create canvas 2d context');
         }


### PR DESCRIPTION
When setting willReadFrequently to true, it is a hint to the browser that it can decelerate the canvas. This can be beneficial to perf if the canvas is only used for decoding and getting image data in raw pixels. If the canvas was accelerated (i.e. hosting data on the GPU) there could be a lot of latency to get the image data back to the main thread. 

Perf-wise, I was able to isolate this function into a benchmark to show the improvement:

From chromium on a relatively fast machine (~8ms vs ~2ms):

![image](https://user-images.githubusercontent.com/20366429/199854087-969d46ab-ecfa-4a1c-a4f6-e74824f6ea98.png)

In practice, I'm seeing this improvement is better for slower machines and less noticeable on faster machines.

On Firefox I saw no difference.

Using the hint also removes the source of a warning when using hillshade layer:

![image](https://user-images.githubusercontent.com/20366429/199854988-f85f97a0-7747-4d3c-acd6-f0c76a1a6b18.png)


## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!  
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [x] Post benchmark scores.
 - [x] Manually test the debug page.
