### PR TITLE
Update Changelog and Release processes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -183,9 +183,8 @@ What warrants a changelog entry?
 
 How to add your changelog?
 
+- Edit the [`CHANGELOG.md`](CHANGELOG.md) file directly, inserting a new entry at the top of the appropriate list
 - Any changelog entry should be descriptive and concise; it should explain the change to a reader without context
-- Any changelog entry should be added to the pull request in the following format: `<changelog>Changelog description</changelog>`
-- Any change that does not require a changelog should be labelled `skip changelog`
 
 ## Recommended Reading
 

--- a/docs/RELEASE-PROCESS.md
+++ b/docs/RELEASE-PROCESS.md
@@ -1,9 +1,12 @@
 ## Publish to NPM
 
-1. Review [`CHANGELOG.md`](../CHANGELOG.md) and double-check that all changes included in the release are [appropriately documented](https://github.com/maplibre/maplibre-gl-js/blob/main/CONTRIBUTING.md#changelog-conventions).
-2. Use [semantic version rules](https://docs.npmjs.com/about-semantic-versioning) to define a version. The command [`npm version`](https://docs.npmjs.com/cli/commands/npm-version) will bump the version and create a commit (e.g. if making a backwards-compatible release with new features, `npm version minor`).
+1. Review [`CHANGELOG.md`](../CHANGELOG.md)
+   - Double-check that all changes included in the release are [appropriately documented](../CONTRIBUTING.md#changelog-conventions).
+   - To-be-released changes should be under a placeholder header. Update that header to the version number which is about to be released. This project uses [semantic versioning](https://docs.npmjs.com/about-semantic-versioning).
+   - Commit any final changes to the changelog.
+2. Bump the version number with `npm version VERSIONTYPE --no-git-tag-version`
+  - e.g. if making a backwards-compatible release with new features, run `npm version minor --no-git-tag-version`
+  - [`npm version`](https://docs.npmjs.com/cli/commands/npm-version) will increment the version in `package.json` and `package-lock.json`.
 3. Run [`release.yml`](https://github.com/maplibre/maplibre-gl-js/actions/workflows/release.yml) by manual workflow dispatch. This builds the minified library, tags the commit based on the version in `package.json`, creates a GitHub release, uploads release assets, and publishes the build output to NPM.
-
-The changelog should be updated on every PR - there is a placeholder at the top of the document - and heading should be renamed to the same version which is going to be set in the version tag during release.
 
 The workflow expects `${{ secrets.NPM_ORG_TOKEN }}` organization secret in order to push to NPM registry.

--- a/docs/RELEASE-PROCESS.md
+++ b/docs/RELEASE-PROCESS.md
@@ -1,6 +1,6 @@
 ## Publish to NPM
 
-1. Review [`CHANGELOG.md`](../CHANGELOG.md) and double checkx that all changes included in the release are [appropriately documented](https://github.com/maplibre/maplibre-gl-js/blob/main/CONTRIBUTING.md#changelog-conventions).
+1. Review [`CHANGELOG.md`](../CHANGELOG.md) and double-check that all changes included in the release are [appropriately documented](https://github.com/maplibre/maplibre-gl-js/blob/main/CONTRIBUTING.md#changelog-conventions).
 2. Use [semantic version rules](https://docs.npmjs.com/about-semantic-versioning) to define a version. The command [`npm version`](https://docs.npmjs.com/cli/commands/npm-version) will bump the version and create a commit (e.g. if making a backwards-compatible release with new features, `npm version minor`).
 3. Run [`release.yml`](https://github.com/maplibre/maplibre-gl-js/actions/workflows/release.yml) by manual workflow dispatch. This builds the minified library, tags the commit based on the version in `package.json`, creates a GitHub release, uploads release assets, and publishes the build output to NPM.
 

--- a/docs/RELEASE-PROCESS.md
+++ b/docs/RELEASE-PROCESS.md
@@ -1,8 +1,8 @@
 ## Publish to NPM
 
-1. Use [semantic version rules](https://classic.yarnpkg.com/en/docs/dependency-versions#toc-semantic-versioning) to define a version in `package.json`.
-2. Update `CHANGELOG.md`.
-3. Run `release.yml` by manual workflow dispatch. This builds the minified library, tags the commit based on the version in `package.json`, creates a GitHub release, uploads release assets, and publishes the build output to NPM.
+1. Review [`CHANGELOG.md`](../CHANGELOG.md) and double checkx that all changes included in the release are [appropriately documented](https://github.com/maplibre/maplibre-gl-js/blob/main/CONTRIBUTING.md#changelog-conventions).
+2. Use [semantic version rules](https://docs.npmjs.com/about-semantic-versioning) to define a version. The command [`npm version`](https://docs.npmjs.com/cli/commands/npm-version) will bump the version and create a commit (e.g. if making a backwards-compatible release with new features, `npm version minor`).
+3. Run [`release.yml`](https://github.com/maplibre/maplibre-gl-js/actions/workflows/release.yml) by manual workflow dispatch. This builds the minified library, tags the commit based on the version in `package.json`, creates a GitHub release, uploads release assets, and publishes the build output to NPM.
 
 The changelog should be updated on every PR - there is a placeholder at the top of the document - and heading should be renamed to the same version which is going to be set in the version tag during release.
 


### PR DESCRIPTION
1. Redirect semver help to npm's page, not yarn's.
2. Link to changelog guidelines
3. Add recommendation to use the new `npm version`, which also updates the lockfile.

https://github.com/maplibre/maplibre-gl-js/pull/1916#issuecomment-1348503903