### PR TITLE
Small benchmark fixes

### DIFF
--- a/test/bench/README.md
+++ b/test/bench/README.md
@@ -8,6 +8,8 @@ Start the benchmark server with `npm run start-bench`.
 
 To run all benchmarks, open [the benchmark page, `http://localhost:9966/test/bench/versions/index.html`](http://localhost:9966/test/bench/versions/index.html).
 
+To run all benchmarks for the checkout only, that is without comparing to any releases, open [`http://localhost:9966/test/bench/versions/index.html?compare=`](http://localhost:9966/test/bench/versions/index.html?compare=).
+
 To run a specific benchmark, add its name to the url hash, for example [`http://localhost:9966/test/bench/versions/index.html#Layout`](http://localhost:9966/test/bench/versions/index.html#Layout).
 
 By default, the benchmark page will compare the local branch against `main` and the latest release. To change this, include one or more `compare` query parameters in the URL: E.g., [localhost:9966/test/bench/versions/index.html?compare=main](http://localhost:9966/test/bench/versions/index.html?compare=main) or [localhost:9966/test/bench/versions/index.html?compare=main#Layout](http://localhost:9966/test/bench/versions/index.html?compare=main#Layout) to compare only to main, or [localhost:9966/test/bench/versions/index.html?compare=v1.13.1](http://localhost:9966/test/bench/versions/index.html?compare=v1.13.1) to compare to `v1.13.1` (but not `main`).  Versions available for comparison are the ones stored in the `gh-pages` branch, see [here](https://github.com/maplibre/maplibre-gl-js/tree/gh-pages/benchmarks).

--- a/test/bench/README.md
+++ b/test/bench/README.md
@@ -23,9 +23,9 @@ MAPLIBRE_STYLES={YOUR STYLES HERE} npm run start-bench
 ```
 Note: `MAPLIBRE_STYLES` takes a comma-separated list of up to 3 MapLibre styles provided as a style URL or file system path (e.g. `path/to/style-a.json,path/to/style-b.json`)
 
-To run all benchmarks, open [the benchmark page, `http://localhost:9966/test/bench/styles`](http://localhost:9966/test/bench/styles).
+To run all benchmarks, open [the benchmark page, `http://localhost:9966/test/bench/styles/index.html`](http://localhost:9966/test/bench/styles/index.html).
 
-To run a specific benchmark, add its name to the url hash, for example [`http://localhost:9966/test/bench/styles#Layout`](http://localhost:9966/test/bench/styles#Layout).
+To run a specific benchmark, add its name to the url hash, for example [`http://localhost:9966/test/bench/styles/index.html#Layout`](http://localhost:9966/test/bench/styles/index.html#Layout).
 
 By default, the style benchmark page will run its benchmarks against `https://api.maptiler.com/maps/streets/style.json?key=get_your_own_OpIi9ZULNHzrESv6T2vL`. `Layout` and `Paint` styles will run one instance of the test for each tile/location in an internal list of tiles. This behavior helps visualize the ways in which a style performs given various conditions present in each tile (CJK text, dense urban areas, rural areas, etc). `QueryBox` and `QueryPoint` use the internal list of tiles but otherwise run the same as their non-style benchmark equivalents. `StyleLayerCreate` and `StyleValidate` are not tile/location dependent and run the same way as their non-style benchmark equivalents. All other benchmark tests from the non-style suite are not used when benchmarking styles.
 

--- a/test/bench/lib/tile_parser.ts
+++ b/test/bench/lib/tile_parser.ts
@@ -31,6 +31,10 @@ class StubMap extends Evented {
     }
 
     setTerrain() {}
+
+    _getMapId() {
+        return 1;
+    }
 }
 
 function createStyle(styleJSON: StyleSpecification): Promise<Style> {

--- a/test/bench/versions/index.html
+++ b/test/bench/versions/index.html
@@ -18,7 +18,7 @@
             try {
                 const params = new URL(location).searchParams;
                 let versions = params.getAll('compare').filter(Boolean);
-                if (!versions.length) {
+                if (!params.has('compare')) {
                     const response = await fetch('https://api.github.com/repos/maplibre/maplibre-gl-js/releases/latest');
                     const responseJson = await response.json();
                     versions = [responseJson['tag_name'], 'main'];


### PR DESCRIPTION
## Launch Checklist

I forgot to add the link changes of the first commit to #2412. Sorry about the confusion.

The second commit brings back the possibility to run the benchmarks without comparing to any releases. As the feature was somewhat obscure but useful especially to develop on the benchmarks itself, I added a short documentation to the README.

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
