### PR TITLE
Add className option to Marker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 - Change all internal exports to named exports([#2711](https://github.com/maplibre/maplibre-gl-js/pull/2711))
 - _...Add new stuff here..._
 
+### ✨ Features and improvements
+- Add `className` option to Marker constructor ([#2729](https://github.com/maplibre/maplibre-gl-js/pull/2729))
+
 ### 🐞 Bug fixes
 - Return undefined instead of throwing from `Style.serialize()` when the style hasn't loaded yet ([#2712](https://github.com/maplibre/maplibre-gl-js/pull/2712)) 
 - Don't throw an exception from `checkMaxAngle` when a label with length 0 is on the last segment of a line ([#2710](https://github.com/maplibre/maplibre-gl-js/pull/2710))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,8 @@
 ### ✨ Features and improvements
 
 - Change all internal exports to named exports([#2711](https://github.com/maplibre/maplibre-gl-js/pull/2711))
-- _...Add new stuff here..._
-
-### ✨ Features and improvements
 - Add `className` option to Marker constructor ([#2729](https://github.com/maplibre/maplibre-gl-js/pull/2729))
+- _...Add new stuff here..._
 
 ### 🐞 Bug fixes
 - Return undefined instead of throwing from `Style.serialize()` when the style hasn't loaded yet ([#2712](https://github.com/maplibre/maplibre-gl-js/pull/2712)) 

--- a/src/ui/marker.test.ts
+++ b/src/ui/marker.test.ts
@@ -87,6 +87,37 @@ describe('marker', () => {
         map.remove();
     });
 
+    test('Marker adds classes from className option, methods for class manipulations works properly', () => {
+        const map = createMap();
+        const marker = new Marker({className: 'some classes'})
+            .setLngLat([0, 0])
+            .addTo(map);
+
+        const markerElement = marker.getElement();
+        expect(markerElement.classList.contains('some')).toBeTruthy();
+        expect(markerElement.classList.contains('classes')).toBeTruthy();
+
+        marker.addClassName('addedClass');
+        expect(markerElement.classList.contains('addedClass')).toBeTruthy();
+
+        marker.removeClassName('addedClass');
+        expect(!markerElement.classList.contains('addedClass')).toBeTruthy();
+
+        marker.toggleClassName('toggle');
+        expect(markerElement.classList.contains('toggle')).toBeTruthy();
+
+        marker.toggleClassName('toggle');
+        expect(!markerElement.classList.contains('toggle')).toBeTruthy();
+
+        expect(() => marker.addClassName('should throw exception')).toThrow(window.DOMException);
+        expect(() => marker.removeClassName('should throw exception')).toThrow(window.DOMException);
+        expect(() => marker.toggleClassName('should throw exception')).toThrow(window.DOMException);
+
+        expect(() => marker.addClassName('')).toThrow(window.DOMException);
+        expect(() => marker.removeClassName('')).toThrow(window.DOMException);
+        expect(() => marker.toggleClassName('')).toThrow(window.DOMException);
+    });
+
     test('Marker provides LngLat accessors', () => {
         expect(new Marker().getLngLat()).toBeUndefined();
 

--- a/src/ui/marker.ts
+++ b/src/ui/marker.ts
@@ -23,6 +23,7 @@ type MarkerOptions = {
     rotation?: number;
     rotationAlignment?: string;
     pitchAlignment?: string;
+    className?: string;
 };
 
 /**
@@ -218,6 +219,10 @@ export class Marker extends Evented {
             e.preventDefault();
         });
         applyAnchorClass(this._element, this._anchor, 'marker');
+        if (options.className) {
+            options.className.split(' ').forEach(name =>
+                this._element.classList.add(name));
+        }
 
         this._popup = null;
     }
@@ -491,6 +496,53 @@ export class Marker extends Evented {
         this._offset = Point.convert(offset);
         this._update();
         return this;
+    }
+
+    /**
+     * Adds a CSS class to the marker element.
+     *
+     * @param {string} className Non-empty string with CSS class name to add to marker element
+     *
+     * @example
+     * let marker = new maplibregl.Marker()
+     * marker.addClassName('some-class')
+     */
+    addClassName(className: string) {
+        if (this._element) {
+            this._element.classList.add(className);
+        }
+    }
+
+    /**
+     * Removes a CSS class from the marker element.
+     *
+     * @param {string} className Non-empty string with CSS class name to remove from marker element
+     *
+     * @example
+     * let marker = new maplibregl.Marker()
+     * marker.removeClassName('some-class')
+     */
+    removeClassName(className: string) {
+        if (this._element) {
+            this._element.classList.remove(className);
+        }
+    }
+
+    /**
+     * Add or remove the given CSS class on the marker element, depending on whether the element currently has that class.
+     *
+     * @param {string} className Non-empty string with CSS class name to add/remove
+     *
+     * @returns {boolean} if the class was removed return false, if class was added, then return true
+     *
+     * @example
+     * let marker = new maplibregl.Marker()
+     * marker.toggleClassName('toggleClass')
+     */
+    toggleClassName(className: string) {
+        if (this._element) {
+            return this._element.classList.toggle(className);
+        }
     }
 
     _onMove = (e: MapMouseEvent | MapTouchEvent) => {

--- a/src/ui/marker.ts
+++ b/src/ui/marker.ts
@@ -508,9 +508,7 @@ export class Marker extends Evented {
      * marker.addClassName('some-class')
      */
     addClassName(className: string) {
-        if (this._element) {
-            this._element.classList.add(className);
-        }
+        this._element.classList.add(className);
     }
 
     /**
@@ -523,9 +521,7 @@ export class Marker extends Evented {
      * marker.removeClassName('some-class')
      */
     removeClassName(className: string) {
-        if (this._element) {
-            this._element.classList.remove(className);
-        }
+        this._element.classList.remove(className);
     }
 
     /**
@@ -540,9 +536,7 @@ export class Marker extends Evented {
      * marker.toggleClassName('toggleClass')
      */
     toggleClassName(className: string) {
-        if (this._element) {
-            return this._element.classList.toggle(className);
-        }
+        return this._element.classList.toggle(className);
     }
 
     _onMove = (e: MapMouseEvent | MapTouchEvent) => {

--- a/src/ui/marker.ts
+++ b/src/ui/marker.ts
@@ -14,6 +14,7 @@ import type {PointLike} from './camera';
 
 type MarkerOptions = {
     element?: HTMLElement;
+    className?: string;
     offset?: PointLike;
     anchor?: PositionAnchor;
     color?: string;
@@ -23,13 +24,13 @@ type MarkerOptions = {
     rotation?: number;
     rotationAlignment?: string;
     pitchAlignment?: string;
-    className?: string;
 };
 
 /**
  * Creates a marker component
  * @param {MarkerOptions} [options]
  * @param {HTMLElement} [options.element] DOM element to use as a marker. The default is a light blue, droplet-shaped SVG marker.
+ * @param {string} [options.className] Space-separated CSS class names to add to marker element.
  * @param {PositionAnchor} [options.anchor='center'] A string indicating the part of the Marker that should be positioned closest to the coordinate set via {@link Marker#setLngLat}.
  * Options are `'center'`, `'top'`, `'bottom'`, `'left'`, `'right'`, `'top-left'`, `'top-right'`, `'bottom-left'`, and `'bottom-right'`.
  * @param {PointLike} [options.offset] The offset in pixels as a {@link PointLike} object to apply relative to the element's center. Negatives indicate left and up.
@@ -219,9 +220,11 @@ export class Marker extends Evented {
             e.preventDefault();
         });
         applyAnchorClass(this._element, this._anchor, 'marker');
-        if (options.className) {
-            options.className.split(' ').forEach(name =>
-                this._element.classList.add(name));
+
+        if (options && options.className) {
+            for (const name of options.className.split(' ')) {
+                this._element.classList.add(name);
+            }
         }
 
         this._popup = null;

--- a/src/ui/popup.ts
+++ b/src/ui/popup.ts
@@ -520,8 +520,9 @@ export class Popup extends Evented {
             this._tip       = DOM.create('div', 'maplibregl-popup-tip', this._container);
             this._container.appendChild(this._content);
             if (this.options.className) {
-                this.options.className.split(' ').forEach(name =>
-                    this._container.classList.add(name));
+                for (const name of this.options.className.split(' ')) {
+                    this._container.classList.add(name);
+                }
             }
 
             if (this._trackPointer) {


### PR DESCRIPTION
Add `className` option to Marker,  also add `addClassName`, `removeClassName` and `toggleClassName` methods to be more consistent with the Popup.

Made similar PR to `mapbox-gl-js` https://github.com/mapbox/mapbox-gl-js/pull/12770 and `react-map-gl` https://github.com/visgl/react-map-gl/pull/2213 to keep the same APIs between libraries.


## Launch Checklist

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [x] Add an entry to `CHANGELOG.md` under the `## main` section.
