### PR TITLE
Remove dependency on gazetteer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### 🐞 Bug fixes
 - *...Add new stuff here...*
+- Remove dependency on `@mapbox/gazetteer` which caused some build warnings ([#1898](https://github.com/maplibre/maplibre-gl-js/pull/1757)[#1898](https://github.com/maplibre/maplibre-gl-js/pull/1898))
 - Fix `getElevation()` causing uncaught error ([#1650](https://github.com/maplibre/maplibre-gl-js/issues/1650)).
 - Add dev version for csp build ([#1730](https://github.com/maplibre/maplibre-gl-js/pull/1730))
 - Fix headless benchmark execution especially on VM ([#1732](https://github.com/maplibre/maplibre-gl-js/pull/1732))

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,6 @@
         "vt-pbf": "^3.1.3"
       },
       "devDependencies": {
-        "@mapbox/gazetteer": "^5.1.0",
         "@mapbox/mapbox-gl-rtl-text": "^0.2.3",
         "@mapbox/mvt-fixtures": "^3.10.0",
         "@rollup/plugin-commonjs": "^23.0.3",
@@ -807,45 +806,6 @@
       "integrity": "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==",
       "dev": true
     },
-    "node_modules/@hapi/address": {
-      "version": "2.1.4",
-      "deprecated": "Moved to 'npm install @sideway/address'",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@hapi/bourne": {
-      "version": "1.3.2",
-      "deprecated": "This version has been deprecated and is no longer supported or maintained",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@hapi/hoek": {
-      "version": "8.5.1",
-      "deprecated": "This version has been deprecated and is no longer supported or maintained",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@hapi/joi": {
-      "version": "15.1.1",
-      "deprecated": "Switch to 'npm install joi'",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@hapi/address": "2.x.x",
-        "@hapi/bourne": "1.x.x",
-        "@hapi/hoek": "8.x.x",
-        "@hapi/topo": "3.x.x"
-      }
-    },
-    "node_modules/@hapi/topo": {
-      "version": "3.1.6",
-      "deprecated": "This version has been deprecated and is no longer supported or maintained",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@hapi/hoek": "^8.3.0"
-      }
-    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.6",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.6.tgz",
@@ -1303,15 +1263,6 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
-    "node_modules/@mapbox/gazetteer": {
-      "version": "5.1.0",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "@hapi/joi": "^15.0.3",
-        "@mapbox/geojsonhint": "^2.2.0"
-      }
-    },
     "node_modules/@mapbox/geojson-rewind": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/@mapbox/geojson-rewind/-/geojson-rewind-0.5.2.tgz",
@@ -1330,27 +1281,6 @@
       "integrity": "sha512-e9EBqHHv3EORHrSfbR9DqecPNn+AmuAoQxV6aL8Xu30bJMJR1o8PZLZzpk1Wq7/NfCbuhmakHTPYRhoqLsXRnw==",
       "dev": true,
       "peer": true
-    },
-    "node_modules/@mapbox/geojsonhint": {
-      "version": "2.2.0",
-      "deprecated": "Please make plans to check GeoJSON in some other way",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "concat-stream": "^1.6.1",
-        "jsonlint-lines": "1.7.1",
-        "minimist": "1.2.0",
-        "vfile": "^4.0.0",
-        "vfile-reporter": "^5.1.1"
-      },
-      "bin": {
-        "geojsonhint": "bin/geojsonhint"
-      }
-    },
-    "node_modules/@mapbox/geojsonhint/node_modules/minimist": {
-      "version": "1.2.0",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@mapbox/jsonlint-lines-primitives": {
       "version": "2.0.2",
@@ -4372,20 +4302,6 @@
       "version": "0.0.1",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/concat-stream": {
-      "version": "1.6.2",
-      "dev": true,
-      "engines": [
-        "node >= 0.8"
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "buffer-from": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^2.2.2",
-        "typedarray": "^0.0.6"
-      }
     },
     "node_modules/console-control-strings": {
       "version": "1.1.0",
@@ -7658,14 +7574,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/has-color": {
-      "version": "0.1.7",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -8529,11 +8437,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/isarray": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -9880,27 +9783,6 @@
       "dev": true,
       "engines": {
         "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/jsonlint-lines": {
-      "version": "1.7.1",
-      "dev": true,
-      "dependencies": {
-        "JSV": ">= 4.0.x",
-        "nomnom": ">= 1.5.x"
-      },
-      "bin": {
-        "jsonlint": "lib/cli.js"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/JSV": {
-      "version": "4.0.2",
-      "dev": true,
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/jsx-ast-utils": {
@@ -11987,36 +11869,6 @@
       "integrity": "sha512-PiVXnNuFm5+iYkLBNeq5211hvO38y63T0i2KKh2KnUs3RpzJ+JtODFjkD8yjLwnDkTYF1eKXheUwdssR+NRZdg==",
       "dev": true
     },
-    "node_modules/nomnom": {
-      "version": "1.8.1",
-      "deprecated": "Package no longer supported. Contact support@npmjs.com for more info.",
-      "dev": true,
-      "dependencies": {
-        "chalk": "~0.4.0",
-        "underscore": "~1.6.0"
-      }
-    },
-    "node_modules/nomnom/node_modules/ansi-styles": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/nomnom/node_modules/chalk": {
-      "version": "0.4.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "~1.0.0",
-        "has-color": "~0.1.0",
-        "strip-ansi": "~0.1.0"
-      },
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
     "node_modules/nopt": {
       "version": "5.0.0",
       "dev": true,
@@ -13736,11 +13588,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/process-nextick-args": {
-      "version": "2.0.1",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/process-on-spawn": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/process-on-spawn/-/process-on-spawn-1.0.0.tgz",
@@ -14165,29 +14012,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/readable-stream": {
-      "version": "2.3.7",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/readable-stream/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
     "node_modules/readdirp": {
       "version": "3.6.0",
       "dev": true,
@@ -14358,14 +14182,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/repeat-string": {
-      "version": "1.6.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10"
       }
     },
     "node_modules/require-directory": {
@@ -15490,17 +15306,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/strip-ansi": {
-      "version": "0.1.1",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "strip-ansi": "cli.js"
-      },
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
     "node_modules/strip-bom": {
       "version": "3.0.0",
       "dev": true,
@@ -16360,12 +16165,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/typedarray": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
-      "dev": true
-    },
     "node_modules/typedarray-to-buffer": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
@@ -16411,12 +16210,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/underscore": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
-      "integrity": "sha512-z4o1fvKUojIWh9XuaVLUDdf86RQiq13AC1dmHbTpoyuu+bquHms76v16CjycCbec87J7z0k//SiQVk0sMdFmpQ==",
-      "dev": true
     },
     "node_modules/unified": {
       "version": "10.1.2",
@@ -16735,153 +16528,6 @@
       "dependencies": {
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
-      }
-    },
-    "node_modules/vfile": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/vfile/-/vfile-4.2.1.tgz",
-      "integrity": "sha512-O6AE4OskCG5S1emQ/4gl8zK586RqA3srz3nfK/Viy0UPToBc5Trp9BVFb1u0CjsKrAWwnpr4ifM/KBXPWwJbCA==",
-      "dev": true,
-      "dependencies": {
-        "@types/unist": "^2.0.0",
-        "is-buffer": "^2.0.0",
-        "unist-util-stringify-position": "^2.0.0",
-        "vfile-message": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/vfile-message": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-2.0.4.tgz",
-      "integrity": "sha512-DjssxRGkMvifUOJre00juHoP9DPWuzjxKuMDrhNbk2TdaYYBNMStsNhEOt3idrtI12VQYM/1+iM0KOzXi4pxwQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/unist": "^2.0.0",
-        "unist-util-stringify-position": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/vfile-message/node_modules/unist-util-stringify-position": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-2.0.3.tgz",
-      "integrity": "sha512-3faScn5I+hy9VleOq/qNbAd6pAx7iH5jYBMS9I1HgQVijz/4mv5Bvw5iw1sC/90CODiKo81G/ps8AJrISn687g==",
-      "dev": true,
-      "dependencies": {
-        "@types/unist": "^2.0.2"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/vfile-reporter": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/vfile-reporter/-/vfile-reporter-5.1.2.tgz",
-      "integrity": "sha512-b15sTuss1wOPWVlyWOvu+n6wGJ/eTYngz3uqMLimQvxZ+Q5oFQGYZZP1o3dR9sk58G5+wej0UPCZSwQBX/mzrQ==",
-      "dev": true,
-      "dependencies": {
-        "repeat-string": "^1.5.0",
-        "string-width": "^2.0.0",
-        "supports-color": "^5.0.0",
-        "unist-util-stringify-position": "^2.0.0",
-        "vfile-sort": "^2.1.2",
-        "vfile-statistics": "^1.1.0"
-      }
-    },
-    "node_modules/vfile-reporter/node_modules/has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/vfile-reporter/node_modules/supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/vfile-reporter/node_modules/unist-util-stringify-position": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-2.0.3.tgz",
-      "integrity": "sha512-3faScn5I+hy9VleOq/qNbAd6pAx7iH5jYBMS9I1HgQVijz/4mv5Bvw5iw1sC/90CODiKo81G/ps8AJrISn687g==",
-      "dev": true,
-      "dependencies": {
-        "@types/unist": "^2.0.2"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/vfile-reporter/node_modules/vfile-sort": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/vfile-sort/-/vfile-sort-2.2.2.tgz",
-      "integrity": "sha512-tAyUqD2R1l/7Rn7ixdGkhXLD3zsg+XLAeUDUhXearjfIcpL1Hcsj5hHpCoy/gvfK/Ws61+e972fm0F7up7hfYA==",
-      "dev": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/vfile-statistics": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/vfile-statistics/-/vfile-statistics-1.1.4.tgz",
-      "integrity": "sha512-lXhElVO0Rq3frgPvFBwahmed3X03vjPF8OcjKMy8+F1xU/3Q3QU3tKEDp743SFtb74PdF0UWpxPvtOP0GCLheA==",
-      "dev": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/vfile/node_modules/is-buffer": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
-      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/vfile/node_modules/unist-util-stringify-position": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-2.0.3.tgz",
-      "integrity": "sha512-3faScn5I+hy9VleOq/qNbAd6pAx7iH5jYBMS9I1HgQVijz/4mv5Bvw5iw1sC/90CODiKo81G/ps8AJrISn687g==",
-      "dev": true,
-      "dependencies": {
-        "@types/unist": "^2.0.2"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/vt-pbf": {
@@ -17899,35 +17545,6 @@
       "integrity": "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==",
       "dev": true
     },
-    "@hapi/address": {
-      "version": "2.1.4",
-      "dev": true
-    },
-    "@hapi/bourne": {
-      "version": "1.3.2",
-      "dev": true
-    },
-    "@hapi/hoek": {
-      "version": "8.5.1",
-      "dev": true
-    },
-    "@hapi/joi": {
-      "version": "15.1.1",
-      "dev": true,
-      "requires": {
-        "@hapi/address": "2.x.x",
-        "@hapi/bourne": "1.x.x",
-        "@hapi/hoek": "8.x.x",
-        "@hapi/topo": "3.x.x"
-      }
-    },
-    "@hapi/topo": {
-      "version": "3.1.6",
-      "dev": true,
-      "requires": {
-        "@hapi/hoek": "^8.3.0"
-      }
-    },
     "@humanwhocodes/config-array": {
       "version": "0.11.6",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.6.tgz",
@@ -18288,14 +17905,6 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
-    "@mapbox/gazetteer": {
-      "version": "5.1.0",
-      "dev": true,
-      "requires": {
-        "@hapi/joi": "^15.0.3",
-        "@mapbox/geojsonhint": "^2.2.0"
-      }
-    },
     "@mapbox/geojson-rewind": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/@mapbox/geojson-rewind/-/geojson-rewind-0.5.2.tgz",
@@ -18311,23 +17920,6 @@
       "integrity": "sha512-e9EBqHHv3EORHrSfbR9DqecPNn+AmuAoQxV6aL8Xu30bJMJR1o8PZLZzpk1Wq7/NfCbuhmakHTPYRhoqLsXRnw==",
       "dev": true,
       "peer": true
-    },
-    "@mapbox/geojsonhint": {
-      "version": "2.2.0",
-      "dev": true,
-      "requires": {
-        "concat-stream": "^1.6.1",
-        "jsonlint-lines": "1.7.1",
-        "minimist": "1.2.0",
-        "vfile": "^4.0.0",
-        "vfile-reporter": "^5.1.1"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.0",
-          "dev": true
-        }
-      }
     },
     "@mapbox/jsonlint-lines-primitives": {
       "version": "2.0.2"
@@ -20603,16 +20195,6 @@
     "concat-map": {
       "version": "0.0.1",
       "dev": true
-    },
-    "concat-stream": {
-      "version": "1.6.2",
-      "dev": true,
-      "requires": {
-        "buffer-from": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^2.2.2",
-        "typedarray": "^0.0.6"
-      }
     },
     "console-control-strings": {
       "version": "1.1.0",
@@ -22977,10 +22559,6 @@
       "integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
       "dev": true
     },
-    "has-color": {
-      "version": "0.1.7",
-      "dev": true
-    },
     "has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -23545,10 +23123,6 @@
       "requires": {
         "is-docker": "^2.0.0"
       }
-    },
-    "isarray": {
-      "version": "1.0.0",
-      "dev": true
     },
     "isexe": {
       "version": "2.0.0"
@@ -24591,18 +24165,6 @@
           "dev": true
         }
       }
-    },
-    "jsonlint-lines": {
-      "version": "1.7.1",
-      "dev": true,
-      "requires": {
-        "JSV": ">= 4.0.x",
-        "nomnom": ">= 1.5.x"
-      }
-    },
-    "JSV": {
-      "version": "4.0.2",
-      "dev": true
     },
     "jsx-ast-utils": {
       "version": "3.2.1",
@@ -26090,29 +25652,6 @@
       "integrity": "sha512-PiVXnNuFm5+iYkLBNeq5211hvO38y63T0i2KKh2KnUs3RpzJ+JtODFjkD8yjLwnDkTYF1eKXheUwdssR+NRZdg==",
       "dev": true
     },
-    "nomnom": {
-      "version": "1.8.1",
-      "dev": true,
-      "requires": {
-        "chalk": "~0.4.0",
-        "underscore": "~1.6.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "1.0.0",
-          "dev": true
-        },
-        "chalk": {
-          "version": "0.4.0",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "~1.0.0",
-            "has-color": "~0.1.0",
-            "strip-ansi": "~0.1.0"
-          }
-        }
-      }
-    },
     "nopt": {
       "version": "5.0.0",
       "dev": true,
@@ -27253,10 +26792,6 @@
       "version": "1.0.3",
       "dev": true
     },
-    "process-nextick-args": {
-      "version": "2.0.1",
-      "dev": true
-    },
     "process-on-spawn": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/process-on-spawn/-/process-on-spawn-1.0.0.tgz",
@@ -27561,30 +27096,6 @@
         }
       }
     },
