### PR TITLE
change the cluster properties on the sources option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 ## main
 
 ### ✨ Features and improvements
+- Add `setiClusterOptions` to update cluster properties of the added sources: fixing these issues ([#429](https://github.com/maplibre/maplibre-gl-js/issues/429)) and ([1384](https://github.com/maplibre/maplibre-gl-js/issues/1384))
+- Add types for `workerOptions` and `_options` in `geojson_source.ts`
 - *...Add new stuff here...*
-
 ### 🐞 Bug fixes
 - *...Add new stuff here...*
 ## 3.0.0-pre.3

--- a/src/source/geojson_source.test.ts
+++ b/src/source/geojson_source.test.ts
@@ -248,6 +248,27 @@ describe('GeoJSONSource#update', () => {
         } as GeoJSONSourceOptions, mockDispatcher, undefined).load();
     });
 
+    test('modifying cluster properties after adding a source', done => {
+        // test setCluster fonction on GeoJSONSource
+        const mockDispatcher = wrapDispatcher({
+            send(message, params) {
+                expect(message).toBe('geojson.loadData');
+                expect(params.cluster).toBe(true);
+                expect(params.superclusterOptions.radius).toBe(80);
+                expect(params.superclusterOptions.maxZoom).toBe(16);
+                done();
+            }
+        });
+        new GeoJSONSource('id', {
+            data: {},
+            cluster: false,
+            clusterMaxZoom: 8,
+            clusterRadius: 100,
+            clusterMinPoints: 3,
+            generateId: true
+        } as GeoJSONSourceOptions, mockDispatcher, undefined).setClusterOptions({cluster: true, clusterRadius: 80, clusterMaxZoom: 16});
+    });
+
     test('forwards Supercluster options with worker request, ignore max zoom of source', done => {
         const mockDispatcher = wrapDispatcher({
             send(message, params) {

--- a/src/source/geojson_source.ts
+++ b/src/source/geojson_source.ts
@@ -19,6 +19,45 @@ export type GeoJSONSourceOptions = GeoJSONSourceSpecification & {
     collectResourceTiming: boolean;
 }
 
+export type GeoJsonSourceOptions = {
+    data?: GeoJSON.GeoJSON | string | undefined;
+    cluster?: boolean;
+    clusterMaxZoom?: number;
+    clusterRadius?: number;
+    clusterMinPoints?: number;
+    generateId?: boolean;
+}
+export type WorkerOptions = {
+    source?: string;
+    cluster?: boolean;
+    geojsonVtOptions?: {
+        buffer?: number;
+        tolerance?: number;
+        extent?: number;
+        maxZoom?: number;
+        linemetrics?: boolean;
+        generateId?: boolean;
+    };
+    superclusterOptions?: {
+        maxZoom?: number;
+        miniPoints?: number;
+        extent?: number;
+        radius?: number;
+        log?: boolean;
+        generateId?: boolean;
+    };
+    clusterProperties?: any;
+    fliter?: any;
+    promoteId?: any;
+    collectResourceTiming?: boolean;
+}
+
+export type SetClusterOptions = {
+    cluster?: boolean;
+    clusterMaxZoom?: number;
+    clusterRadius?: number;
+}
+
 /**
  * A source containing GeoJSON.
  * (See the [Style Specification](https://maplibre.org/maplibre-gl-js-docs/style-spec/#sources-geojson) for detailed documentation of options.)
@@ -77,8 +116,8 @@ class GeoJSONSource extends Evented implements Source {
     isTileClipped: boolean;
     reparseOverscaled: boolean;
     _data: GeoJSON.GeoJSON | string | undefined;
-    _options: any;
-    workerOptions: any;
+    _options: GeoJsonSourceOptions;
+    workerOptions: WorkerOptions;
     map: Map;
     actor: Actor;
     _pendingLoads: number;
@@ -193,6 +232,25 @@ class GeoJSONSource extends Evented implements Source {
     updateData(diff: GeoJSONSourceDiff) {
         this._updateWorkerData(diff);
 
+        return this;
+    }
+
+    /**
+     * To disable/enable clustering on the source options
+     * @param {SetClusterOptions} options The options to set
+     * @returns {GeoJSONSource} this
+     * @example
+     * map.getSource('some id').setClusterOptions({cluster: false});
+     * map.getSource('some id').setClusterOptions({cluster: false, clusterRadius: 50, clusterMaxZoom: 14});
+     *
+     */
+    setClusterOptions(options:SetClusterOptions) {
+        this.workerOptions.cluster = options.cluster;
+        if (options) {
+            if (options.clusterRadius !== undefined) this.workerOptions.superclusterOptions.radius = options.clusterRadius;
+            if (options.clusterMaxZoom !== undefined) this.workerOptions.superclusterOptions.maxZoom = options.clusterMaxZoom;
+        }
+        this._updateWorkerData();
         return this;
     }
 


### PR DESCRIPTION
## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - I Confirm that **my changes do not include backports from Mapbox projects** (unless with compliant license) 
 - fix issue #1384 and #429 
 -  enable users to change cluster properties on the source by adding setClusterOptions in [src/source/geojson-source.ts](https://github.com/maplibre/maplibre-gl-js/blob/v2.4.0/src/source/geojson_source.ts#L68-L346)
 - `setClusterOptions(cluster: boolean, clusterRadius?: number; clusterMaxZoom?: number})`  The value of the clusters properties.
 
Exemple:
```js
map.addSource('earthquakes', {
                type: 'geojson',
                data:
                    'https://maplibre.org/maplibre-gl-js-docs/assets/earthquakes.geojson',
                cluster: true,
            });
///////////////
         map.getSource('earthquakes').setClusterOptions(cluster:false);
        map.getSource('earthquakes').setClusterOptions(clust: true, clusterRadius: 80, clusterMaxZoom: 50 });
/////////////
```