### PR TITLE
Change default original event type from undefined to unknown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Add method to enable/disable cooperative gestures
 - [Breaking] toBounds method of class LngLat is replaced by a static method fromLngLat of class LngLatBounds ([#2188](https://github.com/maplibre/maplibre-gl-js/pull/2188))
 - Update CONTRIBUTING.md with details on setting up on M1 mac ([#2196](https://github.com/maplibre/maplibre-gl-js/pull/2196))
+- Update default type of originalEvent in MapLibreEvent to be `unknown` ([#2243](https://github.com/maplibre/maplibre-gl-js/pull/2243))
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes

--- a/src/ui/events.ts
+++ b/src/ui/events.ts
@@ -31,7 +31,7 @@ export type MapLayerEventType = {
     touchcancel: MapLayerTouchEvent;
 };
 
-export interface MapLibreEvent<TOrig = undefined> {
+export interface MapLibreEvent<TOrig = unknown> {
     type: string;
     target: Map;
     originalEvent: TOrig;

--- a/src/ui/map_events.test.ts
+++ b/src/ui/map_events.test.ts
@@ -2,7 +2,7 @@ import simulate, {window} from '../../test/unit/lib/simulate_interaction';
 import StyleLayer from '../style/style_layer';
 import {createMap, beforeMapTest} from '../util/test/util';
 import {MapGeoJSONFeature} from '../util/vectortile_to_geojson';
-import {MapLayerEventType} from './events';
+import {MapLayerEventType, MapLibreEvent} from './events';
 
 beforeEach(() => {
     beforeMapTest();
@@ -153,6 +153,21 @@ describe('map events', () => {
 
         expect(spyA).toHaveBeenCalledTimes(1);
         expect(spyB).toHaveBeenCalledTimes(1);
+    });
+
+    test('Map#on calls an event listener with no type arguments, defaulting to \'unknown\' originalEvent type', () => {
+        const map = createMap();
+
+        const handler = {
+            onMove: function onMove(_event: MapLibreEvent) {}
+        };
+
+        jest.spyOn(handler, 'onMove');
+
+        map.on('move', (event) => handler.onMove(event));
+        map.jumpTo({center: {lng: 10, lat: 10}});
+
+        expect(handler.onMove).toHaveBeenCalledTimes(1);
     });
 
     test('Map#off removes a delegated event listener', () => {


### PR DESCRIPTION
## Launch Checklist

Currently, the default type for originalEvent on a MapLibreEvent is "undefined." This can lead to type errors when handling some events unless the type for originalEvent is specified on the handler, even when we may not care about the type of orginalEvent at all. For example, let's say I want to handle a zoom event. If I define an event handler like this:

onZoom(event: MapLibreEvent) {}

I will get a type error if I try to subscribe to a zoom event using that callback, because that event is typed as `MapLibreEvent<MouseEvent | TouchEvent | WheelEvent | undefined>`. The TypeScript compiler complains about the three non-undefined event types being unassignable to undefined.

Moreover, the type "unknown" is more correct here anyway, as the base case is not knowing what the type is. In the case where the handler doesn't care about originalEvent, using unknown as the default instead means you don't have to provide the type at all.

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Add an entry to `CHANGELOG.md` under the `## main` section.
