### PR TITLE
Migrate toBounds method to be a static fromLngLat method in LngLatBounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Improve performance by sending style layers to worker thread before processing it on main thread to allow parallel processing ([#2131](https://github.com/maplibre/maplibre-gl-js/pull/2131))
 - [Breaking] Resize map when container element is resized. the resize related events now has different data associated with it ([#2157](https://github.com/maplibre/maplibre-gl-js/pull/2157))
 - Add Map.getImage() to retrieve previously-loaded images. ([#2168](https://github.com/maplibre/maplibre-gl-js/pull/2168))
+- [Breaking] toBounds method of class LngLat is replaced by a static method fromLngLat of class LngLatBounds ([#2188](https://github.com/maplibre/maplibre-gl-js/pull/2188))
 - *...Add new stuff here...*
 
 ### 🐞 Bug fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -107,7 +107,7 @@
         "pngjs": "^6.0.0",
         "postcss": "^8.4.21",
         "postcss-cli": "^10.1.0",
-        "postcss-inline-svg": "^5.0.0",
+        "postcss-inline-svg": "^6.0.0",
         "pretty-bytes": "^6.1.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -10873,14 +10873,15 @@
       }
     },
     "node_modules/postcss-inline-svg": {
-      "version": "5.0.0",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-inline-svg/-/postcss-inline-svg-6.0.0.tgz",
+      "integrity": "sha512-ok5j0Iqsn8mS/5U1W+Im6qkQjm6nBxdwwJU+BSnBaDhLjC06h1xvy9MA+tefxhfZP/ARTRwARSozzYGf/sqEGg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "css-select": "^3.1.0",
-        "dom-serializer": "^1.1.0",
-        "htmlparser2": "^5.0.1",
-        "postcss-value-parser": "^4.0.0"
+        "css-select": "^5.1.0",
+        "dom-serializer": "^2.0.0",
+        "htmlparser2": "^8.0.1",
+        "postcss-value-parser": "^4.2.0"
       },
       "peerDependencies": {
         "postcss": "^8.1.4"

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,7 +55,7 @@
         "@types/gl": "^6.0.2",
         "@types/glob": "^8.0.1",
         "@types/jest": "^29.2.5",
-        "@types/jsdom": "^20.0.0",
+        "@types/jsdom": "^21.1.0",
         "@types/minimist": "^1.2.2",
         "@types/murmurhash-js": "^1.0.3",
         "@types/nise": "^1.4.1",
@@ -2092,9 +2092,10 @@
       }
     },
     "node_modules/@types/jsdom": {
-      "version": "20.0.0",
+      "version": "21.1.0",
+      "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-21.1.0.tgz",
+      "integrity": "sha512-leWreJOdnuIxq9Y70tBVm/bvTuh31DSlF/r4l7Cfi4uhVQqLHD0Q4v301GMisEMwwbMgF7ZKxuZ+Jbd4NcdmRw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@types/node": "*",
         "@types/tough-cookie": "*",
@@ -7506,6 +7507,17 @@
         "canvas": {
           "optional": true
         }
+      }
+    },
+    "node_modules/jest-environment-jsdom/node_modules/@types/jsdom": {
+      "version": "20.0.1",
+      "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-20.0.1.tgz",
+      "integrity": "sha512-d0r18sZPmMQr1eG35u12FZfhIXNrnsPU/g5wvRKCUf/tOGilKKwYMYGqh33BNR6ba+2gkHw1EUiHoN3mn7E5IQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "@types/tough-cookie": "*",
+        "parse5": "^7.0.0"
       }
     },
     "node_modules/jest-environment-jsdom/node_modules/form-data": {

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "pngjs": "^6.0.0",
     "postcss": "^8.4.21",
     "postcss-cli": "^10.1.0",
-    "postcss-inline-svg": "^5.0.0",
+    "postcss-inline-svg": "^6.0.0",
     "pretty-bytes": "^6.1.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@types/gl": "^6.0.2",
     "@types/glob": "^8.0.1",
     "@types/jest": "^29.2.5",
-    "@types/jsdom": "^20.0.0",
+    "@types/jsdom": "^21.1.0",
     "@types/minimist": "^1.2.2",
     "@types/murmurhash-js": "^1.0.3",
     "@types/nise": "^1.4.1",

--- a/src/geo/lng_lat.test.ts
+++ b/src/geo/lng_lat.test.ts
@@ -62,14 +62,4 @@ describe('LngLat', () => {
         expect(d > 8667079).toBeTruthy();
         expect(d < 8667081).toBeTruthy();
     });
-
-    test('#toBounds', () => {
-        expect(new LngLat(0, 0).toBounds(10).toArray()).toEqual(
-            [[-0.00008983152770714982, -0.00008983152770714982], [0.00008983152770714982, 0.00008983152770714982]]
-        );
-        expect(new LngLat(-73.9749, 40.7736).toBounds(10).toArray()).toEqual(
-            [[-73.97501862141328, 40.77351016847229], [-73.97478137858673, 40.77368983152771]]
-        );
-        expect(new LngLat(-73.9749, 40.7736).toBounds().toArray()).toEqual([[-73.9749, 40.7736], [-73.9749, 40.7736]]);
-    });
 });

--- a/src/geo/lng_lat.ts
+++ b/src/geo/lng_lat.ts
@@ -1,5 +1,4 @@
 import {wrap} from '../util/util';
-import LngLatBounds from './lng_lat_bounds';
 
 /*
 * Approximate radius of the earth in meters.
@@ -99,24 +98,6 @@ class LngLat {
 
         const maxMeters = earthRadius * Math.acos(Math.min(a, 1));
         return maxMeters;
-    }
-
-    /**
-     * Returns a `LngLatBounds` from the coordinates extended by a given `radius`. The returned `LngLatBounds` completely contains the `radius`.
-     *
-     * @param {number} [radius=0] Distance in meters from the coordinates to extend the bounds.
-     * @returns {LngLatBounds} A new `LngLatBounds` object representing the coordinates extended by the `radius`.
-     * @example
-     * var ll = new maplibregl.LngLat(-73.9749, 40.7736);
-     * ll.toBounds(100).toArray(); // = [[-73.97501862141328, 40.77351016847229], [-73.97478137858673, 40.77368983152771]]
-     */
-    toBounds(radius: number = 0) {
-        const earthCircumferenceInMetersAtEquator = 40075017;
-        const latAccuracy = 360 * radius / earthCircumferenceInMetersAtEquator,
-            lngAccuracy = latAccuracy / Math.cos((Math.PI / 180) * this.lat);
-
-        return new LngLatBounds(new LngLat(this.lng - lngAccuracy, this.lat - latAccuracy),
-            new LngLat(this.lng + lngAccuracy, this.lat + latAccuracy));
     }
 
     /**

--- a/src/geo/lng_lat_bounds.test.ts
+++ b/src/geo/lng_lat_bounds.test.ts
@@ -174,6 +174,23 @@ describe('LngLatBounds', () => {
         expect(bounds.isEmpty()).toBe(false);
     });
 
+    test('#createBounds', () => {
+        const center0 = new LngLat(0, 0);
+        const center1 = new LngLat(-73.9749, 40.7736);
+
+        const center0Radius10 = LngLatBounds.createBounds(center0, 10);
+        const center1Radius10 = LngLatBounds.createBounds(center1, 10);
+        const center1Radius0 = LngLatBounds.createBounds(center1);
+
+        expect(center0Radius10.toArray()).toEqual(
+            [[-0.00008983152770714982, -0.00008983152770714982], [0.00008983152770714982, 0.00008983152770714982]]
+        );
+        expect(center1Radius10.toArray()).toEqual(
+            [[-73.97501862141328, 40.77351016847229], [-73.97478137858673, 40.77368983152771]]
+        );
+        expect(center1Radius0.toArray()).toEqual([[-73.9749, 40.7736], [-73.9749, 40.7736]]);
+    });
+
     describe('contains', () => {
         describe('point', () => {
             test('point is in bounds', () => {

--- a/src/geo/lng_lat_bounds.test.ts
+++ b/src/geo/lng_lat_bounds.test.ts
@@ -178,9 +178,9 @@ describe('LngLatBounds', () => {
         const center0 = new LngLat(0, 0);
         const center1 = new LngLat(-73.9749, 40.7736);
 
-        const center0Radius10 = LngLatBounds.createBounds(center0, 10);
-        const center1Radius10 = LngLatBounds.createBounds(center1, 10);
-        const center1Radius0 = LngLatBounds.createBounds(center1);
+        const center0Radius10 = LngLatBounds.fromLngLat(center0, 10);
+        const center1Radius10 = LngLatBounds.fromLngLat(center1, 10);
+        const center1Radius0 = LngLatBounds.fromLngLat(center1);
 
         expect(center0Radius10.toArray()).toEqual(
             [[-0.00008983152770714982, -0.00008983152770714982], [0.00008983152770714982, 0.00008983152770714982]]

--- a/src/geo/lng_lat_bounds.test.ts
+++ b/src/geo/lng_lat_bounds.test.ts
@@ -174,7 +174,7 @@ describe('LngLatBounds', () => {
         expect(bounds.isEmpty()).toBe(false);
     });
 
-    test('#createBounds', () => {
+    test('#fromLngLat', () => {
         const center0 = new LngLat(0, 0);
         const center1 = new LngLat(-73.9749, 40.7736);
 

--- a/src/geo/lng_lat_bounds.ts
+++ b/src/geo/lng_lat_bounds.ts
@@ -273,14 +273,14 @@ class LngLatBounds {
     /**
      * Returns a `LngLatBounds` from the coordinates extended by a given `radius`. The returned `LngLatBounds` completely contains the `radius`.
      *
-     * @param center
+     * @param center center postion of the new bounds.
      * @param {number} [radius=0] Distance in meters from the coordinates to extend the bounds.
      * @returns {LngLatBounds} A new `LngLatBounds` object representing the coordinates extended by the `radius`.
      * @example
      * var center = new maplibregl.LngLat(-73.9749, 40.7736);
-     * maplibregl.LngLatBounds.createBounds(100).toArray(); // = [[-73.97501862141328, 40.77351016847229], [-73.97478137858673, 40.77368983152771]]
+     * maplibregl.LngLatBounds.fromLngLat(100).toArray(); // = [[-73.97501862141328, 40.77351016847229], [-73.97478137858673, 40.77368983152771]]
      */
-    static createBounds(center: LngLat, radius:number = 0): LngLatBounds {
+    static fromLngLat(center: LngLat, radius:number = 0): LngLatBounds {
         const earthCircumferenceInMetersAtEquator = 40075017;
         const latAccuracy = 360 * radius / earthCircumferenceInMetersAtEquator,
             lngAccuracy = latAccuracy / Math.cos((Math.PI / 180) * center.lat);

--- a/src/geo/lng_lat_bounds.ts
+++ b/src/geo/lng_lat_bounds.ts
@@ -25,6 +25,7 @@ class LngLatBounds {
     /**
      * @param {LngLatLike} [sw] The southwest corner of the bounding box.
      * OR array of 4 numbers in the order of  west, south, east, north
+     * OR array of 2 LngLatLike: [sw,ne]
      * @param {LngLatLike} [ne] The northeast corner of the bounding box.
      * @example
      * var sw = new maplibregl.LngLat(-73.9876, 40.7661);
@@ -273,7 +274,7 @@ class LngLatBounds {
     /**
      * Returns a `LngLatBounds` from the coordinates extended by a given `radius`. The returned `LngLatBounds` completely contains the `radius`.
      *
-     * @param center center postion of the new bounds.
+     * @param center center coordinates of the new bounds.
      * @param {number} [radius=0] Distance in meters from the coordinates to extend the bounds.
      * @returns {LngLatBounds} A new `LngLatBounds` object representing the coordinates extended by the `radius`.
      * @example

--- a/src/ui/control/geolocate_control.test.ts
+++ b/src/ui/control/geolocate_control.test.ts
@@ -1,4 +1,5 @@
 import geolocation from 'mock-geolocation';
+import LngLatBounds from '../../geo/lng_lat_bounds';
 import {createMap, beforeMapTest} from '../../util/test/util';
 import GeolocateControl from './geolocate_control';
 
@@ -174,12 +175,14 @@ describe('GeolocateControl with no options', () => {
         geolocate._geolocateButton.dispatchEvent(click);
         geolocation.send({latitude: 10, longitude: 20, accuracy: 1000});
         await moveEndPromise;
-        expect(lngLatAsFixed(map.getCenter(), 4)).toEqual({'lat': '10.0000', 'lng': '20.0000'});
+        const mapCenter = map.getCenter();
+        expect(lngLatAsFixed(mapCenter, 4)).toEqual({'lat': '10.0000', 'lng': '20.0000'});
 
         const mapBounds = map.getBounds();
 
         // map bounds should contain or equal accuracy bounds, that is the ensure accuracy bounds doesn't fall outside the map bounds
-        const accuracyBounds = map.getCenter().toBounds(1000);
+        const accuracyBounds = LngLatBounds.createBounds(mapCenter, 1000);
+
         expect(accuracyBounds.getNorth().toFixed(4) <= mapBounds.getNorth().toFixed(4)).toBeTruthy();
         expect(accuracyBounds.getSouth().toFixed(4) >= mapBounds.getSouth().toFixed(4)).toBeTruthy();
         expect(accuracyBounds.getEast().toFixed(4) <= mapBounds.getEast().toFixed(4)).toBeTruthy();
@@ -187,7 +190,8 @@ describe('GeolocateControl with no options', () => {
 
         // map bounds should not be too much bigger on all edges of the accuracy bounds (this test will only work for an orthogonal bearing),
         // ensures map bounds does not contain buffered accuracy bounds, as if it does there is too much gap around the accuracy bounds
-        const bufferedAccuracyBounds = map.getCenter().toBounds(1100);
+        const bufferedAccuracyBounds = LngLatBounds.createBounds(mapCenter, 1100);
+
         expect(
             (bufferedAccuracyBounds.getNorth().toFixed(4) < mapBounds.getNorth().toFixed(4)) &&
             (bufferedAccuracyBounds.getSouth().toFixed(4) > mapBounds.getSouth().toFixed(4)) &&

--- a/src/ui/control/geolocate_control.test.ts
+++ b/src/ui/control/geolocate_control.test.ts
@@ -181,7 +181,7 @@ describe('GeolocateControl with no options', () => {
         const mapBounds = map.getBounds();
 
         // map bounds should contain or equal accuracy bounds, that is the ensure accuracy bounds doesn't fall outside the map bounds
-        const accuracyBounds = LngLatBounds.createBounds(mapCenter, 1000);
+        const accuracyBounds = LngLatBounds.fromLngLat(mapCenter, 1000);
 
         expect(accuracyBounds.getNorth().toFixed(4) <= mapBounds.getNorth().toFixed(4)).toBeTruthy();
         expect(accuracyBounds.getSouth().toFixed(4) >= mapBounds.getSouth().toFixed(4)).toBeTruthy();
@@ -190,7 +190,7 @@ describe('GeolocateControl with no options', () => {
 
         // map bounds should not be too much bigger on all edges of the accuracy bounds (this test will only work for an orthogonal bearing),
         // ensures map bounds does not contain buffered accuracy bounds, as if it does there is too much gap around the accuracy bounds
-        const bufferedAccuracyBounds = LngLatBounds.createBounds(mapCenter, 1100);
+        const bufferedAccuracyBounds = LngLatBounds.fromLngLat(mapCenter, 1100);
 
         expect(
             (bufferedAccuracyBounds.getNorth().toFixed(4) < mapBounds.getNorth().toFixed(4)) &&

--- a/src/ui/control/geolocate_control.ts
+++ b/src/ui/control/geolocate_control.ts
@@ -7,6 +7,7 @@ import Marker from '../marker';
 import type Map from '../map';
 import type {FitBoundsOptions} from '../camera';
 import type {IControl} from './control';
+import LngLatBounds from '../../geo/lng_lat_bounds';
 
 type GeolocateOptions = {
     positionOptions?: PositionOptions;
@@ -277,8 +278,9 @@ class GeolocateControl extends Evented implements IControl {
         const radius = position.coords.accuracy;
         const bearing = this._map.getBearing();
         const options = extend({bearing}, this.options.fitBoundsOptions);
+        const newBounds = LngLatBounds.createBounds(center, radius);
 
-        this._map.fitBounds(center.toBounds(radius), options, {
+        this._map.fitBounds(newBounds, options, {
             geolocateSource: true // tag this camera change so it won't cause the control to change to background state
         });
     }

--- a/src/ui/control/geolocate_control.ts
+++ b/src/ui/control/geolocate_control.ts
@@ -278,7 +278,7 @@ class GeolocateControl extends Evented implements IControl {
         const radius = position.coords.accuracy;
         const bearing = this._map.getBearing();
         const options = extend({bearing}, this.options.fitBoundsOptions);
-        const newBounds = LngLatBounds.createBounds(center, radius);
+        const newBounds = LngLatBounds.fromLngLat(center, radius);
 
         this._map.fitBounds(newBounds, options, {
             geolocateSource: true // tag this camera change so it won't cause the control to change to background state


### PR DESCRIPTION
## Launch Checklist

- Add types to LngLatBounds constructor.
- remove toBounds
- Create a static method called fromLngLat(lnglat, radius).
- Fail build on all warnings to stop all future circular dependency problems

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license)
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [x] Write tests for all new functionality.
 - [x] Document any changes to public APIs.
 - [x] Add an entry to `CHANGELOG.md` under the `## main` section.
