### PR TITLE
Remove `supported` from index.ts

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -204,23 +204,6 @@ const exported = {
 Debug.extend(exported, {isSafari, getPerformanceMetrics: PerformanceUtils.getPerformanceMetrics});
 
 /**
- * Test whether the browser supports MapLibre GL JS.
- *
- * @function supported
- * @param {Object} [options]
- * @param {boolean} [options.failIfMajorPerformanceCaveat=false] If `true`,
- * the function will return `false` if the performance of MapLibre GL JS would
- * be dramatically worse than expected (e.g. a software WebGL renderer would be used).
- * @return {boolean}
- * @example
- * // Show an alert if the browser does not support MapLibre GL
- * if (!maplibregl.supported()) {
- *   alert('Your browser does not support MapLibre GL');
- * }
- * @see [Check for browser support](https://maplibre.org/maplibre-gl-js-docs/example/check-for-support/)
- */
-
-/**
  * Sets the map's [RTL text plugin](https://www.mapbox.com/mapbox-gl-js/plugins/#mapbox-gl-rtl-text).
  * Necessary for supporting the Arabic and Hebrew languages, which are written right-to-left.
  *


### PR DESCRIPTION
Since supported was still in the index.ts docs, the Maplibre 3.0 [documentation](https://maplibre.org/maplibre-gl-js-docs/api/properties/#supported) still includes it although it's not exported anymore. 
This PR removes that doc comment. We'll need to regenerate the docs when this is merged in.
Also, not sure if this needs a changelog entry?

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [x] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality.
 - [x] Document any changes to public APIs.
 - [x] Post benchmark scores.
 - [x] Add an entry to `CHANGELOG.md` under the `## main` section.
