### PR TITLE
Support changing, diffing of glyphs and sprites

### DIFF
--- a/src/render/glyph_manager.ts
+++ b/src/render/glyph_manager.ts
@@ -100,6 +100,13 @@ export default class GlyphManager {
                 return;
             }
 
+            if (!this.url) {
+                console.trace();
+                console.log(stack, range);
+                callback(new Error('glyphsUrl is not set'));
+                return;
+            }
+
             let requests = entry.requests[range];
             if (!requests) {
                 requests = entry.requests[range] = [];

--- a/src/render/glyph_manager.ts
+++ b/src/render/glyph_manager.ts
@@ -101,8 +101,6 @@ export default class GlyphManager {
             }
 
             if (!this.url) {
-                console.trace();
-                console.log(stack, range);
                 callback(new Error('glyphsUrl is not set'));
                 return;
             }

--- a/src/render/image_manager.ts
+++ b/src/render/image_manager.ts
@@ -132,9 +132,9 @@ class ImageManager extends Evented {
         return true;
     }
 
-    updateImage(id: string, image: StyleImage) {
+    updateImage(id: string, image: StyleImage, validate = true) {
         const oldImage = this.images[id];
-        if (oldImage.data.width !== image.data.width || oldImage.data.height !== image.data.height) {
+        if (validate && (oldImage.data.width !== image.data.width || oldImage.data.height !== image.data.height)) {
             throw new Error(`size mismatch between old image (${oldImage.data.width}x${oldImage.data.height}) and new image (${image.data.width}x${image.data.height}).`);
         }
         image.version = oldImage.version + 1;

--- a/src/source/worker_tile.ts
+++ b/src/source/worker_tile.ts
@@ -140,7 +140,7 @@ class WorkerTile {
 
         const stacks = mapObject(options.glyphDependencies, (glyphs) => Object.keys(glyphs).map(Number));
         if (Object.keys(stacks).length) {
-            actor.send('getGlyphs', {uid: this.uid, stacks}, (err, result) => {
+            actor.send('getGlyphs', {uid: this.uid, stacks, source: this.source, tileID: this.tileID, type: 'glyphs'}, (err, result) => {
                 if (!error) {
                     error = err;
                     glyphMap = result;

--- a/src/style/style.ts
+++ b/src/style/style.ts
@@ -10,7 +10,7 @@ import {pick, clone, extend, deepEqual, filterObject, mapObject} from '../util/u
 import {getJSON, getReferrer, makeRequest, ResourceType} from '../util/ajax';
 import browser from '../util/browser';
 import Dispatcher from '../util/dispatcher';
-import {validateStyle, emitValidationErrors as _emitValidationErrors} from './validate_style';
+import {validateStyle, validateGlyphsUrl, emitValidationErrors as _emitValidationErrors, validateSprite} from './validate_style';
 import {getSourceType, setSourceType, Source} from '../source/source';
 import type {SourceClass} from '../source/source';
 import {queryRenderedFeatures, queryRenderedSymbols, querySourceFeatures} from '../source/query_features';
@@ -60,7 +60,6 @@ import type {
 import type {CustomLayerInterface} from './style_layer/custom_style_layer';
 import type {Validator} from './validate_style';
 import type {OverscaledTileID} from '../source/tile_id';
-import { layer } from '../style-spec/validate_style';
 
 const supportedDiffOperations = pick(diffOperations, [
     'addLayer',
@@ -176,8 +175,12 @@ class Style extends Evented {
     _updatedLayers: {[_: string]: true};
     _removedLayers: {[_: string]: StyleLayer};
     _changedImages: {[_: string]: true};
+    _glyphsDidChange: boolean;
     _updatedPaintProps: {[layer: string]: true};
     _layerOrderChanged: boolean;
+    // image ids of images loaded from style's sprite
+    _spriteImages: Array<string>;
+    // image ids of all images loaded (sprite + user)
     _availableImages: Array<string>;
 
     crossTileSymbolIndex: CrossTileSymbolIndex;
@@ -332,26 +335,58 @@ class Style extends Evented {
         this.fire(new Event('style.load'));
     }
 
-    _loadSprite(url: string) {
+    _loadSprite(url: string, isUpdate: boolean = false, completion: (err: Error) => void = undefined) {
         this._spriteRequest = loadSprite(url, this.map._requestManager, this.map.getPixelRatio(), (err, images) => {
             this._spriteRequest = null;
             if (err) {
                 this.fire(new ErrorEvent(err));
             } else if (images) {
                 for (const id in images) {
-                    if(id in this.imageManager.images){
-                        this.imageManager.updateImage(id, images[id]);
+                    if (id in this.imageManager.images) {
+                        this.imageManager.updateImage(id, images[id], false);
                     } else {
                         this.imageManager.addImage(id, images[id]);
+                    }
+
+                    if (isUpdate) {
+                        this._changedImages[id] = true;
                     }
                 }
             }
 
+            // remove old sprite's loaded images that are not in new sprite
+            const imagesToRemove = this._spriteImages ? this._spriteImages.filter(id => !(id in images)) : [];
+            for (const id of imagesToRemove) {
+                this.imageManager.removeImage(id);
+                this._changedImages[id] = true;
+            }
+
+            this._spriteImages = Object.keys(images);
             this.imageManager.setLoaded(true);
             this._availableImages = this.imageManager.listImages();
+            if (isUpdate) {
+                this._changed = true;
+            }
+
             this.dispatcher.broadcast('setImages', this._availableImages);
             this.fire(new Event('data', {dataType: 'style'}));
+            if (completion) {
+                completion(err);
+            }
         });
+    }
+
+    _unloadSprite() {
+        for (const id of this._spriteImages) {
+            this.imageManager.removeImage(id);
+            this._changedImages[id] = true;
+        }
+
+        this._spriteImages = [];
+        this._availableImages = this.imageManager.listImages();
+        this._changed = true;
+        this.dispatcher.broadcast('setImages', this._availableImages);
+        this.fire(new Event('data', {dataType: 'style'}));
     }
 
     _validateLayer(layer: StyleLayer) {
@@ -459,6 +494,7 @@ class Style extends Evented {
             }
 
             this._updateTilesForChangedImages();
+            this._updateTilesForChangedGlyphs();
 
             for (const id in this._updatedPaintProps) {
                 this._layers[id].updateTransitions(parameters);
@@ -515,6 +551,15 @@ class Style extends Evented {
         }
     }
 
+    _updateTilesForChangedGlyphs() {
+        if (this._glyphsDidChange) {
+            for (const name in this.sourceCaches) {
+                this.sourceCaches[name].reloadTilesForDependencies(['glyphs'], ['']);
+            }
+            this._glyphsDidChange = false;
+        }
+    }
+
     _updateWorkerLayers(updatedIds: Array<string>, removedIds: Array<string>) {
         this.dispatcher.broadcast('updateLayers', {
             layers: this._serializeLayers(updatedIds),
@@ -532,6 +577,7 @@ class Style extends Evented {
         this._updatedPaintProps = {};
 
         this._changedImages = {};
+        this._glyphsDidChange = false;
     }
 
     /**
@@ -1434,45 +1480,60 @@ class Style extends Evented {
 
     getGlyphs(
         mapId: string,
-        params: {stacks: {[_: string]: Array<number>}},
+        params: {
+            stacks: {[_: string]: Array<number>};
+            source: string;
+            tileID: OverscaledTileID;
+            type: string;
+        },
         callback: Callback<{[_: string]: {[_: number]: StyleGlyph}}>
     ) {
         this.glyphManager.getGlyphs(params.stacks, callback);
+        const sourceCache = this.sourceCaches[params.source];
+        if (sourceCache) {
+            // we are not setting stacks as dependencies since for now
+            // we just need to know which tiles have glyph dependencies
+            sourceCache.setDependencies(params.tileID.key, params.type, ['']);
+        }
     }
 
     getResource(mapId: string, params: RequestParameters, callback: ResponseCallback<any>): Cancelable {
         return makeRequest(params, callback);
     }
 
-    setGlyphs(glyphsUrl: string | null){
+    getGlyphsUrl() {
+        return this.stylesheet.glyphs || null;
+    }
+
+    setGlyphs(glyphsUrl: string | null, options: StyleSetterOptions = {}) {
+        this._checkLoaded();
+        if (glyphsUrl && options.validate && emitValidationErrors(this, validateGlyphsUrl({key: 'glyphs', value: glyphsUrl}))) {
+            return;
+        }
+
+        this._glyphsDidChange = true;
         this.stylesheet.glyphs = glyphsUrl;
         this.glyphManager.entries = {};
         this.glyphManager.setURL(glyphsUrl);
-        
-        const sourcesToUpdate = new Set(Object.values(this._layers)
-            .filter(layer => layer.type === 'symbol')
-            .map(layer => layer.source));
-        sourcesToUpdate.forEach(sourceId => {
-            if(this.sourceCaches[sourceId]){
-                this.sourceCaches[sourceId].reload();
-            }
-        });
     }
 
-    setSprite(spriteUrl: string | null){
-        this.stylesheet.sprite = spriteUrl;
-        if(spriteUrl){
-            this._loadSprite(spriteUrl);
+    getSpriteUrl() {
+        return this.stylesheet.sprite || null;
+    }
+
+    setSprite(spriteUrl: string | null, options: StyleSetterOptions = {}, completion: (err: Error) => void) {
+        this._checkLoaded();
+        if (spriteUrl && options.validate && emitValidationErrors(this, validateSprite({key: 'sprite', value: spriteUrl}))) {
+            return;
         }
 
-        const sourcesToUpdate = new Set(Object.values(this._layers)
-            .filter(layer => layer.type === 'symbol')
-            .map(layer => layer.source));
-        sourcesToUpdate.forEach(sourceId => {
-            if(this.sourceCaches[sourceId]){
-                this.sourceCaches[sourceId].reload();
-            }
-        });
+        this.stylesheet.sprite = spriteUrl;
+        if (spriteUrl) {
+            this._loadSprite(spriteUrl, true, completion);
+        } else {
+            this._unloadSprite();
+            completion(null);
+        }
     }
 }
 

--- a/src/style/validate_style.ts
+++ b/src/style/validate_style.ts
@@ -2,6 +2,8 @@ import validateStyleMin from '../style-spec/validate_style.min';
 import {ErrorEvent} from '../util/evented';
 
 import type {Evented} from '../util/evented';
+import validateGlyphsUrl from '../style-spec/validate/validate_glyphs_url';
+import validateString from '../style-spec/validate/validate_string';
 
 type ValidationError = {
     message: string;
@@ -30,6 +32,8 @@ export const validateTerrain = validateStyle.terrain;
 export const validateFilter = validateStyle.filter;
 export const validatePaintProperty = validateStyle.paintProperty;
 export const validateLayoutProperty = validateStyle.layoutProperty;
+export {validateString as validateSprite};
+export {validateGlyphsUrl};
 
 export function emitValidationErrors(
     emitter: Evented,

--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -2277,6 +2277,59 @@ class Map extends Camera {
     }
 
     /**
+     * Sets the value of the style's glyphs property.
+     *
+     * @param glyphsUrl Glyph URL to set. Must conform to the [MapLibre Style Specification](https://maplibre.org/maplibre-gl-js-docs/style-spec/glyphs/).
+     * @param {Object} [options] Options object.
+     * @param {boolean} [options.validate=true] Whether to check if the filter conforms to the MapLibre GL Style Specification. Disabling validation is a performance optimization that should only be used if you have previously validated the values you will be passing to this function.
+     * @returns {Map} `this`
+     * @example
+     * map.setGlyphs('https://demotiles.maplibre.org/font/{fontstack}/{range}.pbf');
+     */
+    setGlyphs(glyphsUrl: string | null, options: StyleSetterOptions = {}) {
+        this._lazyInitEmptyStyle();
+        this.style.setGlyphs(glyphsUrl, options);
+        return this._update(true);
+    }
+
+    /**
+     * Returns the value of the style's glyphs URL
+     *
+     * @returns {string | null} glyphs Style's glyphs url
+     */
+    getGlyphs() {
+        return this.style.getGlyphsUrl();
+    }
+
+    /**
+     * Sets the value of the style's sprite property.
+     *
+     * @param spriteUrl Sprite URL to set.
+     * @param {Object} [options] Options object.
+     * @param {boolean} [options.validate=true] Whether to check if the filter conforms to the MapLibre GL Style Specification. Disabling validation is a performance optimization that should only be used if you have previously validated the values you will be passing to this function.
+     * @returns {Map} `this`
+     * @example
+     * map.setSprite('YOUR_SPRITE_URL');
+     */
+    setSprite(spriteUrl: string | null, options: StyleSetterOptions = {}) {
+        this._lazyInitEmptyStyle();
+        this.style.setSprite(spriteUrl, options, (err) => {
+            if (!err) {
+                this._update(true);
+            }
+        });
+    }
+
+    /**
+     * Returns the value of the style's sprite URL
+     *
+     * @returns {string | null} sprite Style's sprite url
+     */
+    getSprite() {
+        return this.style.getSpriteUrl();
+    }
+
+    /**
      * Sets the any combination of light values.
      *
      * @param light Light properties to set. Must conform to the [MapLibre Style Specification](https://maplibre.org/maplibre-gl-js-docs/style-spec/#light).


### PR DESCRIPTION
Enables the support for changing glyphs and sprites as well as diffing them during the `map.setStyle(style, { diff: true })`, previously discussed at https://github.com/maplibre/maplibre-gl-js/pull/1238#issuecomment-1180333217

## Launch Checklist

 - [X] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [X] Link to related issues.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [ ] Manually test the debug page.
 - [ ] Add an entry to `CHANGELOG.md` under the `## main` section.
