### PR TITLE
VectorTileWorkerSource: change reloadTile behavior to reload right away instead of waiting for previous parse to complete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,8 +72,13 @@
 - Add validateStyle MapOption to allow disabling style validation for faster performance in production environment. ([#2390](https://github.com/maplibre/maplibre-gl-js/pull/2390))
 - Add `setiClusterOptions` to update cluster properties of the added sources: fixing these issues ([#429](https://github.com/maplibre/maplibre-gl-js/issues/429)) and ([#1384](https://github.com/maplibre/maplibre-gl-js/issues/1384))
 - Add types for `workerOptions` and `_options` in `geojson_source.ts`
-- Add fullscreenstart, fullscreenend events to FullscreenControl ([#2128](https://github.com/maplibre/maplibre-gl-js/issues/2128)
-- Throttle the image request queue while the map is moving to improve performance ([#2097](https://github.com/maplibre/maplibre-gl-js/issues/2097)
+- *...Add new stuff here...*
+### 🐞 Bug fixes
+- Fix reloadCallback not firing on VectorTileWorkerSource.reloadTile ([#1874](https://github.com/maplibre/maplibre-gl-js/pull/1874))
+- *...Add new stuff here...*
+## 3.0.0-pre.3
+
+### ✨ Features and improvements
 - Add support for multiple `sprite` declarations in one style file ([#1805](https://github.com/maplibre/maplibre-gl-js/pull/1805))
 - Extract sprite image on demand to reduce memory usage and improve performance by reducing the number of getImageData calls ([#1809](https://github.com/maplibre/maplibre-gl-js/pull/1809))
 - `QueryRenderedFeaturesOptions` type added to both of the params in queryRenderedFeatures in map.ts ([#1900](https://github.com/maplibre/maplibre-gl-js/issues/1900))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🐞 Bug fixes
 
-- _...Add new stuff here..._
+- Fix reloadCallback not firing on VectorTileWorkerSource.reloadTile ([#1874](https://github.com/maplibre/maplibre-gl-js/pull/1874))
 
 ## 3.2.0
 
@@ -72,13 +72,8 @@
 - Add validateStyle MapOption to allow disabling style validation for faster performance in production environment. ([#2390](https://github.com/maplibre/maplibre-gl-js/pull/2390))
 - Add `setiClusterOptions` to update cluster properties of the added sources: fixing these issues ([#429](https://github.com/maplibre/maplibre-gl-js/issues/429)) and ([#1384](https://github.com/maplibre/maplibre-gl-js/issues/1384))
 - Add types for `workerOptions` and `_options` in `geojson_source.ts`
-- *...Add new stuff here...*
-### 🐞 Bug fixes
-- Fix reloadCallback not firing on VectorTileWorkerSource.reloadTile ([#1874](https://github.com/maplibre/maplibre-gl-js/pull/1874))
-- *...Add new stuff here...*
-## 3.0.0-pre.3
-
-### ✨ Features and improvements
+- Add fullscreenstart, fullscreenend events to FullscreenControl ([#2128](https://github.com/maplibre/maplibre-gl-js/issues/2128)
+- Throttle the image request queue while the map is moving to improve performance ([#2097](https://github.com/maplibre/maplibre-gl-js/issues/2097)
 - Add support for multiple `sprite` declarations in one style file ([#1805](https://github.com/maplibre/maplibre-gl-js/pull/1805))
 - Extract sprite image on demand to reduce memory usage and improve performance by reducing the number of getImageData calls ([#1809](https://github.com/maplibre/maplibre-gl-js/pull/1809))
 - `QueryRenderedFeaturesOptions` type added to both of the params in queryRenderedFeatures in map.ts ([#1900](https://github.com/maplibre/maplibre-gl-js/issues/1900))

--- a/src/source/vector_tile_worker_source.test.ts
+++ b/src/source/vector_tile_worker_source.test.ts
@@ -130,7 +130,7 @@ describe('vector tile worker source', () => {
     });
 
     test('VectorTileWorkerSource#loadTile reparses tile if the reloadTile has been called during parsing', (done) => {
-        const rawTileData = fs.readFileSync(path.join(__dirname, '/../../test/unit/assets/mbsv5-6-18-23.vector.pbf'));
+        const rawTileData = new Uint8Array([]);
         function loadVectorData(params, callback) {
             return callback(null, {
                 vectorTile: new vt.VectorTile(new Protobuf(rawTileData)),

--- a/src/source/vector_tile_worker_source.test.ts
+++ b/src/source/vector_tile_worker_source.test.ts
@@ -13,25 +13,16 @@ import {setPerformance} from '../util/test/util';
 describe('vector tile worker source', () => {
     const actor = {send: () => {}} as any as Actor;
     let server: FakeServer;
-    let originalGetEntriesByName;
-    let originalMeasure;
-    let originalMark;
 
     beforeEach(() => {
         global.fetch = null;
         server = fakeServer.create();
         setPerformance();
-        originalGetEntriesByName = window.performance.getEntriesByName;
-        originalMeasure = window.performance.measure;
-        originalMark = window.performance.mark;
     });
 
     afterEach(() => {
         server.restore();
         jest.clearAllMocks();
-        window.performance.getEntriesByName = originalGetEntriesByName;
-        window.performance.measure = originalMeasure;
-        window.performance.mark = originalMark;
     });
     test('VectorTileWorkerSource#abortTile aborts pending request', () => {
         const source = new VectorTileWorkerSource(actor, new StyleLayerIndex(), []);

--- a/src/source/vector_tile_worker_source.test.ts
+++ b/src/source/vector_tile_worker_source.test.ts
@@ -137,7 +137,7 @@ describe('vector tile worker source', () => {
                 rawData: rawTileData
             });
         }
-        
+
         const layerIndex = new StyleLayerIndex([{
             id: 'test',
             source: 'source',
@@ -146,9 +146,9 @@ describe('vector tile worker source', () => {
         }]);
 
         const source = new VectorTileWorkerSource(actor, layerIndex, [], loadVectorData);
-        
+
         // mock implementation of WorkerTile parse that would take some time to complete
-        WorkerTile.prototype.parse = jest.fn().mockImplementation(function(data, layerIndex, availableImages, actor, callback){
+        WorkerTile.prototype.parse = jest.fn().mockImplementation(function(data, layerIndex, availableImages, actor, callback) {
             this.status = 'parsing';
             window.setTimeout(() => callback(null, {}), 10);
         });
@@ -172,10 +172,10 @@ describe('vector tile worker source', () => {
         } as any as WorkerTileParameters, (err, res) => {
             expect(err).toBeFalsy();
             expect(res).toBeDefined();
-            expect(WorkerTile.prototype.parse).toBeCalledTimes(2);
+            expect(WorkerTile.prototype.parse).toHaveBeenCalledTimes(2);
             expect(loadCallbackCalled).toBeTruthy();
             done();
-        })
+        });
     });
 
     test('VectorTileWorkerSource#reloadTile handles multiple pending reloads', () => {

--- a/src/source/vector_tile_worker_source.test.ts
+++ b/src/source/vector_tile_worker_source.test.ts
@@ -86,37 +86,6 @@ describe('vector tile worker source', () => {
         expect(callback).toHaveBeenCalledTimes(1);
     });
 
-    test('VectorTileWorkerSource#reloadTile queues a reload when parsing is in progress', () => {
-        const source = new VectorTileWorkerSource(actor, new StyleLayerIndex(), []);
-        const parse = jest.fn();
-
-        source.loaded = {
-            '0': {
-                status: 'done',
-                vectorTile: {},
-                parse
-            } as any as WorkerTile
-        };
-
-        const callback1 = jest.fn();
-        const callback2 = jest.fn();
-        source.reloadTile({uid: 0} as any as WorkerTileParameters, callback1);
-        expect(parse).toHaveBeenCalledTimes(1);
-
-        source.loaded[0].status = 'parsing';
-        source.reloadTile({uid: 0} as any as WorkerTileParameters, callback2);
-        expect(parse).toHaveBeenCalledTimes(1);
-
-        parse.mock.calls[0][4]();
-        expect(parse).toHaveBeenCalledTimes(2);
-        expect(callback1).toHaveBeenCalledTimes(1);
-        expect(callback2).toHaveBeenCalledTimes(0);
-
-        parse.mock.calls[1][4]();
-        expect(callback1).toHaveBeenCalledTimes(1);
-        expect(callback2).toHaveBeenCalledTimes(1);
-    });
-
     test('VectorTileWorkerSource#loadTile reparses tile if the reloadTile has been called during parsing', (done) => {
         const rawTileData = new Uint8Array([]);
         function loadVectorData(params, callback) {
@@ -165,54 +134,6 @@ describe('vector tile worker source', () => {
             expect(loadCallbackCalled).toBeTruthy();
             done();
         });
-    });
-
-    test('VectorTileWorkerSource#reloadTile handles multiple pending reloads', () => {
-        // https://github.com/mapbox/mapbox-gl-js/issues/6308
-        const source = new VectorTileWorkerSource(actor, new StyleLayerIndex(), []);
-        const parse = jest.fn();
-
-        source.loaded = {
-            '0': {
-                status: 'done',
-                vectorTile: {},
-                parse
-            } as any as WorkerTile
-        };
-
-        const callback1 = jest.fn();
-        const callback2 = jest.fn();
-        const callback3 = jest.fn();
-        source.reloadTile({uid: 0} as any as WorkerTileParameters, callback1);
-        expect(parse).toHaveBeenCalledTimes(1);
-
-        source.loaded[0].status = 'parsing';
-        source.reloadTile({uid: 0} as any as WorkerTileParameters, callback2);
-        expect(parse).toHaveBeenCalledTimes(1);
-
-        parse.mock.calls[0][4]();
-        expect(parse).toHaveBeenCalledTimes(2);
-        expect(callback1).toHaveBeenCalledTimes(1);
-        expect(callback2).toHaveBeenCalledTimes(0);
-        expect(callback3).toHaveBeenCalledTimes(0);
-
-        source.reloadTile({uid: 0} as any as WorkerTileParameters, callback3);
-        expect(parse).toHaveBeenCalledTimes(2);
-        expect(callback1).toHaveBeenCalledTimes(1);
-        expect(callback2).toHaveBeenCalledTimes(0);
-        expect(callback3).toHaveBeenCalledTimes(0);
-
-        parse.mock.calls[1][4]();
-        expect(parse).toHaveBeenCalledTimes(3);
-        expect(callback1).toHaveBeenCalledTimes(1);
-        expect(callback2).toHaveBeenCalledTimes(1);
-        expect(callback3).toHaveBeenCalledTimes(0);
-
-        parse.mock.calls[2][4]();
-        expect(callback1).toHaveBeenCalledTimes(1);
-        expect(callback2).toHaveBeenCalledTimes(1);
-        expect(callback3).toHaveBeenCalledTimes(1);
-
     });
 
     test('VectorTileWorkerSource#reloadTile does not reparse tiles with no vectorTile data but does call callback', () => {

--- a/src/source/vector_tile_worker_source.ts
+++ b/src/source/vector_tile_worker_source.ts
@@ -124,12 +124,6 @@ export class VectorTileWorkerSource implements WorkerSource {
 
             workerTile.vectorTile = response.vectorTile;
             workerTile.parse(response.vectorTile, this.layerIndex, this.availableImages, this.actor, (err, result) => {
-                const reloadCallback = workerTile.reloadCallback;
-                if (workerTile.reloadCallback) {
-                    delete workerTile.reloadCallback;
-                    workerTile.parse(workerTile.vectorTile, this.layerIndex, this.availableImages, this.actor, reloadCallback);
-                }
-
                 if (err || !result) return callback(err);
 
                 // Transferring a copy of rawTileData because the worker needs to retain its copy.
@@ -151,24 +145,14 @@ export class VectorTileWorkerSource implements WorkerSource {
         if (loaded && loaded[uid]) {
             const workerTile = loaded[uid];
             workerTile.showCollisionBoxes = params.showCollisionBoxes;
-
-            const done = (err?: Error, data?: any) => {
-                const reloadCallback = workerTile.reloadCallback;
-                if (reloadCallback) {
-                    delete workerTile.reloadCallback;
-                    workerTile.parse(workerTile.vectorTile, vtSource.layerIndex, this.availableImages, vtSource.actor, reloadCallback);
-                }
-                callback(err, data);
-            };
-
             if (workerTile.status === 'parsing') {
-                workerTile.reloadCallback = done;
+                workerTile.parse(workerTile.vectorTile, this.layerIndex, this.availableImages, this.actor, callback);
             } else if (workerTile.status === 'done') {
                 // if there was no vector tile data on the initial load, don't try and re-parse tile
                 if (workerTile.vectorTile) {
-                    workerTile.parse(workerTile.vectorTile, this.layerIndex, this.availableImages, this.actor, done);
+                    workerTile.parse(workerTile.vectorTile, this.layerIndex, this.availableImages, this.actor, callback);
                 } else {
-                    done();
+                    callback();
                 }
             }
         }

--- a/src/source/vector_tile_worker_source.ts
+++ b/src/source/vector_tile_worker_source.ts
@@ -124,6 +124,12 @@ export class VectorTileWorkerSource implements WorkerSource {
 
             workerTile.vectorTile = response.vectorTile;
             workerTile.parse(response.vectorTile, this.layerIndex, this.availableImages, this.actor, (err, result) => {
+                const reloadCallback = workerTile.reloadCallback;
+                if (workerTile.reloadCallback) {
+                    delete workerTile.reloadCallback;
+                    workerTile.parse(workerTile.vectorTile, this.layerIndex, this.availableImages, this.actor, reloadCallback);
+                }
+
                 if (err || !result) return callback(err);
 
                 // Transferring a copy of rawTileData because the worker needs to retain its copy.

--- a/src/source/worker_tile.test.ts
+++ b/src/source/worker_tile.test.ts
@@ -99,4 +99,147 @@ describe('worker tile', () => {
             done();
         });
     });
+
+    test('WorkerTile#parse would request all types of dependencies', done => {
+        const tile = createWorkerTile();
+        const layerIndex = new StyleLayerIndex([{
+            id: '1',
+            type: 'fill',
+            source: 'source',
+            'source-layer': 'test',
+            paint: {
+                'fill-pattern': 'hello'
+            }
+        }, {
+            id: 'test',
+            source: 'source',
+            'source-layer': 'test',
+            type: 'symbol',
+            layout: {
+                'icon-image': 'hello',
+                'text-font': ['StandardFont-Bold'],
+                'text-field': '{name}'
+            }
+        }]);
+
+        const data = {
+            layers: {
+                test: {
+                    version: 2,
+                    name: 'test',
+                    extent: 8192,
+                    length: 1,
+                    feature: (featureIndex: number) => ({
+                        extent: 8192,
+                        type: 1,
+                        id: featureIndex,
+                        properties: {
+                            name: 'test'
+                        },
+                        loadGeometry () {
+                            return [[{x: 0, y: 0}]];
+                        }
+                    })
+                }
+            }
+        } as any as VectorTile;
+
+        const send = jest.fn().mockImplementation((type: string, data: unknown, callback: Function) => {
+            setTimeout(() => callback(null,
+                type === 'getImages' ?
+                    {'hello': {width: 1, height: 1, data: new Uint8Array([0])}} :
+                    {'StandardFont-Bold': {width: 1, height: 1, data: new Uint8Array([0])}}
+            ));
+        });
+
+        const actorMock = {
+            send
+        } as unknown as Actor;
+        tile.parse(data, layerIndex, ['hello'], actorMock, (err, result) => {
+            expect(err).toBeFalsy();
+            expect(result).toBeDefined();
+            expect(send).toHaveBeenCalledTimes(3);
+            expect(send).toHaveBeenCalledWith('getImages', expect.objectContaining({'icons': ['hello'], 'type': 'icons'}), expect.any(Function));
+            expect(send).toHaveBeenCalledWith('getImages', expect.objectContaining({'icons': ['hello'], 'type': 'patterns'}), expect.any(Function));
+            expect(send).toHaveBeenCalledWith('getGlyphs', expect.objectContaining({'source': 'source', 'type': 'glyphs', 'stacks': {'StandardFont-Bold': [101, 115, 116]}}), expect.any(Function));
+            done();
+        });
+    });
+
+    test('WorkerTile#parse would cancel and only event once on repeated reparsing', done => {
+        const tile = createWorkerTile();
+        const layerIndex = new StyleLayerIndex([{
+            id: '1',
+            type: 'fill',
+            source: 'source',
+            'source-layer': 'test',
+            paint: {
+                'fill-pattern': 'hello'
+            }
+        }, {
+            id: 'test',
+            source: 'source',
+            'source-layer': 'test',
+            type: 'symbol',
+            layout: {
+                'icon-image': 'hello',
+                'text-font': ['StandardFont-Bold'],
+                'text-field': '{name}'
+            }
+        }]);
+
+        const data = {
+            layers: {
+                test: {
+                    version: 2,
+                    name: 'test',
+                    extent: 8192,
+                    length: 1,
+                    feature: (featureIndex: number) => ({
+                        extent: 8192,
+                        type: 1,
+                        id: featureIndex,
+                        properties: {
+                            name: 'test'
+                        },
+                        loadGeometry () {
+                            return [[{x: 0, y: 0}]];
+                        }
+                    })
+                }
+            }
+        } as any as VectorTile;
+
+        let cancelCount = 0;
+        const send = jest.fn().mockImplementation((type: string, data: unknown, callback: Function) => {
+            const res = setTimeout(() => callback(null,
+                type === 'getImages' ?
+                    {'hello': {width: 1, height: 1, data: new Uint8Array([0])}} :
+                    {'StandardFont-Bold': {width: 1, height: 1, data: new Uint8Array([0])}}
+            ));
+
+            return {
+                cancel: () => {
+                    cancelCount += 1;
+                    clearTimeout(res);
+                }
+            };
+        });
+
+        const actorMock = {
+            send
+        } as unknown as Actor;
+        tile.parse(data, layerIndex, ['hello'], actorMock, () => done.fail('should not be called'));
+        tile.parse(data, layerIndex, ['hello'], actorMock, () => done.fail('should not be called'));
+        tile.parse(data, layerIndex, ['hello'], actorMock, (err, result) => {
+            expect(err).toBeFalsy();
+            expect(result).toBeDefined();
+            expect(cancelCount).toBe(6);
+            expect(send).toHaveBeenCalledTimes(9);
+            expect(send).toHaveBeenCalledWith('getImages', expect.objectContaining({'icons': ['hello'], 'type': 'icons'}), expect.any(Function));
+            expect(send).toHaveBeenCalledWith('getImages', expect.objectContaining({'icons': ['hello'], 'type': 'patterns'}), expect.any(Function));
+            expect(send).toHaveBeenCalledWith('getGlyphs', expect.objectContaining({'source': 'source', 'type': 'glyphs', 'stacks': {'StandardFont-Bold': [101, 115, 116]}}), expect.any(Function));
+            done();
+        });
+    });
 });

--- a/src/source/worker_tile.ts
+++ b/src/source/worker_tile.ts
@@ -24,7 +24,7 @@ import type {
 } from '../source/worker_source';
 import type {PromoteIdSpecification} from '@maplibre/maplibre-gl-style-spec';
 import type {VectorTile} from '@mapbox/vector-tile';
-import { Cancelable } from '../types/cancelable';
+import {Cancelable} from '../types/cancelable';
 
 export class WorkerTile {
     tileID: OverscaledTileID;
@@ -145,7 +145,7 @@ export class WorkerTile {
 
         this.inFlightDependencies.forEach((request) => request?.cancel());
         this.inFlightDependencies = [];
-        
+
         // cancelling seems to be not sufficient, we seems to still manage to get a callback hit, so use a sentinel to drop stale results
         const dependencySentinel = ++this.dependencySentinel;
         if (Object.keys(stacks).length) {


### PR DESCRIPTION
As pointed out in https://github.com/maplibre/maplibre-gl-js/pull/1805#issuecomment-1315978349, the issue occurred where after adding a geojson source, a bunch of symbol layers and new spritesheets in a `load` callback, the sprites would be not shown for geojson's source tiles already loaded (which are loaded before the sprites are loaded), as a result of tiles not being reparsed:

https://github.com/maplibre/maplibre-gl-js/blob/870c2a38550a363ca62833a2f401f599d2720f97/src/source/worker_tile.ts#L64

not getting called inside the web-worker and so the https://github.com/maplibre/maplibre-gl-js/blob/870c2a38550a363ca62833a2f401f599d2720f97/src/source/worker_tile.ts#L169 would not fire to grab the new loaded image assets. 

This issue would not happen if browser have cached sprite assets, hinting on some async behavior weirdness. Tracing the flow of https://github.com/maplibre/maplibre-gl-js/blob/870c2a38550a363ca62833a2f401f599d2720f97/src/style/style.ts#L503

happened to show that https://github.com/maplibre/maplibre-gl-js/blob/870c2a38550a363ca62833a2f401f599d2720f97/src/source/vector_tile_worker_source.ts#L157-L167 done callback that would perform reparsing and would be set if the workerTile is already in the `parsing` state would not fire. This happened because the workerTile.reloadCallback would only happen if the `workerTile.parse` (that sets the status to `parsing`) would itself be called from `reloadTile`, but would not from its own `loadTile` logic that could happen prior to this `reloadTile` call.

This PR fixes that by checking the reloadCallback inside the `loadTile`'s `workerTile.parse` callback.

# **UPDATE: 2023/07/15**

reload callback has been eliminated per conversation in favor of reloading right away and cancelling in flight dependency sprite / glyphs dependency loading during parse at https://github.com/maplibre/maplibre-gl-js/blob/main/src/source/worker_tile.ts#L141:L177. 
## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [X] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [X] Briefly describe the changes in this PR.
 - [X] Link to related issues.
 - [x] Write tests for all new functionality.
 - [x] Add an entry to `CHANGELOG.md` under the `## main` section.
