### PR TITLE
remove EXT_sRGB

### DIFF
--- a/src/gl/context.ts
+++ b/src/gl/context.ts
@@ -114,11 +114,6 @@ class Context {
 
         this.maxTextureSize = gl.getParameter(gl.MAX_TEXTURE_SIZE);
 
-        const extSRGB = gl.getExtension('EXT_sRGB');
-        if (!extSRGB) {
-            console.warn('EXT_sRGB extension not supported');
-        }
-
         if (isWebGL2(gl)) {
             this.HALF_FLOAT = gl.HALF_FLOAT;
             const extColorBufferHalfFloat = gl.getExtension('EXT_color_buffer_half_float');


### PR DESCRIPTION
Remove this webgl extension which was added as a part of #2656 .

It didn't exist before WebGL2 was introduced (https://github.com/maplibre/maplibre-gl-js/pull/1891/files), and it still isn't needed.

Fixes #2678 