### PR TITLE
Use resizeObserver instead of window resize events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### ✨ Features and improvements
 - Add `setiClusterOptions` to update cluster properties of the added sources: fixing these issues ([#429](https://github.com/maplibre/maplibre-gl-js/issues/429)) and ([1384](https://github.com/maplibre/maplibre-gl-js/issues/1384))
 - Add types for `workerOptions` and `_options` in `geojson_source.ts`
+- Resize map when container element is resized.  ([#2013](https://github.com/maplibre/maplibre-gl-js/pull/2013))
 - *...Add new stuff here...*
 ### 🐞 Bug fixes
 - *...Add new stuff here...*

--- a/src/ui/map.test.ts
+++ b/src/ui/map.test.ts
@@ -702,47 +702,6 @@ describe('Map', () => {
             expect(events).toEqual(['movestart', 'move', 'resize', 'moveend']);
 
         });
-
-        test('listen to window resize event', done => {
-            const original = global.addEventListener;
-            global.addEventListener = function (type) {
-                if (type === 'resize') {
-                    //restore original function not to mess with other tests
-                    global.addEventListener = original;
-
-                    done();
-                }
-            };
-
-            createMap();
-        });
-
-        test('do not resize if trackResize is false', () => {
-            const map = createMap({trackResize: false});
-
-            const spyA = jest.spyOn(map, 'stop');
-            const spyB = jest.spyOn(map, '_update');
-            const spyC = jest.spyOn(map, 'resize');
-
-            map._onWindowResize(undefined);
-
-            expect(spyA).not.toHaveBeenCalled();
-            expect(spyB).not.toHaveBeenCalled();
-            expect(spyC).not.toHaveBeenCalled();
-        });
-
-        test('do resize if trackResize is true (default)', () => {
-            const map = createMap();
-
-            const spyA = jest.spyOn(map, '_update');
-            const spyB = jest.spyOn(map, 'resize');
-
-            map._onWindowResize(undefined);
-
-            expect(spyA).toHaveBeenCalled();
-            expect(spyB).toHaveBeenCalled();
-        });
-
     });
 
     describe('#getBounds', () => {

--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -319,6 +319,7 @@ class Map extends Camera {
     // accounts for placement finishing as well
     _fullyLoaded: boolean;
     _trackResize: boolean;
+    _resizeObserver: ResizeObserver;
     _preserveDrawingBuffer: boolean;
     _failIfMajorPerformanceCaveat: boolean;
     _antialias: boolean;
@@ -457,7 +458,6 @@ class Map extends Camera {
 
         bindAll([
             '_onWindowOnline',
-            '_onWindowResize',
             '_onMapScroll',
             '_contextLost',
             '_contextRestored'
@@ -476,8 +476,6 @@ class Map extends Camera {
 
         if (typeof window !== 'undefined') {
             addEventListener('online', this._onWindowOnline, false);
-            addEventListener('resize', this._onWindowResize, false);
-            addEventListener('orientationchange', this._onWindowResize, false);
         }
 
         this.handlers = new HandlerManager(this, options as CompleteMapOptions);
@@ -529,6 +527,14 @@ class Map extends Camera {
         this.on('dataabort', (event: MapDataEvent) => {
             this.fire(new Event('sourcedataabort', event));
         });
+
+        if (window.ResizeObserver) {
+            this._resizeObserver = new window.ResizeObserver((entries) => {
+                if (this._trackResize)
+                    this.resize(entries);
+            });
+            this._resizeObserver.observe(this._container);
+        }
     }
 
     /*
@@ -2946,13 +2952,12 @@ class Map extends Camera {
         delete this.handlers;
         this.setStyle(null);
         if (typeof window !== 'undefined') {
-            removeEventListener('resize', this._onWindowResize, false);
-            removeEventListener('orientationchange', this._onWindowResize, false);
             removeEventListener('online', this._onWindowOnline, false);
         }
 
         ImageRequest.removeThrottleControl(this._imageQueueHandle);
 
+        this._resizeObserver?.disconnect();
         const extension = this.painter.context.gl.getExtension('WEBGL_lose_context');
         if (extension) extension.loseContext();
         this._canvas.removeEventListener('webglcontextrestored', this._contextRestored, false);
@@ -2991,12 +2996,6 @@ class Map extends Camera {
 
     _onWindowOnline() {
         this._update();
-    }
-
-    _onWindowResize(event: Event) {
-        if (this._trackResize) {
-            this.resize({originalEvent: event})._update();
-        }
     }
 
     /**


### PR DESCRIPTION
Previously, if a map was created before the page was rendered, it would have the wrong size. Or if the map was resized by anything other than resizing the window, it would also have the wrong size.

Now, the map will have the correct size no matter why the container element is resized.