### PR TITLE
Docs: Example for stylemissingimage

### DIFF
--- a/src/ui/events.ts
+++ b/src/ui/events.ts
@@ -1384,10 +1384,10 @@ export type MapEvent =
      * @example
      * // Initialize the map
      * var map = new maplibregl.Map({ // map options });
-     * // Set an event listener that fires
-     * // an icon or pattern is missing.
-     * map.on('styleimagemissing', function() {
-     *   console.log('A styleimagemissing event occurred.');
+     * // Set an event listener that fires an icon or pattern is missing.
+     * map.on('styleimagemissing', function(event: MapStyleImageMissingEvent) {
+     *   const imageId: event.id
+     *   console.log('A styleimagemissing event occurred for image Id', imageId);
      * });
      * @see [Generate and add a missing icon to the map](https://maplibre.org/maplibre-gl-js-docs/example/add-image-missing-generated/)
      */


### PR DESCRIPTION
This is supposed to improve the example at https://maplibre.org/maplibre-gl-js-docs/api/map/#map.event:styleimagemissing by…

- adding `imageId` to the logged output and implicitly explaining in the code that `event.id` is the image's id
- adding the TypeScript event type

