### PR TITLE
Update WebGL types in vertex buffer and uniform binding

### DIFF
--- a/src/gl/vertex_buffer.ts
+++ b/src/gl/vertex_buffer.ts
@@ -67,7 +67,7 @@ class VertexBuffer {
         gl.bufferSubData(gl.ARRAY_BUFFER, 0, array.arrayBuffer);
     }
 
-    enableAttributes(gl: WebGLRenderingContext, program: Program<any>) {
+    enableAttributes(gl: WebGL2RenderingContext, program: Program<any>) {
         for (let j = 0; j < this.attributes.length; j++) {
             const member = this.attributes[j];
             const attribIndex: number | void = program.attributes[member.name];
@@ -83,7 +83,7 @@ class VertexBuffer {
      * @param program The active WebGL program
      * @param vertexOffset Index of the starting vertex of the segment
      */
-    setVertexAttribPointers(gl: WebGLRenderingContext, program: Program<any>, vertexOffset?: number | null) {
+    setVertexAttribPointers(gl: WebGL2RenderingContext, program: Program<any>, vertexOffset?: number | null) {
         for (let j = 0; j < this.attributes.length; j++) {
             const member = this.attributes[j];
             const attribIndex: number | void = program.attributes[member.name];

--- a/src/render/uniform_binding.ts
+++ b/src/render/uniform_binding.ts
@@ -11,7 +11,7 @@ export type UniformValues<Us extends {}> = $ObjMap<Us, <V>(u: Uniform<V>) => V>;
 export type UniformLocations = {[_: string]: WebGLUniformLocation};
 
 abstract class Uniform<T> {
-    gl: WebGLRenderingContext;
+    gl: WebGL2RenderingContext;
     location: WebGLUniformLocation;
     current: T;
 


### PR DESCRIPTION
Part of #2515 

Updates:
- uniform_binding
- vertex_buffer

## Launch Checklist
 - [X] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!