### PR TITLE
Resolve typescript error

### DIFF
--- a/src/util/web_worker_transfer.ts
+++ b/src/util/web_worker_transfer.ts
@@ -9,9 +9,9 @@ import {AJAXError} from './ajax';
 import type {Transferable} from '../types/transferable';
 import {isImageBitmap} from './util';
 
-type SerializedObject = {
-    [_: string]: Serialized;
-}; // eslint-disable-line
+type SerializedObject<S extends Serialized = any> = {
+    [_: string]: S;
+};
 
 export type Serialized = null | void | boolean | number | string | Boolean | Number | String | Date | RegExp | ArrayBuffer | ArrayBufferView | ImageData | ImageBitmap | Blob | Array<Serialized> | SerializedObject;
 


### PR DESCRIPTION
The following typescript error is no longer reported when running `npm
run typecheck`

src/util/web_worker_transfer.ts:114:9 - error TS2322: Type 'unknown' is
not assignable to type 'Serialized'.

114         return input;
