### PR TITLE
Reinstate CI unit test coverage

### DIFF
--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -61,6 +61,7 @@ jobs:
           echo "DISPLAY=:0" >> $GITHUB_ENV
       - run: npm run jest-ci -- --coverage --coverageReporters text html-spa --selectProjects unit
       - name: Upload unit test coverage
+        if: success() || failure()
         uses: actions/upload-artifact@v3
         with:
           name: unit-test-coverage

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -59,7 +59,12 @@ jobs:
         run:
           nohup Xvfb &
           echo "DISPLAY=:0" >> $GITHUB_ENV
-      - run: npm run jest-ci -- --selectProjects unit
+      - run: npm run jest-ci -- --coverage --selectProjects unit
+      - name: Upload a Build Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: coverage
+          path: ${{ github.workspace }}/coverage
       - run: npm run build-dev
         if: success() || failure()
       - run: npm run test-render

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -59,7 +59,7 @@ jobs:
         run:
           nohup Xvfb &
           echo "DISPLAY=:0" >> $GITHUB_ENV
-      - run: npm run jest-ci -- --coverage --selectProjects unit
+      - run: npm run jest-ci -- --coverage --coverageReporters text html-spa --selectProjects unit
       - name: Upload unit test coverage
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -60,10 +60,10 @@ jobs:
           nohup Xvfb &
           echo "DISPLAY=:0" >> $GITHUB_ENV
       - run: npm run jest-ci -- --coverage --selectProjects unit
-      - name: Upload a Build Artifact
+      - name: Upload unit test coverage
         uses: actions/upload-artifact@v3
         with:
-          name: coverage
+          name: unit-test-coverage
           path: ${{ github.workspace }}/coverage
       - run: npm run build-dev
         if: success() || failure()


### PR DESCRIPTION
## Launch Checklist

PR #2044 removed the unit test coverage reports. This PR reinstates them and uploads the coverage reports as build artifacts.

Per https://github.com/maplibre/maplibre-gl-js/pull/2044#issuecomment-1468107043

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [X] Briefly describe the changes in this PR.
 - [X] Link to related issues.
 - [X] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality.
 - [X] Document any changes to public APIs.
 - [x] Post benchmark scores.
 - [x] Add an entry to `CHANGELOG.md` under the `## main` section.
