### PR TITLE
Move failing tests to use ubuntu 20.04 instead of 22.04

### DIFF
--- a/.github/workflows/test-browser.yml
+++ b/.github/workflows/test-browser.yml
@@ -7,8 +7,8 @@ on:
 
 jobs:
   test_browser:
-    name: ubuntu-latest
-    runs-on: ubuntu-latest
+    name: ubuntu-20.04
+    runs-on: ubuntu-20.04
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test-render.yml
+++ b/.github/workflows/test-render.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   test_render:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Latest pull request are failing render and browser tests.
On my mac, everything is working as expected.
I think it's an environment change.
I checked passing tests, with node 16.18.1 they pass, so it doesn't look like a change in node.
I saw there was a change in ubuntu-latest to use 22 instead of 20.
This PR is aimed at allowing the tests to pass, if they do, I'll open a different issue to solve the ability to move to latest ubuntu...