### PR TITLE
Update DOM.mousePos() with Leaflet code

### DIFF
--- a/src/util/dom.ts
+++ b/src/util/dom.ts
@@ -84,12 +84,32 @@ export default class DOM {
         }, 0);
     }
 
-    public static mousePos(el: HTMLElement, e: MouseEvent | Touch) {
-        const rect = el.getBoundingClientRect();
+    public static getScale(element: HTMLElement) {
+        const rect = element.getBoundingClientRect(); // Read-only in old browsers.
+
+        return {
+            x: rect.width / element.offsetWidth || 1,
+            y: rect.height / element.offsetHeight || 1,
+            boundingClientRect: rect,
+        };
+    }
+
+    public static mousePos(el: HTMLElement, ev: MouseEvent | Touch) {
+        // Uses technique from https://github.com/Leaflet/Leaflet/pull/6055
+        if (!el) {
+            return new Point(ev.clientX, ev.clientY);
+        }
+
+        const scale = DOM.getScale(el),
+            offset = scale.boundingClientRect; // left and top  values are in page scale (like the event clientX/Y)
+
         return new Point(
-            e.clientX - rect.left - el.clientLeft,
-            e.clientY - rect.top - el.clientTop
+            // offset.left/top values are in page scale (like clientX/Y),
+            // whereas clientLeft/Top (border width) values are the original values (before CSS scale applies).
+            (ev.clientX - offset.left) / scale.x - el.clientLeft,
+            (ev.clientY - offset.top) / scale.y - el.clientTop
         );
+
     }
 
     public static touchPos(el: HTMLElement, touches: TouchList) {


### PR DESCRIPTION
This **partially** fixes #1160, by using an adaptation of Leaflet's `L.DOMEvent.getMousePosition()` (see https://github.com/Leaflet/Leaflet/blob/18d703176bec040a06f233702d3eec141e95daaf/src/dom/DomEvent.js#L245-L262).

The `DOM.touchPos()` static method should still display the bug.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [ ] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [ ] Add an entry to `CHANGELOG.md` under the `## main` section.
