### PR TITLE
inline types into d.ts

### DIFF
--- a/build/dts-bundle-generator-config.json
+++ b/build/dts-bundle-generator-config.json
@@ -1,0 +1,27 @@
+{
+  "compilationOptions": {
+    "preferredConfigPath": "../tsconfig.json"
+  },
+  "entries": [
+    {
+      "filePath": "../src/index.ts",
+      "outFile": "../dist/maplibre-gl.d.ts",
+      "libraries": {
+        "inlinedLibraries": [
+          "@mapbox/tiny-sdf",
+          "@types/geojson",
+          "@types/kdbush",
+          "@types/mapbox__point-geometry",
+          "@types/mapbox__vector-tile",
+          "@types/pbf",
+          "gl-matrix",
+          "potpack"
+        ]
+      },
+      "output": {
+        "umdModuleName": "maplibregl",
+        "exportReferencedTypes": true
+      }
+    }
+  ]
+}

--- a/build/generate-typings.ts
+++ b/build/generate-typings.ts
@@ -8,11 +8,11 @@ if (!fs.existsSync('dist')) {
 
 console.log('Starting bundling types');
 const outputFile = './dist/maplibre-gl.d.ts';
-childProcess.execSync(`dts-bundle-generator --umd-module-name=maplibregl -o ${outputFile} ./src/index.ts`);
+childProcess.execSync(`dts-bundle-generator --umd-module-name=maplibregl -o ${outputFile} --config ./build/dts-bundle-generator-config.json ./src/index.ts`);
 let types = fs.readFileSync(outputFile, 'utf8');
 // Classes are not exported but should be since this is exported as UMD - fixing...
 types = types.replace(/declare class/g, 'export declare class');
 fs.writeFileSync(outputFile, types);
 
-console.log('Finifhed bundling types for maplibre-gl ');
+console.log('Finished bundling types for maplibre-gl ');
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,35 +8,17 @@
       "name": "maplibre-gl",
       "version": "3.1.0",
       "license": "BSD-3-Clause",
-      "dependencies": {
+      "devDependencies": {
         "@mapbox/geojson-rewind": "^0.5.2",
         "@mapbox/jsonlint-lines-primitives": "^2.0.2",
+        "@mapbox/mapbox-gl-rtl-text": "^0.2.3",
+        "@mapbox/mvt-fixtures": "^3.10.0",
         "@mapbox/point-geometry": "^0.1.0",
         "@mapbox/tiny-sdf": "^2.0.6",
         "@mapbox/unitbezier": "^0.0.1",
         "@mapbox/vector-tile": "^1.3.1",
         "@mapbox/whoots-js": "^3.1.0",
         "@maplibre/maplibre-gl-style-spec": "^19.2.1",
-        "@types/geojson": "^7946.0.10",
-        "@types/mapbox__point-geometry": "^0.1.2",
-        "@types/mapbox__vector-tile": "^1.3.0",
-        "@types/pbf": "^3.0.2",
-        "earcut": "^2.2.4",
-        "geojson-vt": "^3.2.1",
-        "gl-matrix": "^3.4.3",
-        "global-prefix": "^3.0.0",
-        "kdbush": "^4.0.2",
-        "murmurhash-js": "^1.0.0",
-        "pbf": "^3.2.1",
-        "potpack": "^2.0.0",
-        "quickselect": "^2.0.0",
-        "supercluster": "^8.0.1",
-        "tinyqueue": "^2.0.3",
-        "vt-pbf": "^3.1.3"
-      },
-      "devDependencies": {
-        "@mapbox/mapbox-gl-rtl-text": "^0.2.3",
-        "@mapbox/mvt-fixtures": "^3.10.0",
         "@rollup/plugin-commonjs": "^25.0.2",
         "@rollup/plugin-json": "^6.0.0",
         "@rollup/plugin-node-resolve": "^15.1.0",
@@ -50,15 +32,19 @@
         "@types/diff": "^5.0.3",
         "@types/earcut": "^2.1.1",
         "@types/eslint": "^8.40.2",
+        "@types/geojson": "^7946.0.10",
         "@types/gl": "^6.0.2",
         "@types/glob": "^8.1.0",
         "@types/jest": "^29.5.2",
         "@types/jsdom": "^21.1.1",
+        "@types/mapbox__point-geometry": "^0.1.2",
+        "@types/mapbox__vector-tile": "^1.3.0",
         "@types/minimist": "^1.2.2",
         "@types/murmurhash-js": "^1.0.4",
         "@types/nise": "^1.4.1",
         "@types/node": "^20.3.2",
         "@types/offscreencanvas": "^2019.7.0",
+        "@types/pbf": "^3.0.2",
         "@types/pixelmatch": "^5.2.4",
         "@types/pngjs": "^6.0.1",
         "@types/react": "^18.2.14",
@@ -79,6 +65,7 @@
         "diff": "^5.1.0",
         "documentation": "14.0.2",
         "dts-bundle-generator": "^8.0.1",
+        "earcut": "^2.2.4",
         "eslint": "^8.43.0",
         "eslint-config-mourner": "^3.0.0",
         "eslint-plugin-html": "^7.1.0",
@@ -87,28 +74,36 @@
         "eslint-plugin-jsdoc": "^46.4.0",
         "eslint-plugin-react": "^7.32.2",
         "expect": "^29.5.0",
+        "geojson-vt": "^3.2.1",
         "gl": "^6.0.2",
+        "gl-matrix": "^3.4.3",
         "glob": "^10.3.1",
+        "global-prefix": "^3.0.0",
         "is-builtin-module": "^3.2.1",
         "jest": "^29.5.0",
         "jest-canvas-mock": "^2.5.2",
         "jest-environment-jsdom": "^29.5.0",
         "jsdom": "^22.1.0",
         "json-stringify-pretty-compact": "^4.0.0",
+        "kdbush": "^4.0.2",
         "minimist": "^1.2.8",
         "mock-geolocation": "^1.0.11",
+        "murmurhash-js": "^1.0.0",
         "nise": "^5.1.4",
         "node-plantuml": "^0.9.0",
         "npm-font-open-sans": "^1.1.0",
         "npm-run-all": "^4.1.5",
+        "pbf": "^3.2.1",
         "pdf-merger-js": "^4.3.0",
         "pixelmatch": "^5.3.0",
         "pngjs": "^7.0.0",
         "postcss": "^8.4.24",
         "postcss-cli": "^10.1.0",
         "postcss-inline-svg": "^6.0.0",
+        "potpack": "^2.0.0",
         "pretty-bytes": "^6.1.0",
         "puppeteer": "^20.7.3",
+        "quickselect": "^2.0.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "rollup": "^3.25.3",
@@ -120,13 +115,16 @@
         "st": "^3.0.0",
         "stylelint": "^15.9.0",
         "stylelint-config-standard": "^33.0.0",
+        "supercluster": "^8.0.1",
+        "tinyqueue": "^2.0.3",
         "ts-jest": "^29.1.0",
         "ts-node": "^10.9.1",
         "tslib": "^2.6.0",
         "typedoc": "^0.24.8",
         "typedoc-plugin-markdown": "^3.15.3",
         "typedoc-plugin-missing-exports": "^2.0.0",
-        "typescript": "^5.1.5"
+        "typescript": "^5.1.5",
+        "vt-pbf": "^3.1.3"
       },
       "engines": {
         "node": ">=16.14.0",
@@ -1286,6 +1284,7 @@
     },
     "node_modules/@mapbox/geojson-rewind": {
       "version": "0.5.2",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "get-stream": "^6.0.1",
@@ -1304,6 +1303,7 @@
     },
     "node_modules/@mapbox/jsonlint-lines-primitives": {
       "version": "2.0.2",
+      "dev": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -1359,6 +1359,7 @@
     },
     "node_modules/@mapbox/point-geometry": {
       "version": "0.1.0",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/@mapbox/sphericalmercator": {
@@ -1374,14 +1375,17 @@
     "node_modules/@mapbox/tiny-sdf": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-2.0.6.tgz",
-      "integrity": "sha512-qMqa27TLw+ZQz5Jk+RcwZGH7BQf5G/TrutJhspsca/3SHwmgKQ1iq+d3Jxz5oysPVYTGP6aXxCo5Lk9Er6YBAA=="
+      "integrity": "sha512-qMqa27TLw+ZQz5Jk+RcwZGH7BQf5G/TrutJhspsca/3SHwmgKQ1iq+d3Jxz5oysPVYTGP6aXxCo5Lk9Er6YBAA==",
+      "dev": true
     },
     "node_modules/@mapbox/unitbezier": {
       "version": "0.0.1",
+      "dev": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/@mapbox/vector-tile": {
       "version": "1.3.1",
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@mapbox/point-geometry": "~0.1.0"
@@ -1389,6 +1393,7 @@
     },
     "node_modules/@mapbox/whoots-js": {
       "version": "3.1.0",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=6.0.0"
@@ -1398,6 +1403,7 @@
       "version": "19.2.1",
       "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-19.2.1.tgz",
       "integrity": "sha512-ZVT5QlkVhlxlPav+ca0NO3Moc7EzbHDO2FXW4ic3Q0Vm+TDUw9I8A2EBws7xUUQZf7HQB3kQ+3Jsh5mFLRD4GQ==",
+      "dev": true,
       "dependencies": {
         "@mapbox/jsonlint-lines-primitives": "~2.0.2",
         "@mapbox/point-geometry": "^0.1.0",
@@ -1417,7 +1423,8 @@
     "node_modules/@maplibre/maplibre-gl-style-spec/node_modules/json-stringify-pretty-compact": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-3.0.0.tgz",
-      "integrity": "sha512-Rc2suX5meI0S3bfdZuA7JMFBGkJ875ApfVyq2WHELjBiiG22My/l7/8zPpH/CfFVQHuVLd8NLR0nv6vi0BYYKA=="
+      "integrity": "sha512-Rc2suX5meI0S3bfdZuA7JMFBGkJ875ApfVyq2WHELjBiiG22My/l7/8zPpH/CfFVQHuVLd8NLR0nv6vi0BYYKA==",
+      "dev": true
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -2196,6 +2203,7 @@
     },
     "node_modules/@types/geojson": {
       "version": "7946.0.10",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/github-slugger": {
@@ -2289,10 +2297,12 @@
     },
     "node_modules/@types/mapbox__point-geometry": {
       "version": "0.1.2",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/mapbox__vector-tile": {
       "version": "1.3.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/geojson": "*",
@@ -2358,6 +2368,7 @@
     },
     "node_modules/@types/pbf": {
       "version": "3.0.2",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/pixelmatch": {
@@ -2988,6 +2999,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
       "integrity": "sha512-sKpyeERZ02v1FeCZT8lrfJq5u6goHCtpTAzPwJYe7c8SPFOboNjNg1vz2L4VTn9T4PQxEx13TbXLmYUcS6Ug7Q==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3078,6 +3090,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
       "integrity": "sha512-Q+JC7Whu8HhmTdBph/Tq59IoRtoy6KAm5zzPv00WdujX82lbAL8K7WVjne7vdCsAmbF4AYaDOPyO3k0kl8qIrw==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3449,6 +3462,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/bytewise/-/bytewise-1.1.0.tgz",
       "integrity": "sha512-rHuuseJ9iQ0na6UDhnrRVDh8YnWVlU6xM3VH6q/+yHDeUH2zIhUzP+2/h3LIrhLDBtTqzWpE3p3tP/boefskKQ==",
+      "dev": true,
       "dependencies": {
         "bytewise-core": "^1.2.2",
         "typewise": "^1.0.3"
@@ -3458,6 +3472,7 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/bytewise-core/-/bytewise-core-1.2.3.tgz",
       "integrity": "sha512-nZD//kc78OOxeYtRlVk8/zXqTB4gf/nlguL1ggWA8FuchMyOxcyHR4QPQZMUmA7czC+YnaBrPUCubqAWe50DaA==",
+      "dev": true,
       "dependencies": {
         "typewise-core": "^1.2"
       }
@@ -5396,6 +5411,7 @@
     },
     "node_modules/earcut": {
       "version": "2.2.4",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/eastasianwidth": {
@@ -6334,6 +6350,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
       "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+      "dev": true,
       "dependencies": {
         "is-extendable": "^0.1.0"
       },
@@ -6745,6 +6762,7 @@
     },
     "node_modules/geojson-vt": {
       "version": "3.2.1",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/get-caller-file": {
@@ -6778,6 +6796,7 @@
     },
     "node_modules/get-stream": {
       "version": "6.0.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -6852,6 +6871,7 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
       "integrity": "sha512-Ln0UQDlxH1BapMu3GPtf7CuYNwRZf2gwCuPqbyG6pB8WfmFpzqcy4xtAaAMUhnNqjMKTiCPZG2oMT3YSx8U2NA==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6903,6 +6923,7 @@
     },
     "node_modules/gl-matrix": {
       "version": "3.4.3",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/glob": {
@@ -6985,6 +7006,7 @@
     },
     "node_modules/global-prefix": {
       "version": "3.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ini": "^1.3.5",
@@ -6997,6 +7019,7 @@
     },
     "node_modules/global-prefix/node_modules/which": {
       "version": "1.3.1",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -7430,6 +7453,7 @@
     },
     "node_modules/ieee754": {
       "version": "1.2.1",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -7543,6 +7567,7 @@
     },
     "node_modules/ini": {
       "version": "1.3.8",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/internal-slot": {
@@ -7695,6 +7720,7 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
       "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7945,12 +7971,14 @@
     },
     "node_modules/isexe": {
       "version": "2.0.0",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/isobject": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9105,10 +9133,12 @@
     "node_modules/kdbush": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/kdbush/-/kdbush-4.0.2.tgz",
-      "integrity": "sha512-WbCVYJ27Sz8zi9Q7Q0xHC+05iwkm3Znipc2XTlrnJbsHMYktW4hPhXUE8Ys1engBrvffoSCqbil1JQAa7clRpA=="
+      "integrity": "sha512-WbCVYJ27Sz8zi9Q7Q0xHC+05iwkm3Znipc2XTlrnJbsHMYktW4hPhXUE8Ys1engBrvffoSCqbil1JQAa7clRpA==",
+      "dev": true
     },
     "node_modules/kind-of": {
       "version": "6.0.3",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -10591,6 +10621,7 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -10747,6 +10778,7 @@
     },
     "node_modules/murmurhash-js": {
       "version": "1.0.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/nan": {
@@ -11693,6 +11725,7 @@
     },
     "node_modules/pbf": {
       "version": "3.2.1",
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "ieee754": "^1.1.12",
@@ -12459,6 +12492,7 @@
     },
     "node_modules/potpack": {
       "version": "2.0.0",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/prebuild-install": {
@@ -12661,6 +12695,7 @@
     },
     "node_modules/protocol-buffers-schema": {
       "version": "3.6.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/protocols": {
@@ -12885,6 +12920,7 @@
     },
     "node_modules/quickselect": {
       "version": "2.0.0",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/randombytes": {
@@ -13339,6 +13375,7 @@
     },
     "node_modules/resolve-protobuf-schema": {
       "version": "2.1.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "protocol-buffers-schema": "^3.3.1"
@@ -13505,6 +13542,7 @@
     },
     "node_modules/rw": {
       "version": "1.3.3",
+      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/sade": {
@@ -13599,6 +13637,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
       "integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
+      "dev": true,
       "dependencies": {
         "extend-shallow": "^2.0.1",
         "is-extendable": "^0.1.1",
@@ -13613,6 +13652,7 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
       "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "dev": true,
       "dependencies": {
         "isobject": "^3.0.1"
       },
@@ -13829,6 +13869,7 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/sort-asc/-/sort-asc-0.2.0.tgz",
       "integrity": "sha512-umMGhjPeHAI6YjABoSTrFp2zaBtXBej1a0yKkuMUyjjqu6FJsTF+JYwCswWDg+zJfk/5npWUUbd33HH/WLzpaA==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -13837,6 +13878,7 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/sort-desc/-/sort-desc-0.2.0.tgz",
       "integrity": "sha512-NqZqyvL4VPW+RAxxXnB8gvE1kyikh8+pR+T+CXLksVRN9eiQqkQlPwqWYU0mF9Jm7UnctShlxLyAt1CaBOTL1w==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -13845,6 +13887,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/sort-object/-/sort-object-3.0.3.tgz",
       "integrity": "sha512-nK7WOY8jik6zaG9CRwZTaD5O7ETWDLZYMM12pqY8htll+7dYeqGfEUPcUBHOpSJg2vJOrvFIY2Dl5cX2ih1hAQ==",
+      "dev": true,
       "dependencies": {
         "bytewise": "^1.1.0",
         "get-value": "^2.0.2",
@@ -14066,6 +14109,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
       "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+      "dev": true,
       "dependencies": {
         "extend-shallow": "^3.0.0"
       },
@@ -14077,6 +14121,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
       "integrity": "sha512-BwY5b5Ql4+qZoefgMj2NUmx+tehVTH/Kf4k1ZEtOHNFcm2wSxMRo992l6X3TIgni2eZVTZ85xMOjF31fwZAj6Q==",
+      "dev": true,
       "dependencies": {
         "assign-symbols": "^1.0.0",
         "is-extendable": "^1.0.1"
@@ -14089,6 +14134,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
       "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+      "dev": true,
       "dependencies": {
         "is-plain-object": "^2.0.4"
       },
@@ -14100,6 +14146,7 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
       "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "dev": true,
       "dependencies": {
         "isobject": "^3.0.1"
       },
@@ -14555,6 +14602,7 @@
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-8.0.1.tgz",
       "integrity": "sha512-IiOea5kJ9iqzD2t7QJq/cREyLHTtSmUT6gQsweojg9WH2sYJqZK9SswTu6jrscO6D1G5v5vYZ9ru/eq85lXeZQ==",
+      "dev": true,
       "dependencies": {
         "kdbush": "^4.0.2"
       }
@@ -14816,6 +14864,7 @@
     },
     "node_modules/tinyqueue": {
       "version": "2.0.3",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/tmpl": {
@@ -15170,6 +15219,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/typewise/-/typewise-1.0.3.tgz",
       "integrity": "sha512-aXofE06xGhaQSPzt8hlTY+/YWQhm9P0jYUp1f2XtmW/3Bk0qzXcyFWAtPoo2uTGQj1ZwbDuSyuxicq+aDo8lCQ==",
+      "dev": true,
       "dependencies": {
         "typewise-core": "^1.2.0"
       }
@@ -15177,7 +15227,8 @@
     "node_modules/typewise-core": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/typewise-core/-/typewise-core-1.2.0.tgz",
-      "integrity": "sha512-2SCC/WLzj2SbUwzFOzqMCkz5amXLlxtJqDKTICqg30x+2DZxcfZN2MvQZmGfXWKNWaKK9pBPsvkcwv8bF/gxKg=="
+      "integrity": "sha512-2SCC/WLzj2SbUwzFOzqMCkz5amXLlxtJqDKTICqg30x+2DZxcfZN2MvQZmGfXWKNWaKK9pBPsvkcwv8bF/gxKg==",
+      "dev": true
     },
     "node_modules/uglify-js": {
       "version": "3.17.4",
@@ -15307,6 +15358,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
       "integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
+      "dev": true,
       "dependencies": {
         "arr-union": "^3.1.0",
         "get-value": "^2.0.6",
@@ -15558,6 +15610,7 @@
     },
     "node_modules/vt-pbf": {
       "version": "3.1.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@mapbox/point-geometry": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "types": "dist/maplibre-gl.d.ts",
   "type": "module",
-  "dependencies": {
+  "devDependencies": {
     "@mapbox/geojson-rewind": "^0.5.2",
     "@mapbox/jsonlint-lines-primitives": "^2.0.2",
     "@mapbox/point-geometry": "^0.1.0",
@@ -36,9 +36,7 @@
     "quickselect": "^2.0.0",
     "supercluster": "^8.0.1",
     "tinyqueue": "^2.0.3",
-    "vt-pbf": "^3.1.3"
-  },
-  "devDependencies": {
+    "vt-pbf": "^3.1.3",
     "@mapbox/mapbox-gl-rtl-text": "^0.2.3",
     "@mapbox/mvt-fixtures": "^3.10.0",
     "@rollup/plugin-commonjs": "^25.0.2",


### PR DESCRIPTION
After this PR, the released `maplibre-gl.d.ts` should be self-contained, requiring no additional external libraries to resolve types.

1. Use a json file to store config. Especially adding so many extra command line options, this makes the build process a bit more straightforward.
2. The previous `d.ts` has a bunch of imports. This means you needed to install those type packages to properly consume the exported types. This should no longer be the case.:

```typescript
import Point from '@mapbox/point-geometry';
import TinySDF from '@mapbox/tiny-sdf';
import { VectorTileFeature, VectorTileLayer } from '@mapbox/vector-tile';
import { mat2, mat4, vec4 } from 'gl-matrix';
import { PotpackBox } from 'potpack';
```

Note that there are some conflicts between declarations of types named `Point` and `Feature`. I'm not quite sure how to resolve them. These don't break the build but do produce some warnings that will probably show up in the IDE as well:

```
dist/maplibre-gl.d.ts(1106,15): error TS2395: Individual declarations in merged declaration 'Point' must be all exported or all local.
dist/maplibre-gl.d.ts(1595,13): error TS2300: Duplicate identifier 'Feature'.
dist/maplibre-gl.d.ts(3149,36): error TS2339: Property 'type' does not exist on type 'GeoJSON'.
dist/maplibre-gl.d.ts(3214,18): error TS2395: Individual declarations in merged declaration 'Point' must be all exported or all local.
dist/maplibre-gl.d.ts(3273,18): error TS2300: Duplicate identifier 'Feature'.
dist/maplibre-gl.d.ts(3295,18): error TS2315: Type 'Feature' is not generic.

Error: Compiled with errors
```