### PR TITLE
Fix typing error when consuming maplibre-gl with TypeScript compiler …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 ### 🐞 Bug fixes
 - Fix `RequestTransformFunction` type to return RequestParameters or undefined ([#2586](https://github.com/maplibre/maplibre-gl-js/pull/2586))
 - Load `EXT_color_buffer_float` WebGL2 extension to fix heatmap in firefox ([#2595](https://github.com/maplibre/maplibre-gl-js/pull/2595))
-
+- Fix typing error when consuming maplibre-gl with TypeScript compiler set to strict mode
 
 ## 3.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@
 ### 🐞 Bug fixes
 - Fix `RequestTransformFunction` type to return RequestParameters or undefined ([#2586](https://github.com/maplibre/maplibre-gl-js/pull/2586))
 - Load `EXT_color_buffer_float` WebGL2 extension to fix heatmap in firefox ([#2595](https://github.com/maplibre/maplibre-gl-js/pull/2595))
-- Fix typing error when consuming maplibre-gl with TypeScript compiler set to strict mode ([#2600](https://github.com/maplibre/maplibre-gl-js/pull/2600))
 
 ## 3.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 ### 🐞 Bug fixes
 - Fix `RequestTransformFunction` type to return RequestParameters or undefined ([#2586](https://github.com/maplibre/maplibre-gl-js/pull/2586))
 - Load `EXT_color_buffer_float` WebGL2 extension to fix heatmap in firefox ([#2595](https://github.com/maplibre/maplibre-gl-js/pull/2595))
-- Fix typing error when consuming maplibre-gl with TypeScript compiler set to strict mode
+- Fix typing error when consuming maplibre-gl with TypeScript compiler set to strict mode ([#2600](https://github.com/maplibre/maplibre-gl-js/pull/2600))
 
 ## 3.0.0
 

--- a/src/gl/value.ts
+++ b/src/gl/value.ts
@@ -418,7 +418,7 @@ export class BindElementBuffer extends BaseValue<WebGLBuffer> {
 }
 
 export class BindVertexArray extends BaseValue<WebGLVertexArrayObject> {
-    getDefault(): WebGLVertexArrayObject | null {
+    getDefault(): WebGLVertexArrayObject {
         return null;
     }
     set(v: WebGLVertexArrayObject | null) {


### PR DESCRIPTION
Simple typing change that closes #2588. Note that the removal of `| null` makes the class consistent with all others in the file. With this change, I'm able to consume the library from a project without `strict: false` set in its tsconfig.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [x] Add an entry to `CHANGELOG.md` under the `## main` section.
