### PR TITLE
Use resizeObserver instead of window resize events, fix and clean tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### ✨ Features and improvements
 - Improve performance by sending style layers to worker thread before processing it on main thread to allow parallel processing ([#2131](https://github.com/maplibre/maplibre-gl-js/pull/2131))
+- Resize map when container element is resized. ([#2013](https://github.com/maplibre/maplibre-gl-js/pull/2013))
 - *...Add new stuff here...*
 
 ### 🐞 Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### ✨ Features and improvements
 - Improve performance by sending style layers to worker thread before processing it on main thread to allow parallel processing ([#2131](https://github.com/maplibre/maplibre-gl-js/pull/2131))
-- Resize map when container element is resized. ([#2157](https://github.com/maplibre/maplibre-gl-js/pull/2157))
+- [Breaking] Resize map when container element is resized. the resize related events now has different data associated with it ([#2157](https://github.com/maplibre/maplibre-gl-js/pull/2157))
 - *...Add new stuff here...*
 
 ### 🐞 Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### ✨ Features and improvements
 - Improve performance by sending style layers to worker thread before processing it on main thread to allow parallel processing ([#2131](https://github.com/maplibre/maplibre-gl-js/pull/2131))
-- Resize map when container element is resized. ([#2013](https://github.com/maplibre/maplibre-gl-js/pull/2013))
+- Resize map when container element is resized. ([#2157](https://github.com/maplibre/maplibre-gl-js/pull/2157))
 - *...Add new stuff here...*
 
 ### 🐞 Bug fixes

--- a/src/source/vector_tile_worker_source.test.ts
+++ b/src/source/vector_tile_worker_source.test.ts
@@ -13,9 +13,6 @@ import {setPerformance} from '../util/test/util';
 describe('vector tile worker source', () => {
     const actor = {send: () => {}} as any as Actor;
     let server: FakeServer;
-    let originalGetEntriesByName;
-    let originalMeasure;
-    let originalMark;
 
     beforeEach(() => {
         global.fetch = null;

--- a/src/source/vector_tile_worker_source.test.ts
+++ b/src/source/vector_tile_worker_source.test.ts
@@ -21,18 +21,12 @@ describe('vector tile worker source', () => {
         global.fetch = null;
         server = fakeServer.create();
         setPerformance();
-        originalGetEntriesByName = window.performance.getEntriesByName;
-        originalMeasure = window.performance.measure;
-        originalMark = window.performance.mark;
 
     });
 
     afterEach(() => {
         server.restore();
         jest.clearAllMocks();
-        window.performance.getEntriesByName = originalGetEntriesByName;
-        window.performance.measure = originalMeasure;
-        window.performance.mark = originalMark;
     });
     test('VectorTileWorkerSource#abortTile aborts pending request', () => {
         const source = new VectorTileWorkerSource(actor, new StyleLayerIndex(), []);

--- a/src/ui/control/attribution_control.test.ts
+++ b/src/ui/control/attribution_control.test.ts
@@ -1,5 +1,5 @@
 import AttributionControl from './attribution_control';
-import {createMap as globalCreateMap, setWebGlContext, setPerformance, setMatchMedia} from '../../util/test/util';
+import {createMap as globalCreateMap, beforeMapTest} from '../../util/test/util';
 import simulate from '../../../test/unit/lib/simulate_interaction';
 import {fakeServer} from 'nise';
 
@@ -21,9 +21,7 @@ function createMap() {
 let map;
 
 beforeEach(() => {
-    setWebGlContext();
-    setPerformance();
-    setMatchMedia();
+    beforeMapTest();
     map = createMap();
 });
 

--- a/src/ui/control/fullscreen_control.test.ts
+++ b/src/ui/control/fullscreen_control.test.ts
@@ -1,9 +1,8 @@
-import {createMap, setWebGlContext} from '../../util/test/util';
+import {createMap, beforeMapTest} from '../../util/test/util';
 import FullscreenControl from './fullscreen_control';
 
 beforeEach(() => {
-    setWebGlContext();
-    window.performance.mark = jest.fn();
+    beforeMapTest();
 });
 
 describe('FullscreenControl', () => {

--- a/src/ui/control/geolocate_control.test.ts
+++ b/src/ui/control/geolocate_control.test.ts
@@ -1,5 +1,5 @@
 import geolocation from 'mock-geolocation';
-import {createMap, setWebGlContext, setPerformance, setMatchMedia} from '../../util/test/util';
+import {createMap, beforeMapTest} from '../../util/test/util';
 import GeolocateControl from './geolocate_control';
 
 geolocation.use();
@@ -14,9 +14,7 @@ function lngLatAsFixed(lngLat, digits) {
 }
 
 beforeEach(() => {
-    setWebGlContext();
-    setPerformance();
-    setMatchMedia();
+    beforeMapTest();
     map = createMap(undefined, undefined);
 });
 

--- a/src/ui/control/logo_control.test.ts
+++ b/src/ui/control/logo_control.test.ts
@@ -1,4 +1,4 @@
-import {createMap as globalCreateMap, setWebGlContext, setPerformance} from '../../util/test/util';
+import {createMap as globalCreateMap, beforeMapTest} from '../../util/test/util';
 
 function createMap(logoPosition, maplibreLogo) {
 
@@ -16,8 +16,7 @@ function createMap(logoPosition, maplibreLogo) {
 }
 
 beforeEach(() => {
-    setWebGlContext();
-    setPerformance();
+    beforeMapTest();
 });
 
 describe('LogoControl', () => {

--- a/src/ui/control/navigation_control.test.ts
+++ b/src/ui/control/navigation_control.test.ts
@@ -1,5 +1,5 @@
 import simulate from '../../../test/unit/lib/simulate_interaction';
-import {createMap as globalCreateMap, setWebGlContext, setPerformance, setMatchMedia} from '../../util/test/util';
+import {createMap as globalCreateMap, beforeMapTest} from '../../util/test/util';
 import NavigationControl from './navigation_control';
 
 function createMap() {
@@ -9,9 +9,7 @@ function createMap() {
 let map;
 
 beforeEach(() => {
-    setWebGlContext();
-    setPerformance();
-    setMatchMedia();
+    beforeMapTest();
     map = createMap();
 });
 

--- a/src/ui/control/scale_control.test.ts
+++ b/src/ui/control/scale_control.test.ts
@@ -1,9 +1,8 @@
-import {createMap, setWebGlContext} from '../../util/test/util';
+import {createMap, beforeMapTest} from '../../util/test/util';
 import ScaleControl from './scale_control';
 
 beforeEach(() => {
-    setWebGlContext();
-    window.performance.mark = jest.fn();
+    beforeMapTest();
 });
 
 describe('ScaleControl', () => {

--- a/src/ui/control/terrain_control.test.ts
+++ b/src/ui/control/terrain_control.test.ts
@@ -1,5 +1,5 @@
 import TerrainControl from './terrain_control';
-import {createMap as globalCreateMap, setWebGlContext, setPerformance, setMatchMedia} from '../../util/test/util';
+import {createMap as globalCreateMap, beforeMapTest} from '../../util/test/util';
 
 function createMap() {
 
@@ -27,9 +27,7 @@ function createMap() {
 let map;
 
 beforeEach(() => {
-    setWebGlContext();
-    setPerformance();
-    setMatchMedia();
+    beforeMapTest();
     map = createMap();
 });
 

--- a/src/ui/handler/box_zoom.test.ts
+++ b/src/ui/handler/box_zoom.test.ts
@@ -1,16 +1,14 @@
 import Map from '../map';
 import DOM from '../../util/dom';
 import simulate from '../../../test/unit/lib/simulate_interaction';
-import {setWebGlContext, setPerformance, setMatchMedia} from '../../util/test/util';
+import {beforeMapTest} from '../../util/test/util';
 
 function createMap(clickTolerance) {
     return new Map({style: '', container: DOM.create('div', '', window.document.body), clickTolerance});
 }
 
 beforeEach(() => {
-    setWebGlContext();
-    setPerformance();
-    setMatchMedia();
+    beforeMapTest();
 });
 
 describe('BoxZoomHandler', () => {

--- a/src/ui/handler/cooperative_gestures.test.ts
+++ b/src/ui/handler/cooperative_gestures.test.ts
@@ -2,7 +2,7 @@ import browser from '../../util/browser';
 import Map from '../map';
 import DOM from '../../util/dom';
 import simulate from '../../../test/unit/lib/simulate_interaction';
-import {setMatchMedia, setPerformance, setWebGlContext} from '../../util/test/util';
+import {beforeMapTest} from '../../util/test/util';
 
 function createMap() {
     return new Map({
@@ -17,9 +17,7 @@ function createMap() {
 }
 
 beforeEach(() => {
-    setPerformance();
-    setWebGlContext();
-    setMatchMedia();
+    beforeMapTest();
 });
 
 describe('CoopGesturesHandler', () => {

--- a/src/ui/handler/dblclick_zoom.test.ts
+++ b/src/ui/handler/dblclick_zoom.test.ts
@@ -1,5 +1,5 @@
 import simulate from '../../../test/unit/lib/simulate_interaction';
-import {setMatchMedia, setPerformance, setWebGlContext} from '../../util/test/util';
+import {beforeMapTest} from '../../util/test/util';
 import Map, {MapOptions} from '../map';
 
 function createMap() {
@@ -21,9 +21,7 @@ function simulateDoubleTap(map, delay = 100) {
 }
 
 beforeEach(() => {
-    setPerformance();
-    setWebGlContext();
-    setMatchMedia();
+    beforeMapTest();
 });
 
 describe('dbclick_zoom', () => {

--- a/src/ui/handler/drag_pan.test.ts
+++ b/src/ui/handler/drag_pan.test.ts
@@ -1,6 +1,6 @@
 import DOM from '../../util/dom';
 import simulate from '../../../test/unit/lib/simulate_interaction';
-import {setMatchMedia, setPerformance, setWebGlContext} from '../../util/test/util';
+import {beforeMapTest} from '../../util/test/util';
 import Map, {MapOptions} from '../map';
 import type {MapGeoJSONFeature} from '../../util/vectortile_to_geojson';
 
@@ -13,9 +13,7 @@ function createMap(clickTolerance?, dragPan?) {
 }
 
 beforeEach(() => {
-    setPerformance();
-    setWebGlContext();
-    setMatchMedia();
+    beforeMapTest();
 });
 
 // MouseEvent.buttons = 1 // left button

--- a/src/ui/handler/drag_rotate.test.ts
+++ b/src/ui/handler/drag_rotate.test.ts
@@ -4,16 +4,14 @@ import DOM from '../../util/dom';
 import simulate from '../../../test/unit/lib/simulate_interaction';
 import browser from '../../util/browser';
 
-import {setMatchMedia, setPerformance, setWebGlContext} from '../../util/test/util';
+import {beforeMapTest} from '../../util/test/util';
 
 function createMap(options?) {
     return new Map(extend({container: DOM.create('div', '', window.document.body)}, options));
 }
 
 beforeEach(() => {
-    setPerformance();
-    setWebGlContext();
-    setMatchMedia();
+    beforeMapTest();
 });
 
 describe('drag rotate', () => {

--- a/src/ui/handler/keyboard.test.ts
+++ b/src/ui/handler/keyboard.test.ts
@@ -2,7 +2,7 @@ import Map from '../../ui/map';
 import DOM from '../../util/dom';
 import simulate from '../../../test/unit/lib/simulate_interaction';
 import {extend} from '../../util/util';
-import {setMatchMedia, setPerformance, setWebGlContext} from '../../util/test/util';
+import {beforeMapTest} from '../../util/test/util';
 
 function createMap(options?) {
     return new Map(extend({
@@ -11,9 +11,7 @@ function createMap(options?) {
 }
 
 beforeEach(() => {
-    setPerformance();
-    setWebGlContext();
-    setMatchMedia();
+    beforeMapTest();
 });
 
 describe('keyboard', () => {

--- a/src/ui/handler/map_event.test.ts
+++ b/src/ui/handler/map_event.test.ts
@@ -1,16 +1,14 @@
 import Map, {MapOptions} from '../map';
 import DOM from '../../util/dom';
 import simulate from '../../../test/unit/lib/simulate_interaction';
-import {setMatchMedia, setPerformance, setWebGlContext} from '../../util/test/util';
+import {beforeMapTest} from '../../util/test/util';
 
 function createMap() {
     return new Map({interactive: true, container: DOM.create('div', '', window.document.body)} as any as MapOptions);
 }
 
 beforeEach(() => {
-    setPerformance();
-    setWebGlContext();
-    setMatchMedia();
+    beforeMapTest();
 });
 
 describe('map events', () => {

--- a/src/ui/handler/mouse_handler_interface.test.ts
+++ b/src/ui/handler/mouse_handler_interface.test.ts
@@ -1,13 +1,6 @@
 import Point from '@mapbox/point-geometry';
 
-import {setMatchMedia, setPerformance, setWebGlContext} from '../../util/test/util';
 import {generateMousePanHandler, generateMousePitchHandler, generateMouseRotationHandler} from './mouse';
-
-beforeEach(() => {
-    setPerformance();
-    setWebGlContext();
-    setMatchMedia();
-});
 
 describe('mouse handler tests', () => {
     test('MouseRotateHandler', () => {

--- a/src/ui/handler/mouse_rotate.test.ts
+++ b/src/ui/handler/mouse_rotate.test.ts
@@ -3,21 +3,19 @@ import Map from '../../ui/map';
 import DOM from '../../util/dom';
 import simulate from '../../../test/unit/lib/simulate_interaction';
 import browser from '../../util/browser';
-import {setMatchMedia, setPerformance, setWebGlContext} from '../../util/test/util';
+import {beforeMapTest} from '../../util/test/util';
 
 function createMap(options?) {
     return new Map(extend({container: DOM.create('div', '', window.document.body)}, options));
 }
 
 beforeEach(() => {
-    setPerformance();
-    setWebGlContext();
-    setMatchMedia();
+    beforeMapTest();
 });
 
 describe('mouse rotate', () => {
     test('MouseRotateHandler#isActive', () => {
-        const map = createMap();
+        const map = createMap({interactive: true});
         const mouseRotate = map.handlers._handlersById.mouseRotate;
 
         // Prevent inertial rotation.
@@ -40,7 +38,7 @@ describe('mouse rotate', () => {
     });
 
     test('MouseRotateHandler#isActive #4622 regression test', () => {
-        const map = createMap();
+        const map = createMap({interactive: true});
         const mouseRotate = map.handlers._handlersById.mouseRotate;
 
         // Prevent inertial rotation.

--- a/src/ui/handler/one_finger_touch_drag_handler_interface.test.ts
+++ b/src/ui/handler/one_finger_touch_drag_handler_interface.test.ts
@@ -1,13 +1,6 @@
 import Point from '@mapbox/point-geometry';
 
-import {setMatchMedia, setPerformance, setWebGlContext} from '../../util/test/util';
 import {generateOneFingerTouchPitchHandler, generateOneFingerTouchRotationHandler} from './one_finger_touch_drag';
-
-beforeEach(() => {
-    setPerformance();
-    setWebGlContext();
-    setMatchMedia();
-});
 
 const testTouch = {identifier: 0} as Touch;
 

--- a/src/ui/handler/scroll_zoom.test.ts
+++ b/src/ui/handler/scroll_zoom.test.ts
@@ -2,7 +2,7 @@ import browser from '../../util/browser';
 import Map from '../../ui/map';
 import DOM from '../../util/dom';
 import simulate from '../../../test/unit/lib/simulate_interaction';
-import {setMatchMedia, setPerformance, setWebGlContext} from '../../util/test/util';
+import {setPerformance, beforeMapTest} from '../../util/test/util';
 
 function createMap() {
     return new Map({
@@ -16,9 +16,7 @@ function createMap() {
 }
 
 beforeEach(() => {
-    setPerformance();
-    setWebGlContext();
-    setMatchMedia();
+    beforeMapTest();
 });
 
 describe('ScrollZoomHandler', () => {

--- a/src/ui/handler/two_fingers_touch.test.ts
+++ b/src/ui/handler/two_fingers_touch.test.ts
@@ -2,16 +2,14 @@ import Map, {MapOptions} from '../map';
 import Marker from '../marker';
 import DOM from '../../util/dom';
 import simulate from '../../../test/unit/lib/simulate_interaction';
-import {setMatchMedia, setPerformance, setWebGlContext} from '../../util/test/util';
+import {beforeMapTest} from '../../util/test/util';
 
 function createMap() {
     return new Map({container: DOM.create('div', '', window.document.body)} as any as MapOptions);
 }
 
 beforeEach(() => {
-    setPerformance();
-    setWebGlContext();
-    setMatchMedia();
+    beforeMapTest();
 });
 
 describe('touch zoom rotate', () => {

--- a/src/ui/hash.test.ts
+++ b/src/ui/hash.test.ts
@@ -1,5 +1,5 @@
 import Hash from './hash';
-import {setPerformance, createMap as globalCreateMap, setWebGlContext} from '../util/test/util';
+import {createMap as globalCreateMap, beforeMapTest} from '../util/test/util';
 
 describe('hash', () => {
     function createHash(name: string = undefined) {
@@ -18,8 +18,7 @@ describe('hash', () => {
     let map;
 
     beforeEach(() => {
-        setWebGlContext();
-        setPerformance();
+        beforeMapTest();
         map = createMap();
     });
 

--- a/src/ui/map.test.ts
+++ b/src/ui/map.test.ts
@@ -1,5 +1,5 @@
 import Map, {MapOptions} from './map';
-import {createMap, setMatchMedia, setPerformance, setWebGlContext, setErrorWebGlContext} from '../util/test/util';
+import {createMap, setErrorWebGlContext, beforeMapTest} from '../util/test/util';
 import LngLat from '../geo/lng_lat';
 import Tile from '../source/tile';
 import {OverscaledTileID} from '../source/tile_id';
@@ -31,9 +31,7 @@ function createStyleSource() {
 let server: FakeServer;
 
 beforeEach(() => {
-    setPerformance();
-    setWebGlContext();
-    setMatchMedia();
+    beforeMapTest();
     global.fetch = null;
     server = fakeServer.create();
 });
@@ -722,18 +720,15 @@ describe('Map', () => {
 
         });
 
-        test('listen to window resize event', done => {
-            const original = global.addEventListener;
-            global.addEventListener = function (type) {
-                if (type === 'resize') {
-                    //restore original function not to mess with other tests
-                    global.addEventListener = original;
-
-                    done();
-                }
-            };
+        test('listen to window resize event', () => {
+            const spy = jest.fn();
+            global.ResizeObserver = jest.fn().mockImplementation(() => ({
+                observe: spy
+            }));
 
             createMap();
+
+            expect(spy).toHaveBeenCalled();
         });
 
         test('do not resize if trackResize is false', () => {

--- a/src/ui/map.test.ts
+++ b/src/ui/map.test.ts
@@ -732,9 +732,9 @@ describe('Map', () => {
         });
 
         test('do not resize if trackResize is false', () => {
-            let observerCb = null;
+            let observerCallback: Function = null;
             global.ResizeObserver = jest.fn().mockImplementation((c) => ({
-                observe: () => { observerCb = c; }
+                observe: () => { observerCallback = c; }
             }));
 
             const map = createMap({trackResize: false});
@@ -743,7 +743,7 @@ describe('Map', () => {
             const spyB = jest.spyOn(map, '_update');
             const spyC = jest.spyOn(map, 'resize');
 
-            observerCb();
+            observerCallback();
 
             expect(spyA).not.toHaveBeenCalled();
             expect(spyB).not.toHaveBeenCalled();
@@ -751,9 +751,9 @@ describe('Map', () => {
         });
 
         test('do resize if trackResize is true (default)', () => {
-            let observerCb = null;
+            let observerCallback: Function = null;
             global.ResizeObserver = jest.fn().mockImplementation((c) => ({
-                observe: () => { observerCb = c; }
+                observe: () => { observerCallback = c; }
             }));
 
             const map = createMap();
@@ -761,7 +761,7 @@ describe('Map', () => {
             const spyA = jest.spyOn(map, '_update');
             const spyB = jest.spyOn(map, 'resize');
 
-            observerCb();
+            observerCallback();
 
             expect(spyA).toHaveBeenCalled();
             expect(spyB).toHaveBeenCalled();

--- a/src/ui/map.test.ts
+++ b/src/ui/map.test.ts
@@ -734,9 +734,9 @@ describe('Map', () => {
         test('do not resize if trackResize is false', () => {
             let observerCb = null;
             global.ResizeObserver = jest.fn().mockImplementation((c) => ({
-                observe: () => observerCb = c
+                observe: () => { observerCb = c; }
             }));
-            
+
             const map = createMap({trackResize: false});
 
             const spyA = jest.spyOn(map, 'stop');
@@ -753,7 +753,7 @@ describe('Map', () => {
         test('do resize if trackResize is true (default)', () => {
             let observerCb = null;
             global.ResizeObserver = jest.fn().mockImplementation((c) => ({
-                observe: () => observerCb = c
+                observe: () => { observerCb = c; }
             }));
 
             const map = createMap();

--- a/src/ui/map.test.ts
+++ b/src/ui/map.test.ts
@@ -732,13 +732,18 @@ describe('Map', () => {
         });
 
         test('do not resize if trackResize is false', () => {
+            let observerCb = null;
+            global.ResizeObserver = jest.fn().mockImplementation((c) => ({
+                observe: () => observerCb = c
+            }));
+            
             const map = createMap({trackResize: false});
 
             const spyA = jest.spyOn(map, 'stop');
             const spyB = jest.spyOn(map, '_update');
             const spyC = jest.spyOn(map, 'resize');
 
-            map._onWindowResize(undefined);
+            observerCb();
 
             expect(spyA).not.toHaveBeenCalled();
             expect(spyB).not.toHaveBeenCalled();
@@ -746,12 +751,17 @@ describe('Map', () => {
         });
 
         test('do resize if trackResize is true (default)', () => {
+            let observerCb = null;
+            global.ResizeObserver = jest.fn().mockImplementation((c) => ({
+                observe: () => observerCb = c
+            }));
+
             const map = createMap();
 
             const spyA = jest.spyOn(map, '_update');
             const spyB = jest.spyOn(map, 'resize');
 
-            map._onWindowResize(undefined);
+            observerCb();
 
             expect(spyA).toHaveBeenCalled();
             expect(spyB).toHaveBeenCalled();

--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -458,7 +458,6 @@ class Map extends Camera {
 
         bindAll([
             '_onWindowOnline',
-            '_onWindowResize', // need to remove
             '_onMapScroll',
             '_contextLost',
             '_contextRestored'
@@ -477,14 +476,12 @@ class Map extends Camera {
 
         if (typeof window !== 'undefined') {
             addEventListener('online', this._onWindowOnline, false);
-            addEventListener('resize', this._onWindowResize, false);
-            addEventListener('orientationchange', this._onWindowResize, false);
-            //this._resizeObserver = new ResizeObserver((entries) => {
-            //    if (this._trackResize) {
-            //        this.resize(entries);
-            //    }
-            //});
-            //this._resizeObserver.observe(this._container);
+            this._resizeObserver = new ResizeObserver((entries) => {
+                if (this._trackResize) {
+                    this.resize(entries)._update();
+                }
+            });
+            this._resizeObserver.observe(this._container);
         }
 
         this.handlers = new HandlerManager(this, options as CompleteMapOptions);
@@ -2956,13 +2953,11 @@ class Map extends Camera {
         this.setStyle(null);
         if (typeof window !== 'undefined') {
             removeEventListener('online', this._onWindowOnline, false);
-            removeEventListener('resize', this._onWindowResize, false);
-            removeEventListener('orientationchange', this._onWindowResize, false);
         }
 
         ImageRequest.removeThrottleControl(this._imageQueueHandle);
 
-        //this._resizeObserver?.disconnect();
+        this._resizeObserver?.disconnect();
         const extension = this.painter.context.gl.getExtension('WEBGL_lose_context');
         if (extension) extension.loseContext();
         this._canvas.removeEventListener('webglcontextrestored', this._contextRestored, false);
@@ -3001,12 +2996,6 @@ class Map extends Camera {
 
     _onWindowOnline() {
         this._update();
-    }
-
-    _onWindowResize(event: Event) {
-        if (this._trackResize) {
-            this.resize({originalEvent: event})._update();
-        }
     }
 
     /**

--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -319,6 +319,7 @@ class Map extends Camera {
     // accounts for placement finishing as well
     _fullyLoaded: boolean;
     _trackResize: boolean;
+    _resizeObserver: ResizeObserver;
     _preserveDrawingBuffer: boolean;
     _failIfMajorPerformanceCaveat: boolean;
     _antialias: boolean;
@@ -457,7 +458,6 @@ class Map extends Camera {
 
         bindAll([
             '_onWindowOnline',
-            '_onWindowResize',
             '_onMapScroll',
             '_contextLost',
             '_contextRestored'
@@ -476,8 +476,12 @@ class Map extends Camera {
 
         if (typeof window !== 'undefined') {
             addEventListener('online', this._onWindowOnline, false);
-            addEventListener('resize', this._onWindowResize, false);
-            addEventListener('orientationchange', this._onWindowResize, false);
+            this._resizeObserver = new ResizeObserver((entries) => {
+                if (this._trackResize) {
+                    this.resize(entries);
+                }
+            });
+            this._resizeObserver.observe(this._container);
         }
 
         this.handlers = new HandlerManager(this, options as CompleteMapOptions);
@@ -2948,13 +2952,12 @@ class Map extends Camera {
         delete this.handlers;
         this.setStyle(null);
         if (typeof window !== 'undefined') {
-            removeEventListener('resize', this._onWindowResize, false);
-            removeEventListener('orientationchange', this._onWindowResize, false);
             removeEventListener('online', this._onWindowOnline, false);
         }
 
         ImageRequest.removeThrottleControl(this._imageQueueHandle);
 
+        this._resizeObserver?.disconnect();
         const extension = this.painter.context.gl.getExtension('WEBGL_lose_context');
         if (extension) extension.loseContext();
         this._canvas.removeEventListener('webglcontextrestored', this._contextRestored, false);

--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -458,6 +458,7 @@ class Map extends Camera {
 
         bindAll([
             '_onWindowOnline',
+            '_onWindowResize', // need to remove
             '_onMapScroll',
             '_contextLost',
             '_contextRestored'
@@ -476,12 +477,14 @@ class Map extends Camera {
 
         if (typeof window !== 'undefined') {
             addEventListener('online', this._onWindowOnline, false);
-            this._resizeObserver = new ResizeObserver((entries) => {
-                if (this._trackResize) {
-                    this.resize(entries);
-                }
-            });
-            this._resizeObserver.observe(this._container);
+            addEventListener('resize', this._onWindowResize, false);
+            addEventListener('orientationchange', this._onWindowResize, false);
+            //this._resizeObserver = new ResizeObserver((entries) => {
+            //    if (this._trackResize) {
+            //        this.resize(entries);
+            //    }
+            //});
+            //this._resizeObserver.observe(this._container);
         }
 
         this.handlers = new HandlerManager(this, options as CompleteMapOptions);
@@ -2953,11 +2956,13 @@ class Map extends Camera {
         this.setStyle(null);
         if (typeof window !== 'undefined') {
             removeEventListener('online', this._onWindowOnline, false);
+            removeEventListener('resize', this._onWindowResize, false);
+            removeEventListener('orientationchange', this._onWindowResize, false);
         }
 
         ImageRequest.removeThrottleControl(this._imageQueueHandle);
 
-        this._resizeObserver?.disconnect();
+        //this._resizeObserver?.disconnect();
         const extension = this.painter.context.gl.getExtension('WEBGL_lose_context');
         if (extension) extension.loseContext();
         this._canvas.removeEventListener('webglcontextrestored', this._contextRestored, false);

--- a/src/ui/map/isMoving.test.ts
+++ b/src/ui/map/isMoving.test.ts
@@ -2,7 +2,7 @@ import browser from '../../util/browser';
 import Map from '../map';
 import DOM from '../../util/dom';
 import simulate from '../../../test/unit/lib/simulate_interaction';
-import {setWebGlContext, setPerformance, setMatchMedia} from '../../util/test/util';
+import {beforeMapTest} from '../../util/test/util';
 
 let map;
 
@@ -11,9 +11,7 @@ function createMap() {
 }
 
 beforeEach(() => {
-    setWebGlContext();
-    setPerformance();
-    setMatchMedia();
+    beforeMapTest();
     map = createMap();
 });
 

--- a/src/ui/map/isRotating.test.ts
+++ b/src/ui/map/isRotating.test.ts
@@ -2,7 +2,7 @@ import Map from '../../ui/map';
 import DOM from '../../util/dom';
 import simulate from '../../../test/unit/lib/simulate_interaction';
 import browser from '../../util/browser';
-import {setWebGlContext, setPerformance, setMatchMedia} from '../../util/test/util';
+import {beforeMapTest} from '../../util/test/util';
 
 let map;
 
@@ -11,9 +11,7 @@ function createMap() {
 }
 
 beforeEach(() => {
-    setWebGlContext();
-    setPerformance();
-    setMatchMedia();
+    beforeMapTest();
     map = createMap();
 });
 

--- a/src/ui/map/isZooming.test.ts
+++ b/src/ui/map/isZooming.test.ts
@@ -2,16 +2,14 @@ import browser from '../../util/browser';
 import Map from '../../ui/map';
 import DOM from '../../util/dom';
 import simulate from '../../../test/unit/lib/simulate_interaction';
-import {setWebGlContext, setPerformance, setMatchMedia} from '../../util/test/util';
+import {beforeMapTest} from '../../util/test/util';
 
 function createMap() {
     return new Map({style: '', container: DOM.create('div', '', window.document.body)});
 }
 
 beforeEach(() => {
-    setWebGlContext();
-    setPerformance();
-    setMatchMedia();
+    beforeMapTest();
 });
 
 describe('Map#isZooming', () => {

--- a/src/ui/map/requestRenderFrame.test.ts
+++ b/src/ui/map/requestRenderFrame.test.ts
@@ -1,9 +1,7 @@
-import {createMap, setMatchMedia, setPerformance, setWebGlContext} from '../../util/test/util';
+import {createMap, beforeMapTest} from '../../util/test/util';
 
 beforeEach(() => {
-    setPerformance();
-    setWebGlContext();
-    setMatchMedia();
+    beforeMapTest();
 });
 
 describe('requestRenderFrame', () => {

--- a/src/ui/map_events.test.ts
+++ b/src/ui/map_events.test.ts
@@ -1,12 +1,11 @@
 import simulate, {window} from '../../test/unit/lib/simulate_interaction';
 import StyleLayer from '../style/style_layer';
-import {createMap, setPerformance, setWebGlContext} from '../util/test/util';
+import {createMap, beforeMapTest} from '../util/test/util';
 import {MapGeoJSONFeature} from '../util/vectortile_to_geojson';
 import {MapLayerEventType} from './events';
 
 beforeEach(() => {
-    setPerformance();
-    setWebGlContext();
+    beforeMapTest();
 });
 
 describe('map events', () => {

--- a/src/ui/marker.test.ts
+++ b/src/ui/marker.test.ts
@@ -1,4 +1,4 @@
-import {createMap as globalCreateMap, setPerformance, setWebGlContext} from '../util/test/util';
+import {createMap as globalCreateMap, beforeMapTest} from '../util/test/util';
 import Marker from './marker';
 import Popup from './popup';
 import LngLat from '../geo/lng_lat';
@@ -15,8 +15,7 @@ function createMap(options = {}) {
 }
 
 beforeEach(() => {
-    setWebGlContext();
-    setPerformance();
+    beforeMapTest();
 });
 
 describe('marker', () => {

--- a/src/ui/popup.test.ts
+++ b/src/ui/popup.test.ts
@@ -1,4 +1,4 @@
-import {createMap as globalCreateMap, setPerformance, setWebGlContext} from '../util/test/util';
+import {createMap as globalCreateMap, beforeMapTest} from '../util/test/util';
 import Popup, {Offset} from './popup';
 import LngLat from '../geo/lng_lat';
 import Point from '@mapbox/point-geometry';
@@ -18,8 +18,7 @@ function createMap(options?) {
 }
 
 beforeEach(() => {
-    setPerformance();
-    setWebGlContext();
+    beforeMapTest();
 });
 
 describe('popup', () => {

--- a/src/util/test/util.ts
+++ b/src/util/test/util.ts
@@ -40,7 +40,7 @@ export function equalWithPrecision(test, expected, actual, multiplier, message, 
 }
 
 // Add webgl context with the supplied GL
-export function setWebGlContext() {
+function setWebGlContext() {
     const originalGetContext = global.HTMLCanvasElement.prototype.getContext;
 
     function imitateWebGlGetContext(type, attributes) {
@@ -98,6 +98,21 @@ export function setMatchMedia() {
             dispatchEvent: jest.fn(),
         })),
     });
+}
+
+function setResizeObserver() {
+    global.ResizeObserver = jest.fn().mockImplementation(() => ({
+        observe: jest.fn(),
+        unobserve: jest.fn(),
+        disconnect: jest.fn(),
+    }));
+}
+
+export function beforeMapTest() {
+    setPerformance();
+    setWebGlContext();
+    setMatchMedia();
+    setResizeObserver();
 }
 
 export function getWrapDispatcher() {

--- a/test/integration/browser/browser.test.ts
+++ b/test/integration/browser/browser.test.ts
@@ -63,10 +63,10 @@ describe('browser tests', () => {
             await newTest(impl);
 
             const canvas = await page.$('.maplibregl-canvas');
-            const canvasBB = await canvas.boundingBox();
+            const canvasBB = await canvas?.boundingBox();
 
             // Perform drag action, wait a bit the end to avoid the momentum mode.
-            await page.mouse.move(canvasBB.x, canvasBB.y);
+            await page.mouse.move(canvasBB!.x, canvasBB!.y);
             await page.mouse.down();
             await page.mouse.move(100, 0);
             await new Promise(r => setTimeout(r, 200));
@@ -78,6 +78,33 @@ describe('browser tests', () => {
 
             expect(center.lng).toBeCloseTo(-35.15625, 4);
             expect(center.lat).toBeCloseTo(0, 7);
+        }, 20000);
+
+        test(`${impl.name()} - resizeing view port`, async () => {
+            await newTest(impl);
+
+            await page.setViewportSize({width: 400, height: 400});
+
+            await new Promise(r => setTimeout(r, 200));
+
+            const canvas = await page.$('.maplibregl-canvas');
+            const canvasBB = await canvas?.boundingBox();
+            expect(canvasBB?.width).toBeCloseTo(400);
+            expect(canvasBB?.height).toBeCloseTo(400);
+        }, 20000);
+
+        test(`${impl.name()} - resizeing div`, async () => {
+            await newTest(impl);
+
+            await page.evaluate(() => {
+                document.getElementById('map')!.style.width = '200px';
+                document.getElementById('map')!.style.height = '200px';
+            });
+
+            const canvas = await page.$('.maplibregl-canvas');
+            const canvasBB = await canvas?.boundingBox();
+            expect(canvasBB!.width).toBeCloseTo(200);
+            expect(canvasBB!.height).toBeCloseTo(200);
         }, 20000);
 
         test(`${impl.name()} Zoom: Double click at the center`, async () => {

--- a/test/integration/render/mock_browser_for_node.ts
+++ b/test/integration/render/mock_browser_for_node.ts
@@ -38,6 +38,12 @@ global.Blob = window.Blob;
 global.URL = window.URL;
 global.fetch = window.fetch;
 global.document = window.document;
+global.ResizeObserver = function (callback) {
+    return { 
+        observe: () => {callback()},
+        disconnect: () => {}
+    }
+} as any;
 //@ts-ignore
 global.window = window;
 // stubbing image load as it is not implemented in jsdom

--- a/test/integration/render/mock_browser_for_node.ts
+++ b/test/integration/render/mock_browser_for_node.ts
@@ -39,10 +39,10 @@ global.URL = window.URL;
 global.fetch = window.fetch;
 global.document = window.document;
 global.ResizeObserver = function (callback) {
-    return { 
-        observe: () => {callback()},
+    return {
+        observe: () => { callback(); },
         disconnect: () => {}
-    }
+    };
 } as any;
 //@ts-ignore
 global.window = window;

--- a/test/integration/render/mock_browser_for_node.ts
+++ b/test/integration/render/mock_browser_for_node.ts
@@ -38,9 +38,9 @@ global.Blob = window.Blob;
 global.URL = window.URL;
 global.fetch = window.fetch;
 global.document = window.document;
-global.ResizeObserver = function (callback) {
+global.ResizeObserver = function () {
     return {
-        observe: () => { callback(); },
+        observe: () => {},
         disconnect: () => {}
     };
 } as any;

--- a/test/integration/render/mock_browser_for_node.ts
+++ b/test/integration/render/mock_browser_for_node.ts
@@ -43,7 +43,7 @@ global.ResizeObserver = function () {
         observe: () => {},
         disconnect: () => {}
     };
-} as any;
+} as any as typeof ResizeObserver;
 //@ts-ignore
 global.window = window;
 // stubbing image load as it is not implemented in jsdom


### PR DESCRIPTION
This adds the relevant unit test.
Cleans the other tests that has duplicate code in every before function.
Clear some test that did not need some methods.

@rotu Feel free to review :-)

Replaces #2013