### PR TITLE
Make Style.serialize() return undefined instead of throwing if style hasn't loaded yet.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes
+- Return undefined instead of throwing from `Style.serialize()` when the style hasn't loaded yet ([#2712](https://github.com/maplibre/maplibre-gl-js/pull/2712)) 
 - Fix the `tap then drag` zoom gesture detection to abort when the two taps are far away ([#2673](https://github.com/maplibre/maplibre-gl-js/pull/2673))
 - _...Add new stuff here..._
 

--- a/src/style/style.test.ts
+++ b/src/style/style.test.ts
@@ -224,6 +224,16 @@ describe('Style#loadURL', () => {
 });
 
 describe('Style#loadJSON', () => {
+    test('serialize() returns undefined until style is loaded', done => {
+        const style = new Style(getStubMap());
+        style.loadJSON(createStyleJSON());
+        expect(style.serialize()).toBeUndefined();
+        style.on('style.load', () => {
+            expect(style.serialize()).toEqual(createStyleJSON());
+            done();
+        });
+    });
+
     test('fires "dataloading" (synchronously)', () => {
         const style = new Style(getStubMap());
         const spy = jest.fn();

--- a/src/style/style.ts
+++ b/src/style/style.ts
@@ -1160,6 +1160,11 @@ class Style extends Evented {
     }
 
     serialize(): StyleSpecification {
+        // We return undefined before we're loaded, following the pattern of Map.getStyle() before
+        // the Style object is initialized.
+        // Internally, Style._validate() calls Style.serialize() but callers are responsible for
+        // calling Style._checkLoaded() first if their validation requires the style to be loaded.
+        if (!this._loaded) return;
 
         const sources = mapObject(this.sourceCaches, (source) => source.serialize());
         const layers = this._serializeByIds(this._order);

--- a/src/ui/map.test.ts
+++ b/src/ui/map.test.ts
@@ -600,6 +600,13 @@ describe('Map', () => {
     });
 
     describe('#getStyle', () => {
+        test('returns undefined if the style has not loaded yet', done => {
+            const style = createStyle();
+            const map = createMap({style});
+            expect(map.getStyle()).toBeUndefined();
+            done();
+        });
+
         test('returns the style', done => {
             const style = createStyle();
             const map = createMap({style});


### PR DESCRIPTION
This PR fixes issue #2692.

One of the things that I think is a bit tricky about MapLibre is knowing how to interact with it when it's in an intermediate/loading state (thus the standard pattern in examples where your logic all lives in a `map.on('load', ...` block). I don't really have a clear idea of how to improve that situation, although I have the vague impression that moving to a promise-based interface could be helpful.

Given the current setup though, there's basically two types of things that are supposed to happen when you call a method that depends on something that still needs to be loaded:

- You get a specific "not loaded yet" error, e.g. `throw new Error('Style is not done loading.');`, or
- You get some version of an "empty" result

I don't know a hard/fast rule for how to choose between those but I think it's something like "if you think your caller can understand an empty result, return that, otherwise throw".

`Style.serialize()` threw an exception, but instead of a specific, intentional one, it was an invalid dereference. This PR changes it to return undefined, with the reasoning that the one current external user of (`Map.getStyle()`) understands what to do with undefined (and that's what it already returns if the style is undefined).

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [x] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [ ] Add an entry to `CHANGELOG.md` under the `## main` section.
