### PR TITLE
Migrated popup and marker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Immediately redraw the map after setting pixel ratio ([#2674](https://github.com/maplibre/maplibre-gl-js/pull/2673))
 - Add maxCanvasSize option to limit canvas size. It can prevent reaching the GL limits and reduce the load on the devices. Default value is [4096, 4096].
 - Reduce maxCanvasSize when hitting GL limits to avoid distortions ([#2674](https://github.com/maplibre/maplibre-gl-js/pull/2673))
+- ⚠️ Removed non documented `Marker` constructor parameter ([#2756](https://github.com/maplibre/maplibre-gl-js/pull/2756))
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes

--- a/src/render/painter.ts
+++ b/src/render/painter.ts
@@ -63,7 +63,6 @@ type PainterOptions = {
 /**
  * Initialize a new painter object.
  *
- * @param {Canvas} gl a webgl drawing context
  * @private
  */
 export class Painter {

--- a/src/render/render_to_texture.ts
+++ b/src/render/render_to_texture.ts
@@ -108,8 +108,8 @@ export class RenderToTexture {
      * Because of the stylesheet possibility to mixing render-to-texture layers
      * and 'live'-layers (f.e. symbols) it is necessary to create more stacks. For example
      * a symbol-layer is in between of fill-layers.
-     * @param {StyleLayer} layer the layer to render
-     * @returns {boolean} if true layer is rendered to texture, otherwise false
+     * @param layer the layer to render
+     * @returns if true layer is rendered to texture, otherwise false
      */
     renderLayer(layer: StyleLayer): boolean {
         if (layer.isHidden(this.painter.transform.zoom)) return false;

--- a/src/ui/control/navigation_control.ts
+++ b/src/ui/control/navigation_control.ts
@@ -8,6 +8,9 @@ import {generateOneFingerTouchPitchHandler, generateOneFingerTouchRotationHandle
 import type {Map} from '../map';
 import type {IControl} from './control';
 
+/**
+ * The {@link NavigationControl} options object
+ */
 type NavigationOptions = {
     /**
      * If `true` the compass button is included.

--- a/src/ui/hash.ts
+++ b/src/ui/hash.ts
@@ -2,11 +2,11 @@ import {throttle} from '../util/throttle';
 
 import type {Map} from './map';
 
-/*
+/**
  * Adds the map's position to its page's location hash.
  * Passed as an option to the map object.
  *
- * @returns {Hash} `this`
+ * @group Controls
  */
 export class Hash {
     _map: Map;
@@ -16,11 +16,11 @@ export class Hash {
         this._hashName = hashName && encodeURIComponent(hashName);
     }
 
-    /*
+    /**
      * Map element to listen for coordinate changes
      *
-     * @param {Object} map
-     * @returns {Hash} `this`
+     * @param map
+     * @returns `this`
      */
     addTo(map: Map) {
         this._map = map;
@@ -29,10 +29,10 @@ export class Hash {
         return this;
     }
 
-    /*
+    /**
      * Removes hash
      *
-     * @returns {Popup} `this`
+     * @returns `this`
      */
     remove() {
         removeEventListener('hashchange', this._onHashChange, false);

--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -76,7 +76,7 @@ export type MapOptions = {
      * An additional string may optionally be provided to indicate a parameter-styled hash,
      * e.g. http://path/to/my/page.html#map=2.59/39.26/53.07/-24.1/60&foo=bar, where foo
      * is a custom parameter and bar is an arbitrary hash distinct from the map hash.
-     * @devalueValue false
+     * @defaultValue false
      */
     hash?: boolean | string;
     /**

--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -420,7 +420,7 @@ const defaultOptions = {
  * object.
  *
  * @group Main
- * 
+ *
  * @example
  * var map = new maplibregl.Map({
  *   container: 'map',

--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -68,7 +68,7 @@ import {config} from '../util/config';
 import type {QueryRenderedFeaturesOptions, QuerySourceFeatureOptions} from '../source/query_features';
 
 const version = packageJSON.version;
-/* eslint-enable no-use-before-define */
+
 export type MapOptions = {
     /**
      * If `true`, the map's position (zoom, center latitude, center longitude, bearing, and pitch) will be synced with the hash fragment of the page's URL.

--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -419,8 +419,8 @@ const defaultOptions = {
  * Then MapLibre GL JS initializes the map on the page and returns your `Map`
  * object.
  *
- * @group Map
- * @param options - the map options
+ * @group Main
+ * 
  * @example
  * var map = new maplibregl.Map({
  *   container: 'map',

--- a/src/ui/marker.test.ts
+++ b/src/ui/marker.test.ts
@@ -263,17 +263,6 @@ describe('marker', () => {
         map.remove();
     });
 
-    test('Marker accepts backward-compatible constructor parameters', () => {
-        const element = window.document.createElement('div');
-
-        const m1 = new Marker(element);
-        expect(m1.getElement()).toBe(element);
-
-        const m2 = new Marker(element, {offset: [1, 2]});
-        expect(m2.getElement()).toBe(element);
-        expect(m2.getOffset().equals(new Point(1, 2))).toBeTruthy();
-    });
-
     test('Popup offsets around default Marker', () => {
         const map = createMap();
 

--- a/src/ui/marker.ts
+++ b/src/ui/marker.ts
@@ -12,6 +12,9 @@ import type {LngLatLike} from '../geo/lng_lat';
 import type {MapMouseEvent, MapTouchEvent} from './events';
 import type {PointLike} from './camera';
 
+/**
+ * Alignment options of rotation and pitch
+ */
 type Alignment = 'map' | 'viewport' | 'auto';
 
 type MarkerOptions = {

--- a/src/ui/marker.ts
+++ b/src/ui/marker.ts
@@ -17,6 +17,9 @@ import type {PointLike} from './camera';
  */
 type Alignment = 'map' | 'viewport' | 'auto';
 
+/**
+ * The {@link Marker} options object
+ */
 type MarkerOptions = {
     /**
      * DOM element to use as a marker. The default is a light blue, droplet-shaped SVG marker.
@@ -124,13 +127,11 @@ export class Marker extends Evented {
     _originalTabIndex: string; // original tabindex of _element
     _opacityTimeout: ReturnType<typeof setTimeout>;
 
-    constructor(options?: MarkerOptions, legacyOptions?: MarkerOptions) {
+    /**
+     * @param options the options
+     */
+    constructor(options?: MarkerOptions) {
         super();
-        // For backward compatibility -- the constructor used to accept the element as a
-        // required first argument, before it was made optional.
-        if (options instanceof HTMLElement || legacyOptions) {
-            options = extend({element: options}, legacyOptions);
-        }
 
         this._anchor = options && options.anchor || 'center';
         this._color = options && options.color || '#3FB1CE';

--- a/src/ui/marker.ts
+++ b/src/ui/marker.ts
@@ -77,7 +77,7 @@ type MarkerOptions = {
  * var marker = new maplibregl.Marker()
  *   .setLngLat([30.5, 50.5])
  *   .addTo(map);
- * 
+ *
  * @group Main
  *
  * @example
@@ -89,7 +89,7 @@ type MarkerOptions = {
  *   .addTo(map);
  * @see [Add custom icons with Markers](https://maplibre.org/maplibre-gl-js-docs/example/custom-marker-icons/)
  * @see [Create a draggable Marker](https://maplibre.org/maplibre-gl-js-docs/example/drag-a-marker/)
- * 
+ *
  * ## Events
  *
  * @event `dragstart` Fired when dragging starts, `marker` object that is being dragged

--- a/src/ui/marker.ts
+++ b/src/ui/marker.ts
@@ -2,7 +2,6 @@ import {DOM} from '../util/dom';
 import {LngLat} from '../geo/lng_lat';
 import Point from '@mapbox/point-geometry';
 import {smartWrap} from '../util/smart_wrap';
-import {extend} from '../util/util';
 import {anchorTranslate, applyAnchorClass} from './anchor';
 import type {PositionAnchor} from './anchor';
 import {Event, Evented} from '../util/evented';

--- a/src/ui/popup.ts
+++ b/src/ui/popup.ts
@@ -25,13 +25,53 @@ export type Offset = number | PointLike | {
 };
 
 export type PopupOptions = {
+    /**
+     * If `true`, a close button will appear in the top right corner of the popup.
+     * @defaultValue true
+     */
     closeButton?: boolean;
+    /**
+     * If `true`, the popup will closed when the map is clicked.
+     * @defaultValue true
+     */
     closeOnClick?: boolean;
+    /**
+     * If `true`, the popup will closed when the map moves.
+     * @defaultValue false
+     */
     closeOnMove?: boolean;
+    /**
+     * If `true`, the popup will try to focus the first focusable element inside the popup.
+     * @defaultValue true
+     */
     focusAfterOpen?: boolean;
+    /**
+     * A string indicating the part of the Popup that should
+     * be positioned closest to the coordinate set via {@link Popup#setLngLat}.
+     * Options are `'center'`, `'top'`, `'bottom'`, `'left'`, `'right'`, `'top-left'`,
+     * `'top-right'`, `'bottom-left'`, and `'bottom-right'`. If unset the anchor will be
+     * dynamically set to ensure the popup falls within the map container with a preference
+     * for `'bottom'`.
+     */
     anchor?: PositionAnchor;
+    /**
+     * A pixel offset applied to the popup's location specified as:
+     * - a single number specifying a distance from the popup's location
+     * - a {@link PointLike} specifying a constant offset
+     * - an object of {@link Point}s specifying an offset for each anchor position
+     * Negative offsets indicate left and up.
+     */
     offset?: Offset;
+    /**
+     * Space-separated CSS class names to add to popup container
+     */
     className?: string;
+    /**
+     * A string that sets the CSS property of the popup's maximum width, eg `'300px'`.
+     * To ensure the popup resizes to fit its content, set this property to `'none'`.
+     * Available values can be found here: https://developer.mozilla.org/en-US/docs/Web/CSS/max-width
+     * @defaultValue '240px'
+     */
     maxWidth?: string;
 };
 
@@ -48,32 +88,27 @@ const focusQuerySelector = [
 /**
  * A popup component.
  *
- * @param {PopupOptions} [options]
- * @param {boolean} [options.closeButton=true] If `true`, a close button will appear in the
- * top right corner of the popup.
- * @param {boolean} [options.closeOnClick=true] If `true`, the popup will closed when the
- * map is clicked.
- * @param {boolean} [options.closeOnMove=false] If `true`, the popup will closed when the
- * map moves.
- * @param {boolean} [options.focusAfterOpen=true] If `true`, the popup will try to focus the
- * first focusable element inside the popup.
- * @param {PositionAnchor} [options.anchor] - A string indicating the part of the Popup that should
- * be positioned closest to the coordinate set via {@link Popup#setLngLat}.
- * Options are `'center'`, `'top'`, `'bottom'`, `'left'`, `'right'`, `'top-left'`,
- * `'top-right'`, `'bottom-left'`, and `'bottom-right'`. If unset the anchor will be
- * dynamically set to ensure the popup falls within the map container with a preference
- * for `'bottom'`.
- * @param {number|PointLike|Object} [options.offset] -
- * A pixel offset applied to the popup's location specified as:
- * - a single number specifying a distance from the popup's location
- * - a {@link PointLike} specifying a constant offset
- * - an object of {@link Point}s specifying an offset for each anchor position
- * Negative offsets indicate left and up.
- * @param {string} [options.className] Space-separated CSS class names to add to popup container
- * @param {string} [options.maxWidth='240px'] -
- * A string that sets the CSS property of the popup's maximum width, eg `'300px'`.
- * To ensure the popup resizes to fit its content, set this property to `'none'`.
- * Available values can be found here: https://developer.mozilla.org/en-US/docs/Web/CSS/max-width
+ * @group Main
+ *
+ *
+ * @example
+ * // Create a popup
+ * var popup = new maplibregl.Popup();
+ * // Set an event listener that will fire
+ * // any time the popup is opened
+ * popup.on('open', function(){
+ *   console.log('popup was opened');
+ * });
+ *
+ * @example
+ * // Create a popup
+ * var popup = new maplibregl.Popup();
+ * // Set an event listener that will fire
+ * // any time the popup is closed
+ * popup.on('close', function(){
+ *   console.log('popup was closed');
+ * });
+ *
  * @example
  * var markerHeight = 50, markerRadius = 10, linearOffset = 25;
  * var popupOffsets = {
@@ -95,6 +130,12 @@ const focusQuerySelector = [
  * @see [Display a popup on hover](https://maplibre.org/maplibre-gl-js-docs/example/popup-on-hover/)
  * @see [Display a popup on click](https://maplibre.org/maplibre-gl-js-docs/example/popup-on-click/)
  * @see [Attach a popup to a marker instance](https://maplibre.org/maplibre-gl-js-docs/example/set-popup/)
+ * 
+ * ## Events
+ *
+ * @event `open` Fired when the popup is opened manually or programmatically. `popup` object that was opened
+ *
+ * @event `close` Fired when the popup is closed manually or programmatically. `popup` object that was closed
  */
 export class Popup extends Evented {
     _map: Map;
@@ -115,8 +156,8 @@ export class Popup extends Evented {
     /**
      * Adds the popup to a map.
      *
-     * @param {Map} map The MapLibre GL JS map to add the popup to.
-     * @returns {Popup} `this`
+     * @param map The MapLibre GL JS map to add the popup to.
+     * @returns `this`
      * @example
      * new maplibregl.Popup()
      *   .setLngLat([0, 0])
@@ -127,7 +168,7 @@ export class Popup extends Evented {
      * @see [Display a popup on click](https://maplibre.org/maplibre-gl-js-docs/example/popup-on-click/)
      * @see [Show polygon information on click](https://maplibre.org/maplibre-gl-js-docs/example/polygon-popup-on-click/)
      */
-    addTo(map: Map) {
+    addTo(map: Map): this {
         if (this._map) this.remove();
 
         this._map = map;
@@ -154,32 +195,13 @@ export class Popup extends Evented {
             this._map.on('move', this._update);
         }
 
-        /**
-         * Fired when the popup is opened manually or programmatically.
-         *
-         * @event open
-         * @memberof Popup
-         * @instance
-         * @type {Object}
-         * @property {Popup} popup object that was opened
-         *
-         * @example
-         * // Create a popup
-         * var popup = new maplibregl.Popup();
-         * // Set an event listener that will fire
-         * // any time the popup is opened
-         * popup.on('open', function(){
-         *   console.log('popup was opened');
-         * });
-         *
-         */
         this.fire(new Event('open'));
 
         return this;
     }
 
     /**
-     * @returns {boolean} `true` if the popup is open, `false` if it is closed.
+     * @returns `true` if the popup is open, `false` if it is closed.
      */
     isOpen() {
         return !!this._map;
@@ -191,9 +213,9 @@ export class Popup extends Evented {
      * @example
      * var popup = new maplibregl.Popup().addTo(map);
      * popup.remove();
-     * @returns {Popup} `this`
+     * @returns `this`
      */
-    remove = () => {
+    remove = (): this => {
         if (this._content) {
             DOM.remove(this._content);
         }
@@ -214,25 +236,6 @@ export class Popup extends Evented {
             delete this._map;
         }
 
-        /**
-         * Fired when the popup is closed manually or programmatically.
-         *
-         * @event close
-         * @memberof Popup
-         * @instance
-         * @type {Object}
-         * @property {Popup} popup object that was closed
-         *
-         * @example
-         * // Create a popup
-         * var popup = new maplibregl.Popup();
-         * // Set an event listener that will fire
-         * // any time the popup is closed
-         * popup.on('close', function(){
-         *   console.log('popup was closed');
-         * });
-         *
-         */
         this.fire(new Event('close'));
 
         return this;
@@ -245,9 +248,9 @@ export class Popup extends Evented {
      * set by `setLngLat` because `Popup` wraps the anchor longitude across copies of the world to keep
      * the popup on screen.
      *
-     * @returns {LngLat} The geographical location of the popup's anchor.
+     * @returns The geographical location of the popup's anchor.
      */
-    getLngLat() {
+    getLngLat(): LngLat {
         return this._lngLat;
     }
 
@@ -255,9 +258,9 @@ export class Popup extends Evented {
      * Sets the geographical location of the popup's anchor, and moves the popup to it. Replaces trackPointer() behavior.
      *
      * @param lnglat The geographical location to set as the popup's anchor.
-     * @returns {Popup} `this`
+     * @returns `this`
      */
-    setLngLat(lnglat: LngLatLike) {
+    setLngLat(lnglat: LngLatLike): this {
         this._lngLat = LngLat.convert(lnglat);
         this._pos = null;
 
@@ -285,9 +288,9 @@ export class Popup extends Evented {
      *   .setHTML("<h1>Hello World!</h1>")
      *   .trackPointer()
      *   .addTo(map);
-     * @returns {Popup} `this`
+     * @returns `this`
      */
-    trackPointer() {
+    trackPointer(): this {
         this._trackPointer = true;
         this._pos = null;
         this._update();
@@ -315,9 +318,9 @@ export class Popup extends Evented {
      *   .addTo(map);
      * var popupElem = popup.getElement();
      * popupElem.style.fontSize = "25px";
-     * @returns {HTMLElement} element
+     * @returns element
      */
-    getElement() {
+    getElement(): HTMLElement {
         return this._container;
     }
 
@@ -329,14 +332,14 @@ export class Popup extends Evented {
      * if the popup content is user-provided.
      *
      * @param text Textual content for the popup.
-     * @returns {Popup} `this`
+     * @returns `this`
      * @example
      * var popup = new maplibregl.Popup()
      *   .setLngLat(e.lngLat)
      *   .setText('Hello, world!')
      *   .addTo(map);
      */
-    setText(text: string) {
+    setText(text: string): this {
         return this.setDOMContent(document.createTextNode(text));
     }
 
@@ -348,7 +351,7 @@ export class Popup extends Evented {
      * the content is an untrusted text string.
      *
      * @param html A string representing HTML content for the popup.
-     * @returns {Popup} `this`
+     * @returns `this`
      * @example
      * var popup = new maplibregl.Popup()
      *   .setLngLat(e.lngLat)
@@ -359,7 +362,7 @@ export class Popup extends Evented {
      * @see [Display a popup on click](https://maplibre.org/maplibre-gl-js-docs/example/popup-on-click/)
      * @see [Attach a popup to a marker instance](https://maplibre.org/maplibre-gl-js-docs/example/set-popup/)
      */
-    setHTML(html: string) {
+    setHTML(html: string): this {
         const frag = document.createDocumentFragment();
         const temp = document.createElement('body');
         let child;
@@ -387,9 +390,9 @@ export class Popup extends Evented {
      * Available values can be found here: https://developer.mozilla.org/en-US/docs/Web/CSS/max-width
      *
      * @param maxWidth A string representing the value for the maximum width.
-     * @returns {Popup} `this`
+     * @returns `this`
      */
-    setMaxWidth(maxWidth: string) {
+    setMaxWidth(maxWidth: string): this {
         this.options.maxWidth = maxWidth;
         this._update();
         return this;
@@ -399,7 +402,7 @@ export class Popup extends Evented {
      * Sets the popup's content to the element provided as a DOM node.
      *
      * @param htmlNode A DOM node to be used as content for the popup.
-     * @returns {Popup} `this`
+     * @returns `this`
      * @example
      * // create an element with the popup content
      * var div = document.createElement('div');
@@ -409,7 +412,7 @@ export class Popup extends Evented {
      *   .setDOMContent(div)
      *   .addTo(map);
      */
-    setDOMContent(htmlNode: Node) {
+    setDOMContent(htmlNode: Node): this {
         if (this._content) {
             // Clear out children first.
             while (this._content.hasChildNodes()) {
@@ -432,7 +435,7 @@ export class Popup extends Evented {
     /**
      * Adds a CSS class to the popup container element.
      *
-     * @param {string} className Non-empty string with CSS class name to add to popup container
+     * @param className Non-empty string with CSS class name to add to popup container
      *
      * @example
      * let popup = new maplibregl.Popup()
@@ -447,7 +450,7 @@ export class Popup extends Evented {
     /**
      * Removes a CSS class from the popup container element.
      *
-     * @param {string} className Non-empty string with CSS class name to remove from popup container
+     * @param className Non-empty string with CSS class name to remove from popup container
      *
      * @example
      * let popup = new maplibregl.Popup()
@@ -463,9 +466,9 @@ export class Popup extends Evented {
      * Sets the popup's offset.
      *
      * @param offset Sets the popup's offset.
-     * @returns {Popup} `this`
+     * @returns `this`
      */
-    setOffset (offset?: Offset) {
+    setOffset (offset?: Offset): this {
         this.options.offset = offset;
         this._update();
         return this;
@@ -474,15 +477,15 @@ export class Popup extends Evented {
     /**
      * Add or remove the given CSS class on the popup container, depending on whether the container currently has that class.
      *
-     * @param {string} className Non-empty string with CSS class name to add/remove
+     * @param className Non-empty string with CSS class name to add/remove
      *
-     * @returns {boolean} if the class was removed return false, if class was added, then return true
+     * @returns if the class was removed return false, if class was added, then return true, undefined if there is no container
      *
      * @example
      * let popup = new maplibregl.Popup()
      * popup.toggleClassName('toggleClass')
      */
-    toggleClassName(className: string) {
+    toggleClassName(className: string): boolean | undefined {
         if (this._container) {
             return this._container.classList.toggle(className);
         }

--- a/src/ui/popup.ts
+++ b/src/ui/popup.ts
@@ -130,7 +130,7 @@ const focusQuerySelector = [
  * @see [Display a popup on hover](https://maplibre.org/maplibre-gl-js-docs/example/popup-on-hover/)
  * @see [Display a popup on click](https://maplibre.org/maplibre-gl-js-docs/example/popup-on-click/)
  * @see [Attach a popup to a marker instance](https://maplibre.org/maplibre-gl-js-docs/example/set-popup/)
- * 
+ *
  * ## Events
  *
  * @event `open` Fired when the popup is opened manually or programmatically. `popup` object that was opened

--- a/src/util/evented.ts
+++ b/src/util/evented.ts
@@ -56,11 +56,11 @@ export class Evented {
     /**
      * Adds a listener to a specified event type.
      *
-     * @param {string} type The event type to add a listen for.
-     * @param {Function} listener The function to be called when the event is fired.
+     * @param type The event type to add a listen for.
+     * @param listener The function to be called when the event is fired.
      * The listener function is called with the data object passed to `fire`,
      * extended with `target` and `type` properties.
-     * @returns {Object} `this`
+     * @returns `this`
      */
     on(type: string, listener: Listener): this {
         this._listeners = this._listeners || {};
@@ -72,9 +72,9 @@ export class Evented {
     /**
      * Removes a previously registered event listener.
      *
-     * @param {string} type The event type to remove listeners for.
-     * @param {Function} listener The listener function to remove.
-     * @returns {Object} `this`
+     * @param type The event type to remove listeners for.
+     * @param listener The listener function to remove.
+     * @returns `this`
      */
     off(type: string, listener: Listener) {
         _removeEventListener(type, listener, this._listeners);
@@ -88,9 +88,9 @@ export class Evented {
      *
      * The listener will be called first time the event fires after the listener is registered.
      *
-     * @param {string} type The event type to listen for.
-     * @param {Function} listener The function to be called when the event is fired the first time.
-     * @returns {Object} `this` or a promise if a listener is not provided
+     * @param type The event type to listen for.
+     * @param listener The function to be called when the event is fired the first time.
+     * @returns `this` or a promise if a listener is not provided
      */
     once(type: string, listener?: Listener): this | Promise<any> {
         if (!listener) {
@@ -148,11 +148,11 @@ export class Evented {
     /**
      * Returns a true if this instance of Evented or any forwardeed instances of Evented have a listener for the specified type.
      *
-     * @param {string} type The event type
-     * @returns {boolean} `true` if there is at least one registered listener for specified event type, `false` otherwise
+     * @param type The event type
+     * @returns `true` if there is at least one registered listener for specified event type, `false` otherwise
      * @private
      */
-    listens(type: string) {
+    listens(type: string): boolean {
         return (
             (this._listeners && this._listeners[type] && this._listeners[type].length > 0) ||
             (this._oneTimeListeners && this._oneTimeListeners[type] && this._oneTimeListeners[type].length > 0) ||
@@ -164,7 +164,7 @@ export class Evented {
      * Bubble all events fired by this instance of Evented to this parent instance of Evented.
      *
      * @private
-     * @returns {Object} `this`
+     * @returns `this`
      * @private
      */
     setEventedParent(parent?: Evented | null, data?: any | (() => any)) {

--- a/src/util/performance.ts
+++ b/src/util/performance.ts
@@ -77,8 +77,7 @@ export const PerformanceUtils = {
 /**
  * Safe wrapper for the performance resource timing API in web workers with graceful degradation
  *
- * @param {RequestParameters} request
- * @private
+ * @hidden
  */
 export class RequestPerformance {
     _marks: {

--- a/typedoc.json
+++ b/typedoc.json
@@ -2,7 +2,7 @@
     "$schema": "https://typedoc.org/schema.json",
     "plugin": ["typedoc-plugin-missing-exports", "typedoc-plugin-markdown"],
     "groupOrder": [
-        "Map",
+        "Main",
         "Controls",
         "Handlers"
     ],


### PR DESCRIPTION
Migrated Popup and Marker and changed the Map group to "Main":
It seems that setting the `## Events` section below the examples helps with the grouping for some reason...
![image](https://github.com/maplibre/maplibre-gl-js/assets/3269297/eafff69d-dd32-4901-8c7f-a5e90bb4ceb1)
