### PR TITLE
Add a script to watch run tests in watch mode for a specific folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -170,6 +170,7 @@
     "test-expression": "jest --roots ./test/integration/expression",
     "test-unit": "jest --roots ./src  -c ./jest.config.ts ",
     "test-unit-ci": "jest --roots ./src  -c ./jest.config.ts --ci --coverage --testLocationInResults",
+    "test-watch-roots": "jest --watch  -c ./jest.config.ts --roots ",
     "codegen": "npm run generate-style-code && npm run generate-struct-arrays && npm run generate-style-spec && npm run generate-shaders && npm run generate-debug-index-file",
     "benchmark": "node --loader ts-node/esm --experimental-specifier-resolution=node test/bench/run-benchmarks.ts",
     "gl-stats": "node --loader ts-node/esm --experimental-specifier-resolution=node test/bench/gl-stats.ts",

--- a/test/README.md
+++ b/test/README.md
@@ -10,6 +10,8 @@ To run individual tests:
  - Unit tests: `npx jest path/to/file.test.js` (e.g. `npx jest src/style/style_layer.test.ts`)
  - Render tests: `npm run test-render -- render-test-name` (e.g. `npm run test-render -- text-rotation-alignment`)
 
+To run folders in watch mode, meaning they will run continuously as you make changes to relevant code, (i.e. for test driven development): use `npm run test-watch-roots *folder1* [*folder2*...]` (e.g. `npm run test-watch-roots ./src/ui/control`)
+
  ## Debugging Tests on Windows
 
 Steps to use Visual Studio Code:


### PR DESCRIPTION
While I was refactoring some code I was looking for a script to watch specific subfolders while developing to make the test runs fast enough to aid in test driven development. Since I could not find an implemented script - I added one myself, and thought others may find this useful too.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.