### PR TITLE
Rename buttonStillPressed to better reflect what it does

### DIFF
--- a/src/ui/handler/mouse.ts
+++ b/src/ui/handler/mouse.ts
@@ -10,7 +10,7 @@ const BUTTONS_FLAGS = {
     [RIGHT_BUTTON]: 2
 };
 
-function buttonStillPressed(e: MouseEvent, button: number) {
+function buttonNoLongerPressed(e: MouseEvent, button: number) {
     const flag = BUTTONS_FLAGS[button];
     return e.buttons === undefined || (e.buttons & flag) !== flag;
 }
@@ -61,7 +61,7 @@ class MouseHandler {
         if (!lastPoint) return;
         e.preventDefault();
 
-        if (buttonStillPressed(e, this._eventButton)) {
+        if (buttonNoLongerPressed(e, this._eventButton)) {
             // Some browsers don't fire a `mouseup` when the mouseup occurs outside
             // the window or iframe:
             // https://github.com/mapbox/mapbox-gl-js/issues/4622


### PR DESCRIPTION
Rename buttonStillPressed in the mouse handling module to buttonNoLongerPressed as this is what it is checking. This function is only used in this context and should have no impact beyond code legibility.

Split from https://github.com/maplibre/maplibre-gl-js/pull/1852 based on instructions by @HarelM.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.