### PR TITLE
Fix `LngLatBounds.extend()` to Handle Object Coordinates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### 🐞 Bug fixes
 
+- Fix `LngLatBounds.extend()` to correctly handle `{ lng: number, lat: number }` coordinates. ([#2425](https://github.com/maplibre/maplibre-gl-js/pull/2425))
 - _...Add new stuff here..._
 
 ## 3.0.0-pre.5

--- a/src/geo/lng_lat_bounds.test.ts
+++ b/src/geo/lng_lat_bounds.test.ts
@@ -56,7 +56,21 @@ describe('LngLatBounds', () => {
         expect(bounds.getNorth()).toBe(10);
         expect(bounds.getEast()).toBe(10);
 
-        bounds.extend([-90, -90, 90, 90]);
+        bounds.extend([-80, -80, 80, 80]);
+
+        expect(bounds.getSouth()).toBe(-80);
+        expect(bounds.getWest()).toBe(-80);
+        expect(bounds.getNorth()).toBe(80);
+        expect(bounds.getEast()).toBe(80);
+
+        bounds.extend({lng: -90, lat: -90});
+
+        expect(bounds.getSouth()).toBe(-90);
+        expect(bounds.getWest()).toBe(-90);
+        expect(bounds.getNorth()).toBe(80);
+        expect(bounds.getEast()).toBe(80);
+
+        bounds.extend({lon: 90, lat: 90});
 
         expect(bounds.getSouth()).toBe(-90);
         expect(bounds.getWest()).toBe(-90);

--- a/src/geo/lng_lat_bounds.ts
+++ b/src/geo/lng_lat_bounds.ts
@@ -103,7 +103,11 @@ class LngLatBounds {
                     const lngLatObj = (obj as any as LngLatLike);
                     return this.extend(LngLat.convert(lngLatObj));
                 }
+
+            } else if (typeof obj === 'object' && obj !== null) {
+                return this.extend(LngLat.convert(obj));
             }
+
             return this;
         }
 

--- a/src/geo/lng_lat_bounds.ts
+++ b/src/geo/lng_lat_bounds.ts
@@ -104,7 +104,7 @@ class LngLatBounds {
                     return this.extend(LngLat.convert(lngLatObj));
                 }
 
-            } else if (typeof obj === 'object' && obj !== null) {
+            } else if (obj && ('lng' in obj || 'lon' in obj) && 'lat' in obj) {
                 return this.extend(LngLat.convert(obj));
             }
 


### PR DESCRIPTION
This PR fixes `LngLatBounds.extend()` to handle `{ lng: number, lat: number }` and `{ lon: number, lat: number }` coordinates.

Fixes #2424.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [x] Add an entry to `CHANGELOG.md` under the `## main` section.
