### PR TITLE
Increase test timeouts, to accommodate for windows runners 

### DIFF
--- a/test/integration/query/query.test.ts
+++ b/test/integration/query/query.test.ts
@@ -135,7 +135,7 @@ describe('query tests', () => {
         );
         browser = await puppeteer.launch({headless: 'new'});
         await new Promise<void>((resolve) => server.listen(resolve));
-    });
+    }, 30000);
 
     afterAll(async () => {
         await browser.close();

--- a/test/integration/render/tests/zoomed-raster/underzoom/style.json
+++ b/test/integration/render/tests/zoomed-raster/underzoom/style.json
@@ -2,7 +2,8 @@
   "version": 8,
   "metadata": {
     "test": {
-      "height": 256
+      "height": 256,
+      "timeout": 40000
     }
   },
   "center": [


### PR DESCRIPTION
This fixes the CI tests in the main branch.

**Query test:**
On windows, the query test server / browser start isn't able to complete within the 5s timeout. This PR increases it to 30 sec to make sure the tests will run.
Example here: https://github.com/maplibre/maplibre-gl-js/actions/runs/4925448119/jobs/8820183726


**Render test:**
Also, extends the zoomed-raster\underzoom render test timeout, because it's flaky on the slower windows runners.