### PR TITLE
Remove webgl1-only extensions

### DIFF
--- a/src/gl/context.ts
+++ b/src/gl/context.ts
@@ -109,7 +109,6 @@ class Context {
         this.maxTextureSize = gl.getParameter(gl.MAX_TEXTURE_SIZE);
         this.HALF_FLOAT = gl.HALF_FLOAT;
 
-        gl.getExtension('OES_texture_half_float_linear');
         this.RGBA16F = gl.RGBA16F;
         this.RGB16F = gl.RGB16F;
     }

--- a/src/gl/context.ts
+++ b/src/gl/context.ts
@@ -109,6 +109,7 @@ class Context {
         this.maxTextureSize = gl.getParameter(gl.MAX_TEXTURE_SIZE);
         this.HALF_FLOAT = gl.HALF_FLOAT;
 
+        gl.getExtension('EXT_color_buffer_half_float');
         this.RGBA16F = gl.RGBA16F;
         this.RGB16F = gl.RGB16F;
     }

--- a/src/gl/context.ts
+++ b/src/gl/context.ts
@@ -107,11 +107,9 @@ class Context {
         }
 
         this.maxTextureSize = gl.getParameter(gl.MAX_TEXTURE_SIZE);
-        const extTextureHalfFloat = gl.getExtension('OES_texture_half_float');
         this.HALF_FLOAT = gl.HALF_FLOAT;
 
         gl.getExtension('OES_texture_half_float_linear');
-        const extColorBufferHalfFloat = gl.getExtension('EXT_color_buffer_half_float');
         this.RGBA16F = gl.RGBA16F;
         this.RGB16F = gl.RGB16F;
     }


### PR DESCRIPTION
Part of #2515 

This removes loading of some webgl1 extensions, as they are bundled with webgl2.

## Launch Checklist

 - [X] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!