### PR TITLE
Fixes Image source content is not loaded properly on iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### 🐞 Bug fixes
 
+- Fixes Image source content is not loaded properly on iOS ([#2419](https://github.com/maplibre/maplibre-gl-js/pull/2419))
 - _...Add new stuff here..._
 
 ## 3.0.0-pre.5

--- a/src/source/image_source.test.ts
+++ b/src/source/image_source.test.ts
@@ -6,6 +6,7 @@ import {fakeXhr} from 'nise';
 import {RequestManager} from '../util/request_manager';
 import Dispatcher from '../util/dispatcher';
 import {stubAjaxGetImage} from '../util/test/util';
+import browser from '../util/browser';
 
 function createSource(options) {
     options = extend({
@@ -52,6 +53,17 @@ describe('ImageSource', () => {
         expect(source.minzoom).toBe(0);
         expect(source.maxzoom).toBe(22);
         expect(source.tileSize).toBe(512);
+    });
+
+    test('load should convert image to image data', done => {
+        const source = createSource({url: '/image.png'});
+        jest.spyOn(browser, "getImageData").mockImplementation(() => new ImageData(1,1));
+        
+        source.load([[0, 0], [1, 0], [1, 1], [0, 1]], () => {
+            expect(source.image instanceof ImageData).toBeTruthy();
+            done();
+        })
+        
     });
 
     test('fires dataloading event', () => {

--- a/src/source/image_source.test.ts
+++ b/src/source/image_source.test.ts
@@ -57,13 +57,13 @@ describe('ImageSource', () => {
 
     test('load should convert image to image data', done => {
         const source = createSource({url: '/image.png'});
-        jest.spyOn(browser, "getImageData").mockImplementation(() => new ImageData(1,1));
-        
+        jest.spyOn(browser, 'getImageData').mockImplementation(() => new ImageData(1, 1));
+
         source.load([[0, 0], [1, 0], [1, 1], [0, 1]], () => {
             expect(source.image instanceof ImageData).toBeTruthy();
             done();
-        })
-        
+        });
+
     });
 
     test('fires dataloading event', () => {

--- a/src/source/image_source.test.ts
+++ b/src/source/image_source.test.ts
@@ -55,14 +55,13 @@ describe('ImageSource', () => {
         expect(source.tileSize).toBe(512);
     });
 
-    test('load should convert image to image data', done => {
+    test('load should convert image to image data', () => {
         const source = createSource({url: '/image.png'});
         jest.spyOn(browser, 'getImageData').mockImplementation(() => new ImageData(1, 1));
 
-        source.load([[0, 0], [1, 0], [1, 1], [0, 1]], () => {
-            expect(source.image instanceof ImageData).toBeTruthy();
-            done();
-        });
+        source.onAdd(new StubMap() as any);
+        respond();
+        expect(source.image instanceof ImageData).toBeTruthy();
 
     });
 

--- a/src/source/image_source.ts
+++ b/src/source/image_source.ts
@@ -21,6 +21,7 @@ import type {
     VideoSourceSpecification
 } from '@maplibre/maplibre-gl-style-spec';
 import {Cancelable} from '../types/cancelable';
+import browser from '../util/browser';
 
 export type Coordinates = [[number, number], [number, number], [number, number], [number, number]];
 
@@ -77,7 +78,7 @@ class ImageSource extends Evented implements Source {
     dispatcher: Dispatcher;
     map: Map;
     texture: Texture | null;
-    image: HTMLImageElement | ImageBitmap;
+    image: ImageData;
     tileID: CanonicalTileID;
     _boundsArray: RasterBoundsArray;
     boundsBuffer: VertexBuffer;
@@ -119,7 +120,7 @@ class ImageSource extends Evented implements Source {
             if (err) {
                 this.fire(new ErrorEvent(err));
             } else if (image) {
-                this.image = image;
+                this.image = browser.getImageData(image);
                 if (newCoordinates) {
                     this.coordinates = newCoordinates;
                 }


### PR DESCRIPTION
Fixes #1314 - by loading the image when the callback is called instead of later on.
## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [x] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality.
 - [x] Document any changes to public APIs.
 - [x] Post benchmark scores.
 - [x] Add an entry to `CHANGELOG.md` under the `## main` section.
