### PR TITLE
Revert to typescript 5.0.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -123,7 +123,7 @@
         "ts-jest": "^29.1.0",
         "ts-node": "^10.9.1",
         "tslib": "^2.5.2",
-        "typescript": "^5.1.3"
+        "typescript": "^5.0.4"
       },
       "engines": {
         "node": ">=16.14.0",
@@ -15379,16 +15379,16 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.3.tgz",
-      "integrity": "sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
+      "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=14.17"
+        "node": ">=12.20"
       }
     },
     "node_modules/typewise": {

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "ts-jest": "^29.1.0",
     "ts-node": "^10.9.1",
     "tslib": "^2.5.2",
-    "typescript": "^5.1.3"
+    "typescript": "^5.0.4"
   },
   "overrides": {
     "postcss-inline-svg": {


### PR DESCRIPTION
Not sure why this was merged... But it broke the CI.
I've opened an issue with the typescript repo here:
https://github.com/microsoft/TypeScript/issues/54639
The original PR that failed was #2638 
