### PR TITLE
[Performance] Drop additional view update when map moving

### DIFF
--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -547,7 +547,9 @@ class Map extends Camera {
             }
         });
         this.on('data', (event: MapDataEvent) => {
-            this._update(event.dataType === 'style');
+            if (!this.isMoving()) {
+                this._update(event.dataType === 'style');
+            }
             this.fire(new Event(`${event.dataType}data`, event));
         });
         this.on('dataloading', (event: MapDataEvent) => {


### PR DESCRIPTION
While the map is moving or zooming, there is no need to call view update after loading new data because moving the map already causes view updates. 

Unit test and banch test I will complete later. 
## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [ ] Link to related issues.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [ ] Add an entry to `CHANGELOG.md` under the `## main` section.
