### PR TITLE
Document that dblclick is preceded by click events

### DIFF
--- a/src/ui/events.ts
+++ b/src/ui/events.ts
@@ -564,6 +564,8 @@ export type MapEvent =
      * If `layerId` is included as the second argument in {@link Map#on}, the event listener will fire only
      * when the point that is clicked twice contains a visible portion of the specified layer.
      *
+     * **Note:** Two {@link Map.event:click} events will precede this event.
+     *
      * @event dblclick
      * @memberof Map
      * @instance

--- a/src/ui/events.ts
+++ b/src/ui/events.ts
@@ -564,7 +564,7 @@ export type MapEvent =
      * If `layerId` is included as the second argument in {@link Map#on}, the event listener will fire only
      * when the point that is clicked twice contains a visible portion of the specified layer.
      *
-     * **Note:** Two {@link Map.event:click} events will precede this event.
+     * **Note:** Under normal conditions, this event will be preceded by two {@link Map.event:click} events.
      *
      * @event dblclick
      * @memberof Map


### PR DESCRIPTION
I spent at least a few minutes puzzling through the fact that `dblclick` handlers don't magically suppress `click` events. It makes sense in hindsight, but I want to try and save the next person a little bit of time. See https://osmus.slack.com/archives/C01G3D28DAB/p1685016451984109 for some discussion.

## Launch Checklist

 - [X] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [X] Briefly describe the changes in this PR.
