### PR TITLE
Parallelize code generation and run it before builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
     "generate-struct-arrays": "ts-node build/generate-struct-arrays.ts",
     "generate-style-code": "ts-node build/generate-style-code.ts",
     "generate-typings": "ts-node build/generate-typings.ts",
-    "build-dist": "npm run prepare && run-p --print-label generate-typings build-dev build-prod build-csp build-csp-dev build-css",
+    "build-dist": "npm run codegen && run-p --print-label generate-typings build-dev build-prod build-csp build-csp-dev build-css",
     "build-dev": "rollup --configPlugin @rollup/plugin-typescript -c --environment BUILD:dev",
     "watch-dev": "rollup --configPlugin @rollup/plugin-typescript -c --environment BUILD:dev --watch",
     "build-prod": "rollup --configPlugin @rollup/plugin-typescript -c --environment BUILD:production",
@@ -170,7 +170,7 @@
     "test-watch-roots": "jest --watch",
     "benchmark": "ts-node test/bench/run-benchmarks.ts",
     "gl-stats": "ts-node test/bench/gl-stats.ts",
-    "prepare": "run-p generate-dist-package generate-style-code generate-struct-arrays generate-shaders",
+    "codegen": "run-p generate-dist-package generate-style-code generate-struct-arrays generate-shaders",
     "typecheck": "tsc --noEmit"
   },
   "files": [

--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
     "generate-struct-arrays": "ts-node build/generate-struct-arrays.ts",
     "generate-style-code": "ts-node build/generate-style-code.ts",
     "generate-typings": "ts-node build/generate-typings.ts",
-    "build-dist": "run-p --print-label generate-typings build-dev build-prod build-csp build-csp-dev build-css",
+    "build-dist": "npm run prepare && run-p --print-label generate-typings build-dev build-prod build-csp build-csp-dev build-css",
     "build-dev": "rollup --configPlugin @rollup/plugin-typescript -c --environment BUILD:dev",
     "watch-dev": "rollup --configPlugin @rollup/plugin-typescript -c --environment BUILD:dev --watch",
     "build-prod": "rollup --configPlugin @rollup/plugin-typescript -c --environment BUILD:production",
@@ -168,10 +168,9 @@
     "test-render": "ts-node test/integration/render/run_render_tests.ts",
     "test-unit": "jest --selectProjects=unit",
     "test-watch-roots": "jest --watch",
-    "codegen": "npm run generate-style-code && npm run generate-struct-arrays && npm run generate-shaders",
     "benchmark": "ts-node test/bench/run-benchmarks.ts",
     "gl-stats": "ts-node test/bench/gl-stats.ts",
-    "prepare": "npm run generate-dist-package && npm run codegen",
+    "prepare": "run-p generate-dist-package generate-style-code generate-struct-arrays generate-shaders",
     "typecheck": "tsc --noEmit"
   },
   "files": [

--- a/package.json
+++ b/package.json
@@ -170,7 +170,8 @@
     "test-watch-roots": "jest --watch",
     "benchmark": "ts-node test/bench/run-benchmarks.ts",
     "gl-stats": "ts-node test/bench/gl-stats.ts",
-    "prepare": "run-p generate-dist-package generate-style-code generate-struct-arrays generate-shaders",
+    "codegen": "run-p generate-dist-package generate-style-code generate-struct-arrays generate-shaders",
+    "prepare": "npm run codegen",
     "typecheck": "tsc --noEmit"
   },
   "files": [

--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
     "generate-struct-arrays": "ts-node build/generate-struct-arrays.ts",
     "generate-style-code": "ts-node build/generate-style-code.ts",
     "generate-typings": "ts-node build/generate-typings.ts",
-    "build-dist": "npm run codegen && run-p --print-label generate-typings build-dev build-prod build-csp build-csp-dev build-css",
+    "build-dist": "run-p --print-label generate-typings build-dev build-prod build-csp build-csp-dev build-css",
     "build-dev": "rollup --configPlugin @rollup/plugin-typescript -c --environment BUILD:dev",
     "watch-dev": "rollup --configPlugin @rollup/plugin-typescript -c --environment BUILD:dev --watch",
     "build-prod": "rollup --configPlugin @rollup/plugin-typescript -c --environment BUILD:production",
@@ -170,7 +170,7 @@
     "test-watch-roots": "jest --watch",
     "benchmark": "ts-node test/bench/run-benchmarks.ts",
     "gl-stats": "ts-node test/bench/gl-stats.ts",
-    "codegen": "run-p generate-dist-package generate-style-code generate-struct-arrays generate-shaders",
+    "prepare": "run-p generate-dist-package generate-style-code generate-struct-arrays generate-shaders",
     "typecheck": "tsc --noEmit"
   },
   "files": [

--- a/package.json
+++ b/package.json
@@ -168,9 +168,9 @@
     "test-render": "ts-node test/integration/render/run_render_tests.ts",
     "test-unit": "jest --selectProjects=unit",
     "test-watch-roots": "jest --watch",
+    "codegen": "run-p generate-dist-package generate-style-code generate-struct-arrays generate-shaders",
     "benchmark": "ts-node test/bench/run-benchmarks.ts",
     "gl-stats": "ts-node test/bench/gl-stats.ts",
-    "codegen": "run-p generate-dist-package generate-style-code generate-struct-arrays generate-shaders",
     "prepare": "npm run codegen",
     "typecheck": "tsc --noEmit"
   },


### PR DESCRIPTION
Parallelize the codegen task, to save time for all CI's

In windows, the npm ci sometimes takes > 3 min, where it's almost always <1 min. on ubuntu.

## Launch Checklist
 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!