### PR TITLE
Use a more up-to-date rollup sourcemap plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -113,7 +113,7 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "rollup": "^3.7.5",
-        "rollup-plugin-sourcemaps": "^0.6.3",
+        "rollup-plugin-include-sourcemaps": "^0.7.0",
         "rw": "^1.3.3",
         "semver": "^7.3.8",
         "shuffle-seed": "^1.1.6",
@@ -3355,8 +3355,9 @@
     },
     "node_modules/atob": {
       "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
+      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
       "dev": true,
-      "license": "(MIT OR Apache-2.0)",
       "bin": {
         "atob": "bin/atob.js"
       },
@@ -14231,13 +14232,15 @@
         "fsevents": "~2.3.2"
       }
     },
-    "node_modules/rollup-plugin-sourcemaps": {
-      "version": "0.6.3",
+    "node_modules/rollup-plugin-include-sourcemaps": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-include-sourcemaps/-/rollup-plugin-include-sourcemaps-0.7.0.tgz",
+      "integrity": "sha512-zAlN2IkFSaptlHhuWVROZ5xrviEULRSInN9AzETsBD++Ab5aMKAtXhDH2aRHbE2cRW6cVT9FFrAQHwZXxqDCIQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@rollup/pluginutils": "^3.0.9",
-        "source-map-resolve": "^0.6.0"
+        "@rollup/pluginutils": "^5.0.2",
+        "atob": "^2.1.2",
+        "decode-uri-component": "^0.2.0"
       },
       "engines": {
         "node": ">=10.0.0"
@@ -14250,38 +14253,6 @@
         "@types/node": {
           "optional": true
         }
-      }
-    },
-    "node_modules/rollup-plugin-sourcemaps/node_modules/@rollup/pluginutils": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
-      "integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
-      "dev": true,
-      "dependencies": {
-        "@types/estree": "0.0.39",
-        "estree-walker": "^1.0.1",
-        "picomatch": "^2.2.2"
-      },
-      "engines": {
-        "node": ">= 8.0.0"
-      },
-      "peerDependencies": {
-        "rollup": "^1.20.0||^2.0.0"
-      }
-    },
-    "node_modules/rollup-plugin-sourcemaps/node_modules/estree-walker": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
-      "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
-      "dev": true
-    },
-    "node_modules/rollup-plugin-sourcemaps/node_modules/source-map-resolve": {
-      "version": "0.6.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "atob": "^2.1.2",
-        "decode-uri-component": "^0.2.0"
       }
     },
     "node_modules/run-parallel": {
@@ -19354,6 +19325,8 @@
     },
     "atob": {
       "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
+      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
       "dev": true
     },
     "babel-jest": {
@@ -27066,39 +27039,15 @@
         "fsevents": "~2.3.2"
       }
     },
-    "rollup-plugin-sourcemaps": {
-      "version": "0.6.3",
+    "rollup-plugin-include-sourcemaps": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-include-sourcemaps/-/rollup-plugin-include-sourcemaps-0.7.0.tgz",
+      "integrity": "sha512-zAlN2IkFSaptlHhuWVROZ5xrviEULRSInN9AzETsBD++Ab5aMKAtXhDH2aRHbE2cRW6cVT9FFrAQHwZXxqDCIQ==",
       "dev": true,
       "requires": {
-        "@rollup/pluginutils": "^3.0.9",
-        "source-map-resolve": "^0.6.0"
-      },
-      "dependencies": {
-        "@rollup/pluginutils": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
-          "integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
-          "dev": true,
-          "requires": {
-            "@types/estree": "0.0.39",
-            "estree-walker": "^1.0.1",
-            "picomatch": "^2.2.2"
-          }
-        },
-        "estree-walker": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
-          "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
-          "dev": true
-        },
-        "source-map-resolve": {
-          "version": "0.6.0",
-          "dev": true,
-          "requires": {
-            "atob": "^2.1.2",
-            "decode-uri-component": "^0.2.0"
-          }
-        }
+        "@rollup/pluginutils": "^5.0.2",
+        "atob": "^2.1.2",
+        "decode-uri-component": "^0.2.0"
       }
     },
     "run-parallel": {

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "rollup": "^3.7.5",
-    "rollup-plugin-sourcemaps": "^0.6.3",
+    "rollup-plugin-include-sourcemaps": "^0.7.0",
     "rw": "^1.3.3",
     "semver": "^7.3.8",
     "shuffle-seed": "^1.1.6",

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -1,5 +1,5 @@
 import fs from 'fs';
-import sourcemaps from 'rollup-plugin-sourcemaps';
+import sourcemaps from 'rollup-plugin-include-sourcemaps';
 import {plugins} from './build/rollup_plugins';
 import banner from './build/banner';
 import {RollupOptions} from 'rollup';

--- a/test/bench/rollup_config_benchmarks.ts
+++ b/test/bench/rollup_config_benchmarks.ts
@@ -1,5 +1,5 @@
 import fs from 'fs';
-import sourcemaps from 'rollup-plugin-sourcemaps';
+import sourcemaps from 'rollup-plugin-include-sourcemaps';
 import replace from '@rollup/plugin-replace';
 import {plugins, nodeResolve} from '../../build/rollup_plugins';
 import commonjs from '@rollup/plugin-commonjs';


### PR DESCRIPTION
We previously used: https://github.com/maxdavidson/rollup-plugin-sourcemaps

It hasn't been updated for years and is not rollup-3 compatible due to a 'peerDependency' in @rollup/pluginutils which it relies on. This PR change to a more recent fork of it.

This PR can be tested by running 'npm i' and checking that the dependency warning about conflicting rollup versions is gone.