### PR TITLE
Fix slice expression type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### 🐞 Bug fixes
 - *...Add new stuff here...*
+- Fix the `slice` expression type ([#1886](https://github.com/maplibre/maplibre-gl-js/issues/1886))
 - Fix `getElevation()` causing uncaught error ([#1650](https://github.com/maplibre/maplibre-gl-js/issues/1650)).
 - Add dev version for csp build ([#1730](https://github.com/maplibre/maplibre-gl-js/pull/1730))
 - Fix headless benchmark execution especially on VM ([#1732](https://github.com/maplibre/maplibre-gl-js/pull/1732))

--- a/build/generate-style-spec.ts
+++ b/build/generate-style-spec.ts
@@ -174,7 +174,7 @@ export type ExpressionSpecification =
     | ['in', ExpressionInputType | ExpressionSpecification, ExpressionInputType | ExpressionSpecification]
     | ['index-of', ExpressionInputType | ExpressionSpecification, ExpressionInputType | ExpressionSpecification] // number
     | ['length', string | ExpressionSpecification]
-    | ['slice', string | ExpressionSpecification, number | ExpressionSpecification]
+    | ['slice', string | ExpressionSpecification, number | ExpressionSpecification, (number | ExpressionSpecification)?]
     // Decision
     | ['!', boolean | ExpressionSpecification] // boolean
     | ['!=', ExpressionInputType | ExpressionSpecification, ExpressionInputType | ExpressionSpecification, CollatorExpressionSpecification?] // boolean


### PR DESCRIPTION
The endIndex was not specified as an optional argument to the slice expression in the type. It does work in practice.

Fixes #1886.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - ~~Include before/after visuals or gifs if this PR includes visual changes.~~
 - ~~Write tests for all new functionality.~~
 - ~~Document any changes to public APIs.~~
 - ~~Post benchmark scores.~~
 - ~~Manually test the debug page.~~
 - [x] Add an entry to `CHANGELOG.md` under the `## main` section.
