### PR TITLE
Fix staging typescript errors

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -40,6 +40,8 @@
   "exclude": [
     "node_modules",
     "dist",
+    "build/rollup",
+    "test/bench/rollup",
     "test/bench/**/*generated*",
   ]
 }


### PR DESCRIPTION
This is a fix to the problem of running typecheck after building using `npm run build-prod` for example.
The reason that this works is that there's a reference to the staging folder in the rollup configs and this is what creates this issue.
This should be solved by this PR now.
cc @birkskyum 