### PR TITLE
Add strict typecheck to generated d.ts file

### DIFF
--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -27,7 +27,7 @@ jobs:
         if: success() || failure()
       - run: npm run lint-docs
         if: success() || failure()
-      - run: npm generate-typings
+      - run: npm run generate-typings
         if: success() || failure()
       - run: npm run typecheck
         if: success() || failure()

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -27,6 +27,8 @@ jobs:
         if: success() || failure()
       - run: npm run lint-docs
         if: success() || failure()
+      - run: npm generate-typings
+        if: success() || failure()
       - run: npm run typecheck
         if: success() || failure()
 

--- a/build/readme.md
+++ b/build/readme.md
@@ -29,9 +29,6 @@ Rollup is generating 3 files throughout the process of bundling:
 
 These 3 files are then referenced and used by the `bundle_prelude.js` file. It allows loading the web wroker code automatically in web workers without any extra effort from someone who would like to use the library, i.e. it simply works.
 
-### check-bundle-size.js
-This file is used by CI to make sure the bundle size is kept constant
-
 <hr>
 
 ### `npm run codegen`
@@ -43,8 +40,6 @@ Generates `data/array_types.ts`, which consists of:
  - Specific named `StructArray` subclasses, when type-specific struct accessors are needed (e.g., `CollisionBoxArray`)
 #### generate-style-code.ts			
 Generates the various `style/style_layer/[layer type]_style_layer_properties.ts` code files based on the content of `v8.json`. These files provide the type signatures for the paint and layout properties for each type of style layer.
-#### generate-style-spec.ts			
-Generates `style-spec/types.ts` based on the content of `v8.json`. This provides the type signatures for a style specification (sources, layers, etc.).
 <hr>
 
 ### Generate Release Nodes

--- a/package.json
+++ b/package.json
@@ -172,7 +172,7 @@
     "benchmark": "ts-node test/bench/run-benchmarks.ts",
     "gl-stats": "ts-node test/bench/gl-stats.ts",
     "prepare": "npm run codegen",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit && tsc --project tsconfig.dist.json"
   },
   "files": [
     "build/",

--- a/src/gl/value.ts
+++ b/src/gl/value.ts
@@ -417,7 +417,7 @@ export class BindElementBuffer extends BaseValue<WebGLBuffer> {
     }
 }
 
-export class BindVertexArray extends BaseValue<WebGLVertexArrayObject> {
+export class BindVertexArray extends BaseValue<WebGLVertexArrayObject | null> {
     getDefault(): WebGLVertexArrayObject | null {
         return null;
     }

--- a/tsconfig.dist.json
+++ b/tsconfig.dist.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "strictNullChecks": true,
+  },
+  "include": [
+    "dist/maplibre-gl.d.ts"
+  ],
+  "exclude": []
+}

--- a/tsconfig.dist.json
+++ b/tsconfig.dist.json
@@ -1,7 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "strictNullChecks": true,
+    "strict": true,
   },
   "include": [
     "dist/maplibre-gl.d.ts"


### PR DESCRIPTION
Fixes #2588.

This adds a tsconfig file that is specific to the `d.ts` file in the dist folder in order to make sure that the generated file is following the strict mode.
