### PR TITLE
fix fitBounds crossing AM with 3d - add wrap for lng in transform getElevation 

### DIFF
--- a/src/geo/transform.test.ts
+++ b/src/geo/transform.test.ts
@@ -459,4 +459,13 @@ describe('transform', () => {
         expect(transform.getBounds().getNorthWest().toArray()).toStrictEqual(transform.pointLocation(new Point(0, top)).toArray());
     });
 
+    test('getElevation with lng less than -180 wraps correctly', () => {
+        const WRAPPED_OVERSCALETILEID_DOES_NOT_THROW = 4;
+        const terrain = {
+            getElevation: () => WRAPPED_OVERSCALETILEID_DOES_NOT_THROW
+        } as any as Terrain;
+        const transform = new Transform(0, 22, 0, 85, true);
+        expect(transform.getElevation(new LngLat(-183, 40), terrain)).toBe(WRAPPED_OVERSCALETILEID_DOES_NOT_THROW);
+    });
+
 });

--- a/src/geo/transform.test.ts
+++ b/src/geo/transform.test.ts
@@ -460,12 +460,12 @@ describe('transform', () => {
     });
 
     test('getElevation with lng less than -180 wraps correctly', () => {
-        const WRAPPED_OVERSCALETILEID_DOES_NOT_THROW = 4;
+        const OVERSCALETILEID_DOES_NOT_THROW = 4;
         const terrain = {
-            getElevation: () => WRAPPED_OVERSCALETILEID_DOES_NOT_THROW
+            getElevation: () => OVERSCALETILEID_DOES_NOT_THROW
         } as any as Terrain;
         const transform = new Transform(0, 22, 0, 85, true);
-        expect(transform.getElevation(new LngLat(-183, 40), terrain)).toBe(WRAPPED_OVERSCALETILEID_DOES_NOT_THROW);
+        expect(transform.getElevation(new LngLat(-183, 40), terrain)).toBe(OVERSCALETILEID_DOES_NOT_THROW);
     });
 
 });

--- a/src/geo/transform.ts
+++ b/src/geo/transform.ts
@@ -494,7 +494,6 @@ class Transform {
      * @returns {number} elevation in meters
      */
     getElevation(lnglat: LngLat, terrain: Terrain) {
-        const merc = MercatorCoordinate.fromLngLat(lnglat);
         const merc = MercatorCoordinate.fromLngLat(lnglat.wrap());
         const worldSize = (1 << this.tileZoom) * EXTENT;
         const mercX = merc.x * worldSize, mercY = merc.y * worldSize;

--- a/src/geo/transform.ts
+++ b/src/geo/transform.ts
@@ -495,6 +495,7 @@ class Transform {
      */
     getElevation(lnglat: LngLat, terrain: Terrain) {
         const merc = MercatorCoordinate.fromLngLat(lnglat);
+        const merc = MercatorCoordinate.fromLngLat(lnglat.wrap());
         const worldSize = (1 << this.tileZoom) * EXTENT;
         const mercX = merc.x * worldSize, mercY = merc.y * worldSize;
         const tileX = Math.floor(mercX / EXTENT), tileY = Math.floor(mercY / EXTENT);


### PR DESCRIPTION
wrap `lnglat` point so `fitBounds` across anti-meridian no longer throws error

## Launch Checklist



 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues. https://github.com/maplibre/maplibre-gl-js/issues/2095
 - [x] Write tests for all new functionality.
