### PR TITLE
Fix format expression typing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### 🐞 Bug fixes
 
+- Fix `format` expression type to make `text-color` optional.
 - Fix issue unloading sprite sheet when using `setStyle(style, {diff:true})` ([#2146](https://github.com/maplibre/maplibre-gl-js/pull/2146))
 - Fix wrap coords in `getTerrain` when `fitBounds` accross the AM ([#2155](https://github.com/maplibre/maplibre-gl-js/pull/2155))
 - _...Add new stuff here..._

--- a/build/generate-style-spec.ts
+++ b/build/generate-style-spec.ts
@@ -151,7 +151,7 @@ export type ExpressionSpecification =
     | ['array', ExpressionInputType | ExpressionSpecification, number | ExpressionSpecification, unknown | ExpressionSpecification] // array
     | ['boolean', ...(unknown | ExpressionSpecification)[], unknown | ExpressionSpecification] // boolean
     | CollatorExpressionSpecification
-    | ['format', ...(string | ['image', ExpressionSpecification] | ExpressionSpecification | {'font-scale'?: number | ExpressionSpecification, 'text-font'?: string[] | ExpressionSpecification, 'text-color': ColorSpecification | ExpressionSpecification})[]] // string
+    | ['format', ...(string | ['image', ExpressionSpecification] | ExpressionSpecification | {'font-scale'?: number | ExpressionSpecification, 'text-font'?: string[] | ExpressionSpecification, 'text-color'?: ColorSpecification | ExpressionSpecification})[]] // string
     | ['image', unknown | ExpressionSpecification] // image
     | ['literal', unknown]
     | ['number', unknown | ExpressionSpecification, ...(unknown | ExpressionSpecification)[]] // number

--- a/src/style-spec/feature_filter/feature_filter.test.ts
+++ b/src/style-spec/feature_filter/feature_filter.test.ts
@@ -48,8 +48,8 @@ describe('filter', () => {
         compileTimeCheck(['slice', ['literal', [0]], 0]);
         compileTimeCheck(['slice', 'myString', 0, 1]);
         compileTimeCheck(['slice', ['literal', [0, 1, 2]], 0, 1]);
-        compileTimeCheck(['format', ["get", "title"], { "font-scale": 0.8 }]);
-        compileTimeCheck(['format', ["get", "title"], { "font-scale": 0.8, "text-color": '#fff' }]);
+        compileTimeCheck(['format', ['get', 'title'], {'font-scale': 0.8}]);
+        compileTimeCheck(['format', ['get', 'title'], {'font-scale': 0.8, 'text-color': '#fff'}]);
         compileTimeCheck(['step', ['get', 'point_count'], '#df2d43', 50, '#df2d43', 200, '#df2d43']);
         compileTimeCheck(['step', ['get', 'point_count'], 20, 50, 30, 200, 40]);
         compileTimeCheck(['step', ['get', 'point_count'], 0.6, 50, 0.7, 200, 0.8]);

--- a/src/style-spec/feature_filter/feature_filter.test.ts
+++ b/src/style-spec/feature_filter/feature_filter.test.ts
@@ -48,6 +48,8 @@ describe('filter', () => {
         compileTimeCheck(['slice', ['literal', [0]], 0]);
         compileTimeCheck(['slice', 'myString', 0, 1]);
         compileTimeCheck(['slice', ['literal', [0, 1, 2]], 0, 1]);
+        compileTimeCheck(['format', ["get", "title"], { "font-scale": 0.8 }]);
+        compileTimeCheck(['format', ["get", "title"], { "font-scale": 0.8, "text-color": '#fff' }]);
         compileTimeCheck(['step', ['get', 'point_count'], '#df2d43', 50, '#df2d43', 200, '#df2d43']);
         compileTimeCheck(['step', ['get', 'point_count'], 20, 50, 30, 200, 40]);
         compileTimeCheck(['step', ['get', 'point_count'], 0.6, 50, 0.7, 200, 0.8]);


### PR DESCRIPTION
## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->
Fix `format` expression typing to make `text-color` optional as it is used in [examples](https://maplibre.org/maplibre-gl-js-docs/example/display-and-style-rich-text-labels/)


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Write tests for all new functionality.
 - [x] Add an entry to `CHANGELOG.md` under the `## main` section.
