### PR TITLE
Make checkMaxAngle return "true" for empty labels, to avoid potentially indexing off end of line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### 🐞 Bug fixes
 - Return undefined instead of throwing from `Style.serialize()` when the style hasn't loaded yet ([#2712](https://github.com/maplibre/maplibre-gl-js/pull/2712)) 
+- Don't throw an exception from `checkMaxAngle` when a label with length 0 is on the last segment of a line ([#2710](https://github.com/maplibre/maplibre-gl-js/pull/2710))
 - Fix the `tap then drag` zoom gesture detection to abort when the two taps are far away ([#2673](https://github.com/maplibre/maplibre-gl-js/pull/2673))
 - _...Add new stuff here..._
 

--- a/src/symbol/check_max_angle.test.ts
+++ b/src/symbol/check_max_angle.test.ts
@@ -45,4 +45,10 @@ describe('checkMaxAngle', () => {
         expect(checkMaxAngle(line, anchor, 11, 5, Math.PI)).toBeFalsy();
         expect(checkMaxAngle(line, anchor, 10, 5, Math.PI)).toBeTruthy();
     });
+
+    test('one segment and label length is 0', () => {
+        const line = [new Point(0, 0), new Point(10, 0)];
+        const anchor = new Anchor(5, 0, 0, 0);
+        expect(checkMaxAngle(line, anchor, 0, 5, Math.PI)).toBeTruthy();
+    });
 });

--- a/src/symbol/check_max_angle.ts
+++ b/src/symbol/check_max_angle.ts
@@ -16,8 +16,8 @@ import type {Anchor} from './anchor';
  */
 export function checkMaxAngle(line: Array<Point>, anchor: Anchor, labelLength: number, windowSize: number, maxAngle: number) {
 
-    // horizontal labels always pass
-    if (anchor.segment === undefined) return true;
+    // horizontal labels and labels with length 0 always pass
+    if (anchor.segment === undefined || labelLength === 0) return true;
 
     let p = anchor;
     let index = anchor.segment + 1;


### PR DESCRIPTION
This fixes issue #2654. As documented in the issue, a zero-length label would _almost_ always return true in the check max angle check (and of course it should, since it's impossible for there to be a bend), but would throw an exception if the anchor happened to be on the last segment of the line. The unit test introduced with this PR would fail on the exception without the matching code change. The impact of throwing the exception is to entirely prevent tiles from loading.

cc @ibesora 

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality.
 - [x] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [ ] Add an entry to `CHANGELOG.md` under the `## main` section.
