### PR TITLE
TSDocs JSDocs migration: build warning removal

### DIFF
--- a/src/data/feature_index.ts
+++ b/src/data/feature_index.ts
@@ -39,6 +39,9 @@ type QueryParameters = {
     };
 };
 
+/**
+ * An in memory index class to allow fast interaction with features
+ */
 export class FeatureIndex {
     tileID: OverscaledTileID;
     x: number;

--- a/src/data/segment.ts
+++ b/src/data/segment.ts
@@ -5,6 +5,9 @@ import {register} from '../util/web_worker_transfer';
 import type {VertexArrayObject} from '../render/vertex_array_object';
 import type {StructArray} from '../util/struct_array';
 
+/**
+ * A single segment of a vector
+ */
 export type Segment = {
     sortKey?: number;
     vertexOffset: number;
@@ -14,6 +17,9 @@ export type Segment = {
     vaos: {[_: string]: VertexArrayObject};
 };
 
+/**
+ * Used for calculations on vector segments
+ */
 export class SegmentVector {
     static MAX_VERTEX_ARRAY_LENGTH: number;
     segments: Array<Segment>;

--- a/src/gl/context.ts
+++ b/src/gl/context.ts
@@ -23,6 +23,9 @@ type ClearArgs = {
     stencil?: number;
 };
 
+/**
+ * A webgl wrapper class to allow injection, mocking and abstaction
+ */
 export class Context {
     gl: WebGLRenderingContext | WebGL2RenderingContext;
 

--- a/src/gl/framebuffer.ts
+++ b/src/gl/framebuffer.ts
@@ -2,6 +2,9 @@ import {ColorAttachment, DepthAttachment, DepthStencilAttachment} from './value'
 
 import type {Context} from './context';
 
+/**
+ * A framebuffer holder object
+ */
 export class Framebuffer {
     context: Context;
     width: number;

--- a/src/gl/index_buffer.ts
+++ b/src/gl/index_buffer.ts
@@ -3,6 +3,9 @@ import type {StructArray} from '../util/struct_array';
 import type {TriangleIndexArray, LineIndexArray, LineStripIndexArray} from '../data/index_array_type';
 import type {Context} from '../gl/context';
 
+/**
+ * an index buffer class
+ */
 export class IndexBuffer {
     context: Context;
     buffer: WebGLBuffer;

--- a/src/render/glyph_atlas.ts
+++ b/src/render/glyph_atlas.ts
@@ -6,6 +6,9 @@ import type {GlyphMetrics, StyleGlyph} from '../style/style_glyph';
 
 const padding = 1;
 
+/**
+ * A rectangle type with postion, width and height.
+ */
 export type Rect = {
     x: number;
     y: number;
@@ -13,11 +16,17 @@ export type Rect = {
     h: number;
 };
 
+/**
+ * The glyph's position
+ */
 export type GlyphPosition = {
     rect: Rect;
     metrics: GlyphMetrics;
 };
 
+/**
+ * The glyphs' positions
+ */
 export type GlyphPositions = {
     [_: string]: {
         [_: number]: GlyphPosition;

--- a/src/render/image_atlas.ts
+++ b/src/render/image_atlas.ts
@@ -60,6 +60,9 @@ export class ImagePosition {
     }
 }
 
+/**
+ * A class holding all the images
+ */
 export class ImageAtlas {
     image: RGBAImage;
     iconPositions: {[_: string]: ImagePosition};

--- a/src/render/program.ts
+++ b/src/render/program.ts
@@ -28,6 +28,10 @@ function getTokenizedAttributesAndUniforms(array: Array<string>): Array<string> 
     }
     return result;
 }
+
+/**
+ * A webgl program to execute in the GPU space
+ */
 export class Program<Us extends UniformBindings> {
     program: WebGLProgram;
     attributes: {[_: string]: number};

--- a/src/render/terrain.ts
+++ b/src/render/terrain.ts
@@ -20,6 +20,9 @@ import {EXTENT} from '../data/extent';
 import type {TerrainSpecification} from '@maplibre/maplibre-gl-style-spec';
 import {earthRadius} from '../geo/lng_lat';
 
+/**
+ * A terrain GPU related object
+ */
 export type TerrainData = {
     'u_depth': number;
     'u_terrain': number;
@@ -32,6 +35,9 @@ export type TerrainData = {
     tile: Tile;
 }
 
+/**
+ * A terrain mesh object
+ */
 export type TerrainMesh = {
     indexBuffer: IndexBuffer;
     vertexBuffer: VertexBuffer;

--- a/src/render/texture.ts
+++ b/src/render/texture.ts
@@ -15,6 +15,9 @@ type EmptyImage = {
 type DataTextureImage = RGBAImage | AlphaImage | EmptyImage;
 export type TextureImage = TexImageSource | DataTextureImage;
 
+/**
+ * A `Texture` GL related object
+ */
 export class Texture {
     context: Context;
     size: [number, number];

--- a/src/render/uniform_binding.ts
+++ b/src/render/uniform_binding.ts
@@ -10,6 +10,9 @@ type $ObjMap<T extends {}, F extends (v: any) => any> = {
 export type UniformValues<Us extends {}> = $ObjMap<Us, <V>(u: Uniform<V>) => V>;
 export type UniformLocations = {[_: string]: WebGLUniformLocation};
 
+/**
+ * A base uniform abstract class
+ */
 abstract class Uniform<T> {
     gl: WebGLRenderingContext|WebGL2RenderingContext;
     location: WebGLUniformLocation;
@@ -146,4 +149,7 @@ export {
     UniformMatrix4f
 };
 
+/**
+ * A uniform bindings
+ */
 export type UniformBindings = {[_: string]: Uniform<any>};

--- a/src/render/vertex_array_object.ts
+++ b/src/render/vertex_array_object.ts
@@ -4,6 +4,9 @@ import type {VertexBuffer} from '../gl/vertex_buffer';
 import type {IndexBuffer} from '../gl/index_buffer';
 import type {Context} from '../gl/context';
 
+/**
+ * A vertex array object used to pass data to the webgl code
+ */
 export class VertexArrayObject {
     context: Context;
     boundProgram: Program<any>;

--- a/src/source/geojson_source_diff.ts
+++ b/src/source/geojson_source_diff.ts
@@ -1,3 +1,6 @@
+/**
+ * A way to indentify a feature, either by string or by number
+ */
 export type GeoJSONFeatureId = number | string;
 
 /**

--- a/src/source/image_source.ts
+++ b/src/source/image_source.ts
@@ -22,18 +22,24 @@ import type {
 } from '@maplibre/maplibre-gl-style-spec';
 import {Cancelable} from '../types/cancelable';
 
+/**
+ * Four geographical coordinates,
+ * represented as arrays of longitude and latitude numbers, which define the corners of the image.
+ * The coordinates start at the top left corner of the image and proceed in clockwise order.
+ * They do not have to represent a rectangle.
+ */
 export type Coordinates = [[number, number], [number, number], [number, number], [number, number]];
 
+/**
+ * The options object for the {@link ImageSource#updateImage} method
+ */
 export type UpdateImageOptions = {
     /**
      * Required image URL.
      */
     url: string;
     /**
-     * Four geographical coordinates,
-     * represented as arrays of longitude and latitude numbers, which define the corners of the image.
-     * The coordinates start at the top left corner of the image and proceed in clockwise order.
-     * They do not have to represent a rectangle.
+     * The image coordinates
      */
     coordinates?: Coordinates;
 }

--- a/src/source/query_features.ts
+++ b/src/source/query_features.ts
@@ -31,6 +31,9 @@ export type QueryRenderedFeaturesOptions = {
     validate?: boolean;
 };
 
+/**
+ * The options object related to the {@link Map#queryRenderedFeatures} method
+ */
 export type QuerySourceFeatureOptions = {
     /**
      * The name of the source layer to query. *For vector tile sources, this parameter is required.* For GeoJSON sources, it is ignored.

--- a/src/source/source.ts
+++ b/src/source/source.ts
@@ -70,6 +70,9 @@ export interface Source {
     readonly prepare?: () => void;
 }
 
+/**
+ * A supporting type to the source definition
+ */
 type SourceStatics = {
     /*
      * An optional URL to a script which, when run by a Worker, registers a {@link WorkerSource}
@@ -78,6 +81,9 @@ type SourceStatics = {
     workerSourceURL?: URL;
 };
 
+/**
+ * A general definition of a {@link Source} class for factory usage
+ */
 export type SourceClass = {
     new (id: string, specification: SourceSpecification | CanvasSourceSpecification, dispatcher: Dispatcher, eventedParent: Evented): Source;
 } & SourceStatics;

--- a/src/source/tile_id.ts
+++ b/src/source/tile_id.ts
@@ -60,6 +60,9 @@ export class CanonicalTileID implements ICanonicalTileID {
     }
 }
 
+/**
+ * An unwrapped tile identifier
+ */
 export class UnwrappedTileID {
     wrap: number;
     canonical: CanonicalTileID;
@@ -72,6 +75,9 @@ export class UnwrappedTileID {
     }
 }
 
+/**
+ * An overscaled tile identifier
+ */
 export class OverscaledTileID {
     overscaledZ: number;
     wrap: number;

--- a/src/source/tile_id.ts
+++ b/src/source/tile_id.ts
@@ -6,6 +6,9 @@ import {register} from '../util/web_worker_transfer';
 import {mat4} from 'gl-matrix';
 import {ICanonicalTileID, IMercatorCoordinate} from '@maplibre/maplibre-gl-style-spec';
 
+/**
+ * A canonical way to define a tile ID
+ */
 export class CanonicalTileID implements ICanonicalTileID {
     z: number;
     x: number;

--- a/src/source/worker_source.ts
+++ b/src/source/worker_source.ts
@@ -40,6 +40,9 @@ export type WorkerDEMTileParameters = TileParameters & {
     encoding: 'mapbox' | 'terrarium';
 };
 
+/**
+ * The worker tile's result type
+ */
 export type WorkerTileResult = {
     buckets: Array<Bucket>;
     imageAtlas: ImageAtlas;

--- a/src/style/evaluation_parameters.ts
+++ b/src/style/evaluation_parameters.ts
@@ -10,6 +10,9 @@ export type CrossfadeParameters = {
     t: number;
 };
 
+/**
+ * A parameter that can be evaluated to a value
+ */
 export class EvaluationParameters {
     zoom: number;
     now: number;

--- a/src/style/properties.ts
+++ b/src/style/properties.ts
@@ -13,6 +13,9 @@ import {CanonicalTileID} from '../source/tile_id';
 
 type TimePoint = number;
 
+/**
+ * A from-to type
+ */
 export type CrossFaded<T> = {
     to: T;
     from: T;

--- a/src/style/style.ts
+++ b/src/style/style.ts
@@ -85,7 +85,9 @@ const ignoredDiffOperations = pick(diffOperations, [
 ]);
 
 const empty = emptyStyle() as StyleSpecification;
-
+/**
+ * A feature identifier that is bound to a source
+ */
 export type FeatureIdentifier = {
     /**
      * Unique id of the feature.
@@ -101,6 +103,9 @@ export type FeatureIdentifier = {
     sourceLayer?: string | undefined;
 };
 
+/**
+ * The options object related to the {@link Map}'s style related methods
+ */
 export type StyleOptions = {
     /**
      * If false, style validation will be skipped. Useful in production environment.
@@ -116,6 +121,9 @@ export type StyleOptions = {
     localIdeographFontFamily?: string;
 };
 
+/**
+ * Supporting type to add validation to another style related type
+ */
 export type StyleSetterOptions = {
     /**
      * Whether to check if the filter conforms to the MapLibre Style Specification. Disabling validation is a performance optimization that should only be used if you have previously validated the values you will be passing to this function.
@@ -165,6 +173,9 @@ export type StyleSetterOptions = {
  */
 export type TransformStyleFunction = (previous: StyleSpecification | undefined, next: StyleSpecification) => StyleSpecification;
 
+/**
+ * The options object related to the {@link Map}'s style related methods
+ */
 export type StyleSwapOptions = {
     /**
      * If false, force a 'full' update, removing the current style

--- a/src/style/style_glyph.ts
+++ b/src/style/style_glyph.ts
@@ -1,5 +1,8 @@
 import type {AlphaImage} from '../util/image';
 
+/**
+ * The glyph's metrices
+ */
 export type GlyphMetrics = {
     width: number;
     height: number;
@@ -8,6 +11,9 @@ export type GlyphMetrics = {
     advance: number;
 };
 
+/**
+ * A style glyph type
+ */
 export type StyleGlyph = {
     id: number;
     bitmap: AlphaImage;

--- a/src/style/style_image.ts
+++ b/src/style/style_image.ts
@@ -2,6 +2,9 @@ import {RGBAImage} from '../util/image';
 
 import type {Map} from '../ui/map';
 
+/**
+ * The sprite data
+ */
 export type SpriteOnDemandStyleImage = {
     width: number;
     height: number;
@@ -10,6 +13,9 @@ export type SpriteOnDemandStyleImage = {
     context: CanvasRenderingContext2D;
 };
 
+/**
+ * The style's image metadata
+ */
 export type StyleImageData = {
     data: RGBAImage;
     version?: number;
@@ -18,6 +24,9 @@ export type StyleImageData = {
     spriteData?: SpriteOnDemandStyleImage;
 };
 
+/**
+ * The style's image metadata
+ */
 export type StyleImageMetadata = {
     /**
      * The ratio of pixels in the image to physical pixels on the screen
@@ -41,6 +50,9 @@ export type StyleImageMetadata = {
     content?: [number, number, number, number];
 };
 
+/**
+ * the style's image, including data and metedata
+ */
 export type StyleImage = StyleImageData & StyleImageMetadata;
 
 /**

--- a/src/style/style_layer.ts
+++ b/src/style/style_layer.ts
@@ -28,6 +28,9 @@ import type {VectorTileFeature} from '@mapbox/vector-tile';
 
 const TRANSITION_SUFFIX = '-transition';
 
+/**
+ * A base class for style layers
+ */
 export abstract class StyleLayer extends Evented {
     id: string;
     metadata: unknown;

--- a/src/style/style_layer/circle_style_layer.ts
+++ b/src/style/style_layer/circle_style_layer.ts
@@ -13,6 +13,9 @@ import type {Bucket, BucketParameters} from '../../data/bucket';
 import type {CircleLayoutProps, CirclePaintProps} from './circle_style_layer_properties.g';
 import type {VectorTileFeature} from '@mapbox/vector-tile';
 
+/**
+ * A style layer that defines a circle
+ */
 export class CircleStyleLayer extends StyleLayer {
     _unevaluatedLayout: Layout<CircleLayoutProps>;
     layout: PossiblyEvaluated<CircleLayoutProps, CircleLayoutPropsPossiblyEvaluated>;

--- a/src/style/style_layer/custom_style_layer.ts
+++ b/src/style/style_layer/custom_style_layer.ts
@@ -24,8 +24,7 @@ type CustomRenderMethod = (gl: WebGLRenderingContext|WebGL2RenderingContext, mat
  * Custom layers must have a unique `id` and must have the `type` of `"custom"`.
  * They must implement `render` and may implement `prerender`, `onAdd` and `onRemove`.
  * They can trigger rendering using {@link Map#triggerRepaint}
- * and they should appropriately handle {@link Map.event:webglcontextlost} and
- * {@link Map.event:webglcontextrestored}.
+ * and they should appropriately handle {@link MapContextEvent} with `webglcontextlost` and `webglcontextrestored`.
  *
  * The `renderingMode` property controls whether the layer is treated as a `"2d"` or `"3d"` map layer. Use:
  * - `"renderingMode": "3d"` to use the depth buffer and share it with other layers

--- a/src/style/style_layer/custom_style_layer.ts
+++ b/src/style/style_layer/custom_style_layer.ts
@@ -9,7 +9,7 @@ import {LayerSpecification} from '@maplibre/maplibre-gl-style-spec';
  * coordinates to gl coordinates. The spherical mercator coordinate `[0, 0]` represents the
  * top left corner of the mercator world and `[1, 1]` represents the bottom right corner. When
  * the `renderingMode` is `"3d"`, the z coordinate is conformal. A box with identical x, y, and z
- * lengths in mercator units would be rendered as a cube. {@link MercatorCoordinate#fromLngLat}
+ * lengths in mercator units would be rendered as a cube. {@link MercatorCoordinate.fromLngLat}
  * can be used to project a `LngLat` to a mercator coordinate.
  */
 type CustomRenderMethod = (gl: WebGLRenderingContext|WebGL2RenderingContext, matrix: mat4) => void;

--- a/src/style/style_layer/heatmap_style_layer.ts
+++ b/src/style/style_layer/heatmap_style_layer.ts
@@ -11,6 +11,9 @@ import type {Framebuffer} from '../../gl/framebuffer';
 import type {HeatmapPaintProps} from './heatmap_style_layer_properties.g';
 import type {LayerSpecification} from '@maplibre/maplibre-gl-style-spec';
 
+/**
+ * A style layer that defines a heatmap
+ */
 export class HeatmapStyleLayer extends StyleLayer {
 
     heatmapFbo: Framebuffer;

--- a/src/style/style_layer/overlap_mode.ts
+++ b/src/style/style_layer/overlap_mode.ts
@@ -2,6 +2,9 @@ import {SymbolLayoutPropsPossiblyEvaluated} from './symbol_style_layer_propertie
 import type {SymbolLayoutProps} from './symbol_style_layer_properties.g';
 import {PossiblyEvaluated} from '../properties';
 
+/**
+ * The overlap mode for properties like `icon-overlap`and `text-overlap`
+ */
 export type OverlapMode = 'never' | 'always' | 'cooperative';
 
 export function getOverlapMode(layout: PossiblyEvaluated<SymbolLayoutProps, SymbolLayoutPropsPossiblyEvaluated>, overlapProp: 'icon-overlap', allowOverlapProp: 'icon-allow-overlap'): OverlapMode;

--- a/src/symbol/grid_index.ts
+++ b/src/symbol/grid_index.ts
@@ -26,6 +26,9 @@ type QueryResult<T> = {
     y2: number;
 };
 
+/**
+ * A key for the grid
+ */
 export type GridKey = {
     overlapMode?: OverlapMode;
 }

--- a/src/types/callback.ts
+++ b/src/types/callback.ts
@@ -1,15 +1,13 @@
-// Flow can't perfectly type Node-style callbacks yet; it does not have a way to
-// express that if the first parameter is null, the second is not, so for the time
-// being, both parameters must be optional. Use the following convention when defining
-// a callback:
-//
-//    asyncFunction((error, result) => {
-//        if (error) {
-//            // handle error
-//        } else if (result) {
-//            // handle success
-//        }
-//    });
-//
-// See https://github.com/facebook/flow/issues/2123 for more.
+/**
+ * A callback definition.
+ *
+ * @example
+ * asyncFunction((error, result) => {
+ *      if (error) {
+ *          // handle error
+ *      } else if (result) {
+ *          // handle success
+ *      }
+ * });
+ */
 export type Callback<T> = (error?: Error | null, result?: T | null) => void;

--- a/src/types/cancelable.ts
+++ b/src/types/cancelable.ts
@@ -1,3 +1,6 @@
+/**
+ * A request that can be cancelled
+ */
 export type Cancelable = {
     cancel: () => void;
 };

--- a/src/types/transferable.ts
+++ b/src/types/transferable.ts
@@ -1,1 +1,4 @@
+/**
+ * An object with is transferable between main and worker thread
+ */
 export type Transferable = ArrayBuffer | MessagePort | ImageBitmap;

--- a/src/ui/anchor.ts
+++ b/src/ui/anchor.ts
@@ -1,3 +1,7 @@
+/**
+ * Where to position the anchor.
+ * Used by a popup and a marker.
+ */
 export type PositionAnchor = 'center' | 'top' | 'bottom' | 'left' | 'right' | 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right';
 
 export const anchorTranslate: {

--- a/src/ui/camera.ts
+++ b/src/ui/camera.ts
@@ -81,6 +81,9 @@ export type CenterZoomBearing = {
     bearing?: number;
 }
 
+/**
+ * The options object related to the {@link Map#jumpTo} method
+ */
 export type JumpToOptions = CameraOptions & {
     /**
      * Dimensions in pixels applied on each side of the viewport for shifting the vanishing point.
@@ -88,6 +91,9 @@ export type JumpToOptions = CameraOptions & {
     padding?: PaddingOptions;
 }
 
+/**
+ * A options object for the {@link Map#cameraForBounds} method
+ */
 export type CameraForBoundsOptions = CameraOptions & {
     /**
      * The amount of padding in pixels to add to the given bounds.

--- a/src/ui/camera.ts
+++ b/src/ui/camera.ts
@@ -23,6 +23,9 @@ import {MercatorCoordinate} from '../geo/mercator_coordinate';
  */
 export type PointLike = Point | [number, number];
 
+/**
+ * A helper to allow require of at least one propery
+ */
 export type RequireAtLeastOne<T> = { [K in keyof T]-?: Required<Pick<T, K>> & Partial<Pick<T, Exclude<keyof T, K>>>; }[keyof T];
 
 /**
@@ -59,6 +62,9 @@ export type CameraOptions = CenterZoomBearing & {
     around?: LngLatLike;
 };
 
+/**
+ * Holds center, zoom and bearing properties
+ */
 export type CenterZoomBearing = {
     /**
      * The desired center.
@@ -98,6 +104,9 @@ export type CameraForBoundsOptions = CameraOptions & {
     maxZoom?: number;
 }
 
+/**
+ * The {@link Map#flyTo} options object
+ */
 export type FlyToOptions = AnimationOptions & CameraOptions & {
     /**
      * The zooming "curve" that will occur along the
@@ -144,6 +153,9 @@ export type EaseToOptions = AnimationOptions & CameraOptions & {
     padding?: number | RequireAtLeastOne<PaddingOptions>;
 }
 
+/**
+ * Options for {@link Map#fitBounds} method
+ */
 export type FitBoundsOptions = FlyToOptions & {
     /**
      * If `true`, the map transitions using {@link Map#easeTo}. If `false`, the map transitions using {@link Map#flyTo}.
@@ -199,6 +211,9 @@ export type AnimationOptions = {
     freezeElevation?: boolean;
 };
 
+/**
+ * A callback hook that allows manipulating the camera and being notified about camera updates before they happen
+ */
 export type CameraUpdateTransformFunction =  (next: {
     center: LngLat;
     zoom: number;

--- a/src/ui/control/control.ts
+++ b/src/ui/control/control.ts
@@ -1,5 +1,11 @@
-export type ControlPosition = 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right';
 import type {Map} from '../map';
+
+/**
+ * A position defintion for the control to be placed, can be in one of the corners of the map.
+ * When two or more controls are places in the same location they are stacked toward the center of the map.
+ */
+export type ControlPosition = 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right';
+
 /**
  * Interface for interactive controls added to the map. This is a
  * specification for implementers to model: it is not

--- a/src/ui/control/geolocate_control.ts
+++ b/src/ui/control/geolocate_control.ts
@@ -11,7 +11,7 @@ import type {IControl} from './control';
 import {LngLatBounds} from '../../geo/lng_lat_bounds';
 
 /**
- * The {@link GeoLocationControl} options
+ * The {@link GeolocateControl} options
  */
 type GeolocateOptions = {
     /**

--- a/src/ui/control/scale_control.ts
+++ b/src/ui/control/scale_control.ts
@@ -4,6 +4,9 @@ import {extend} from '../../util/util';
 import type {Map} from '../map';
 import type {ControlPosition, IControl} from './control';
 
+/**
+ * The unit type for length to use for the {@link ScaleControl}
+ */
 export type Unit = 'imperial' | 'metric' | 'nautical';
 
 /**

--- a/src/ui/events.ts
+++ b/src/ui/events.ts
@@ -9,10 +9,21 @@ import type {Map} from './map';
 import type {LngLat} from '../geo/lng_lat';
 import {SourceSpecification} from '@maplibre/maplibre-gl-style-spec';
 
+/**
+ * @event
+ * An event from the mouse relevant to a specific layer.
+ */
 export type MapLayerMouseEvent = MapMouseEvent & { features?: MapGeoJSONFeature[] };
 
+/**
+ * @event
+ * An event from a touch device relevat to a specific layer.
+ */
 export type MapLayerTouchEvent = MapTouchEvent & { features?: MapGeoJSONFeature[] };
 
+/**
+ * The source event data type
+ */
 export type MapSourceDataType = 'content' | 'metadata' | 'visibility' | 'idle';
 
 /**
@@ -36,6 +47,7 @@ export type MapLayerEventType = {
 };
 
 /**
+ * @event
  * The base event for MapLibre
  */
 export interface MapLibreEvent<TOrig = unknown> {
@@ -44,10 +56,18 @@ export interface MapLibreEvent<TOrig = unknown> {
     originalEvent: TOrig;
 }
 
+/**
+ * @event
+ * The style data event
+ */
 export interface MapStyleDataEvent extends MapLibreEvent {
     dataType: 'style';
 }
 
+/**
+ * @event
+ * The source data event interface
+ */
 export interface MapSourceDataEvent extends MapLibreEvent {
     dataType: 'source';
     /**
@@ -68,7 +88,6 @@ export interface MapSourceDataEvent extends MapLibreEvent {
 }
 /**
  * `MapMouseEvent` is the event type for mouse-related map events.
- * @extends {Event}
  * @example
  * // The `click` event is an example of a `MapMouseEvent`.
  * // Set up an event listener on the map.
@@ -143,7 +162,6 @@ export class MapMouseEvent extends Event implements MapLibreEvent<MouseEvent> {
 
 /**
  * `MapTouchEvent` is the event type for touch-related map events.
- * @extends {Event}
  */
 export class MapTouchEvent extends Event implements MapLibreEvent<TouchEvent> {
     /**
@@ -190,7 +208,7 @@ export class MapTouchEvent extends Event implements MapLibreEvent<TouchEvent> {
      * Calling this method will prevent the following default map behaviors:
      *
      *   * On `touchstart` events, the behavior of {@link DragPanHandler}
-     *   * On `touchstart` events, the behavior of {@link TouchZoomRotateHandler}
+     *   * On `touchstart` events, the behavior of {@link TwoFingersTouchZoomRotateHandler}
      *
      */
     preventDefault() {
@@ -224,8 +242,9 @@ export class MapTouchEvent extends Event implements MapLibreEvent<TouchEvent> {
 }
 
 /**
+ * @event
+ *
  * `MapWheelEvent` is the event type for the `wheel` map event.
- * @extends {Object}
  */
 export class MapWheelEvent extends Event {
     /**
@@ -272,6 +291,7 @@ export class MapWheelEvent extends Event {
 }
 
 /**
+ * @event
  * A `MapLibreZoomEvent` is the event type for the boxzoom-related map events emitted by the {@link BoxZoomHandler}.
  */
 export type MapLibreZoomEvent = {
@@ -290,8 +310,10 @@ export type MapLibreZoomEvent = {
 };
 
 /**
- * A `MapDataEvent` object is emitted with the {@link Map.event:data}
- * and {@link Map.event:dataloading} events. Possible values for
+ * @event
+ *
+ * A `MapDataEvent` object is emitted with the `data`
+ * and `dataloading` events. Possible values for
  * `dataType`s are:
  *
  * - `'source'`: The non-tile data associated with any source
@@ -328,15 +350,29 @@ export type MapDataEvent = {
     sourceDataType: MapSourceDataType;
 };
 
+/**
+ * @event
+ * tThe terrain event
+ */
 export type MapTerrainEvent = {
     type: 'terrain';
 };
 
+/**
+ * @event
+ * An event related to the web gl context
+ */
 export type MapContextEvent = {
     type: 'webglcontextlost' | 'webglcontextrestored';
     originalEvent: WebGLContextEvent;
 };
 
+/**
+ * @event
+ * The style image missing event
+ *
+ * @see [Generate and add a missing icon to the map](https://maplibre.org/maplibre-gl-js-docs/example/add-image-missing-generated/)
+ */
 export interface MapStyleImageMissingEvent extends MapLibreEvent {
     type: 'styleimagemissing';
     id: string;

--- a/src/ui/events.ts
+++ b/src/ui/events.ts
@@ -15,6 +15,9 @@ export type MapLayerTouchEvent = MapTouchEvent & { features?: MapGeoJSONFeature[
 
 export type MapSourceDataType = 'content' | 'metadata' | 'visibility' | 'idle';
 
+/**
+ * A mapping between the layer events and their type
+ */
 export type MapLayerEventType = {
     click: MapLayerMouseEvent;
     dblclick: MapLayerMouseEvent;
@@ -32,6 +35,9 @@ export type MapLayerEventType = {
     touchcancel: MapLayerTouchEvent;
 };
 
+/**
+ * The base event for MapLibre
+ */
 export interface MapLibreEvent<TOrig = unknown> {
     type: string;
     target: Map;
@@ -74,16 +80,7 @@ export interface MapSourceDataEvent extends MapLibreEvent {
  */
 export class MapMouseEvent extends Event implements MapLibreEvent<MouseEvent> {
     /**
-     * The event type (one of {@link Map.event:mousedown},
-     * {@link Map.event:mouseup},
-     * {@link Map.event:click},
-     * {@link Map.event:dblclick},
-     * {@link Map.event:mousemove},
-     * {@link Map.event:mouseover},
-     * {@link Map.event:mouseenter},
-     * {@link Map.event:mouseleave},
-     * {@link Map.event:mouseout},
-     * {@link Map.event:contextmenu}).
+     * The event type {@link MapEventType}
      */
     type: 'mousedown' | 'mouseup' | 'click' | 'dblclick' | 'mousemove' | 'mouseover' | 'mouseenter' | 'mouseleave' | 'mouseout' | 'contextmenu';
 

--- a/src/ui/handler/shim/drag_pan.ts
+++ b/src/ui/handler/shim/drag_pan.ts
@@ -1,6 +1,9 @@
 import type {MousePanHandler} from '../mouse';
 import type {TouchPanHandler} from './../touch_pan';
 
+/**
+ * A {@link DragPanHandler} options object
+ */
 export type DragPanOptions = {
     /**
      * factor used to scale the drag velocity

--- a/src/ui/handler/two_fingers_touch.ts
+++ b/src/ui/handler/two_fingers_touch.ts
@@ -3,6 +3,9 @@ import {DOM} from '../../util/dom';
 import type {Map} from '../map';
 import {Handler} from '../handler_manager';
 
+/**
+ * An options object sent to the enable function of some of the handlers
+ */
 export type AroundCenterOptions = {
     /**
      * If "center" is passed, map will zoom around the center of map

--- a/src/ui/handler_manager.ts
+++ b/src/ui/handler_manager.ts
@@ -28,18 +28,22 @@ class RenderFrameEvent extends Event {
     timeStamp: number;
 }
 
-// Handlers interpret dom events and return camera changes that should be
-// applied to the map (`HandlerResult`s). The camera changes are all deltas.
-// The handler itself should have no knowledge of the map's current state.
-// This makes it easier to merge multiple results and keeps handlers simpler.
-// For example, if there is a mousedown and mousemove, the mousePan handler
-// would return a `panDelta` on the mousemove.
+/**
+ * Handlers interpret dom events and return camera changes that should be
+ * applied to the map (`HandlerResult`s). The camera changes are all deltas.
+ * The handler itself should have no knowledge of the map's current state.
+ * This makes it easier to merge multiple results and keeps handlers simpler.
+ * For example, if there is a mousedown and mousemove, the mousePan handler
+ * would return a `panDelta` on the mousemove.
+ */
 export interface Handler {
     enable(): void;
     disable(): void;
     isEnabled(): boolean;
     isActive(): boolean;
-    // `reset` can be called by the manager at any time and must reset everything to it's original state
+    /**
+     * `reset` can be called by the manager at any time and must reset everything to it's original state
+     */
     reset(): void;
     // Handlers can optionally implement these methods.
     // They are called with dom events whenever those dom evens are received.
@@ -58,29 +62,45 @@ export interface Handler {
     readonly wheel?: (e: WheelEvent, point: Point) => HandlerResult | void;
     readonly keydown?: (e: KeyboardEvent) => HandlerResult | void;
     readonly keyup?: (e: KeyboardEvent) => HandlerResult | void;
-    // `renderFrame` is the only non-dom event. It is called during render
-    // frames and can be used to smooth camera changes (see scroll handler).
+    /**
+     * `renderFrame` is the only non-dom event. It is called during render
+     * frames and can be used to smooth camera changes (see scroll handler).
+     */
     readonly renderFrame?: () => HandlerResult | void;
 }
 
-// All handler methods that are called with events can optionally return a `HandlerResult`.
+/**
+ * All handler methods that are called with events can optionally return a `HandlerResult`.
+ */
 export type HandlerResult = {
     panDelta?: Point;
     zoomDelta?: number;
     bearingDelta?: number;
     pitchDelta?: number;
-    // the point to not move when changing the camera
+    /**
+     * the point to not move when changing the camera
+     */
     around?: Point | null;
-    // same as above, except for pinch actions, which are given higher priority
+    /**
+     * same as above, except for pinch actions, which are given higher priority
+     */
     pinchAround?: Point | null;
-    // A method that can fire a one-off easing by directly changing the map's camera.
+    /**
+     * A method that can fire a one-off easing by directly changing the map's camera.
+     */
     cameraAnimation?: (map: Map) => any;
-    // The last three properties are needed by only one handler: scrollzoom.
-    // The DOM event to be used as the `originalEvent` on any camera change events.
+    /**
+     * The last three properties are needed by only one handler: scrollzoom.
+     * The DOM event to be used as the `originalEvent` on any camera change events.
+     */
     originalEvent?: Event;
-    // Makes the manager trigger a frame, allowing the handler to return multiple results over time (see scrollzoom).
+    /**
+     * Makes the manager trigger a frame, allowing the handler to return multiple results over time (see scrollzoom).
+     */
     needsRenderFrame?: boolean;
-    // The camera changes won't get recorded for inertial zooming.
+    /**
+     * The camera changes won't get recorded for inertial zooming.
+     */
     noInertia?: boolean;
 };
 

--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -1768,7 +1768,7 @@ export class Map extends Camera {
      * @param id The ID of the source to add. Must not conflict with existing sources.
      * @param source The source object, conforming to the
      * MapLibre Style Specification's [source definition](https://maplibre.org/maplibre-style-spec/#sources) or
-     * {@link CanvasSourceOptions}.
+     * {@link CanvasSourceSpecification}.
      * @fires source.add
      * @returns `this`
      * @example
@@ -1954,7 +1954,7 @@ export class Map extends Camera {
      * [`background-pattern`](https://maplibre.org/maplibre-style-spec/#paint-background-background-pattern),
      * [`fill-pattern`](https://maplibre.org/maplibre-style-spec/#paint-fill-fill-pattern),
      * or [`line-pattern`](https://maplibre.org/maplibre-style-spec/#paint-line-line-pattern).
-     * A {@link Map.event:error} event will be fired if there is not enough space in the sprite to add this image.
+     * A {@link ErrorEvent} event will be fired if there is not enough space in the sprite to add this image.
      *
      * @param id The ID of the image.
      * @param image The image as an `HTMLImageElement`, `ImageData`, `ImageBitmap` or object with `width`, `height`, and `data`

--- a/src/ui/popup.ts
+++ b/src/ui/popup.ts
@@ -20,6 +20,13 @@ const defaultOptions = {
     maxWidth: '240px'
 };
 
+/**
+ * A pixel offset specified as:
+ * - a single number specifying a distance from the location
+ * - a {@link PointLike} specifying a constant offset
+ * - an object of {@link Point}s specifying an offset for each anchor position
+ * Negative offsets indicate left and up.
+ */
 export type Offset = number | PointLike | {
     [_ in PositionAnchor]: PointLike;
 };
@@ -55,11 +62,7 @@ export type PopupOptions = {
      */
     anchor?: PositionAnchor;
     /**
-     * A pixel offset applied to the popup's location specified as:
-     * - a single number specifying a distance from the popup's location
-     * - a {@link PointLike} specifying a constant offset
-     * - an object of {@link Point}s specifying an offset for each anchor position
-     * Negative offsets indicate left and up.
+     * A pixel offset applied to the popup's location
      */
     offset?: Offset;
     /**

--- a/src/util/ajax.ts
+++ b/src/util/ajax.ts
@@ -286,7 +286,9 @@ export function sameOrigin(inComingUrl: string) {
     const locationObj = window.location;
     return urlObj.protocol === locationObj.protocol && urlObj.host === locationObj.host;
 }
-
+/**
+ * A type used to store the tile's expiration date and cache control definition
+ */
 export type ExpiryData = {cacheControl?: string | null; expires?: Date | string | null};
 export const getVideo = function(urls: Array<string>, callback: Callback<HTMLVideoElement>): Cancelable {
     const video: HTMLVideoElement = window.document.createElement('video');

--- a/src/util/dispatcher.ts
+++ b/src/util/dispatcher.ts
@@ -2,7 +2,7 @@ import {asyncAll} from './util';
 import {Actor} from './actor';
 
 import type {WorkerPool} from './worker_pool';
-
+import type {WorkerSource} from '../source/worker_source'; /* eslint-disable-line */ // this is used for the docs' import
 /**
  * Responsible for sending messages from a {@link Source} to an associated
  * {@link WorkerSource}.

--- a/src/util/evented.ts
+++ b/src/util/evented.ts
@@ -1,5 +1,8 @@
 import {extend} from './util';
 
+/**
+ * A listener method used as a callback to events
+ */
 export type Listener = (a: any) => any;
 
 type Listeners = {[_: string]: Array<Listener>};
@@ -21,6 +24,9 @@ function _removeEventListener(type: string, listener: Listener, listenerList: Li
     }
 }
 
+/**
+ * The event class
+ */
 export class Event {
     readonly type: string;
 
@@ -34,6 +40,9 @@ interface ErrorLike {
     message: string;
 }
 
+/**
+ * An error event
+ */
 export class ErrorEvent extends Event {
     error: ErrorLike;
 

--- a/src/util/image.ts
+++ b/src/util/image.ts
@@ -81,6 +81,9 @@ function copyImage(srcImg: any, dstImg: any, srcPt: Point2D, dstPt: Point2D, siz
     return dstImg;
 }
 
+/**
+ * An image with alpha color value
+ */
 export class AlphaImage {
     width: number;
     height: number;
@@ -103,14 +106,17 @@ export class AlphaImage {
     }
 }
 
-// Not premultiplied, because ImageData is not premultiplied.
-// UNPACK_PREMULTIPLY_ALPHA_WEBGL must be used when uploading to a texture.
+/**
+ * An object to store image data not premultiplied, because ImageData is not premultiplied.
+ * UNPACK_PREMULTIPLY_ALPHA_WEBGL must be used when uploading to a texture.
+ */
 export class RGBAImage {
     width: number;
     height: number;
 
-    // data must be a Uint8Array instead of Uint8ClampedArray because texImage2D does not
-    // support Uint8ClampedArray in all browsers
+    /**
+     * data must be a Uint8Array instead of Uint8ClampedArray because texImage2D does not support Uint8ClampedArray in all browsers.
+     */
     data: Uint8Array;
 
     constructor(size: Size, data?: Uint8Array | Uint8ClampedArray) {

--- a/src/util/image_request.ts
+++ b/src/util/image_request.ts
@@ -6,6 +6,9 @@ import {arrayBufferToImageBitmap, arrayBufferToImage, extend, isWorker} from './
 import {webpSupported} from './webp_supported';
 import {config} from './config';
 
+/**
+ * The callback that is being called after an image was fetched
+ */
 export type GetImageCallback = (error?: Error | null, image?: HTMLImageElement | ImageBitmap | null, expiry?: ExpiryData | null) => void;
 
 type ImageQueueThrottleControlCallback = () => boolean;

--- a/src/util/request_manager.ts
+++ b/src/util/request_manager.ts
@@ -14,6 +14,10 @@ export const enum ResourceType {
     Unknown = 'Unknown',
 }
 
+/**
+ * This function is used to tranform a request.
+ * It is used just before executing the relevant request.
+ */
 export type RequestTransformFunction = (url: string, resourceType?: ResourceType) => RequestParameters | undefined;
 
 type UrlObject = {

--- a/src/util/struct_array.ts
+++ b/src/util/struct_array.ts
@@ -2,6 +2,9 @@
 
 import type {Transferable} from '../types/transferable';
 
+/**
+ * A view type size
+ */
 const viewTypes = {
     'Int8': Int8Array,
     'Uint8': Uint8Array,
@@ -12,6 +15,9 @@ const viewTypes = {
     'Float32': Float32Array
 };
 
+/**
+ * A view type size
+ */
 export type ViewType = keyof typeof viewTypes;
 
 /**
@@ -44,6 +50,9 @@ class Struct {
 const DEFAULT_CAPACITY = 128;
 const RESIZE_MULTIPLIER = 5;
 
+/**
+ * A struct array memeber
+ */
 export type StructArrayMember = {
     name: string;
     type: ViewType;

--- a/src/util/struct_array.ts
+++ b/src/util/struct_array.ts
@@ -57,6 +57,9 @@ export type StructArrayLayout = {
     alignment: number;
 };
 
+/**
+ * An array that can be desialized
+ */
 export type SerializedStructArray = {
     length: number;
     arrayBuffer: ArrayBuffer;

--- a/src/util/vectortile_to_geojson.ts
+++ b/src/util/vectortile_to_geojson.ts
@@ -1,7 +1,13 @@
 import type {VectorTileFeature} from '@mapbox/vector-tile';
 import type {LayerSpecification} from '@maplibre/maplibre-gl-style-spec';
 
+/**
+ * A helper for type to omit a property from a type
+ */
 type DistributiveKeys<T> = T extends T ? keyof T : never;
+/**
+ * A helper for type to omit a property from a type
+ */
 type DistributiveOmit<T, K extends DistributiveKeys<T>> = T extends unknown
     ? Omit<T, K>
     : never;

--- a/src/util/vectortile_to_geojson.ts
+++ b/src/util/vectortile_to_geojson.ts
@@ -6,6 +6,9 @@ type DistributiveOmit<T, K extends DistributiveKeys<T>> = T extends unknown
     ? Omit<T, K>
     : never;
 
+/**
+ * An extended geojson feature used by the events to return data to the listener
+ */
 export type MapGeoJSONFeature = GeoJSONFeature & {
     layer: DistributiveOmit<LayerSpecification, 'source'> & {source: string};
     source: string;
@@ -13,6 +16,9 @@ export type MapGeoJSONFeature = GeoJSONFeature & {
     state: { [key: string]: any };
 }
 
+/**
+ * A geojson feature
+ */
 export class GeoJSONFeature {
     type: 'Feature';
     _geometry: GeoJSON.Geometry;


### PR DESCRIPTION
Resolved most of the warnings related to the build of the docs.
Mainly added comments at the header of a class/interface/type so that it will be included in the docs.
