### PR TITLE
Set worker count to 2 for Safari browser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 - Fix regression - Add webgl1 fallback to accomondate users without webgl2 support
 - _...Add new stuff here..._
 
+### ⚠️ Potentially breaking changes
+- Worker count statically set to 2 for Safari browser as it doesn't support by default.
+- _...Add new stuff here..._
+
 ## 3.0.1
 
 ### ✨ Features and improvements

--- a/src/index.ts
+++ b/src/index.ts
@@ -109,7 +109,7 @@ const exported = {
 
     /**
      * Gets and sets the number of web workers instantiated on a page with GL JS maps.
-     * By default, workerCount is 1 except for Safari browser where it is set to half the number of CPU cores (capped at 3).
+     * By default, workerCount is 1 except for Safari browser where it is set to 2.
      * Make sure to set this property before creating any map instances for it to have effect.
      *
      * @var {string} workerCount

--- a/src/util/browser.test.ts
+++ b/src/util/browser.test.ts
@@ -19,8 +19,4 @@ describe('browser', () => {
         frame.cancel();
         done();
     });
-
-    test('hardwareConcurrency', () => {
-        expect(typeof browser.hardwareConcurrency).toBe('number');
-    });
 });

--- a/src/util/browser.ts
+++ b/src/util/browser.ts
@@ -46,8 +46,6 @@ const exported = {
         return linkEl.href;
     },
 
-    hardwareConcurrency: typeof navigator !== 'undefined' && navigator.hardwareConcurrency || 4,
-
     get prefersReducedMotion(): boolean {
         // In case your test crashes when checking matchMedia, call setMatchMedia from 'src/util/test/util'
         if (!matchMedia) return false;

--- a/src/util/worker_pool.ts
+++ b/src/util/worker_pool.ts
@@ -1,6 +1,5 @@
 import webWorkerFactory from './web_worker';
 import type {WorkerInterface} from './web_worker';
-import browser from './browser';
 import {isSafari} from './util';
 
 export const PRELOAD_POOL_ID = 'mapboxgl_preloaded_worker_pool';
@@ -55,5 +54,6 @@ export default class WorkerPool {
 }
 
 // Based on results from A/B testing: https://github.com/maplibre/maplibre-gl-js/pull/2354
-const availableLogicalProcessors = Math.floor(browser.hardwareConcurrency / 2);
-WorkerPool.workerCount = isSafari(globalThis) ? Math.max(Math.min(availableLogicalProcessors, 3), 1) : 1;
+// Safari works better with cap 2-3, but almost all versions of safari don't support hardwareConcurrency
+// and the fallback was worker count 2.
+WorkerPool.workerCount = isSafari(globalThis) ? 2 : 1;


### PR DESCRIPTION
After merging #2354 workercount is set to half the number of CPU cores capped at 3 for Safari.

According to [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/hardwareConcurrency) and [Can I Use](https://caniuse.com/hardwareconcurrency) data, all versions of Safari except 10.1 don't support navigator.hardwareConcurrency.
When hardwareConcurrency isn't available the current logic sets 2. 
So just use 2 for Safari and get rid of all that logic.


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Add an entry to `CHANGELOG.md` under the `## main` section.
