### PR TITLE
Export style-spec typings

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -36,6 +36,8 @@ import VideoSource from './source/video_source';
 
 const version = packageJSON.version;
 
+export type * from "@maplibre/maplibre-gl-style-spec";
+
 const exported = {
     supported,
     setRTLTextPlugin,

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,7 +36,7 @@ import VideoSource from './source/video_source';
 
 const version = packageJSON.version;
 
-export type * from "@maplibre/maplibre-gl-style-spec";
+export type * from '@maplibre/maplibre-gl-style-spec';
 
 const exported = {
     supported,


### PR DESCRIPTION
This is related to the change in #2198.
See my comments here:
https://github.com/maplibre/maplibre-gl-js/pull/2198#issuecomment-1516670246

It basically re-exports all the typescript typings of the style-spec package so that there won't be a need to reference the style-spec package when importing its types.

cc: @birkskyum 