### PR TITLE
Fix "npm run test-build" on Windows

### DIFF
--- a/test/build/sourcemaps.test.ts
+++ b/test/build/sourcemaps.test.ts
@@ -6,7 +6,7 @@ import fs from 'node:fs/promises';
 import {pathToFileURL} from 'url';
 
 const distjs = glob.sync('dist/**/*.js');
-jest.setTimeout(1000000);
+
 async function getSourceMapForFile(url: string|URL) {
     const content = await fs.readFile(url, {encoding: 'utf-8'});
     const result = new RegExp('^//# sourceMappingURL=(.*)$', 'm').exec(content);

--- a/test/build/sourcemaps.test.ts
+++ b/test/build/sourcemaps.test.ts
@@ -51,10 +51,10 @@ describe.each(distjs)('release file %s', (file) => {
 describe('main sourcemap', () => {
     test('should match source files', async () => {
         const sourcemapJSON = await getSourceMapForFile(pathToFileURL(packageJson.main));
-        const sourcemapDir = path.relative('.', dirname(packageJson.main));
+        const sourceMapEntryRootDir = path.relative('.', dirname(packageJson.main));
 
         const sourcemapEntriesNormalized = sourcemapJSON.sources.map(f => {
-            const joinedFilePath = path.join(sourcemapDir, f);
+            const joinedFilePath = path.join(sourceMapEntryRootDir, f);
 
             // joined path has back slashes on windows, normalize them to be consistant with
             // entries returned by glob


### PR DESCRIPTION
## Launch Checklist

<code>npm run test-build</code> does not pass because Windows has back slash in path names. Additionally:
- The term "source" and "map" were too ambiguous making the code difficult to read. Renamed to better ones.
- sort the list for easy debugging

 - [ ] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [ ] Briefly describe the changes in this PR.
 - [ ] Link to related issues.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [ ] Add an entry to `CHANGELOG.md` under the `## main` section.
