### PR TITLE
Capture initial resize event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes
-- Fixes issue with ResizeObserver creating infinite loop on launch (since 3.0.0-pre.5) ([#2551](https://github.com/maplibre/maplibre-gl-js/issues/2551))
+- Fixes issue with ResizeObserver firing an initial 'resize' event (since 3.0.0-pre.5) ([#2551](https://github.com/maplibre/maplibre-gl-js/issues/2551))
 - _...Add new stuff here..._
 
 ## 3.0.0-pre.8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes
+- Fixes issue with ResizeObserver creating infinite loop on launch (since 3.0.0-pre.5) ([#2551](https://github.com/maplibre/maplibre-gl-js/issues/2551))
 - _...Add new stuff here..._
 
 ## 3.0.0-pre.8

--- a/src/ui/map.test.ts
+++ b/src/ui/map.test.ts
@@ -803,7 +803,7 @@ describe('Map', () => {
             expect(spyC).not.toHaveBeenCalled();
         });
 
-        test('do resize if trackResize is true (default)', () => {
+        test('do resize if trackResize is true (default)', async () => {
             let observerCallback: Function = null;
             global.ResizeObserver = jest.fn().mockImplementation((c) => ({
                 observe: () => { observerCallback = c; }
@@ -814,6 +814,7 @@ describe('Map', () => {
             const spyA = jest.spyOn(map, '_update');
             const spyB = jest.spyOn(map, 'resize');
 
+            observerCallback(); // The initial "observe" event fired by ResizeObserver is muted in the map constructor
             observerCallback();
 
             expect(spyA).toHaveBeenCalled();

--- a/src/ui/map.test.ts
+++ b/src/ui/map.test.ts
@@ -814,12 +814,16 @@ describe('Map', () => {
             const spyA = jest.spyOn(map, '_update');
             const spyB = jest.spyOn(map, 'resize');
 
-            // Call twice, because the initial "observe" event fired by ResizeObserver
-            // is muted in the map constructor
+            // The initial "observe" event fired by ResizeObserver should be captured/muted
+            // in the map constructor
 
             observerCallback();
-            observerCallback();
+            expect(spyA).not.toHaveBeenCalled();
+            expect(spyB).not.toHaveBeenCalled();
 
+            // Following "observe" events should fire a resize / _update
+
+            observerCallback();
             expect(spyA).toHaveBeenCalled();
             expect(spyB).toHaveBeenCalled();
         });

--- a/src/ui/map.test.ts
+++ b/src/ui/map.test.ts
@@ -814,7 +814,10 @@ describe('Map', () => {
             const spyA = jest.spyOn(map, '_update');
             const spyB = jest.spyOn(map, 'resize');
 
-            observerCallback(); // The initial "observe" event fired by ResizeObserver is muted in the map constructor
+            // Call twice, because the initial "observe" event fired by ResizeObserver
+            // is muted in the map constructor
+
+            observerCallback();
             observerCallback();
 
             expect(spyA).toHaveBeenCalled();

--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -493,7 +493,13 @@ class Map extends Camera {
 
         if (typeof window !== 'undefined') {
             addEventListener('online', this._onWindowOnline, false);
+            let initialResizeEventCaptured = false;
             this._resizeObserver = new ResizeObserver((entries) => {
+                if (!initialResizeEventCaptured) {
+                    initialResizeEventCaptured = true;
+                    return;
+                }
+
                 if (this._trackResize) {
                     this.resize(entries)._update();
                 }

--- a/test/integration/browser/browser.test.ts
+++ b/test/integration/browser/browser.test.ts
@@ -48,7 +48,7 @@ describe('Browser tests', () => {
         });
     }, 40000);
 
-    test('No moveend before load', async () => {
+    test('Load should fire before resize and moveend', async () => {
         const loadWasFirst = await page.evaluate(() => {
             const map2 = new maplibregl.Map({
                 container: 'map', // container id
@@ -56,12 +56,13 @@ describe('Browser tests', () => {
                 center: [10, 10], // starting position [lng, lat]
                 zoom: 10 // starting zoom
             });
-            return new Promise<boolean>((resolve, _reject) => {
-                map2.once('moveend', () => resolve(false));
-                map2.once('load', () => resolve(true));
+            return new Promise<string>((resolve, _reject) => {
+                map2.once('resize', () => resolve('resize'));
+                map2.once('moveend', () => resolve('moveend'));
+                map2.once('load', () => resolve('load'));
             });
         });
-        expect(loadWasFirst).toBeTruthy();
+        expect(loadWasFirst).toBe('load');
     }, 20000);
 
     test('Drag to the left', async () => {

--- a/test/integration/browser/browser.test.ts
+++ b/test/integration/browser/browser.test.ts
@@ -49,7 +49,7 @@ describe('Browser tests', () => {
     }, 40000);
 
     test('Load should fire before resize and moveend', async () => {
-        const loadWasFirst = await page.evaluate(() => {
+        const firstFiredEvent = await page.evaluate(() => {
             const map2 = new maplibregl.Map({
                 container: 'map', // container id
                 style: 'https://demotiles.maplibre.org/style.json', // style URL
@@ -62,7 +62,7 @@ describe('Browser tests', () => {
                 map2.once('load', () => resolve('load'));
             });
         });
-        expect(loadWasFirst).toBe('load');
+        expect(firstFiredEvent).toBe('load');
     }, 20000);
 
     test('Drag to the left', async () => {

--- a/test/integration/browser/browser.test.ts
+++ b/test/integration/browser/browser.test.ts
@@ -51,10 +51,10 @@ describe('Browser tests', () => {
     test('Load should fire before resize and moveend', async () => {
         const firstFiredEvent = await page.evaluate(() => {
             const map2 = new maplibregl.Map({
-                container: 'map', // container id
-                style: 'https://demotiles.maplibre.org/style.json', // style URL
-                center: [10, 10], // starting position [lng, lat]
-                zoom: 10 // starting zoom
+                container: 'map',
+                style: 'https://demotiles.maplibre.org/style.json',
+                center: [10, 10],
+                zoom: 10
             });
             return new Promise<string>((resolve, _reject) => {
                 map2.once('resize', () => resolve('resize'));

--- a/test/integration/browser/browser.test.ts
+++ b/test/integration/browser/browser.test.ts
@@ -48,6 +48,22 @@ describe('Browser tests', () => {
         });
     }, 40000);
 
+    test('No moveend before load', async () => {
+        const loadWasFirst = await page.evaluate(() => {
+            const map2 = new maplibregl.Map({
+                container: 'map', // container id
+                style: 'https://demotiles.maplibre.org/style.json', // style URL
+                center: [10, 10], // starting position [lng, lat]
+                zoom: 10 // starting zoom
+            });
+            return new Promise<boolean>((resolve, _reject) => {
+                map2.once('moveend', () => resolve(false));
+                map2.once('load', () => resolve(true));
+            });
+        });
+        expect(loadWasFirst).toBeTruthy();
+    }, 20000);
+
     test('Drag to the left', async () => {
 
         const canvas = await page.$('.maplibregl-canvas');


### PR DESCRIPTION
Closes #2551 

Captures the initial resize event from the resize observer, so it's more similar to the previous implementation that didn't fire on setup.

Adds the browser test that checks that the 'load' event comes before 'resize' and 'moveend'

## Launch Checklist
 - [X] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!