### PR TITLE
Fix: worker been terminated on setting new style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Add types for `workerOptions` and `_options` in `geojson_source.ts`
 - *...Add new stuff here...*
 ### 🐞 Bug fixes
-- Fix the worker been terminated on setting new style
+- Fix the worker been terminated on setting new style ([#2123](https://github.com/maplibre/maplibre-gl-js/pull/2123))
 
 ## 3.0.0-pre.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 - Add types for `workerOptions` and `_options` in `geojson_source.ts`
 - *...Add new stuff here...*
 ### 🐞 Bug fixes
-- *...Add new stuff here...*
+- Fix the worker been terminated on setting new style
+
 ## 3.0.0-pre.3
 
 ### ✨ Features and improvements

--- a/src/source/terrain_source_cache.test.ts
+++ b/src/source/terrain_source_cache.test.ts
@@ -31,6 +31,10 @@ class StubMap extends Evented {
         } as any as RequestManager;
     }
 
+    _getMapId() {
+        return 1;
+    }
+
     setTerrain() {}
 }
 
@@ -38,7 +42,6 @@ function createSource(options, transformCallback?) {
     const source = new RasterDEMTileSource('id', options, {send() {}} as any as Dispatcher, null);
     source.onAdd({
         transform,
-        _getMapId: () => 1,
         _requestManager: new RequestManager(transformCallback),
         getPixelRatio() { return 1; }
     } as any);

--- a/src/style/style.test.ts
+++ b/src/style/style.test.ts
@@ -175,7 +175,7 @@ describe('Style#loadURL', () => {
     test('cancels pending requests if removed', () => {
         const style = new Style(getStubMap());
         style.loadURL('style.json');
-        style._remove(true);
+        style._remove();
         expect(sinonFakeServer.lastRequest.aborted).toBe(true);
     });
 });
@@ -487,7 +487,7 @@ describe('Style#_remove', () => {
             jest.spyOn(sourceCache, 'onRemove');
             jest.spyOn(sourceCache, 'clearTiles');
 
-            style._remove(true);
+            style._remove();
 
             expect(sourceCache.setEventedParent).toHaveBeenCalledWith(null);
             expect(sourceCache.onRemove).toHaveBeenCalledWith(style.map);
@@ -503,7 +503,7 @@ describe('Style#_remove', () => {
         const mockStyleDispatcherBroadcast = jest.spyOn(style.dispatcher, 'broadcast');
 
         style.on('style.load', () => {
-            style._remove(true);
+            style._remove();
 
             rtlTextPluginEvented.fire(new Event('pluginStateChange'));
             expect(mockStyleDispatcherBroadcast).not.toHaveBeenCalledWith('syncRTLPluginState');

--- a/src/style/style.test.ts
+++ b/src/style/style.test.ts
@@ -129,7 +129,7 @@ describe('Style', () => {
             done();
         });
         sinonFakeServer.respond();
-        new Style(createStyleJSON());
+        new Style(getStubMap());
     });
 });
 
@@ -175,7 +175,7 @@ describe('Style#loadURL', () => {
     test('cancels pending requests if removed', () => {
         const style = new Style(getStubMap());
         style.loadURL('style.json');
-        style._remove();
+        style._remove(true);
         expect(sinonFakeServer.lastRequest.aborted).toBe(true);
     });
 });
@@ -487,7 +487,7 @@ describe('Style#_remove', () => {
             jest.spyOn(sourceCache, 'onRemove');
             jest.spyOn(sourceCache, 'clearTiles');
 
-            style._remove();
+            style._remove(true);
 
             expect(sourceCache.setEventedParent).toHaveBeenCalledWith(null);
             expect(sourceCache.onRemove).toHaveBeenCalledWith(style.map);
@@ -503,7 +503,7 @@ describe('Style#_remove', () => {
         const mockStyleDispatcherBroadcast = jest.spyOn(style.dispatcher, 'broadcast');
 
         style.on('style.load', () => {
-            style._remove();
+            style._remove(true);
 
             rtlTextPluginEvented.fire(new Event('pluginStateChange'));
             expect(mockStyleDispatcherBroadcast).not.toHaveBeenCalledWith('syncRTLPluginState');

--- a/src/style/style.ts
+++ b/src/style/style.ts
@@ -199,7 +199,7 @@ class Style extends Evented {
         super();
 
         this.map = map;
-        this.dispatcher = new Dispatcher(getWorkerPool(), this);
+        this.dispatcher = new Dispatcher(getWorkerPool(), this, map._getMapId());
         this.imageManager = new ImageManager();
         this.imageManager.setEventedParent(this);
         this.glyphManager = new GlyphManager(map._requestManager, options.localIdeographFontFamily);
@@ -1341,7 +1341,7 @@ class Style extends Evented {
         }, props)));
     }
 
-    _remove() {
+    _remove(mapRemoved: boolean) {
         if (this._request) {
             this._request.cancel();
             this._request = null;
@@ -1362,7 +1362,7 @@ class Style extends Evented {
         }
         this.imageManager.setEventedParent(null);
         this.setEventedParent(null);
-        this.dispatcher.remove();
+        this.dispatcher.remove(mapRemoved);
     }
 
     _clearSource(id: string) {

--- a/src/style/style.ts
+++ b/src/style/style.ts
@@ -1341,7 +1341,7 @@ class Style extends Evented {
         }, props)));
     }
 
-    _remove(mapRemoved: boolean) {
+    _remove(mapRemoved: boolean = true) {
         if (this._request) {
             this._request.cancel();
             this._request = null;

--- a/src/ui/map.test.ts
+++ b/src/ui/map.test.ts
@@ -292,6 +292,21 @@ describe('Map', () => {
             expect(style._remove).toHaveBeenCalledTimes(1);
         });
 
+        test('passing null releases the worker', () => {
+            const map = createMap();
+            const spyWorkerPoolAcquire = jest.spyOn(map.style.dispatcher.workerPool, 'acquire');
+            const spyWorkerPoolRelease = jest.spyOn(map.style.dispatcher.workerPool, 'release');
+
+            map.setStyle({version: 8, sources: {}, layers: []}, {diff: false});
+            expect(spyWorkerPoolAcquire).toHaveBeenCalledTimes(1);
+            expect(spyWorkerPoolRelease).toHaveBeenCalledTimes(0);
+
+            spyWorkerPoolAcquire.mockClear();
+            map.setStyle(null);
+            expect(spyWorkerPoolAcquire).toHaveBeenCalledTimes(0);
+            expect(spyWorkerPoolRelease).toHaveBeenCalledTimes(1);
+        });
+
         test('transformStyle should copy the source and the layer into next style', done => {
             const style = extend(createStyle(), {
                 sources: {

--- a/src/ui/map.test.ts
+++ b/src/ui/map.test.ts
@@ -305,6 +305,10 @@ describe('Map', () => {
             map.setStyle(null);
             expect(spyWorkerPoolAcquire).toHaveBeenCalledTimes(0);
             expect(spyWorkerPoolRelease).toHaveBeenCalledTimes(1);
+
+            // Cleanup
+            spyWorkerPoolAcquire.mockClear();
+            spyWorkerPoolRelease.mockClear();
         });
 
         test('transformStyle should copy the source and the layer into next style', done => {
@@ -1045,9 +1049,14 @@ describe('Map', () => {
 
     test('#remove', () => {
         const map = createMap();
+        const spyWorkerPoolRelease = jest.spyOn(map.style.dispatcher.workerPool, 'release');
         expect(map.getContainer().childNodes).toHaveLength(2);
         map.remove();
+        expect(spyWorkerPoolRelease).toHaveBeenCalledTimes(1);
         expect(map.getContainer().childNodes).toHaveLength(0);
+
+        // Cleanup
+        spyWorkerPoolRelease.mockClear();
     });
 
     test('#remove calls onRemove on added controls', () => {

--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -1487,7 +1487,9 @@ class Map extends Camera {
         const previousStyle = this.style && options.transformStyle ? this.style.serialize() : undefined;
         if (this.style) {
             this.style.setEventedParent(null);
-            this.style._remove();
+
+            // Only release workers when map is getting disposed
+            this.style._remove(!style);
         }
 
         if (!style) {

--- a/src/util/dispatcher.test.ts
+++ b/src/util/dispatcher.test.ts
@@ -18,7 +18,7 @@ describe('Dispatcher', () => {
 
         const dispatcher = new Dispatcher(workerPool, {}, mapId);
         expect(dispatcher.actors.map((actor) => { return actor.target; })).toEqual(workers);
-        dispatcher.remove(true);
+        dispatcher.remove();
         expect(dispatcher.actors).toHaveLength(0);
         expect(releaseCalled).toEqual([mapId]);
 
@@ -69,7 +69,7 @@ describe('Dispatcher', () => {
 
         const workerPool = new WorkerPool();
         const dispatcher = new Dispatcher(workerPool, {}, mapId);
-        dispatcher.remove(true);
+        dispatcher.remove();
         expect(actorsRemoved).toHaveLength(4);
     });
 

--- a/src/util/dispatcher.ts
+++ b/src/util/dispatcher.ts
@@ -55,7 +55,7 @@ class Dispatcher {
         return this.actors[this.currentActor];
     }
 
-    remove(mapRemoved: boolean) {
+    remove(mapRemoved: boolean = true) {
         this.actors.forEach((actor) => { actor.remove(); });
         this.actors = [];
         if (mapRemoved) this.workerPool.release(this.id);

--- a/src/util/dispatcher.ts
+++ b/src/util/dispatcher.ts
@@ -1,4 +1,4 @@
-import {uniqueId, asyncAll} from './util';
+import {asyncAll} from './util';
 import Actor from './actor';
 
 import type WorkerPool from './worker_pool';
@@ -20,15 +20,15 @@ class Dispatcher {
         new (...args: any): Actor;
     };
 
-    constructor(workerPool: WorkerPool, parent: any) {
+    constructor(workerPool: WorkerPool, parent: any, mapId: number) {
         this.workerPool = workerPool;
         this.actors = [];
         this.currentActor = 0;
-        this.id = uniqueId();
-        const workers = this.workerPool.acquire(this.id);
+        this.id = mapId;
+        const workers = this.workerPool.acquire(mapId);
         for (let i = 0; i < workers.length; i++) {
             const worker = workers[i];
-            const actor = new Dispatcher.Actor(worker, parent, this.id);
+            const actor = new Dispatcher.Actor(worker, parent, mapId);
             actor.name = `Worker ${i}`;
             this.actors.push(actor);
         }
@@ -55,10 +55,10 @@ class Dispatcher {
         return this.actors[this.currentActor];
     }
 
-    remove() {
+    remove(mapRemoved: boolean) {
         this.actors.forEach((actor) => { actor.remove(); });
         this.actors = [];
-        this.workerPool.release(this.id);
+        if (mapRemoved) this.workerPool.release(this.id);
     }
 }
 


### PR DESCRIPTION
## Issue: 
- On style change (map.setStyle), currently the existing style object is removed and recreated. When style object is removed ( style._remove(), worker is also getting terminated (unless there are other multiple map instances)  and a new worker is created each time which is a very expensive operation.
- Code flow: map.setStyle(<new Style>)--> map._updateStyle(...) --> map.style._remove() --> map.style.dispatcher.remove() --> map.style.dispatcher.workerPool.release() causing the worker to be terminated, if there is no other active map.

## Fix:
Fix is simply to not terminate the worker till map is been removed. When map is removed, then map.setStyle(null) is called. When this happen's we pass the intend and terminate the worker.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [ ] Link to related issues.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [x] Add an entry to `CHANGELOG.md` under the `## main` section.
