### PR TITLE
Make pixel ratio dynamic again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### 🐞 Bug fixes
 - Fix the `tap then drag` zoom gesture detection to abort when the two taps are far away ([#2673](https://github.com/maplibre/maplibre-gl-js/pull/2673))
+- Fix regression - update pixel ratio when devicePixelRatio changes, restoring the v1.x behaviour ([#2706](https://github.com/maplibre/maplibre-gl-js/issues/2706))
 - _...Add new stuff here..._
 
 ## 3.1.0

--- a/src/ui/map.test.ts
+++ b/src/ui/map.test.ts
@@ -2488,6 +2488,14 @@ describe('Map', () => {
         expect(map.getPixelRatio()).toBe(devicePixelRatio);
     });
 
+    test('pixel ratio by default reflects devicePixelRatio changes', () => {
+        global.devicePixelRatio = 0.25;
+        const map = createMap();
+        expect(map.getPixelRatio()).toBe(0.25);
+        global.devicePixelRatio = 1;
+        expect(map.getPixelRatio()).toBe(1);
+    });
+
     test('canvas has the expected size', () => {
         const container = window.document.createElement('div');
         Object.defineProperty(container, 'clientWidth', {value: 512});

--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -356,7 +356,7 @@ class Map extends Camera {
     _locale: any;
     _removed: boolean;
     _clickTolerance: number;
-    _pixelRatio: number;
+    _overridePixelRatio: number | null;
     _terrainDataCallback: (e: MapStyleDataEvent | MapSourceDataEvent) => void;
 
     /** image queue throttling handle. To be used later when clean up */
@@ -455,7 +455,7 @@ class Map extends Camera {
         this._mapId = uniqueId();
         this._locale = extend({}, defaultLocale, options.locale);
         this._clickTolerance = options.clickTolerance;
-        this._pixelRatio = options.pixelRatio ?? devicePixelRatio;
+        this._overridePixelRatio = options.pixelRatio;
         this.transformCameraUpdate = options.transformCameraUpdate;
 
         this._imageQueueHandle = ImageRequest.addThrottleControl(() => this.isMoving());
@@ -707,22 +707,23 @@ class Map extends Camera {
      * @returns {number} The pixel ratio.
      */
     getPixelRatio() {
-        return this._pixelRatio;
+        return this._overridePixelRatio ?? devicePixelRatio;
     }
 
     /**
      * Sets the map's pixel ratio. This allows to override `devicePixelRatio`.
      * After this call, the canvas' `width` attribute will be `container.clientWidth * pixelRatio`
      * and its height attribute will be `container.clientHeight * pixelRatio`.
-     * @param {number} pixelRatio The pixel ratio.
+     * Set this to null to disable `devicePixelRatio` override.
+     * @param {number | null} pixelRatio The pixel ratio.
      */
-    setPixelRatio(pixelRatio: number) {
+    setPixelRatio(pixelRatio: number | null) {
         const [width, height] = this._containerDimensions();
 
-        this._pixelRatio = pixelRatio;
+        this._overridePixelRatio = pixelRatio;
 
-        this._resizeCanvas(width, height, pixelRatio);
-        this.painter.resize(width, height, pixelRatio);
+        this._resizeCanvas(width, height, this.getPixelRatio());
+        this.painter.resize(width, height, this.getPixelRatio());
     }
 
     /**


### PR DESCRIPTION
Since typescript migration (#294) the pixel ratio is fixed, but this isn't desirable. The device pixel ratio may change after map load, for example when zooming in or out the viewport

## Launch Checklist

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Document any changes to public APIs.
 - [x] Add an entry to `CHANGELOG.md` under the `## main` section.
