### PR TITLE
Bump gl package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -88,7 +88,7 @@
         "eslint-plugin-jest": "^27.1.7",
         "eslint-plugin-jsdoc": "^39.6.4",
         "eslint-plugin-react": "^7.31.11",
-        "gl": "^6.0.1",
+        "gl": "^6.0.2",
         "glob": "^8.0.3",
         "is-builtin-module": "^3.2.0",
         "jest": "^29.3.1",
@@ -7107,16 +7107,16 @@
       "dev": true
     },
     "node_modules/gl": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/gl/-/gl-6.0.1.tgz",
-      "integrity": "sha512-OpW8FFG3fuRrt5ZAa3L3Ybrj66UIV+i0MWbA7tHe83P0ze0QycYrt5L6xTMgd3zsFGQPh/uKY86CFCYMnAJVGQ==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/gl/-/gl-6.0.2.tgz",
+      "integrity": "sha512-yBbfpChOtFvg5D+KtMaBFvj6yt3vUnheNAH+UrQH2TfDB8kr0tERdL0Tjhe0W7xJ6jR6ftQBluTZR9jXUnKe8g==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
         "bindings": "^1.5.0",
         "bit-twiddle": "^1.0.2",
         "glsl-tokenizer": "^2.1.5",
-        "nan": "^2.16.0",
+        "nan": "^2.17.0",
         "node-abi": "^3.26.0",
         "node-gyp": "^9.2.0",
         "prebuild-install": "^7.1.1"
@@ -21683,15 +21683,15 @@
       "dev": true
     },
     "gl": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/gl/-/gl-6.0.1.tgz",
-      "integrity": "sha512-OpW8FFG3fuRrt5ZAa3L3Ybrj66UIV+i0MWbA7tHe83P0ze0QycYrt5L6xTMgd3zsFGQPh/uKY86CFCYMnAJVGQ==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/gl/-/gl-6.0.2.tgz",
+      "integrity": "sha512-yBbfpChOtFvg5D+KtMaBFvj6yt3vUnheNAH+UrQH2TfDB8kr0tERdL0Tjhe0W7xJ6jR6ftQBluTZR9jXUnKe8g==",
       "dev": true,
       "requires": {
         "bindings": "^1.5.0",
         "bit-twiddle": "^1.0.2",
         "glsl-tokenizer": "^2.1.5",
-        "nan": "^2.16.0",
+        "nan": "^2.17.0",
         "node-abi": "^3.26.0",
         "node-gyp": "^9.2.0",
         "prebuild-install": "^7.1.1"

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "eslint-plugin-jest": "^27.1.7",
     "eslint-plugin-jsdoc": "^39.6.4",
     "eslint-plugin-react": "^7.31.11",
-    "gl": "^6.0.1",
+    "gl": "^6.0.2",
     "glob": "^8.0.3",
     "is-builtin-module": "^3.2.0",
     "jest": "^29.3.1",


### PR DESCRIPTION
Fix upstream build issue so now things install cleanly on Mac + Node 19