### PR TITLE
Break circular dep: index.ts ... web_worker.ts -> src/index.ts

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -142,7 +142,13 @@ const exported = {
         config.MAX_PARALLEL_IMAGE_REQUESTS = numRequests;
     },
 
-    workerUrl: '',
+    get workerUrl(): string {
+        return config.WORKER_URL;
+    },
+
+    set workerUrl(value: string) {
+        config.WORKER_URL = value;
+    },
 
     /**
      * Sets a custom load tile function that will be called when using a source that starts with a custom url schema.

--- a/src/util/config.ts
+++ b/src/util/config.ts
@@ -2,12 +2,14 @@ type Config = {
     MAX_PARALLEL_IMAGE_REQUESTS: number;
     MAX_PARALLEL_IMAGE_REQUESTS_PER_FRAME: number;
     REGISTERED_PROTOCOLS: {[x: string]: any};
+    WORKER_URL: string;
 };
 
 const config: Config = {
     MAX_PARALLEL_IMAGE_REQUESTS: 16,
     MAX_PARALLEL_IMAGE_REQUESTS_PER_FRAME: 8,
     REGISTERED_PROTOCOLS: {},
+    WORKER_URL: ''
 };
 
 export default config;

--- a/src/util/web_worker.ts
+++ b/src/util/web_worker.ts
@@ -1,4 +1,4 @@
-import maplibregl from '../index';
+import config from './config';
 
 import type {WorkerSource} from '../source/worker_source';
 
@@ -29,5 +29,5 @@ export interface WorkerGlobalScopeInterface {
 }
 
 export default function workerFactory() {
-    return new Worker(maplibregl.workerUrl);
+    return new Worker(config.WORKER_URL);
 }


### PR DESCRIPTION


## Launch Checklist

Long circular depedency:
<code>src/index.ts -> src/ui/map.ts -> src/style/style.ts -> src/util/global_worker_pool.ts -> src/util/worker_pool.ts -> src/util/web_worker.ts -> src/index.ts</code>

It looks very reasonable to move workerURL to config object instead of piggyback on main maplibre.

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.

