### PR TITLE
Fix MapLibre name convention outliers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -375,7 +375,7 @@ Everything from the four previous pre-releases:
 
 ### ✨ Features and improvements
 
-- Changed logic for showing the Maplibre logo. The Maplibre logo is now shown by setting the map option 'maplibreLogo' to true or by adding it to a map with addControl. TileJSON no longer controls if the logo is shown. ([#786](https://github.com/maplibre/maplibre-gl-js/pull/786))
+- Changed logic for showing the MapLibre logo. The MapLibre logo is now shown by setting the map option 'maplibreLogo' to true or by adding it to a map with addControl. TileJSON no longer controls if the logo is shown. ([#786](https://github.com/maplibre/maplibre-gl-js/pull/786))
 
 ### 🐞 Bug fixes
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ The overall migration happens by uninstalling `mapbox-gl` and installing `maplib
 
 #### Compatibility branch
 
-Maplibre v1 is completely backward compatible with Mapbox v1. This compatibility branch (named 1.x) is tagged v1 on npm, and its current version is 1.15.3. 
+MapLibre v1 is completely backward compatible with Mapbox v1. This compatibility branch (named 1.x) is tagged v1 on npm, and its current version is 1.15.3. 
 
 #### CDN Links
 

--- a/README.md
+++ b/README.md
@@ -64,11 +64,11 @@ The overall migration happens by uninstalling `mapbox-gl` and installing `maplib
 
 #### Compatibility branch
 
-MapLibre v1 is completely backward compatible with Mapbox v1. This compatibility branch (named 1.x) is tagged v1 on npm, and its current version is 1.15.3. 
+MapLibre GL JS v1 is completely backward compatible with Mapbox GL JS v1. This compatibility branch (named 1.x) is tagged v1 on npm, and its current version is 1.15.3. 
 
 #### CDN Links
 
-> MapLibre GL JS is distributed via [unpkg.com](https://unpkg.com). For more information, please see [MapLibre GL is on unpkg.com](./documents_and_diagrams/README-unpkg.md#maplibre-gl-on-unpkgcom).
+> MapLibre GL JS is distributed via [unpkg.com](https://unpkg.com). For more information, please see [MapLibre GL JS is on unpkg.com](./documents_and_diagrams/README-unpkg.md#maplibre-gl-on-unpkgcom).
 
 ```diff
 -    <script src="https://api.mapbox.com/mapbox-gl-js/v#.#.#/mapbox-gl.js"></script>

--- a/src/source/vector_tile_source.test.ts
+++ b/src/source/vector_tile_source.test.ts
@@ -41,7 +41,7 @@ describe('VectorTileSource', () => {
         const source = createSource({
             minzoom: 1,
             maxzoom: 10,
-            attribution: 'Maplibre',
+            attribution: 'MapLibre',
             tiles: ['http://example.com/{z}/{x}/{y}.png']
         });
 
@@ -50,7 +50,7 @@ describe('VectorTileSource', () => {
                 expect(source.tiles).toEqual(['http://example.com/{z}/{x}/{y}.png']);
                 expect(source.minzoom).toBe(1);
                 expect(source.maxzoom).toBe(10);
-                expect((source as Source).attribution).toBe('Maplibre');
+                expect((source as Source).attribution).toBe('MapLibre');
                 done();
             }
         });
@@ -66,7 +66,7 @@ describe('VectorTileSource', () => {
                 expect(source.tiles).toEqual(['http://example.com/{z}/{x}/{y}.png']);
                 expect(source.minzoom).toBe(1);
                 expect(source.maxzoom).toBe(10);
-                expect((source as Source).attribution).toBe('Maplibre');
+                expect((source as Source).attribution).toBe('MapLibre');
                 done();
             }
         });
@@ -125,14 +125,14 @@ describe('VectorTileSource', () => {
         const source = createSource({
             minzoom: 1,
             maxzoom: 10,
-            attribution: 'Maplibre',
+            attribution: 'MapLibre',
             tiles: ['http://example.com/{z}/{x}/{y}.png']
         });
         expect(source.serialize()).toEqual({
             type: 'vector',
             minzoom: 1,
             maxzoom: 10,
-            attribution: 'Maplibre',
+            attribution: 'MapLibre',
             tiles: ['http://example.com/{z}/{x}/{y}.png']
         });
     });
@@ -142,7 +142,7 @@ describe('VectorTileSource', () => {
             const source = createSource({
                 minzoom: 1,
                 maxzoom: 10,
-                attribution: 'Maplibre',
+                attribution: 'MapLibre',
                 tiles: ['http://example.com/{z}/{x}/{y}.png'],
                 scheme
             });
@@ -229,7 +229,7 @@ describe('VectorTileSource', () => {
         const source = createSource({
             minzoom: 0,
             maxzoom: 22,
-            attribution: 'Maplibre',
+            attribution: 'MapLibre',
             tiles: ['http://example.com/{z}/{x}/{y}.png'],
             bounds: [-47, -7, -45, -5]
         });
@@ -246,7 +246,7 @@ describe('VectorTileSource', () => {
         const source = createSource({
             minzoom: 0,
             maxzoom: 22,
-            attribution: 'Maplibre',
+            attribution: 'MapLibre',
             tiles: ['http://example.com/{z}/{x}/{y}.png'],
             bounds: [-47, -7, -45, 91]
         });
@@ -263,7 +263,7 @@ describe('VectorTileSource', () => {
         server.respondWith('/source.json', JSON.stringify({
             minzoom: 0,
             maxzoom: 22,
-            attribution: 'Maplibre',
+            attribution: 'MapLibre',
             tiles: ['http://example.com/{z}/{x}/{y}.png'],
             bounds: [-47, -7, -45, -5]
         }));
@@ -331,7 +331,7 @@ describe('VectorTileSource', () => {
         const source = createSource({
             minzoom: 1,
             maxzoom: 10,
-            attribution: 'Maplibre',
+            attribution: 'MapLibre',
             tiles: ['http://example.com/{z}/{x}/{y}.png']
         });
         source.setTiles(['http://example2.com/{z}/{x}/{y}.png']);
@@ -339,7 +339,7 @@ describe('VectorTileSource', () => {
             type: 'vector',
             minzoom: 1,
             maxzoom: 10,
-            attribution: 'Maplibre',
+            attribution: 'MapLibre',
             tiles: ['http://example2.com/{z}/{x}/{y}.png']
         });
     });

--- a/test/integration/browser/README.md
+++ b/test/integration/browser/README.md
@@ -1,4 +1,4 @@
-This folder contains files for automated testing of Maplibre GL in real browsers using [Selenium WebDriver](https://www.npmjs.com/package/selenium-webdriver).
+This folder contains files for automated testing of MapLibre GL in real browsers using [Selenium WebDriver](https://www.npmjs.com/package/selenium-webdriver).
 
 ## Prerequisites
 

--- a/test/integration/browser/README.md
+++ b/test/integration/browser/README.md
@@ -1,4 +1,4 @@
-This folder contains files for automated testing of MapLibre GL in real browsers using [Selenium WebDriver](https://www.npmjs.com/package/selenium-webdriver).
+This folder contains files for automated testing of MapLibre GL JS in real browsers using [Selenium WebDriver](https://www.npmjs.com/package/selenium-webdriver).
 
 ## Prerequisites
 

--- a/test/unit/assets/source.json
+++ b/test/unit/assets/source.json
@@ -2,5 +2,5 @@
     "tiles": ["http://example.com/{z}/{x}/{y}.png"],
     "minzoom": 1,
     "maxzoom": 10,
-    "attribution": "Maplibre"
+    "attribution": "MapLibre"
 }

--- a/test/unit/lib/web_worker_mock.ts
+++ b/test/unit/lib/web_worker_mock.ts
@@ -1,5 +1,5 @@
 import type {WorkerInterface, WorkerGlobalScopeInterface, MessageListener} from '../../../src/util/web_worker';
-import MaplibreWorker from '../../../src/source/worker';
+import MapLibreWorker from '../../../src/source/worker';
 
 export class MessageBus implements WorkerInterface, WorkerGlobalScopeInterface {
     addListeners: Array<MessageListener>;
@@ -55,7 +55,7 @@ export class MessageBus implements WorkerInterface, WorkerGlobalScopeInterface {
     parentBus.target = workerBus;
     workerBus.target = parentBus;
 
-    new MaplibreWorker(workerBus);
+    new MapLibreWorker(workerBus);
 
     return parentBus;
 };


### PR DESCRIPTION
There were a few minor instances of MapLibre spelled as Maplibre.