### PR TITLE
Parallelize test workflow (splitting up jobs)

### DIFF
--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -42,6 +42,11 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: lts/*
+      - name: Start display server
+        if: runner.os == 'Linux'
+        run:
+          nohup Xvfb &
+          echo "DISPLAY=:0" >> $GITHUB_ENV
       - run: npm ci
       - run: npm run jest-ci -- --coverage --coverageReporters text html-spa --selectProjects unit
       - name: Upload unit test coverage
@@ -81,6 +86,11 @@ jobs:
         with:
           node-version: lts/*
       - run: npm ci
+      - name: Start display server
+        if: runner.os == 'Linux'
+        run:
+          nohup Xvfb &
+          echo "DISPLAY=:0" >> $GITHUB_ENV  
       - run: npm run test-render -- --report
         if: success() || failure()
       - name: Upload render test failure

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -1,4 +1,4 @@
-name: Automated Testing
+name: Tests
 
 on:
   push:
@@ -29,20 +29,9 @@ jobs:
         if: success() || failure()
       - run: npm run typecheck
         if: success() || failure()
-  non-gl-tests:
-    name: Tests not using GL
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          node-version: lts/*
-      - run: npm ci
-      - run: npm run jest-ci -- --selectProjects unit --testPathIgnorePatterns "/src/(gl|render|ui)/" 
-      - run: npm run build-dev
-      - run: npm run jest-ci -- --selectProjects integration --testPathIgnorePatterns "/test/integration/(query|browser|build)/"
-  gl-tests:
-    name: Tests including GL
+  
+  unit-tests:
+    name: Unit tests and Coverage
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
@@ -54,11 +43,6 @@ jobs:
         with:
           node-version: lts/*
       - run: npm ci
-      - name: Start display server
-        if: runner.os == 'Linux'
-        run:
-          nohup Xvfb &
-          echo "DISPLAY=:0" >> $GITHUB_ENV
       - run: npm run jest-ci -- --coverage --coverageReporters text html-spa --selectProjects unit
       - name: Upload unit test coverage
         if: success() || failure()
@@ -66,8 +50,37 @@ jobs:
         with:
           name: unit-test-coverage
           path: ${{ github.workspace }}/coverage
-      - run: npm run build-dev
+      
+  integration-tests:
+    name: Integration tests
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 40
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: lts/*
+      - run: npm ci
+      - run: npm run build-dist
+      - run: npm run test-integration
         if: success() || failure()
+        
+  render-tests:
+    name: Render tests
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 40
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: lts/*
+      - run: npm ci
       - run: npm run test-render -- --report
         if: success() || failure()
       - name: Upload render test failure
@@ -76,13 +89,9 @@ jobs:
         with:
           name: render-test-report-${{ matrix.os }}
           path: ${{ github.workspace }}/test/integration/render/results.html
-      - run: npm run build-dist
-        if: success() || failure()
-      - run: npm run jest-ci -- --selectProjects integration
-        if: success() || failure()
 
-  packaging-tests:
-    name: Packaging
+  build-tests:
+    name: Build tests
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
@@ -94,5 +103,5 @@ jobs:
           node-version: lts/*
       - run: npm ci
       - run: npm run build-dist
-      - run: npm run jest-ci -- --selectProjects build
+      - run: npm run test-build
         if: success() || failure()


### PR DESCRIPTION
Close #2482, #2411

This splits up integration, unit, render and build tests. 

In this PR all these tests completed in 7m 57s, which is significantly shorter than a typical ~16 min run.

If i.e. a render test breaks, it only has the potential to cancel the other render test, but not the integration/unit/build tests which will keep running.