### PR TITLE
Reduce rendering calls on initial load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - [Breaking] Improve control initial loading performance by forcing fadeDuration to 0 till first idle event ([#2447](https://github.com/maplibre/maplibre-gl-js/pull/2447))
 - [Breaking] Remove "mapbox-gl-supported" package from API. If needed, please reference it directly instead of going through MapLibre. ([#2451](https://github.com/maplibre/maplibre-gl-js/pull/2451))
 - Set fetchPriority for HTMLImageElement to help improve raster heavy scenarios ([#2459](https://github.com/maplibre/maplibre-gl-js/pull/2459))
+- Rendering is not required before style loaded.
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - [Breaking] Improve control initial loading performance by forcing fadeDuration to 0 till first idle event ([#2447](https://github.com/maplibre/maplibre-gl-js/pull/2447))
 - [Breaking] Remove "mapbox-gl-supported" package from API. If needed, please reference it directly instead of going through MapLibre. ([#2451](https://github.com/maplibre/maplibre-gl-js/pull/2451))
 - Set fetchPriority for HTMLImageElement to help improve raster heavy scenarios ([#2459](https://github.com/maplibre/maplibre-gl-js/pull/2459))
-- Rendering is not required before style loaded.
+- Reduce rendering calls on initial load. No reason to try rendering before style is loaded. ([#2464](https://github.com/maplibre/maplibre-gl-js/pull/2464))
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes

--- a/src/ui/map.test.ts
+++ b/src/ui/map.test.ts
@@ -2159,6 +2159,9 @@ describe('Map', () => {
             }
         });
 
+        // Force a update should not call triggerRepaint till style is loaded.
+        // Once style is loaded, it will trigger the update.
+        map._update();
         server.respond();
     });
 

--- a/src/ui/map.test.ts
+++ b/src/ui/map.test.ts
@@ -2159,8 +2159,6 @@ describe('Map', () => {
             }
         });
 
-        // Invoke a map function which can trigger a map update.
-        map.setMinZoom(1);
         server.respond();
     });
 

--- a/src/ui/map.test.ts
+++ b/src/ui/map.test.ts
@@ -2144,7 +2144,13 @@ describe('Map', () => {
 
     test('no render before style loaded', done => {
         server.respondWith('/styleUrl', JSON.stringify(createStyle()));
-        const map = createMap({style:'/styleUrl'});        
+        const map = createMap({style: '/styleUrl'});
+
+        jest.spyOn(map, 'triggerRepaint').mockImplementationOnce(() => {
+            if (!map.style._loaded) {
+                done('test failed');
+            }
+        });
         map.on('render', () => {
             if (map.style._loaded) {
                 done();
@@ -2152,6 +2158,9 @@ describe('Map', () => {
                 done('test failed');
             }
         });
+
+        // Invoke a map function which can trigger a map update.
+        map.setMinZoom(1);
         server.respond();
     });
 

--- a/src/ui/map.test.ts
+++ b/src/ui/map.test.ts
@@ -2142,6 +2142,19 @@ describe('Map', () => {
         });
     });
 
+    test('no render before style loaded', done => {
+        server.respondWith('/styleUrl', JSON.stringify(createStyle()));
+        const map = createMap({style:'/styleUrl'});        
+        map.on('render', () => {
+            if (map.style._loaded) {
+                done();
+            } else {
+                done('test failed');
+            }
+        });
+        server.respond();
+    });
+
     test('no idle event during move', async () => {
         const style = createStyle();
         const map = createMap({style, fadeDuration: 0});

--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -2806,7 +2806,7 @@ class Map extends Camera {
      * @private
      */
     _update(updateStyle?: boolean) {
-        if (!this.style) return this;
+        if (!this.style || !this.style._loaded) return this;
 
         this._styleDirty = this._styleDirty || updateStyle;
         this._sourcesDirty = true;

--- a/src/ui/map/requestRenderFrame.test.ts
+++ b/src/ui/map/requestRenderFrame.test.ts
@@ -6,11 +6,27 @@ beforeEach(() => {
 
 describe('requestRenderFrame', () => {
 
-    test('Map#_requestRenderFrame schedules a new render frame if necessary', () => {
+    test('Map#_requestRenderFrame schedules a new render frame if necessary', (done) => {
         const map = createMap();
         const spy = jest.spyOn(map, 'triggerRepaint');
         map._requestRenderFrame(() => {});
-        expect(spy).toHaveBeenCalledTimes(1);
+        expect(spy).toHaveBeenCalledTimes(0);
+
+        // wait for style to be loaded
+        map.once('data', () => {
+            spy.mockReset();
+            map._requestRenderFrame(() => {});
+            expect(spy).toHaveBeenCalledTimes(1);
+            map.remove();
+            done();
+        });
+    });
+
+    test('Map#_requestRenderFrame should not schedule a render frame before style load', () => {
+        const map = createMap();
+        const spy = jest.spyOn(map, 'triggerRepaint');
+        map._requestRenderFrame(() => {});
+        expect(spy).toHaveBeenCalledTimes(0);
         map.remove();
     });
 


### PR DESCRIPTION
There is no reason to fire a render before map style is loaded. This change reduces number of render event fired on initial load.

Loading a Maptiler style invokes render 7 times, 1 before the style loaded and 6 after style loaded. After this change it saves the first render pass which is not required as there is nothing to render.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [ ] Briefly describe the changes in this PR.
 - [ ] Link to related issues.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [x] Add an entry to `CHANGELOG.md` under the `## main` section.