-    "readable-stream": {
-      "version": "2.3.7",
-      "dev": true,
-      "requires": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      },
-      "dependencies": {
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        }
-      }
-    },
     "readdirp": {
       "version": "3.6.0",
       "dev": true,
@@ -27704,10 +27215,6 @@
         "mdast-util-toc": "^6.0.0",
         "unified": "^10.0.0"
       }
-    },
-    "repeat-string": {
-      "version": "1.6.1",
-      "dev": true
     },
     "require-directory": {
       "version": "2.1.1",
@@ -28507,10 +28014,6 @@
         "character-entities-legacy": "^3.0.0"
       }
     },
-    "strip-ansi": {
-      "version": "0.1.1",
-      "dev": true
-    },
     "strip-bom": {
       "version": "3.0.0",
       "dev": true
@@ -29139,12 +28642,6 @@
       "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
       "dev": true
     },
-    "typedarray": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
-      "dev": true
-    },
     "typedarray-to-buffer": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
@@ -29176,12 +28673,6 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
       "integrity": "sha512-eXL4nmJT7oCpkZsHZUOJo8hcX3GbsiDOa0Qu9F646fi8dT3XuSVopVqAcEiVzSKKH7UoDti23wNX3qGFxcW5Qg==",
-      "dev": true
-    },
-    "underscore": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
-      "integrity": "sha512-z4o1fvKUojIWh9XuaVLUDdf86RQiq13AC1dmHbTpoyuu+bquHms76v16CjycCbec87J7z0k//SiQVk0sMdFmpQ==",
       "dev": true
     },
     "unified": {
@@ -29406,108 +28897,6 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
-    },
-    "vfile": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/vfile/-/vfile-4.2.1.tgz",
-      "integrity": "sha512-O6AE4OskCG5S1emQ/4gl8zK586RqA3srz3nfK/Viy0UPToBc5Trp9BVFb1u0CjsKrAWwnpr4ifM/KBXPWwJbCA==",
-      "dev": true,
-      "requires": {
-        "@types/unist": "^2.0.0",
-        "is-buffer": "^2.0.0",
-        "unist-util-stringify-position": "^2.0.0",
-        "vfile-message": "^2.0.0"
-      },
-      "dependencies": {
-        "is-buffer": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
-          "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
-          "dev": true
-        },
-        "unist-util-stringify-position": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-2.0.3.tgz",
-          "integrity": "sha512-3faScn5I+hy9VleOq/qNbAd6pAx7iH5jYBMS9I1HgQVijz/4mv5Bvw5iw1sC/90CODiKo81G/ps8AJrISn687g==",
-          "dev": true,
-          "requires": {
-            "@types/unist": "^2.0.2"
-          }
-        }
-      }
-    },
-    "vfile-message": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-2.0.4.tgz",
-      "integrity": "sha512-DjssxRGkMvifUOJre00juHoP9DPWuzjxKuMDrhNbk2TdaYYBNMStsNhEOt3idrtI12VQYM/1+iM0KOzXi4pxwQ==",
-      "dev": true,
-      "requires": {
-        "@types/unist": "^2.0.0",
-        "unist-util-stringify-position": "^2.0.0"
-      },
-      "dependencies": {
-        "unist-util-stringify-position": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-2.0.3.tgz",
-          "integrity": "sha512-3faScn5I+hy9VleOq/qNbAd6pAx7iH5jYBMS9I1HgQVijz/4mv5Bvw5iw1sC/90CODiKo81G/ps8AJrISn687g==",
-          "dev": true,
-          "requires": {
-            "@types/unist": "^2.0.2"
-          }
-        }
-      }
-    },
-    "vfile-reporter": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/vfile-reporter/-/vfile-reporter-5.1.2.tgz",
-      "integrity": "sha512-b15sTuss1wOPWVlyWOvu+n6wGJ/eTYngz3uqMLimQvxZ+Q5oFQGYZZP1o3dR9sk58G5+wej0UPCZSwQBX/mzrQ==",
-      "dev": true,
-      "requires": {
-        "repeat-string": "^1.5.0",
-        "string-width": "^2.0.0",
-        "supports-color": "^5.0.0",
-        "unist-util-stringify-position": "^2.0.0",
-        "vfile-sort": "^2.1.2",
-        "vfile-statistics": "^1.1.0"
-      },
-      "dependencies": {
-        "has-flag": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
-        },
-        "unist-util-stringify-position": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-2.0.3.tgz",
-          "integrity": "sha512-3faScn5I+hy9VleOq/qNbAd6pAx7iH5jYBMS9I1HgQVijz/4mv5Bvw5iw1sC/90CODiKo81G/ps8AJrISn687g==",
-          "dev": true,
-          "requires": {
-            "@types/unist": "^2.0.2"
-          }
-        },
-        "vfile-sort": {
-          "version": "2.2.2",
-          "resolved": "https://registry.npmjs.org/vfile-sort/-/vfile-sort-2.2.2.tgz",
-          "integrity": "sha512-tAyUqD2R1l/7Rn7ixdGkhXLD3zsg+XLAeUDUhXearjfIcpL1Hcsj5hHpCoy/gvfK/Ws61+e972fm0F7up7hfYA==",
-          "dev": true
-        }
-      }
-    },
-    "vfile-statistics": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/vfile-statistics/-/vfile-statistics-1.1.4.tgz",
-      "integrity": "sha512-lXhElVO0Rq3frgPvFBwahmed3X03vjPF8OcjKMy8+F1xU/3Q3QU3tKEDp743SFtb74PdF0UWpxPvtOP0GCLheA==",
-      "dev": true
     },
     "vt-pbf": {
       "version": "3.1.3",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "vt-pbf": "^3.1.3"
   },
   "devDependencies": {
-    "@mapbox/gazetteer": "^5.1.0",
     "@mapbox/mapbox-gl-rtl-text": "^0.2.3",
     "@mapbox/mvt-fixtures": "^3.10.0",
     "@rollup/plugin-commonjs": "^23.0.3",

--- a/test/bench/data/style-benchmark-locations.json
+++ b/test/bench/data/style-benchmark-locations.json
@@ -1,0 +1,198 @@
+{
+  "type": "FeatureCollection",
+  "name": "style-benchmark-locations",
+  "features": [
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [-95.392, 29.799]
+      },
+      "properties": {
+        "place_name": "Roads, Houston, z12",
+        "zoom": 12,
+        "tags": ["road"]
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [-95.381, 29.749]
+      },
+      "properties": {
+        "place_name": "Roads, Houston, z13",
+        "zoom": 13,
+        "tags": ["road", "poi_label", "landuse"]
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [-73.985, 40.758]
+      },
+      "properties": {
+        "place_name": "High zoom labels, buildings, roads, New York City, z16",
+        "zoom": 16,
+        "tags": ["poi_label", "building", "road"]
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [-73.985, 40.758]
+      },
+      "properties": {
+        "place_name": "High zoom labels, buildings, roads, New York City, z17, overzoomed",
+        "zoom": 17,
+        "tags": ["poi_label", "road", "building"]
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [139.76, 35.695]
+      },
+      "properties": {
+        "place_name": "High zoom cjk labels, when using local lang, buildings, roads, Tokyo, z16",
+        "zoom": 16,
+        "tags": ["poi_label", "building", "road"]
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [139.76, 35.695]
+      },
+      "properties": {
+        "place_name": "High zoom cjk labels, when using local lang, buildings, roads, Tokyo, z17, overzoomed",
+        "zoom": 17,
+        "tags": ["poi_label", "road", "building"]
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [27.602, 61.521]
+      },
+      "properties": {
+        "place_name": "Water, Finland, z10",
+        "zoom": 10,
+        "tags": ["water"]
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [2.21, 48.745]
+      },
+      "properties": {
+        "place_name": "Landuse and roads, Paris, z11",
+        "zoom": 11,
+        "tags": [
+          "place_label:settlement",
+          "road",
+          "landuse",
+          "poi_label",
+          "hillshade"
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [-118.314, 33.996]
+      },
+      "properties": {
+        "place_name": "Buildings, LA, z16",
+        "zoom": 16,
+        "tags": ["building", "road"]
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [2.316, 48.867]
+      },
+      "properties": {
+        "place_name": "High zoom roads, paths, landuse, labels, Paris, 15",
+        "zoom": 15,
+        "tags": [
+          "road",
+          "road:pedestrian",
+          "poi_label",
+          "landuse",
+          "transit_stop_label"
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [2.316, 48.867]
+      },
+      "properties": {
+        "place_name": "High zoom pedestrian polygon fills, roads, paths, landuse, labels, Paris, z16",
+        "zoom": 16,
+        "tags": ["landuse", "road", "road:pedestrian", "poi_label", "road:path"]
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [8.835, 46.317]
+      },
+      "properties": {
+        "place_name": "Hillshading, Switzerland, z9",
+        "zoom": 9,
+        "tags": ["hillshade", "place_label"]
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [8.835, 46.317]
+      },
+      "properties": {
+        "place_name": "Hillshading and contours, Switzerland, z12",
+        "zoom": 12,
+        "tags": ["hillshade"]
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [8.416, 51.056]
+      },
+      "properties": {
+        "place_name": "Landcover, Germany z6",
+        "zoom": 6,
+        "tags": ["landcover", "place_label:settlement", "road", "admin"]
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [7.762, 50.322]
+      },
+      "properties": {
+        "place_name": "Landcover, Germany z8",
+        "zoom": 8,
+        "tags": ["place_label:settlement", "road", "hillshade"]
+      }
+    }
+  ]
+}

--- a/test/bench/styles/benchmarks.ts
+++ b/test/bench/styles/benchmarks.ts
@@ -1,6 +1,6 @@
 import maplibregl from '../../../src';
 import locationsWithTileID from '../lib/locations_with_tile_id';
-import styleBenchmarkLocations from '@mapbox/gazetteer/benchmark/style-benchmark-locations.json';
+import styleBenchmarkLocations from '../data/style-benchmark-locations.json';
 import StyleLayerCreate from '../benchmarks/style_layer_create';
 import Validate from '../benchmarks/style_validate';
 import Layout from '../benchmarks/layout';

--- a/test/bench/versions/benchmarks.ts
+++ b/test/bench/versions/benchmarks.ts
@@ -1,6 +1,6 @@
 import maplibregl from '../../../src';
 import locationsWithTileID from '../lib/locations_with_tile_id';
-import styleBenchmarkLocations from '@mapbox/gazetteer/benchmark/style-benchmark-locations.json';
+import styleBenchmarkLocations from '../data/style-benchmark-locations.json';
 import Layout from '../benchmarks/layout';
 import Placement from '../benchmarks/placement';
 import SymbolLayout from '../benchmarks/symbol_layout';


### PR DESCRIPTION
Removes dependency on gazetteer, which was only being used for a single GeoJSON file for benchmarks but pulled in a number of deprecated packages.

Fix #1897

## Launch Checklist

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [X] Briefly describe the changes in this PR.
 - [X] Link to related issues.
 - [X] Include before/after visuals or gifs if this PR includes visual changes.
 - [X] Write tests for all new functionality.
 - [X] Document any changes to public APIs.
 - [X] Manually test the debug page.
 - [X] Add an entry to `CHANGELOG.md` under the `## main` section.
