### PR TITLE
Update new feature template to add user story requirement

### DIFF
--- a/.github/ISSUE_TEMPLATE/Feature_request.md
+++ b/.github/ISSUE_TEMPLATE/Feature_request.md
@@ -14,51 +14,16 @@ This section should have a one-sentence sentence user story, such as:
 See also: https://en.wikipedia.org/wiki/User_story#Common_templates
 -->
 
-## Motivation
+## Rationale
 
 <!--
-What problem are we trying to solve?  Please link any relevant issues.
-What use cases are we trying to accommodate?
-
-Focus on the problem and save design ideas for the next section.
+ - Why is this feature needed?
+ - What are some example use cases?
+ - Can it be done today? Is there a workaround?
 -->
 
-## Design Alternatives
+## Impact
 
 <!--
-How could we accommodate the use cases above?
-Is "do nothing" an option?
--->
-
-## Design
-
-<!--
-Which design should we implement?
-What are the advantages of this design?
-What are some potential drawbacks of this design?
--->
-
-### Mock-Up
-
-<!--
-What will this design look like to developers?
-What will this design look like to end users?
--->
-
-### Concepts
-
-<!--
-How will we teach this design?
-What terminology will work best for the new concepts introduced by this design?
-What existing precedents support the new concepts?
-Where do the concepts set new precedents?
--->
-
-### Implementation
-
-<!--
-How you would implement the design in Javascript?
-How you would implement the design in C++?
-What parts of the Mapbox GL ecosystem will need to change to accommodate this design?
-Are there any important edge cases?
+ - What if we do nothing? What is the impact to end-users if we don't implement this feature?
 -->

--- a/.github/ISSUE_TEMPLATE/Feature_request.md
+++ b/.github/ISSUE_TEMPLATE/Feature_request.md
@@ -4,6 +4,16 @@ about: Suggest a feature or enhancement
 
 ---
 
+## User Story
+
+<!--
+This section should have a one-sentence sentence user story, such as:
+
+ As a <role> I can <capability>, so that <receive benefit>
+
+See also: https://en.wikipedia.org/wiki/User_story#Common_templates
+-->
+
 ## Motivation
 
 <!--


### PR DESCRIPTION
## User Story

As a **developer** I want to **provide useful information to the maintainer team** in order that I **clearly describe the reason for desired code changes**.

## Motivation

In https://github.com/maplibre/maplibre-gl-js/issues/2162#issuecomment-1426745555, it was described that there's an undocumented expectation for issue authors to provide a [user story](https://en.wikipedia.org/wiki/User_story) which succinctly describes the purpose of the requested change. This PR formally adds that expectation explicitly in the issue template.  This will assist authors of new feature tickets in better communicating what they are trying to accomplish.

Sorry for going straight to PR but I felt this was a simple enough change.