### PR TITLE
fix RequestTransformFunction type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes
-- _...Add new stuff here..._
+- Fix `RequestTransformFunction` type to return RequestParameters or undefined ([#2586](https://github.com/maplibre/maplibre-gl-js/pull/2586))
 
 
 ## 3.0.0

--- a/src/util/request_manager.ts
+++ b/src/util/request_manager.ts
@@ -14,7 +14,7 @@ export const enum ResourceType {
     Unknown = 'Unknown',
 }
 
-export type RequestTransformFunction = (url: string, resourceType?: ResourceType) => RequestParameters;
+export type RequestTransformFunction = (url: string, resourceType?: ResourceType) => RequestParameters | undefined;
 
 type UrlObject = {
     protocol: string;


### PR DESCRIPTION
RequestTransformFunction is typed incorrectly. RequestTransformFunction can return RequestParameters or undefined. Documentation even provides an example where RequestTransformFunction returns RequestParameters or undefined.

<img width="500" alt="Screen Shot 2023-05-23 at 8 35 27 PM" src="https://github.com/maplibre/maplibre-gl-js/assets/373691/90ce112e-3097-47b3-8188-7e2bd28dfeb6">

## Launch Checklist
 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Add an entry to `CHANGELOG.md` under the `## main` section.
