### PR TITLE
Load float webgl2 extension to support i.e. RGBA16F

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### 🐞 Bug fixes
 - Fix `RequestTransformFunction` type to return RequestParameters or undefined ([#2586](https://github.com/maplibre/maplibre-gl-js/pull/2586))
+- Load `EXT_color_buffer_float` WebGL2 extension to fix heatmap in firefox ([#2595](https://github.com/maplibre/maplibre-gl-js/pull/2595))
 
 
 ## 3.0.0

--- a/src/gl/context.ts
+++ b/src/gl/context.ts
@@ -110,6 +110,7 @@ class Context {
         this.HALF_FLOAT = gl.HALF_FLOAT;
 
         gl.getExtension('EXT_color_buffer_half_float');
+        gl.getExtension('EXT_color_buffer_float');
         this.RGBA16F = gl.RGBA16F;
         this.RGB16F = gl.RGB16F;
     }


### PR DESCRIPTION
Fixes https://github.com/maplibre/maplibre-gl-js/issues/2590 

Adds the `gl.getExtension('EXT_color_buffer_float');` to support [all these types](https://developer.mozilla.org/en-US/docs/Web/API/EXT_color_buffer_float).