### PR TITLE
Prevent cross-package imports

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -79,7 +79,7 @@
     "no-multiple-empty-lines": [ "error", {
         "max": 1
     }],
-    "import/no-anonymous-default-export": ["error", {"allowLiteral": true} ],
+    "import/no-relative-packages": ["error"],
     "jsdoc/check-param-names": "warn",
     "jsdoc/require-param": "warn",
     "jsdoc/require-param-description": "warn",


### PR DESCRIPTION
Enforces separation of maplibre and style spec by preventing cross-package imports.
No longer as much of an issue since #2198 migrated the style spec to a different repo.

fixes https://github.com/maplibre/maplibre-gl-js/issues/2054

## Launch Checklist

 - [X] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [X] Briefly describe the changes in this PR.
 - [X] Link to related issues.