### PR TITLE
Don't reload raster sources when RTL text plugin loads to avoid flicker.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Fix LngLat `toArray` method return type to [number,number] ([#2233](https://github.com/maplibre/maplibre-gl-js/issues/2233))
 - Fix handling of text-offset with symbol-placement: line ([#2170](https://github.com/maplibre/maplibre-gl-js/issues/2170) and [#2171](https://github.com/maplibre/maplibre-gl-js/issues/2171))
 - Fix geolocate control permissions failure on IOS16 web view with fallback to `window.navigator.geolocation`
+- Prevent unnecessary reload of raster sources when RTL Text Plugin loads ([#2380](https://github.com/maplibre/maplibre-gl-js/issues/2380))
 - _...Add new stuff here..._
 
 ## 3.0.0-pre.4

--- a/src/source/rtl_text_plugin.ts
+++ b/src/source/rtl_text_plugin.ts
@@ -1,6 +1,6 @@
-import {Event, Evented} from '../util/evented';
 import {getArrayBuffer} from '../util/ajax';
 import browser from '../util/browser';
+import {Event, Evented} from '../util/evented';
 import {isWorker} from '../util/util';
 
 const status = {
@@ -56,6 +56,7 @@ export const registerForPluginStateChange = function(callback: PluginStateSyncCa
 export const clearRTLTextPlugin = function() {
     pluginStatus = status.unavailable;
     pluginURL = null;
+    _completionCallback = null;
 };
 
 export const setRTLTextPlugin = function(url: string, callback: ErrorCallback, deferred: boolean = false) {

--- a/src/style/style.test.ts
+++ b/src/style/style.test.ts
@@ -125,7 +125,9 @@ describe('Style', () => {
     });
 
     test('RTL plugin load reloads vector source but not raster source', done => {
-        const style = new Style(getStubMap());
+        const map = getStubMap();
+        const style = new Style(map);
+        map.style = style;
         style.loadJSON({
             'version': 8,
             'sources': {
@@ -163,6 +165,7 @@ describe('Style', () => {
             setRTLTextPlugin('/plugin.js', (error) => {
                 expect(error).toBeUndefined();
                 setTimeout(() => {
+                    clearRTLTextPlugin();
                     expect(style.sourceCaches['raster'].reload).not.toHaveBeenCalled();
                     expect(style.sourceCaches['vector'].reload).toHaveBeenCalled();
                     done();

--- a/src/style/style.ts
+++ b/src/style/style.ts
@@ -229,7 +229,13 @@ class Style extends Evented {
                     const allComplete = results.every((elem) => elem);
                     if (allComplete) {
                         for (const id in self.sourceCaches) {
-                            self.sourceCaches[id].reload(); // Should be a no-op if the plugin loads before any tiles load
+                            const sourceType = self.sourceCaches[id].getSource().type;
+                            if (sourceType === 'vector' || sourceType === 'geojson') {
+                                // Non-vector sources don't have any symbols buckets to reload when the RTL text plugin loads
+                                // They also load more quickly, so they're more likely to have already displaying tiles
+                                // that would be unnecessarily booted by the plugin load event
+                                self.sourceCaches[id].reload(); // Should be a no-op if the plugin loads before any tiles load
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Fixes #2380

## Summary (from Issue)
When a deferred load of the RTL text plugin completes, there's logic that causes the source caches to reload:

https://github.com/maplibre/maplibre-gl-js/blob/9f713cd2299a567e4f2a8000d984cd3f4ca14a19/src/style/style.ts#L226-L238

The purpose of this logic is to cause them to regenerate their symbol buckets with the new RTL shaping applied. If the plugin loads before the initial tile load, this will be a no-op, but if some tiles have already loaded it will reparse them. This is some extra work and the tile cache is cleared out, but the old tiles can still display until the new tiles are ready.

This logic is unnecessary for raster sources, since they don't have any symbols to regenerate. Also, raster tiles tend to load faster (because no parsing/bucket-generation is necessary), and are thus more likely to load before the RTL plugin loads. This generates extra work, but might not be that noticeable except for the fact that reloading a raster tile also resets the tile fade animation to the beginning.

The upshot of all this is an unsightly flicker during map load (in this example I'm just loading a single satellite layer and setting the rtl text plugin).

![load_flicker](https://user-images.githubusercontent.com/375121/231302433-9bf59f27-17b6-4fbd-9924-15e0141f9194.gif)

Stepping through in the debugger, you can see loaded tiles getting dropped one at a time as reloaded images arrive:

![reloading_raster_tiles](https://user-images.githubusercontent.com/375121/231302788-6c19505f-796c-4014-9002-2c3981d112bf.gif)

And this is what the load looks like with the `reload()` call turned off for raster sources (PR coming soon):

![load_no_flicker](https://user-images.githubusercontent.com/375121/231303296-86619e83-4cef-4c57-9586-86a10da07d55.gif)

## Changes in this PR
This PR simply limits the sources that can reload to `vector` and `geojson`, the two types that contain symbol buckets. The bulk of the work was just setting up the mocking in the Style unit test to verify the new behavior.

cc @ibesora @HarelM 

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [x] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality.
 - [x] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [x] Add an entry to `CHANGELOG.md` under the `## main` section.
