### PR TITLE
Reduce pixel ratio when hitting drawing buffer limit

### DIFF
--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -718,12 +718,8 @@ class Map extends Camera {
      * @param {number} pixelRatio The pixel ratio.
      */
     setPixelRatio(pixelRatio: number) {
-        const [width, height] = this._containerDimensions();
-
         this._pixelRatio = pixelRatio;
-
-        this._resizeCanvas(width, height, pixelRatio);
-        this.painter.resize(width, height, pixelRatio);
+        this.resize();
     }
 
     /**

--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -687,6 +687,7 @@ class Map extends Camera {
         this.transform.resize(width, height);
         this._requestedCameraState?.resize(width, height);
         this.painter.resize(width, height, this.getPixelRatio());
+        this._reducePixelRatioIfNeeded();
 
         const fireMoving = !this._moving;
         if (fireMoving) {
@@ -723,6 +724,19 @@ class Map extends Camera {
 
         this._resizeCanvas(width, height, pixelRatio);
         this.painter.resize(width, height, pixelRatio);
+    }
+
+    /**
+     * Check if we have hit client limit for drawing buffer width or height.
+     * In those case they get clamped causing distortions. To avoid that, reduce pixel ratio.
+     */
+    _reducePixelRatioIfNeeded() {
+        const {width, height} = this._canvas;
+        const {drawingBufferWidth, drawingBufferHeight} = this.painter.context.gl;
+        if (drawingBufferWidth !== width || drawingBufferHeight !== height) {
+            const reduceFactor = Math.min(drawingBufferWidth / width, drawingBufferHeight / height);
+            this.setPixelRatio(this.getPixelRatio() * reduceFactor);
+        }
     }
 
     /**

--- a/src/util/test/mock_webgl.ts
+++ b/src/util/test/mock_webgl.ts
@@ -30,6 +30,12 @@ export function setupMockWebGLContext(webglContext: any) {
         }
     });
 
+    // Update drawingBufferWidth and drawingBufferHeigth when viewport changes
+    webglContext.viewport = jest.fn((x, y, width, height) => {
+        webglContext.drawingBufferWidth = width;
+        webglContext.drawingBufferHeight = height;
+    });
+
     // Define the properties on the WebGL context
     Object.defineProperty(webglContext, 'bindVertexArray', {
         get() {


### PR DESCRIPTION
This is an attempt to address #2650.

According to [specification](https://registry.khronos.org/webgl/specs/latest/1.0/#5.14.1), if the implementation is unable to satisfy the requested width or height, **drawing buffer size** may be different from **canvas size**. When this happens, the map may be distorted as described in #2650.

A way to workaround this issue is to reduce pixel ratio when canvas size and drawing buffer size diverge.
This is the same approach used by luma.gl:
https://github.com/visgl/luma.gl/blob/39394e419b879ea714acfb7305d50b490aee7c90/modules/api/src/adapter/canvas-context.ts#L256-L265
And so as a side effect compatibility with deck.gl is improved.

The main caveats of this approach are:
1. This check must be performed each time the canvas size changes, or at least each time the height, width or their multiplication increases. 
To achieve this, I added it to the map.resize() function, but I'm not so sure that all resizes happens there (I "fixed" one in this pull request). If there are better places let me know.
3. This workaround triggers a canvas resize, so it can cause loops. I have added a "basic protection" with a flag, but if it's concerning there are certainly better solutions. For example, trigger the check only if the canvas grows and apply the reduce factor only if it really is a reduce.
4. The original pixel ratio is lost, so the pixel ratio will not return to its original value if within the limits (for example after a window resize).
5. GL mocks must update the drawing buffer size each time the canvas changes (implemented in this pull request).

You can find a demo here: https://stackblitz.com/edit/maplibre-pixelratio-reduce