### PR TITLE
Fix Slack link

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Use MapLibre GL JS bindings for React (https://visgl.github.io/react-map-gl/docs
 
 ### Getting Involved
 
-Join the #maplibre slack channel at OSMUS: get an invite at https://osmus-slack.herokuapp.com/
+Join the #maplibre slack channel at OSMUS: get an invite at https://slack.openstreetmap.us/
 Read the [CONTRIBUTING.md](CONTRIBUTING.md) guide in order to get familiar with how we do things around here.
 
 ### Community Leadership


### PR DESCRIPTION
The old slack link seems to be not working anymore. This replaces it with a new link. Thanks @msbarry for sharing this in the plantiler repo...

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [ ] Briefly describe the changes in this PR.
 - [ ] Link to related issues.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [ ] Manually test the debug page.
 - [ ] Add an entry to `CHANGELOG.md` under the `## main` section.
