### PR TITLE
Add Terra Draw as available plugin

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -25,7 +25,12 @@ Adds a control to allow users to plot driving, walking, and cycling directions o
 #### mapbox-gl-draw
 Adds support for drawing and editing features on maps.
 <br/><small>[View on GitHub](https://github.com/mapbox/mapbox-gl-draw)</small>
-    
+
+#### terra-draw
+
+Provides a MapLibre GL JS adapter to allow creation, selection and editing of geometries.
+<br/><small>[View on GitHub](https://github.com/JamesLMilner/terra-draw)</small>
+
 #### mapbox-gl-elevation
 Adds a control to retrieve altitude from terrain RGB tilesets.
 <br/><small>[View on GitHub](https://github.com/watergis/mapbox-gl-elevation)</small>


### PR DESCRIPTION
## Launch Checklist

 - [ ] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [ ] Briefly describe the changes in this PR.
 - [ ] Link to related issues.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [ ] Add an entry to `CHANGELOG.md` under the `## main` section.


This is a documentation change. It adds [terra-draw](https;//www.github.com/JamesLMilner), a library for drawing with MapLibre GL JS to the list of available plugins.