### PR TITLE
Add retry to render tests

### DIFF
--- a/test/integration/render/run_render_tests.ts
+++ b/test/integration/render/run_render_tests.ts
@@ -747,6 +747,21 @@ function applyDebugParameter(options: RenderOptions, page: Page) {
     }
 }
 
+function runTests(testStyles: StyleWithTestData[], directory: string) {
+    let index = 0;
+    for (const style of testStyles) {
+        try {
+            //@ts-ignore
+            const data = await getImageFromStyle(style, page);
+            compareRenderResults(directory, style.metadata.test, data);
+
+        } catch (ex) {
+            style.metadata.test.error = ex;
+        }
+        printProgress(style.metadata.test, testStyles.length, ++index);
+    }
+}
+
 /**
  * Entry point to run the render test suite, compute differences to expected values (making exceptions based on
  * implementation vagaries), print results to standard output, write test artifacts to the
@@ -794,44 +809,21 @@ async function executeRenderTests() {
     const directory = path.join(__dirname);
     let testStyles = getTestStyles(options, directory, (server.address() as any).port);
 
-    if (process.env.SPLIT_COUNT === '2') {
-
-        const half = Math.ceil(testStyles.length / 2);
-        const firstHalf = testStyles.slice(0, half);
-        const secondHalf = testStyles.slice(half);
-
-        testStyles = [firstHalf, secondHalf][parseInt(process.env.CURRENT_SPLIT_INDEX!)];
+    if (process.env.SPLIT_COUNT && process.env.CURRENT_SPLIT_INDEX) {
+        const numberOfTestsForThisPart = Math.ceil(testStyles.length / +process.env.SPLIT_COUNT);
+        testStyles = testStyles.slice(+process.env.CURRENT_SPLIT_INDEX * numberOfTestsForThisPart, numberOfTestsForThisPart);
     }
-
-    if (process.env.SPLIT_COUNT === '3') {
-
-        const m = Math.ceil(testStyles.length / 3);
-        const n = Math.ceil(2 * testStyles.length / 3);
-
-        const first = testStyles.slice(0, m);
-        const second = testStyles.slice(m, n);
-        const third = testStyles.slice(n, testStyles.length);
-
-        testStyles = [first, second, third][parseInt(process.env.CURRENT_SPLIT_INDEX!)];
-    }
-
-    let index = 0;
 
     const page = await browser.newPage();
     applyDebugParameter(options, page);
     await page.addScriptTag({path: 'dist/maplibre-gl.js'});
 
-    for (const style of testStyles) {
-        try {
-            //@ts-ignore
+    runTests(testStyles, directory)
 
-            const data = await getImageFromStyle(style, page);
-            compareRenderResults(directory, style.metadata.test, data);
-
-        } catch (ex) {
-            style.metadata.test.error = ex;
-        }
-        printProgress(style.metadata.test, testStyles.length, ++index);
+    let failedTests = testStyles.filter(t => t.metadata.test.error || !t.metadata.test.ok);
+    if (failedTests.length > 0 && failedTests.length < testStyles.length) {
+        console.log("Rerunning failed tests: " + failedTests.length);
+        runTests(failedTests, directory);
     }
 
     page.close();

--- a/test/integration/render/run_render_tests.ts
+++ b/test/integration/render/run_render_tests.ts
@@ -747,14 +747,13 @@ function applyDebugParameter(options: RenderOptions, page: Page) {
     }
 }
 
-function runTests(testStyles: StyleWithTestData[], directory: string) {
+async function runTests(page: Page, testStyles: StyleWithTestData[], directory: string) {
     let index = 0;
     for (const style of testStyles) {
         try {
             //@ts-ignore
             const data = await getImageFromStyle(style, page);
             compareRenderResults(directory, style.metadata.test, data);
-
         } catch (ex) {
             style.metadata.test.error = ex;
         }
@@ -818,12 +817,12 @@ async function executeRenderTests() {
     applyDebugParameter(options, page);
     await page.addScriptTag({path: 'dist/maplibre-gl.js'});
 
-    runTests(testStyles, directory)
+    await runTests(page, testStyles, directory);
 
-    let failedTests = testStyles.filter(t => t.metadata.test.error || !t.metadata.test.ok);
+    const failedTests = testStyles.filter(t => t.metadata.test.error || !t.metadata.test.ok);
     if (failedTests.length > 0 && failedTests.length < testStyles.length) {
-        console.log("Rerunning failed tests: " + failedTests.length);
-        runTests(failedTests, directory);
+        console.log(`Rerunning failed tests: ${failedTests.length}`);
+        await runTests(page, failedTests, directory);
     }
 
     page.close();

--- a/test/integration/render/run_render_tests.ts
+++ b/test/integration/render/run_render_tests.ts
@@ -810,7 +810,7 @@ async function executeRenderTests() {
 
     if (process.env.SPLIT_COUNT && process.env.CURRENT_SPLIT_INDEX) {
         const numberOfTestsForThisPart = Math.ceil(testStyles.length / +process.env.SPLIT_COUNT);
-        testStyles = testStyles.slice(+process.env.CURRENT_SPLIT_INDEX * numberOfTestsForThisPart, numberOfTestsForThisPart);
+        testStyles = testStyles.splice(+process.env.CURRENT_SPLIT_INDEX * numberOfTestsForThisPart, numberOfTestsForThisPart);
     }
 
     const page = await browser.newPage();


### PR DESCRIPTION
I've generalized the split code and added a retry for failing tests.
Let's hope this will improve the situation for the render tests...