### PR TITLE
Add check that 'URL.createObjectURL' exists

### DIFF
--- a/build/rollup/bundle_prelude.js
+++ b/build/rollup/bundle_prelude.js
@@ -14,7 +14,7 @@ function define(_, chunk) {
         var sharedChunk = {};
         shared(sharedChunk);
         maplibregl = chunk(sharedChunk);
-        if (typeof window !== 'undefined') {
+        if (typeof window !== 'undefined' && typeof window.URL.createObjectURL !== 'undefined') {
             maplibregl.workerUrl = window.URL.createObjectURL(new Blob([workerBundleString], { type: 'text/javascript' }));
         }
     }


### PR DESCRIPTION
## Launch Checklist

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!

Hi,

While porting MapComplete to use MapLibre, I discovered that my tests are not working.
For some tests, I'm using [fake-dom](https://www.npmjs.com/package/fake-dom), which does implement the `window`-object but _not_ the `window.URL.createObjectURL`-function - which is used here.

As such, my tests would fail.

As it turns out, the easiest approach for me is to patch this here ;)

However, I fully understand that this might not be the appropriate place for this fix - feel free to simply close this PR.