### PR TITLE
fix warning for running jest tests

### DIFF
--- a/jest.config.builds.ts
+++ b/jest.config.builds.ts
@@ -1,5 +1,4 @@
 import type {JestConfigWithTsJest} from 'ts-jest';
-import {defaults as tsjPreset} from 'ts-jest/presets';
 
 const config: JestConfigWithTsJest = {
     roots: [
@@ -11,16 +10,11 @@ const config: JestConfigWithTsJest = {
         '**/?(*.)+(spec|test).+(ts|tsx|js)'
     ],
     transform: {
-        ...tsjPreset.transform,
-    },
-    transformIgnorePatterns: [
-        '/node_modules/@mapbox/jsonlint-lines-primitives/lib/jsonlint.js'
-    ],
-    globals: {
-        'ts-jest': {
+        '[.](js|ts)x?$': ['ts-jest', {
             isolatedModules: true
-        }
+        }],
     },
+    transformIgnorePatterns: [],
     setupFiles: ['jest-canvas-mock'],
 };
 

--- a/jest.config.e2e.ts
+++ b/jest.config.e2e.ts
@@ -1,5 +1,4 @@
 import type {JestConfigWithTsJest} from 'ts-jest';
-import {defaults as tsjPreset} from 'ts-jest/presets';
 
 const config: JestConfigWithTsJest = {
     roots: [
@@ -10,19 +9,13 @@ const config: JestConfigWithTsJest = {
         '**/__tests__/**/*.+(ts|tsx|js)',
         '**/?(*.)+(spec|test).+(ts|tsx|js)'
     ],
-    transform: {
-        ...tsjPreset.transform,
-    },
-    transformIgnorePatterns: [
-        '/node_modules/@mapbox/jsonlint-lines-primitives/lib/jsonlint.js'
-    ],
     preset: 'jest-playwright-preset',
-
-    globals: {
-        'ts-jest': {
+    transform: {
+        '[.](js|ts)x?$': ['ts-jest', {
             isolatedModules: true
-        }
+        }],
     },
+    transformIgnorePatterns: [],
     setupFiles: ['jest-canvas-mock'],
 };
 

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -10,15 +10,12 @@ const config: JestConfigWithTsJest = {
         '**/?(*.)+(spec|test).+(ts|tsx|js)'
     ],
     testEnvironment: 'jsdom',
-    preset: 'ts-jest/presets/js-with-ts-esm',
-    transformIgnorePatterns: [
-        '/node_modules/@mapbox/jsonlint-lines-primitives/lib/jsonlint.js'
-    ],
-    globals: {
-        'ts-jest': {
+    transform: {
+        '[.](js|ts)x?$': ['ts-jest', {
             isolatedModules: true
-        }
+        }],
     },
+    transformIgnorePatterns: [],
     setupFiles: [
         'jest-canvas-mock',
         './test/unit/lib/web_worker_mock.ts'


### PR DESCRIPTION
Fix complaint from jest due to the way ts-jnode interacts with jest ts runner.

see https://github.com/maplibre/maplibre-gl-js/pull/1966#issuecomment-1362079702