### PR TITLE
Add tsdoc.json

### DIFF
--- a/tsdoc.json
+++ b/tsdoc.json
@@ -1,0 +1,4 @@
+{
+    "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+    "extends": ["typedoc/tsdoc.json"]
+}


### PR DESCRIPTION
This adds all the TypeDoc specific tags to TSDoc (see more [here](https://typedoc.org/guides/tags/) and [here](https://typedoc.org/options/configuration/)), thus removing lots of lint warning for tags like `@group, @private` etc. that the linter says aren't configured because it doesn't exist in base [tsdoc](https://tsdoc.org/).

1726 -> 1377 problems

If this doesn't appear to change anything, removing the `cache` flag from `npm run lint` can do wonders