### PR TITLE
Add integration tests for text-offset

### DIFF
--- a/test/integration/style-spec/tests/text-offset.input.json
+++ b/test/integration/style-spec/tests/text-offset.input.json
@@ -1,0 +1,92 @@
+{
+  "version": 8,
+  "glyphs": "local://glyphs/{fontstack}/{range}.pbf",
+  "sources": {
+    "point": {
+      "type": "geojson",
+      "data": {
+        "type": "FeatureCollection",
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "font-scale-override": 2.0,
+              "text-font-override": ["Arial"]
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [ 0, 0 ]
+            }
+          }
+        ]
+      }
+    }
+  },
+  "layers": [
+    {
+      "id": "numeric offset - valid",
+      "type": "symbol",
+      "source": "point",
+      "layout": {
+        "text-offset": [
+          10,
+          5
+        ]
+      }
+    },
+    {
+      "id": "numeric offset with negative values - valid",
+      "type": "symbol",
+      "source": "point",
+      "layout": {
+        "text-offset": [
+          -10,
+          -5
+        ]
+      }
+    },
+    {
+      "id": "numeric offset with three numbers - invalid",
+      "type": "symbol",
+      "source": "point",
+      "layout": {
+        "text-offset": [
+          0,
+          0,
+          0
+        ]
+      }
+    },
+    {
+      "id": "expression get - valid",
+      "type": "symbol",
+      "source": "point",
+      "layout": {
+        "text-offset": [
+          "get",
+          "population"
+        ]
+      }
+    },
+    {
+      "id": "expression interpolate - valid",
+      "type": "symbol",
+      "source": "point",
+      "layout": {
+        "text-offset": [
+          "interpolate",
+          ["linear"],
+          ["zoom"],
+          16,
+          ["literal", [0, 1]],
+          17,
+          ["literal", [0, 2]],
+          18,
+          ["literal", [0, 3]],
+          19,
+          ["literal", [0, 4]]
+        ]
+      }
+    }
+  ]
+}

--- a/test/integration/style-spec/tests/text-offset.output.json
+++ b/test/integration/style-spec/tests/text-offset.output.json
@@ -1,0 +1,6 @@
+[
+  {
+    "message": "layers[2].layout.text-offset: array length 2 expected, length 3 found",
+    "line": 53
+  }
+]


### PR DESCRIPTION
Includes a test for the value of text-offset to be an expression. This test passes, which closes #1899.

These tests can be run with `npm run test-style-spec`.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
