### PR TITLE
Update changelog for style-spec

### DIFF
--- a/src/style-spec/CHANGELOG.md
+++ b/src/style-spec/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 17.1.0
+* Add support for multiple sprites in one style (#1805)
+
 ## 17.0.2
 
 * Fix errors when running style-spec bin scripts and added missing help. Removed unnecessary script 'gl-style-composite'. ([#1971](https://github.com/maplibre/maplibre-gl-js/pull/1971))


### PR DESCRIPTION
When https://github.com/maplibre/maplibre-gl-js/pull/1805 was merged, the version in style-spec package.json was bumped from 17.0.2 to 17.1.0, but the changelog was never updated, and the 17.1.0 version was never released.