### PR TITLE
Sunset webgl1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### ✨ Features and improvements
 - _...Add new stuff here..._
+- [Breaking] Remove WebGL1 support ([#2555](https://github.com/maplibre/maplibre-gl-js/pull/2512))
 
 ### 🐞 Bug fixes
 - _...Add new stuff here..._

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### ✨ Features and improvements
 - _...Add new stuff here..._
-- [Breaking] Remove WebGL1 support ([#2555](https://github.com/maplibre/maplibre-gl-js/pull/2512))
+- [Breaking] Remove WebGL1 support ([#2512](https://github.com/maplibre/maplibre-gl-js/pull/2512))
 
 ### 🐞 Bug fixes
 - _...Add new stuff here..._

--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -2731,8 +2731,7 @@ class Map extends Camera {
         }, {once: true});
 
         const gl =
-            this._canvas.getContext('webgl2', attributes) as WebGL2RenderingContext ||
-            this._canvas.getContext('webgl', attributes) as WebGLRenderingContext;
+            this._canvas.getContext('webgl2', attributes) as WebGL2RenderingContext;
 
         if (!gl) {
             const msg = 'Failed to initialize WebGL';

--- a/src/util/test/util.ts
+++ b/src/util/test/util.ts
@@ -44,10 +44,7 @@ function setWebGlContext() {
     const originalGetContext = global.HTMLCanvasElement.prototype.getContext;
 
     function imitateWebGlGetContext(type, attributes) {
-        if (type === 'webgl2') {
-            return null;
-        }
-        if (type === 'webgl') {
+        if (type === 'webgl2' || type === 'webgl') {
             if (!this._webGLContext) {
                 this._webGLContext = gl(this.width, this.height, attributes);
                 if (!this._webGLContext) {
@@ -68,10 +65,7 @@ export function setErrorWebGlContext() {
     const originalGetContext = global.HTMLCanvasElement.prototype.getContext;
 
     function imitateErrorWebGlGetContext(type, attributes) {
-        if (type === 'webgl2') {
-            return null;
-        }
-        if (type === 'webgl') {
+        if (type === 'webgl2' || type === 'webgl') {
             const errorEvent = new Event('webglcontextcreationerror');
             (errorEvent as any).statusMessage = 'mocked webglcontextcreationerror message';
             this.dispatchEvent(errorEvent);


### PR DESCRIPTION
This PR removes webgl1 from the distributions, but allow our coverage/unit tests to continue using a nodejs webgl1 mock for now.

 - [X] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!