### PR TITLE
migrate background-pattern to glsl 3

### DIFF
--- a/src/render/program.ts
+++ b/src/render/program.ts
@@ -74,6 +74,11 @@ class Program<Us extends UniformBindings> {
         if (terrain) {
             defines.push('#define TERRAIN3D;');
         }
+
+        if (source.fragmentSource.split('\n')[0] === '// #version 300 es') {
+            defines.unshift('#version 300 es');
+        }
+
         const fragmentSource = defines.concat(shaders.prelude.fragmentSource, source.fragmentSource).join('\n');
         const vertexSource = defines.concat(shaders.prelude.vertexSource, source.vertexSource).join('\n');
         const fragmentShader = gl.createShader(gl.FRAGMENT_SHADER);

--- a/src/shaders/background_pattern.fragment.glsl
+++ b/src/shaders/background_pattern.fragment.glsl
@@ -1,4 +1,4 @@
-// #version 300 es
+#version 300 es
 
 uniform vec2 u_pattern_tl_a;
 uniform vec2 u_pattern_br_a;

--- a/src/shaders/background_pattern.fragment.glsl
+++ b/src/shaders/background_pattern.fragment.glsl
@@ -1,3 +1,5 @@
+// #version 300 es
+
 uniform vec2 u_pattern_tl_a;
 uniform vec2 u_pattern_br_a;
 uniform vec2 u_pattern_tl_b;
@@ -8,21 +10,23 @@ uniform float u_opacity;
 
 uniform sampler2D u_image;
 
-varying vec2 v_pos_a;
-varying vec2 v_pos_b;
+in vec2 v_pos_a;
+in vec2 v_pos_b;
+
+out vec4 fragColor;
 
 void main() {
     vec2 imagecoord = mod(v_pos_a, 1.0);
     vec2 pos = mix(u_pattern_tl_a / u_texsize, u_pattern_br_a / u_texsize, imagecoord);
-    vec4 color1 = texture2D(u_image, pos);
+    vec4 color1 = texture(u_image, pos);
 
     vec2 imagecoord_b = mod(v_pos_b, 1.0);
     vec2 pos2 = mix(u_pattern_tl_b / u_texsize, u_pattern_br_b / u_texsize, imagecoord_b);
-    vec4 color2 = texture2D(u_image, pos2);
+    vec4 color2 = texture(u_image, pos2);
 
-    gl_FragColor = mix(color1, color2, u_mix) * u_opacity;
+    fragColor = mix(color1, color2, u_mix) * u_opacity;
 
 #ifdef OVERDRAW_INSPECTOR
-    gl_FragColor = vec4(1.0);
+    fragColor = vec4(1.0);
 #endif
 }

--- a/src/shaders/background_pattern.vertex.glsl
+++ b/src/shaders/background_pattern.vertex.glsl
@@ -1,4 +1,4 @@
-// #version 300 es
+#version 300 es
 
 uniform mat4 u_matrix;
 uniform vec2 u_pattern_size_a;
@@ -9,7 +9,7 @@ uniform float u_scale_a;
 uniform float u_scale_b;
 uniform float u_tile_units_to_pixels;
 
-in vec2 a_pos;
+layout (location = 0) in vec2 a_pos;
 out vec2 v_pos_a;
 out vec2 v_pos_b;
 

--- a/src/shaders/background_pattern.vertex.glsl
+++ b/src/shaders/background_pattern.vertex.glsl
@@ -1,3 +1,5 @@
+// #version 300 es
+
 uniform mat4 u_matrix;
 uniform vec2 u_pattern_size_a;
 uniform vec2 u_pattern_size_b;
@@ -7,10 +9,9 @@ uniform float u_scale_a;
 uniform float u_scale_b;
 uniform float u_tile_units_to_pixels;
 
-attribute vec2 a_pos;
-
-varying vec2 v_pos_a;
-varying vec2 v_pos_b;
+in vec2 a_pos;
+out vec2 v_pos_a;
+out vec2 v_pos_b;
 
 void main() {
     gl_Position = u_matrix * vec4(a_pos, 0, 1);

--- a/src/shaders/background_pattern.vertex.glsl
+++ b/src/shaders/background_pattern.vertex.glsl
@@ -9,7 +9,7 @@ uniform float u_scale_a;
 uniform float u_scale_b;
 uniform float u_tile_units_to_pixels;
 
-layout (location = 0) in vec2 a_pos;
+in vec2 a_pos;
 out vec2 v_pos_a;
 out vec2 v_pos_b;
 

--- a/src/shaders/shaders.ts
+++ b/src/shaders/shaders.ts
@@ -97,7 +97,7 @@ export default shaders;
 function compile(fragmentSource, vertexSource) {
     const re = /#pragma mapbox: ([\w]+) ([\w]+) ([\w]+) ([\w]+)/g;
 
-    const staticAttributes = vertexSource.match(/attribute ([\w]+) ([\w]+)/g);
+    const staticAttributes = vertexSource.match(/(attribute|in) ([\w]+) ([\w]+)/g);
     const fragmentUniforms = fragmentSource.match(/uniform ([\w]+) ([\w]+)([\s]*)([\w]*)/g);
     const vertexUniforms = vertexSource.match(/uniform ([\w]+) ([\w]+)([\s]*)([\w]*)/g);
     const staticUniforms = vertexUniforms ? vertexUniforms.concat(fragmentUniforms) : fragmentUniforms;


### PR DESCRIPTION
This code contains the port of 1 shader pair, the **background-pattern** to GLSL 3.0, to prove the feasibility of a migration. When going through the rest of the shaders, there will likely surface more adjustments.

Closes #2576 

 - [X] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!