### PR TITLE
Bump style spec from 19.1.0 to 19.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@mapbox/unitbezier": "^0.0.1",
         "@mapbox/vector-tile": "^1.3.1",
         "@mapbox/whoots-js": "^3.1.0",
-        "@maplibre/maplibre-gl-style-spec": "^19.1.0",
+        "@maplibre/maplibre-gl-style-spec": "^19.2.0",
         "@types/geojson": "^7946.0.10",
         "@types/mapbox__point-geometry": "^0.1.2",
         "@types/mapbox__vector-tile": "^1.3.0",
@@ -1366,15 +1366,14 @@
       }
     },
     "node_modules/@maplibre/maplibre-gl-style-spec": {
-      "version": "19.1.0",
-      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-19.1.0.tgz",
-      "integrity": "sha512-o95X24j9D/4+lmhxMZ2YAU+8PhJyQVKibEY8YrOFbVyxs6N76hm38ozokKGwRO5i5RAZXWSp8uCfH7w197VSHQ==",
+      "version": "19.2.0",
+      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-19.2.0.tgz",
+      "integrity": "sha512-RQcFaiOqSSqxCHpcQw9tPvMK4fK36Czzm0GNgRum0Q+AcLchtYSshRDz8+0gfQqb1gxGBMXayJc+t/xmFeXSdg==",
       "dependencies": {
         "@mapbox/jsonlint-lines-primitives": "~2.0.2",
         "@mapbox/point-geometry": "^0.1.0",
         "@mapbox/unitbezier": "^0.0.1",
         "@types/mapbox__point-geometry": "^0.1.2",
-        "color-string": "^1.9.1",
         "json-stringify-pretty-compact": "^3.0.0",
         "minimist": "^1.2.8",
         "rw": "^1.3.3",
@@ -4015,16 +4014,8 @@
     },
     "node_modules/color-name": {
       "version": "1.1.3",
+      "dev": true,
       "license": "MIT"
-    },
-    "node_modules/color-string": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
-      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
-      "dependencies": {
-        "color-name": "^1.0.0",
-        "simple-swizzle": "^0.2.2"
-      }
     },
     "node_modules/color-support": {
       "version": "1.1.3",
@@ -13443,19 +13434,6 @@
         "once": "^1.3.1",
         "simple-concat": "^1.0.0"
       }
-    },
-    "node_modules/simple-swizzle": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
-      "integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
-      "dependencies": {
-        "is-arrayish": "^0.3.1"
-      }
-    },
-    "node_modules/simple-swizzle/node_modules/is-arrayish": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
-      "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
     },
     "node_modules/sisteransi": {
       "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@mapbox/unitbezier": "^0.0.1",
     "@mapbox/vector-tile": "^1.3.1",
     "@mapbox/whoots-js": "^3.1.0",
-    "@maplibre/maplibre-gl-style-spec": "^19.1.0",
+    "@maplibre/maplibre-gl-style-spec": "^19.2.0",
     "@types/geojson": "^7946.0.10",
     "@types/mapbox__point-geometry": "^0.1.2",
     "@types/mapbox__vector-tile": "^1.3.0",


### PR DESCRIPTION
This is to include the CSS4 color parser, and allow decimal numbers in rgb() etc.. See https://github.com/maplibre/maplibre-style-spec/pull/175

 - [X] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!