### PR TITLE
Fix perf regression introduced by PR 2097

### DIFF
--- a/src/ui/map.test.ts
+++ b/src/ui/map.test.ts
@@ -18,6 +18,7 @@ import Terrain, {} from '../render/terrain';
 import {mercatorZfromAltitude} from '../geo/mercator_coordinate';
 import Transform from '../geo/transform';
 import {StyleImageInterface} from '../style/style_image';
+import ImageRequest from '../util/image_request';
 
 function createStyleSource() {
     return {
@@ -2595,6 +2596,30 @@ describe('Map', () => {
                 expect(errorMessageObject.statusMessage).toBe('mocked webglcontextcreationerror message');
             }
 
+        });
+
+        test('should call call ImageRequest.processQueue() only when moving', () => {
+            const style = createStyle();
+            const map = createMap({style});
+
+            let imageQueueProcessRequestCallCounter = 0;
+            jest.spyOn(ImageRequest, 'processQueue').mockImplementation(() => {
+                imageQueueProcessRequestCallCounter++;
+                return 0;
+            });
+            let mockIsMoving = true;
+
+            jest.spyOn(map, 'isMoving').mockImplementation(() => {
+                return mockIsMoving;
+            });
+
+            // when moving, expect ImageRequest.processQueue is called on repaint
+            map._render(0);
+            expect(imageQueueProcessRequestCallCounter).toBe(1);
+
+            mockIsMoving = false;
+            map._render(1);
+            expect(imageQueueProcessRequestCallCounter).toBe(1);
         });
     });
 


### PR DESCRIPTION
## Launch Checklist

Fix ~50ms regression introduced by PR #2097 

- When previous set of requests are sent and not finished, image queue appears dirty so _render kicks of another frame and archives nothing. In fact, _imageQueueDirty flag is not needed because when images are received, other code (usually raster tile) will trigger rendering.

- When not throttled, calling processQueue does nothing but wasting time

Therefore, remove this._imageQueueDirty field and only call process queue when throttled (which means moving)

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.