### PR TITLE
Ensure features property is typed as MapGeoJSONFeature[] on MapLayerMouseEvent and MapLayerTouchEvent.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## main
 
+- Fix the type of the `features` property on `MapLayerMouseEvent` and `MapLayerTouchEvent` to be `MapGeoJSONFeature[]` in lieu of `GeoJSON.Feature[]` ([#2244]((https://github.com/maplibre/maplibre-gl-js/pull/2244)))
+
 ### ✨ Features and improvements
 
 - Improve performance by sending style layers to worker thread before processing it on main thread to allow parallel processing ([#2131](https://github.com/maplibre/maplibre-gl-js/pull/2131))

--- a/src/ui/events.ts
+++ b/src/ui/events.ts
@@ -3,14 +3,15 @@ import {Event} from '../util/evented';
 import DOM from '../util/dom';
 import Point from '@mapbox/point-geometry';
 import {extend} from '../util/util';
+import type {MapGeoJSONFeature} from '../util/vectortile_to_geojson';
 
 import type Map from './map';
 import type LngLat from '../geo/lng_lat';
 import {SourceSpecification} from '@maplibre/maplibre-gl-style-spec';
 
-export type MapLayerMouseEvent = MapMouseEvent & { features?: GeoJSON.Feature[] };
+export type MapLayerMouseEvent = MapMouseEvent & { features?: MapGeoJSONFeature[] };
 
-export type MapLayerTouchEvent = MapTouchEvent & { features?: GeoJSON.Feature[] };
+export type MapLayerTouchEvent = MapTouchEvent & { features?: MapGeoJSONFeature[] };
 
 export type MapSourceDataType = 'content' | 'metadata';
 


### PR DESCRIPTION
Currently, `MapLayerMouseEvent` and `MapLayerTouchEvent` are typed with their `features` property as `GeoJSON.Feature[]`. However, the features returned on either of these events are `MapGeoJSONFeature`s; they contain the additional properties of that interface (e.g., `layer`, `source`, `sourceLayer`, and `state`). In addition, it appears the unit tests already cast features returned on `MapLayerMouseEvent`s to `MapGeoJSONFeature[]`; see [here](https://github.com/maplibre/maplibre-gl-js/blob/main/src/ui/map_events.test.ts#L117-L118) for an example. This PR just corrects the types!

Looking through the CHANGELOG, it appears `MapGeoJSONFeature` is a fairly new addition (2.1.8-pre.2), so I think this may just be on spot where the types got missed!

## Launch Checklist

- [X] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [X] Briefly describe the changes in this PR.
 - [X] Document any changes to public APIs.
    - While these types are part of the TypeScript public API, they are not core to the library API (nor currently documented on the docs site).
 - [X] Add an entry to `CHANGELOG.md` under the `## main` section.
