### PR TITLE
Skip release if exist

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,7 +77,8 @@ jobs:
         with:
           tag: ${{ steps.prepare_release.outputs.version_tag }}
           name: ${{steps.prepare_release.outputs.version_tag }}
-          body: ${{ steps.release_notes.outputs.release_notes }}
+          bodyFile: ${{ steps.release_notes.outputs.release_notes }}
+          skipIfReleaseExists: true
           draft: false
           prerelease: false
 


### PR DESCRIPTION
If release exist, skip. 

Also closes #2582 

For reference, there is also another flag called [allowUpdates ](https://github.com/ncipollo/release-action) that would have allowed the CI to continue