### PR TITLE
Cleanup WebGL2 typings

### DIFF
--- a/src/gl/context.ts
+++ b/src/gl/context.ts
@@ -68,7 +68,7 @@ class Context {
     RGBA16F?: GLenum;
     RGB16F?: GLenum;
 
-    constructor(gl: WebGL2RenderingContext | WebGL2RenderingContext) {
+    constructor(gl: WebGLRenderingContext | WebGL2RenderingContext) {
         this.gl = gl;
         this.clearColor = new ClearColor(this);
         this.clearDepth = new ClearDepth(this);

--- a/src/gl/context.ts
+++ b/src/gl/context.ts
@@ -24,7 +24,7 @@ type ClearArgs = {
 };
 
 class Context {
-    gl: WebGLRenderingContext;
+    gl: WebGLRenderingContext | WebGL2RenderingContext;
 
     currentNumAttributes: number;
     maxTextureSize: number;
@@ -68,7 +68,7 @@ class Context {
     RGBA16F?: GLenum;
     RGB16F?: GLenum;
 
-    constructor(gl: WebGLRenderingContext) {
+    constructor(gl: WebGL2RenderingContext | WebGL2RenderingContext) {
         this.gl = gl;
         this.clearColor = new ClearColor(this);
         this.clearDepth = new ClearDepth(this);

--- a/src/gl/webgl2.ts
+++ b/src/gl/webgl2.ts
@@ -1,6 +1,6 @@
 const cache = new WeakMap();
 export function isWebGL2(
-    gl: WebGLRenderingContext
+    gl: WebGLRenderingContext | WebGL2RenderingContext
 ): gl is WebGL2RenderingContext {
     if (cache.has(gl)) {
         return cache.get(gl);

--- a/src/render/painter.ts
+++ b/src/render/painter.ts
@@ -121,7 +121,6 @@ class Painter {
     cache: {[_: string]: Program<any>};
     crossTileSymbolIndex: CrossTileSymbolIndex;
     symbolFadeChange: number;
-    emptyTexture: Texture;
     debugOverlayTexture: Texture;
     debugOverlayCanvas: HTMLCanvasElement;
     // this object stores the current camera-matrix and the last render time
@@ -129,7 +128,7 @@ class Painter {
     // every time the camera-matrix changes the terrain-facilitators will be redrawn.
     terrainFacilitator: {dirty: boolean; matrix: mat4; renderTime: number};
 
-    constructor(gl: WebGLRenderingContext, transform: Transform) {
+    constructor(gl: WebGLRenderingContext | WebGL2RenderingContext, transform: Transform) {
         this.context = new Context(gl);
         this.transform = transform;
         this._tileTextures = {};

--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -2731,8 +2731,8 @@ class Map extends Camera {
         }, {once: true});
 
         const gl =
-            this._canvas.getContext('webgl2', attributes) ||
-            this._canvas.getContext('webgl', attributes);
+            this._canvas.getContext('webgl2', attributes) as WebGL2RenderingContext ||
+            this._canvas.getContext('webgl', attributes) as WebGLRenderingContext;
 
         if (!gl) {
             const msg = 'Failed to initialize WebGL';
@@ -2744,9 +2744,9 @@ class Map extends Camera {
             }
         }
 
-        this.painter = new Painter(gl as WebGLRenderingContext, this.transform);
+        this.painter = new Painter(gl, this.transform);
 
-        webpSupported.testSupport(gl as WebGLRenderingContext);
+        webpSupported.testSupport(gl);
     }
 
     _contextLost(event: any) {

--- a/test/integration/query/query.test.ts
+++ b/test/integration/query/query.test.ts
@@ -135,7 +135,7 @@ describe('query tests', () => {
         );
         browser = await puppeteer.launch({headless: 'new'});
         await new Promise<void>((resolve) => server.listen(resolve));
-    }, 30000);
+    }, 60000);
 
     afterAll(async () => {
         await browser.close();


### PR DESCRIPTION
Continuation of #1891 

Adding more typings for WebGL2RenderingContext.

Also, unused field variable on Painter `emptyTexture: Texture;` is removed.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [X] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [ ] Briefly describe the changes in this PR.
 - [ ] Link to related issues.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [ ] Add an entry to `CHANGELOG.md` under the `## main` section.
