### PR TITLE
Automerge dependabot

### DIFF
--- a/.github/workflows/auto-merge-dependapot.yml
+++ b/.github/workflows/auto-merge-dependapot.yml
@@ -1,0 +1,14 @@
+name: Automerge Dependabot
+
+on:
+  pull_request:
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ahmadnassri/action-dependabot-auto-merge@v2
+        with:
+          target: major
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This is in continue to #2345.
cc @stepankuzmin, @IvanSanchez @wipfli @zhangyiatmicrosoft @birkskyum 

I've also configured the branch protection in the setting of this repo so that all the CI are now required, I hope this is what caused the issue in the original PR.

If this won't work I'll change to use renovate, these PR merges are taking a lot of time...

The following is the configuration on main's branch protection:
![image](https://github.com/maplibre/maplibre-gl-js/assets/3269297/216e90cf-c48c-4ba2-9eea-ef5fe3f4cda3)

