### PR TITLE
Add logging for test case failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### ✨ Features and improvements
 - Add `setiClusterOptions` to update cluster properties of the added sources: fixing these issues ([#429](https://github.com/maplibre/maplibre-gl-js/issues/429)) and ([1384](https://github.com/maplibre/maplibre-gl-js/issues/1384))
 - Add types for `workerOptions` and `_options` in `geojson_source.ts`
+- Log more details to the console when a test case fails 
 - *...Add new stuff here...*
 ### 🐞 Bug fixes
 - *...Add new stuff here...*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,6 @@
 ### ✨ Features and improvements
 - Add `setiClusterOptions` to update cluster properties of the added sources: fixing these issues ([#429](https://github.com/maplibre/maplibre-gl-js/issues/429)) and ([1384](https://github.com/maplibre/maplibre-gl-js/issues/1384))
 - Add types for `workerOptions` and `_options` in `geojson_source.ts`
-- Log more details to the console when a test case fails ([2063](https://github.com/maplibre/maplibre-gl-js/pull/2063))
 - *...Add new stuff here...*
 ### 🐞 Bug fixes
 - *...Add new stuff here...*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### ✨ Features and improvements
 - Add `setiClusterOptions` to update cluster properties of the added sources: fixing these issues ([#429](https://github.com/maplibre/maplibre-gl-js/issues/429)) and ([1384](https://github.com/maplibre/maplibre-gl-js/issues/1384))
 - Add types for `workerOptions` and `_options` in `geojson_source.ts`
-- Log more details to the console when a test case fails 
+- Log more details to the console when a test case fails ([2063](https://github.com/maplibre/maplibre-gl-js/pull/2063))
 - *...Add new stuff here...*
 ### 🐞 Bug fixes
 - *...Add new stuff here...*

--- a/test/integration/expression/expression.test.ts
+++ b/test/integration/expression/expression.test.ts
@@ -39,7 +39,16 @@ describe('expression', () => {
 
                 const expected = fixture.expected;
                 const compileOk = deepEqual(result.compiled, expected.compiled, decimalSigFigs);
+                if (!compileOk) {
+                    console.log(`Expected ${JSON.stringify(expected.compiled)}`);
+                    console.log(`Result   ${JSON.stringify(result.compiled)}`);
+                }
+
                 const evalOk = compileOk && deepEqual(result.outputs, expected.outputs, decimalSigFigs);
+                if (!evalOk) {
+                    console.log(`Expected ${JSON.stringify(expected.outputs)}`);
+                    console.log(`Result   ${JSON.stringify(result.outputs)}`);
+                }
 
                 expect(compileOk).toBeTruthy();
                 expect(evalOk).toBeTruthy();


### PR DESCRIPTION
While testing another PR, I was struggling to figure out why my test case was failing. This PR adds additional logging of test case failures, in order that the author of a failing test can see what's wrong. The extra logging occurs only in the event of a test failure.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Add an entry to `CHANGELOG.md` under the `## main` section.
