### PR TITLE
Adjust build min test to be more frugal

### DIFF
--- a/test/build/min.test.ts
+++ b/test/build/min.test.ts
@@ -34,11 +34,20 @@ describe('test min build', () => {
     });
 
     test('bundle size stays the same', async () => {
-        const bytes = (await fs.promises.stat('dist/maplibre-gl.js')).size;
-        const alpha = 0.05;
+        const actualBytes = (await fs.promises.stat('dist/maplibre-gl.js')).size;
+
+        // Need to be very frugal when it comes to minified script.
+        // Most changes should increase less than 1k.
+        const increaseQuota = 1024;
+
+        // decreasement means optimizations, so more generous (4k) but still
+        // need to make sure not a big bug that resulted in a big loss.
+        const decreaseQuota = 4096;
+
         // feel free to update this value after you've checked that it has changed on purpose :-)
-        const expectedBytes = 756788;
-        expect(bytes).toBeLessThan(expectedBytes * (1 + alpha));
-        expect(bytes).toBeGreaterThan(expectedBytes * (1 - alpha));
+        const expectedBytes = 754929;
+
+        expect(actualBytes - expectedBytes).toBeLessThan(increaseQuota);
+        expect(expectedBytes - actualBytes).toBeLessThan(decreaseQuota);
     });
 });


### PR DESCRIPTION
## Launch Checklist

Previous check was +-5% of 750KB, this means each PR was allowed to change size up to 37KB minified!!!

Based on our data of millions of users, 1k size increasement usually means +1ms of load time, and each change needs to be justified.

Should not use percentage because the net byte change will get bigger and bigger.

Changes:
- Allow up to 1K increasement per PR. Or it needs manual attention. Practically, 1K minified usually means ~4k of debug scripts, and that is already a lot of code for one PR.
- Allow up to 4K reduction. This is just to catch bugs that may have dropped things unintentionally.

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.

