### PR TITLE
Fix invocation of callback in map.style.setSprite() that may be undefined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 ### 🐞 Bug fixes
 - Fix the worker been terminated on setting new style ([#2123](https://github.com/maplibre/maplibre-gl-js/pull/2123))
+- Fix issue unloading sprite sheet when using `setStyle(style, {diff:true})` ([#2146](https://github.com/maplibre/maplibre-gl-js/pull/2146))
 
 ## 3.0.0-pre.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - *...Add new stuff here...*
 
 ### 🐞 Bug fixes
+- Fix issue unloading sprite sheet when using `setStyle(style, {diff:true})` ([#2146](https://github.com/maplibre/maplibre-gl-js/pull/2146))
 - *...Add new stuff here...*
 
 ## 3.0.0-pre.4
@@ -17,7 +18,7 @@
 
 ### 🐞 Bug fixes
 - Fix the worker been terminated on setting new style ([#2123](https://github.com/maplibre/maplibre-gl-js/pull/2123))
-- Fix issue unloading sprite sheet when using `setStyle(style, {diff:true})` ([#2146](https://github.com/maplibre/maplibre-gl-js/pull/2146))
+
 
 ## 3.0.0-pre.3
 

--- a/src/style-spec/diff.test.ts
+++ b/src/style-spec/diff.test.ts
@@ -429,7 +429,7 @@ test('diff', () => {
     }, {
         sprite: [{'id': 'default', 'url': 'b'}]
     })).toEqual([
-        {command: 'setSprite', args: [{'id': 'default', 'url': 'b'}]},
+        {command: 'setSprite', args: [[{'id': 'default', 'url': 'b'}]]},
     ]);
 
     expect(diffStyles({

--- a/src/style-spec/diff.test.ts
+++ b/src/style-spec/diff.test.ts
@@ -413,7 +413,7 @@ test('diff', () => {
     expect(diffStyles({
         sprite: 'a'
     }, {
-        sprite: [{id: 'default', url: 'a'}]
+        sprite: 'a'
     })).toEqual([]);
 
     expect(diffStyles({

--- a/src/style-spec/diff.test.ts
+++ b/src/style-spec/diff.test.ts
@@ -256,6 +256,8 @@ test('diff', () => {
         {command: 'setPitch', args: [1]}
     ]);
 
+
+
     expect(diffStyles({
         light: {
             anchor: 'map',
@@ -408,6 +410,42 @@ test('diff', () => {
         transition: 'transition'
     })).toEqual([
         {command: 'setTransition', args: ['transition']}
+    ]);
+
+    expect(diffStyles({
+        sprite: 'a'
+    }, {
+        sprite: [{id:'default', url:'a'}]
+    })).toEqual([]);
+
+    expect(diffStyles({
+        sprite: 'a'
+    }, {
+        sprite: 'b'
+    })).toEqual([
+        {command: 'setSprite', args: ['b']},
+    ]);
+
+    expect(diffStyles({
+        sprite: 'a'
+    }, {
+        sprite: [{'id':'default', 'url':'b'}]
+    })).toEqual([
+        {command: 'setSprite', args: [{'id':'default','url':'b'}]},
+    ]);
+
+    expect(diffStyles({
+        glyphs: 'a'
+    }, {
+        glyphs: 'a'
+    })).toEqual([]);
+
+    expect(diffStyles({
+        glyphs: 'a'
+    }, {
+        glyphs: 'b'
+    })).toEqual([
+        {command: 'setGlyphs', args: ['b']},
     ]);
 
 });

--- a/src/style-spec/diff.test.ts
+++ b/src/style-spec/diff.test.ts
@@ -256,8 +256,6 @@ test('diff', () => {
         {command: 'setPitch', args: [1]}
     ]);
 
-
-
     expect(diffStyles({
         light: {
             anchor: 'map',
@@ -415,7 +413,7 @@ test('diff', () => {
     expect(diffStyles({
         sprite: 'a'
     }, {
-        sprite: [{id:'default', url:'a'}]
+        sprite: [{id: 'default', url: 'a'}]
     })).toEqual([]);
 
     expect(diffStyles({
@@ -429,9 +427,9 @@ test('diff', () => {
     expect(diffStyles({
         sprite: 'a'
     }, {
-        sprite: [{'id':'default', 'url':'b'}]
+        sprite: [{'id': 'default', 'url': 'b'}]
     })).toEqual([
-        {command: 'setSprite', args: [{'id':'default','url':'b'}]},
+        {command: 'setSprite', args: [{'id': 'default', 'url': 'b'}]},
     ]);
 
     expect(diffStyles({

--- a/src/style/style.ts
+++ b/src/style/style.ts
@@ -1604,7 +1604,7 @@ class Style extends Evented {
      * @param {StyleSetterOptions} [options] style setter options
      * @param completion completion handler
      */
-    setSprite(sprite: SpriteSpecification, options: StyleSetterOptions = {}, completion: (err: Error) => void) {
+    setSprite(sprite: SpriteSpecification, options: StyleSetterOptions = {}, completion: (err: Error) => void = undefined) {
         this._checkLoaded();
 
         if (sprite && this._validate(validateStyle.sprite, 'sprite', sprite, null, options)) {
@@ -1617,7 +1617,9 @@ class Style extends Evented {
             this._loadSprite(sprite, true, completion);
         } else {
             this._unloadSprite();
-            completion(null);
+            if (completion) {
+                completion(null);
+            }
         }
     }
 }

--- a/src/style/style.ts
+++ b/src/style/style.ts
@@ -1602,9 +1602,9 @@ class Style extends Evented {
      *
      * @param {SpriteSpecification} sprite new sprite value
      * @param {StyleSetterOptions} [options] style setter options
-     * @param completion completion handler
+     * @param [completion] completion handler
      */
-    setSprite(sprite: SpriteSpecification, options: StyleSetterOptions = {}, completion: (err: Error) => void = undefined) {
+    setSprite(sprite: SpriteSpecification, options: StyleSetterOptions = {}, completion?: (err: Error) => void) {
         this._checkLoaded();
 
         if (sprite && this._validate(validateStyle.sprite, 'sprite', sprite, null, options)) {
@@ -1617,9 +1617,7 @@ class Style extends Evented {
             this._loadSprite(sprite, true, completion);
         } else {
             this._unloadSprite();
-            if (completion) {
                 completion(null);
-            }
         }
     }
 }

--- a/src/style/style.ts
+++ b/src/style/style.ts
@@ -1617,7 +1617,9 @@ class Style extends Evented {
             this._loadSprite(sprite, true, completion);
         } else {
             this._unloadSprite();
+            if (completion) {
                 completion(null);
+            }
         }
     }
 }


### PR DESCRIPTION
The recent addition of setSprite is great! However, I noticed this small issue when using `map.setStyle(..., {diff:true})` / `map.style.setState()` to unload sprites. `style._loadSprite()` properly checks if `completion` exists, but `style.setSprite()` invokes it blindly. This PR checks that `completion` exists / is not undefined before calling it.

Not sure if this needs to be mentioned in the changelog.

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Add an entry to `CHANGELOG.md` under the `## main` section.
