### PR TITLE
fix style test UT on nodejs 19

### DIFF
--- a/src/style/style.test.ts
+++ b/src/style/style.test.ts
@@ -14,7 +14,7 @@ import {
 import browser from '../util/browser';
 import {OverscaledTileID} from '../source/tile_id';
 import {fakeXhr, fakeServer} from 'nise';
-import {WorkerGlobalScopeInterface} from '../util/web_worker';
+
 import EvaluationParameters from './evaluation_parameters';
 import {LayerSpecification, GeoJSONSourceSpecification, FilterSpecification, SourceSpecification} from '@maplibre/maplibre-gl-style-spec';
 import {SourceClass} from '../source/source';

--- a/src/style/style.test.ts
+++ b/src/style/style.test.ts
@@ -80,7 +80,6 @@ function createStyle(map = getStubMap()) {
 
 let sinonFakeXMLServer;
 let sinonFakeServer;
-let _self;
 let mockConsoleError;
 
 beforeEach(() => {
@@ -88,20 +87,12 @@ beforeEach(() => {
     sinonFakeServer = fakeServer.create();
     sinonFakeXMLServer = fakeXhr.useFakeXMLHttpRequest();
 
-    _self = {
-        addEventListener() {}
-    } as any as WorkerGlobalScopeInterface & typeof globalThis;
-    global.self = _self;
-
     mockConsoleError = jest.spyOn(console, 'error').mockImplementation(() => { });
 });
 
 afterEach(() => {
     sinonFakeXMLServer.restore();
     sinonFakeServer.restore();
-
-    global.self = undefined;
-
     mockConsoleError.mockRestore();
 });
 


### PR DESCRIPTION
## Launch Checklist

Upgraded to nodejs 19 and all style tests failed.
<img width="428" alt="image" src="https://user-images.githubusercontent.com/37553549/227655600-8782e7c2-1c34-41d6-bce1-d43d6cab8c2f.png">

Somehow node 19 does not allow to modify "global.self", although I cannot find any release notes about it.
Nevertheless, looks like Style.ts has also evolved and all UTs are passing without this mock anyway


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.