### PR TITLE
avoid extra loops when terrain does not exist

### DIFF
--- a/src/symbol/placement.ts
+++ b/src/symbol/placement.ts
@@ -496,16 +496,6 @@ export class Placement {
                 verticalTextFeatureIndex = collisionArrays.verticalTextFeatureIndex;
             }
 
-            // update elevation of collisionArrays
-            if (getElevation) {
-                for (const boxType of ['textBox', 'verticalTextBox', 'iconBox', 'verticalIconBox']) {
-                    const box = collisionArrays[boxType];
-                    if (box) {
-                        box.elevation = getElevation(box.anchorPointX, box.anchorPointY);
-                    }
-                }
-            }
-
             const textBox = collisionArrays.textBox;
             if (textBox) {
 

--- a/src/symbol/placement.ts
+++ b/src/symbol/placement.ts
@@ -460,6 +460,9 @@ export class Placement {
             bucket.deserializeCollisionBoxes(collisionBoxArray);
         }
 
+        const tileID = this.retainedQueryData[bucket.bucketInstanceId].tileID;
+        const getElevation = this.terrain ? (x: number, y: number) => this.terrain.getElevation(tileID, x, y) : null;
+
         const placeSymbol = (symbolInstance: SymbolInstance, collisionArrays: CollisionArrays) => {
             if (seenCrossTileIDs[symbolInstance.crossTileID]) return;
             if (holdingForFade) {
@@ -494,11 +497,13 @@ export class Placement {
             }
 
             // update elevation of collisionArrays
-            const tileID = this.retainedQueryData[bucket.bucketInstanceId].tileID;
-            const getElevation = this.terrain ? (x: number, y: number) => this.terrain.getElevation(tileID, x, y) : null;
-            for (const boxType of ['textBox', 'verticalTextBox', 'iconBox', 'verticalIconBox']) {
-                const box = collisionArrays[boxType];
-                if (box) box.elevation = getElevation ? getElevation(box.anchorPointX, box.anchorPointY) : 0;
+            if (getElevation) {
+                for (const boxType of ['textBox', 'verticalTextBox', 'iconBox', 'verticalIconBox']) {
+                    const box = collisionArrays[boxType];
+                    if (box) {
+                        box.elevation = getElevation(box.anchorPointX, box.anchorPointY);
+                    }
+                }
             }
 
             const textBox = collisionArrays.textBox;


### PR DESCRIPTION
## Launch Checklist

placeSymbol is a very hot code path if not the hottest. For most screen sizes, this function is called 1000 to 2000 times. 
When terrain does not exist, it is still doing a loop on 4-element array ['textBox', 'verticalTextBox', 'iconBox', 'verticalIconBox'] which means 4000 to 8000 extra loops.

Please review --- before my change, textBox had elevation of 0, and now it would be undefined. 

However, I cannot find anywhere the elevation of textBox is used for placement or collision. The previous code was added in #1022, @HarelM  @prozessor13, can you share more insights regarding where and how it is used?
There is no UT coverage either.

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
