### PR TITLE
Warnonce for Terrain Source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 - Update CONTRIBUTING.md with details on setting up on M1 mac ([#2196](https://github.com/maplibre/maplibre-gl-js/pull/2196))
 - Update default type of originalEvent in MapLibreEvent to be `unknown` ([#2243](https://github.com/maplibre/maplibre-gl-js/pull/2243))
 - Improve performance when forcing full symbol placement by short circuiting pause checks ([#2241](https://github.com/maplibre/maplibre-gl-js/pull/2241))
-- _...Add new stuff here..._
+- Adding a `warnonce` when terrain and hillshade source are the same
 
 ### 🐞 Bug fixes
 

--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -1697,6 +1697,13 @@ class Map extends Camera {
             // add terrain
             const sourceCache = this.style.sourceCaches[options.source];
             if (!sourceCache) throw new Error(`cannot load terrain, because there exists no source with ID: ${options.source}`);
+            // Warn once if user is using the same source for hillshade and terrain
+            for(const index in this.style._layers) {
+              const thisLayer = this.style._layers[index]
+              if(thisLayer.type === 'hillshade' && thisLayer.source === options.source) {
+                warnOnce("You are using the same source for a hillshade layer and for 3D terrain. Please consider using two separate sources to improve rendering quality.");
+              }
+            }
             this.terrain = new Terrain(this.painter, sourceCache, options);
             this.painter.renderToTexture = new RenderToTexture(this.painter, this.terrain);
             this.transform.updateElevation(this.terrain);


### PR DESCRIPTION
Issue described in to https://github.com/maplibre/maplibre-gl-js/issues/2035.

This change adds a `warnonce` when it detects that a user is using the same source for a hillshade and for 3D terrain. The check only runs when `setTerrain()` is called. I do not check for the visibility of the hillshade layer, and also do not conduct a similar check when a hillshade layer is turned on or added to the map.

I did not include a debug or test page for this, but happy to if required!