### PR TITLE
replace url-search-params with URL

### DIFF
--- a/test/bench/versions/index.html
+++ b/test/bench/versions/index.html
@@ -6,8 +6,6 @@
     <meta charset='utf-8'>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" href="about:blank">
-
-    <script src='https://unpkg.com/url-search-params@0.10.0/build/url-search-params.js'></script>
 </head>
 
 <body>
@@ -18,11 +16,9 @@
 
         async function runComparison() {
             try {
-                const params = new URLSearchParams(location.search.slice(1));
-                let versions = [];
-                if (params.has('compare')) {
-                    versions = params.getAll('compare').filter(Boolean);
-                } else {
+                const params = new URL(location).searchParams;
+                let versions = params.getAll('compare').filter(Boolean);
+                if (!versions.length) {
                     const response = await fetch('https://api.github.com/repos/maplibre/maplibre-gl-js/releases/latest');
                     const responseJson = await response.json();
                     versions = [responseJson['tag_name'], 'main'];


### PR DESCRIPTION
The benchmarks use url-search-params via unpkg to parse arguments. This is unnecessary, since the URL API natively supports this.