### PR TITLE
Enhancement: Add support for multiple Layer Id's in map event methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## main
 
 ### ✨ Features and improvements
+- Add support for multiple layer IDs in the `.on`, `.once` and `.off` methods of the `Map`.
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes

--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -1036,7 +1036,7 @@ class Map extends Camera {
         delegates: {[type in keyof MapEventType]?: (e: any) => void};
     } {
         const filteredLayers = layers.filter(layerId => this.getLayer(layerId));
-        const deduplicatedLayers = [...new Set(layers)]
+        const deduplicatedLayers = [...new Set(layers)];
         if (type === 'mouseenter' || type === 'mouseover') {
             let mousein = false;
             const mousemove = (e) => {


### PR DESCRIPTION
## Launch Checklist

 - [ ] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality.
 - [x] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [x] Add an entry to `CHANGELOG.md` under the `## main` section.

This Pull Request adds support for multiple layer Ids to the `Map` `.on`, `.once` and `.off` methods. 

This is a non-breaking change as the previous API design still works, however a single Layer Id argument is now coerced into an array.

This functionality brings consistency with the mapbox-gl API (I'm not sure if this means it's a backport issue?).

~~I had a quick look around and I couldn't see any tests for the methods impacted by these changes, although there is a debug page I could adapt.~~ Found them when CI failed 😂  , I don't have homebrew installed locally so I'll need to get that sorted to finish off the PR and get the tests running.

Resolves #2592
