### PR TITLE
Fix point-geometry types lost

### DIFF
--- a/build/generate-typings.ts
+++ b/build/generate-typings.ts
@@ -8,7 +8,7 @@ if (!fs.existsSync('dist')) {
 
 console.log('Starting bundling types');
 let outputFile = './dist/maplibre-gl.d.ts';
-childProcess.execSync(`dts-bundle-generator --umd-module-name=maplibregl -o ${outputFile} ./src/index.ts`);
+childProcess.execSync(`dts-bundle-generator --external-inlines=@types/mapbox__point-geometry --umd-module-name=maplibregl -o ${outputFile} ./src/index.ts`);
 let types = fs.readFileSync(outputFile, 'utf8');
 // Classes are not exported but should be since this is exported as UMD - fixing...
 types = types.replace(/declare class/g, 'export declare class');


### PR DESCRIPTION
## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [ ] Link to related issues.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [ ] Manually test the debug page.
 - [ ] Add an entry to `CHANGELOG.md` under the `## main` section.

The `maplibre-gl`  has exported `Point` helper function.
https://github.com/maplibre/maplibre-gl-js/blob/db28737bfcd47d59bf9f0a2ff62bb826ab12bb82/src/index.ts#L57

But with the TypesSript project facing `Module '"maplibre-gl"' has no exported member 'Point`. The below link is an example.
https://codesandbox.io/s/maplibre-gl-point-4gsjtx

So this PR will fix that.

