### PR TITLE
Set fetchPriority for HTMLImageElement to help improve raster heavy scenarios

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Improve performance by using HTMLImageElement to download raster source images when refreshExpiredTiles tiles is false ([#2126](https://github.com/maplibre/maplibre-gl-js/pull/2126))
 - [Breaking] Improve control initial loading performance by forcing fadeDuration to 0 till first idle event ([#2447](https://github.com/maplibre/maplibre-gl-js/pull/2447))
 - [Breaking] Remove "mapbox-gl-supported" package from API. If needed, please reference it directly instead of going through MapLibre. ([#2451](https://github.com/maplibre/maplibre-gl-js/pull/2451))
-- Set fetchPriority for HTMLImageElement to help improve raster heavy scenarios.
+- Set fetchPriority for HTMLImageElement to help improve raster heavy scenarios ([#2459](https://github.com/maplibre/maplibre-gl-js/pull/2459))
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Improve performance by using HTMLImageElement to download raster source images when refreshExpiredTiles tiles is false ([#2126](https://github.com/maplibre/maplibre-gl-js/pull/2126))
 - [Breaking] Improve control initial loading performance by forcing fadeDuration to 0 till first idle event ([#2447](https://github.com/maplibre/maplibre-gl-js/pull/2447))
 - [Breaking] Remove "mapbox-gl-supported" package from API. If needed, please reference it directly instead of going through MapLibre. ([#2451](https://github.com/maplibre/maplibre-gl-js/pull/2451))
+- Set fetchPriority for HTMLImageElement to help improve raster heavy scenarios.
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes

--- a/src/util/image_request.ts
+++ b/src/util/image_request.ts
@@ -260,11 +260,11 @@ namespace ImageRequest {
         } else if ((credentials && credentials === 'same-origin') || !sameOrigin(url)) {
             image.crossOrigin = 'anonymous';
         }
-        
+
         // fetchPriority is experimental property supported on Chromium browsers from Version 102
         // By default images are downloaded with priority low, whereas fetch request downloads with priority high
         // https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/fetchPriority
-        (image as any).fetchPriority = "high";
+        (image as any).fetchPriority = 'high';
         image.onload = () => {
             callback(null, image);
             image.onerror = image.onload = null;

--- a/src/util/image_request.ts
+++ b/src/util/image_request.ts
@@ -260,7 +260,11 @@ namespace ImageRequest {
         } else if ((credentials && credentials === 'same-origin') || !sameOrigin(url)) {
             image.crossOrigin = 'anonymous';
         }
-
+        
+        // fetchPriority is experimental property supported on Chromium browsers from Version 102
+        // By default images are downloaded with priority low, whereas fetch request downloads with priority high
+        // https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/fetchPriority
+        (image as any).fetchPriority = "high";
         image.onload = () => {
             callback(null, image);
             image.onerror = image.onload = null;

--- a/src/util/image_request.ts
+++ b/src/util/image_request.ts
@@ -23,6 +23,14 @@ type ImageQueueThrottleCallbackDictionary = {
     [Key: number]: ImageQueueThrottleControlCallback;
 }
 
+type HTMLImageElementWithPriority = HTMLImageElement &
+{
+    // fetchPriority is experimental property supported on Chromium browsers from Version 102
+    // By default images are downloaded with priority low, whereas fetch request downloads with priority high
+    // https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/fetchPriority
+    fetchPriority?: 'auto' | 'high' | 'low';
+};
+
 /**
  * By default, the image queue is self driven, meaning as soon as one requested item is processed,
  * it will move on to next one as quickly as it can while limiting
@@ -251,7 +259,7 @@ namespace ImageRequest {
     };
 
     const getImageUsingHtmlImage = (requestParameters: RequestParameters, callback: GetImageCallback): Cancelable  => {
-        const image = new Image();
+        const image = new Image() as HTMLImageElementWithPriority;
         const url = requestParameters.url;
         let requestCancelled = false;
         const credentials = requestParameters.credentials;
@@ -261,10 +269,7 @@ namespace ImageRequest {
             image.crossOrigin = 'anonymous';
         }
 
-        // fetchPriority is experimental property supported on Chromium browsers from Version 102
-        // By default images are downloaded with priority low, whereas fetch request downloads with priority high
-        // https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/fetchPriority
-        (image as any).fetchPriority = 'high';
+        image.fetchPriority = 'high';
         image.onload = () => {
             callback(null, image);
             image.onerror = image.onload = null;


### PR DESCRIPTION
fetchPriority is experimental property supported on Chromium browsers from Version 102. By default images are downloaded with priority low, whereas fetch request downloads with priority high. 
Documentation:  https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/fetchPriority
Browser usage: https://caniuse.com/?search=fetchpriority

Our internal A/B testing shows slight (0.5%) page load time improvement in raster tiles heavy scenarios when used with refreshExpiredTiles=false which triggers use of HtmlImageElement instead of fetch to download raster images.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [ ] Link to related issues.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [x] Add an entry to `CHANGELOG.md` under the `## main` section.
