### PR TITLE
Accuracy-circle in geolocate fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### 🐞 Bug fixes
 
 - Fix `LngLatBounds.extend()` to correctly handle `{ lng: number, lat: number }` coordinates. ([#2425](https://github.com/maplibre/maplibre-gl-js/pull/2425))
+- Fix the accuracy-circle in the geolocate control from randomly resizing. ([#2450](https://github.com/maplibre/maplibre-gl-js/pull/2450))
 - _...Add new stuff here..._
 
 ## 3.0.0-pre.5

--- a/package-lock.json
+++ b/package-lock.json
@@ -93,7 +93,6 @@
         "jest": "^29.5.0",
         "jest-canvas-mock": "^2.5.0",
         "jest-environment-jsdom": "^29.5.0",
-        "jest-matcher-utils": "^29.5.0",
         "jsdom": "^21.1.1",
         "json-stringify-pretty-compact": "^4.0.0",
         "minimist": "^1.2.8",

--- a/src/ui/control/geolocate_control.test.ts
+++ b/src/ui/control/geolocate_control.test.ts
@@ -468,14 +468,38 @@ describe('GeolocateControl with no options', () => {
         map.jumpTo({
             center: [10, 20]
         });
+
+        const checkCircle = () => {
+            const bounds = map.getBounds();
+            const southEastPoint = bounds.getSouthEast();
+            const northEastPoint = bounds.getNorthEast();
+            const mapHeightInMeters = southEastPoint.distanceTo(northEastPoint);
+            const mapHeightInPixels = map._container.clientHeight;
+            const metersPerPixel = mapHeightInMeters / mapHeightInPixels;
+            const calculatedAcuraccy = (+geolocate._circleElement.style.width.replace('px', '') / 2) * metersPerPixel;
+            expect(calculatedAcuraccy).toBeCloseTo(geolocate._accuracy, 1);
+        };
+
+        // test with bugger radius
         let zoomendPromise = map.once('zoomend');
-        map.zoomTo(10, {duration: 0});
-        await zoomendPromise;
-        expect(geolocate._circleElement.style.width).toBe('20px'); // 700m = 20px at zoom 10
-        zoomendPromise = map.once('zoomend');
         map.zoomTo(12, {duration: 0});
         await zoomendPromise;
-        expect(geolocate._circleElement.style.width).toBe('79px'); // 700m = 79px at zoom 12
+        checkCircle();
+        zoomendPromise = map.once('zoomend');
+        map.zoomTo(10, {duration: 0});
+        await zoomendPromise;
+        checkCircle();
+        zoomendPromise = map.once('zoomend');
+
+        // test with smaller radius
+        geolocation.send({latitude: 10, longitude: 20, accuracy: 20});
+        map.zoomTo(20, {duration: 0});
+        await zoomendPromise;
+        checkCircle();
+        zoomendPromise = map.once('zoomend');
+        map.zoomTo(18, {duration: 0});
+        await zoomendPromise;
+        checkCircle();
     });
 
     test('shown even if trackUserLocation = false', async () => {

--- a/src/ui/control/geolocate_control.test.ts
+++ b/src/ui/control/geolocate_control.test.ts
@@ -469,37 +469,30 @@ describe('GeolocateControl with no options', () => {
             center: [10, 20]
         });
 
-        const checkCircle = () => {
-            const bounds = map.getBounds();
-            const southEastPoint = bounds.getSouthEast();
-            const northEastPoint = bounds.getNorthEast();
-            const mapHeightInMeters = southEastPoint.distanceTo(northEastPoint);
-            const mapHeightInPixels = map._container.clientHeight;
-            const metersPerPixel = mapHeightInMeters / mapHeightInPixels;
-            const calculatedAcuraccy = (+geolocate._circleElement.style.width.replace('px', '') / 2) * metersPerPixel;
-            expect(calculatedAcuraccy).toBeCloseTo(geolocate._accuracy, 1);
-        };
-
         // test with bugger radius
         let zoomendPromise = map.once('zoomend');
         map.zoomTo(12, {duration: 0});
         await zoomendPromise;
-        checkCircle();
+        expect(geolocate._circleElement.style.width).toBe('79px');
+        console.log(geolocate._circleElement.style.width);
         zoomendPromise = map.once('zoomend');
         map.zoomTo(10, {duration: 0});
         await zoomendPromise;
-        checkCircle();
+        expect(geolocate._circleElement.style.width).toBe('20px');
+        console.log(geolocate._circleElement.style.width);
         zoomendPromise = map.once('zoomend');
 
         // test with smaller radius
         geolocation.send({latitude: 10, longitude: 20, accuracy: 20});
         map.zoomTo(20, {duration: 0});
         await zoomendPromise;
-        checkCircle();
+        expect(geolocate._circleElement.style.width).toBe('19982px');
+        console.log(geolocate._circleElement.style.width);
         zoomendPromise = map.once('zoomend');
         map.zoomTo(18, {duration: 0});
         await zoomendPromise;
-        checkCircle();
+        expect(geolocate._circleElement.style.width).toBe('4996px');
+        console.log(geolocate._circleElement.style.width);
     });
 
     test('shown even if trackUserLocation = false', async () => {

--- a/src/ui/control/geolocate_control.ts
+++ b/src/ui/control/geolocate_control.ts
@@ -286,11 +286,12 @@ class GeolocateControl extends Evented implements IControl {
     }
 
     _updateCircleRadius() {
-        const y = this._map._container.clientHeight / 2;
-        const a = this._map.unproject([0, y]);
-        const b = this._map.unproject([1, y]);
-        const metersPerPixel = a.distanceTo(b);
-        const circleDiameter = Math.ceil(2.0 * this._accuracy / metersPerPixel);
+        const bounds = this._map.getBounds();
+        const southEastPoint = bounds.getSouthEast();
+        const northEastPoint = bounds.getNorthEast();
+        const mapHeightInMeters = southEastPoint.distanceTo(northEastPoint);
+        const mapHeightInPixels = this._map._container.clientHeight;
+        const circleDiameter = 2 * (this._accuracy / (mapHeightInMeters / mapHeightInPixels));
         this._circleElement.style.width = `${circleDiameter}px`;
         this._circleElement.style.height = `${circleDiameter}px`;
     }

--- a/src/ui/control/geolocate_control.ts
+++ b/src/ui/control/geolocate_control.ts
@@ -291,7 +291,7 @@ class GeolocateControl extends Evented implements IControl {
         const northEastPoint = bounds.getNorthEast();
         const mapHeightInMeters = southEastPoint.distanceTo(northEastPoint);
         const mapHeightInPixels = this._map._container.clientHeight;
-        const circleDiameter = 2 * (this._accuracy / (mapHeightInMeters / mapHeightInPixels));
+        const circleDiameter = Math.ceil(2 * (this._accuracy / (mapHeightInMeters / mapHeightInPixels)));
         this._circleElement.style.width = `${circleDiameter}px`;
         this._circleElement.style.height = `${circleDiameter}px`;
     }


### PR DESCRIPTION
Fixes #2449 

Accuracy-circle was going places, chaning size randomly, seams to be fixed with this.

## Changes
Replace _updateCircleRadius in geolocate_control.ts because the calculation was wrong. Code fix heavily inspired from stackoverflow. 

### Before
![firefox_1SSyJ6W6sa](https://user-images.githubusercontent.com/51290462/234637148-63f47822-f95c-4288-86ec-495b8345eac3.gif)
The old "circleDiameter" calculations
![image](https://user-images.githubusercontent.com/51290462/234672871-c9ba373c-11bc-4574-8e20-a208b225eb33.png)

### After
![firefox_smcDyhtXiE](https://user-images.githubusercontent.com/51290462/234672785-cf91c141-9410-4ec8-81b4-3fe4c1a02956.gif)

## Launch Checklist
 - [X] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [X] Briefly describe the changes in this PR.
 - [X] Link to related issues.
 - [X] Include before/after visuals or gifs if this PR includes visual changes.
 - [X] Add an entry to `CHANGELOG.md` under the `## main` section.
 - [X] Write a test

