### PR TITLE
Main docs readme links fixes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,6 +121,19 @@ jobs:
           destination_dir: benchmarks/${{ steps.prepare_release.outputs.version_tag }}
           commit_message: 'deploy: ${{ steps.prepare_release.outputs.version_tag }}'
 
+      - name: Build the Docs
+        run: |
+          npm run generate-docs
+          docker run --rm -v ${PWD}:/docs squidfunk/mkdocs-material build
+
+      - name: Publish the docs
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: site
+          destination_dir: docs
+          commit_message: 'deploy docs: ${{ steps.prepare_release.outputs.version_tag }}'
+
       - name: Clean up
         if: ${{ steps.prepare_release.outputs.release_type == 'regular' }}
         run: |

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -29,6 +29,8 @@ jobs:
         if: success() || failure()
       - run: npm run typecheck
         if: success() || failure()
+      - run: npm run generate-docs
+      - run: docker run --rm -v ${PWD}:/docs squidfunk/mkdocs-material build
 
   unit-tests:
     name: Unit tests and Coverage
@@ -160,7 +162,6 @@ jobs:
         with:
           node-version: lts/*
       - run: npm ci
-      - run: docker run --rm -v ${PWD}:/docs squidfunk/mkdocs-material build
       - run: npm run build-dist
       - run: npm run test-build
         if: success() || failure()

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -160,7 +160,7 @@ jobs:
         with:
           node-version: lts/*
       - run: npm ci
-      - run: docker run --rm -it -v ${PWD}:/docs squidfunk/mkdocs-material build
+      - run: docker run --rm -v ${PWD}:/docs squidfunk/mkdocs-material build
       - run: npm run build-dist
       - run: npm run test-build
         if: success() || failure()

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -160,6 +160,7 @@ jobs:
         with:
           node-version: lts/*
       - run: npm ci
+      - run: docker run --rm -it -v ${PWD}:/docs squidfunk/mkdocs-material build
       - run: npm run build-dist
       - run: npm run test-build
         if: success() || failure()

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,14 +24,14 @@ MapLibre GL JS is a TypeScript library that uses WebGL to render interactive map
 
 This documentation is divided into several sections:
 
-* [**Main**](./API/#main). The Main section holds the following classes
-- `Map` object is the map on your page. It lets you access methods and properties for interacting with the map's style and layers, respond to events, and manipulate the user's perspective with the camera.
-- `MaplibreGL` object is MapLibre GL JS's global properties and options that you might want to access while initializing your map or accessing information about its status.
-* [**Markers and Controls**](./API//#markers-and-controls). This section describes the user interface elements that you can add to your map. The items in this section exist outside of the map's `canvas` element. This consists of `Marker`, `Popup` and all the controls.
-* [**Geography and geometry**](./API/#geography-and-geometry). This section includes general utilities and types that relate to working with and manipulating geographic information or geometries.
-* [**User interaction handlers**](./API/#handlers). The items in this section relate to the ways in which the map responds to user input.
-* [**Sources**](./API/#sources). This section describes the source types MapLibre GL JS can handle besides the ones described in the [MapLibre Style Specification](https://maplibre.org/maplibre-style-spec/).
-* [**Event Related**](./API/#event-related). This section describes the different types of events that MapLibre GL JS can raise.
+* [**Main**](./API/#main) - The Main section holds the following classes
+    * `Map` object is the map on your page. It lets you access methods and properties for interacting with the map's style and layers, respond to events, and manipulate the user's perspective with the camera.
+    * `MaplibreGL` object is MapLibre GL JS's global properties and options that you might want to access while initializing your map or accessing information about its status.
+* [**Markers and Controls**](./API//#markers-and-controls) - This section describes the user interface elements that you can add to your map. The items in this section exist outside of the map's `canvas` element. This consists of `Marker`, `Popup` and all the controls.
+* [**Geography and geometry**](./API/#geography-and-geometry) - This section includes general utilities and types that relate to working with and manipulating geographic information or geometries.
+* [**User interaction handlers**](./API/#handlers) - The items in this section relate to the ways in which the map responds to user input.
+* [**Sources**](./API/#sources) - This section describes the source types MapLibre GL JS can handle besides the ones described in the [MapLibre Style Specification](https://maplibre.org/maplibre-style-spec/).
+* [**Event Related**](./API/#event-related) - This section describes the different types of events that MapLibre GL JS can raise.
 
 Each section describes classes or objects as well as their **properties**, **parameters**, **instance members**, and associated **events**. Many sections also include inline code examples and related resources.
 
@@ -71,15 +71,14 @@ Including it with a `<link>` in the head of the document via the UNPKG CDN is th
 
 Note too that if the CSS isn't available by the first render, as soon as the CSS is provided, the DOM elements that depend on this CSS should recover.
 
-## Dependencies
+## CDN
 
-The dependencies for MapLibre GL JS (`.js` & `.css`) are distributed via [UNPKG.com](https://unpkg.com).  UNPKG can distribute a fixed version, a [semver range](https://semver.org/), a tag, or omit the version/tag entirely to use the `latest` tag.
-
-You can view a listing of all the files in the MapLibre GL JS package by appending a `/` at the end of the MapLibre slug.  This is useful to review other revisions or to review the files at UNPKG or the LICENSE.  See <https://unpkg.com/maplibre-gl/>
+The MapLibre GL JS (`.js` & `.css`) are distributed via [UNPKG.com](https://unpkg.com).
+You can view a listing of all the files in the MapLibre GL JS package by appending a `/` at the end of the MapLibre slug. This is useful to review other revisions or to review the files at UNPKG or the LICENSE. See examples in the following table:
 
 *Examples*
 
 | Use Case  | `.js` | `.css` |
 | :------- | :---: | :----: |
-| `latest` |`https://unpkg.com/maplibre-gl/dist/maplibre-gl.js` | `https://unpkg.com/maplibre-gl/dist/maplibre-gl.css` |
+| `latest` | <https://unpkg.com/maplibre-gl/dist/maplibre-gl.js> | <https://unpkg.com/maplibre-gl/dist/maplibre-gl.css> |
 | Use at least `2.4.x` | <https://unpkg.com/maplibre-gl@^2.4/dist/maplibre-gl.js> | <https://unpkg.com/maplibre-gl@^2.4/dist/maplibre-gl.css> |

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Introduction
 
-MapLibre GL JS is a TypeScript library that uses WebGL2 to render interactive maps from vector tiles in a browser. The customization of the map comply with the [MapLibre Style Spec](https://maplibre.org/maplibre-style-spec). It is part of the [MapLibre ecosystem](https://github.com/maplibre), with a pendant for Mobile, Desktop, Servers called [MapLibre Native](https://maplibre.org/projects/maplibre-native/).
+MapLibre GL JS is a TypeScript library that uses WebGL to render interactive maps from vector tiles in a browser. The customization of the map comply with the [MapLibre Style Spec](https://maplibre.org/maplibre-style-spec). It is part of the [MapLibre ecosystem](https://github.com/maplibre), with a pendant for Mobile, Desktop, Servers called [MapLibre Native](https://maplibre.org/projects/maplibre-native/).
 
 
 ## Quickstart
@@ -24,17 +24,18 @@ MapLibre GL JS is a TypeScript library that uses WebGL2 to render interactive ma
 
 This documentation is divided into several sections:
 
-* [**Map**](https://maplibre.org/maplibre-gl-js-docs/api/map/). The `Map` object is the map on your page. It lets you access methods and properties for interacting with the map's style and layers, respond to events, and manipulate the user's perspective with the camera.
-* [**Properties and options**](https://maplibre.org/maplibre-gl-js-docs/api/properties/). This section describes MapLibre GL JS's global properties and options that you might want to access while initializing your map or accessing information about its status.
-* [**Markers and controls**](https://maplibre.org/maplibre-gl-js-docs/api/markers/). This section describes the user interface elements that you can add to your map. The items in this section exist outside of the map's `canvas` element.
-* [**Geography and geometry**](https://maplibre.org/maplibre-gl-js-docs/api/geography/). This section includes general utilities and types that relate to working with and manipulating geographic information or geometries.
-* [**User interaction handlers**](https://maplibre.org/maplibre-gl-js-docs/api/handlers/). The items in this section relate to the ways in which the map responds to user input.
-* [**Sources**](https://maplibre.org/maplibre-gl-js-docs/api/sources/). This section describes the source types MapLibre GL JS can handle besides the ones described in the [MapLibre Style Specification](https://maplibre.org/maplibre-style-spec/).
-* [**Events**](https://maplibre.org/maplibre-gl-js-docs/api/events/). This section describes the different types of events that MapLibre GL JS can raise.
+* [**Main**](https://maplibre.org/maplibre-gl-js-docs/API/#main). The Main section holds the following classes
+- `Map` object is the map on your page. It lets you access methods and properties for interacting with the map's style and layers, respond to events, and manipulate the user's perspective with the camera.
+- `MaplibreGL` object is MapLibre GL JS's global properties and options that you might want to access while initializing your map or accessing information about its status.
+* [**Markers and Controls**](https://maplibre.org/maplibre-gl-js-docs/API/#markers-and-controls). This section describes the user interface elements that you can add to your map. The items in this section exist outside of the map's `canvas` element. This consists of `Marker`, `Popup` and all the controls.
+* [**Geography and geometry**](https://maplibre.org/maplibre-gl-js-docs/API/#geography-and-geometry). This section includes general utilities and types that relate to working with and manipulating geographic information or geometries.
+* [**User interaction handlers**](https://maplibre.org/maplibre-gl-js-docs/API/#handlers). The items in this section relate to the ways in which the map responds to user input.
+* [**Sources**](https://maplibre.org/maplibre-gl-js-docs/API/#sources). This section describes the source types MapLibre GL JS can handle besides the ones described in the [MapLibre Style Specification](https://maplibre.org/maplibre-style-spec/).
+* [**Event Related**](https://maplibre.org/maplibre-gl-js-docs/API/#event-related). This section describes the different types of events that MapLibre GL JS can raise.
 
 Each section describes classes or objects as well as their **properties**, **parameters**, **instance members**, and associated **events**. Many sections also include inline code examples and related resources.
 
-In the examples, we use vector tiles from [MapTiler](https://maptiler.com). Get your own API key if you want to use MapTiler data in your project.
+In the examples, we use vector tiles our [Demo tiles repository](https://github.com/maplibre/demotiles) and from [MapTiler](https://maptiler.com). Get your own API key if you want to use MapTiler data in your project.
 
 ## CSP Directives
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,14 +24,14 @@ MapLibre GL JS is a TypeScript library that uses WebGL to render interactive map
 
 This documentation is divided into several sections:
 
-* [**Main**](https://maplibre.org/maplibre-gl-js-docs/API/#main). The Main section holds the following classes
+* [**Main**](./API/#main). The Main section holds the following classes
 - `Map` object is the map on your page. It lets you access methods and properties for interacting with the map's style and layers, respond to events, and manipulate the user's perspective with the camera.
 - `MaplibreGL` object is MapLibre GL JS's global properties and options that you might want to access while initializing your map or accessing information about its status.
-* [**Markers and Controls**](https://maplibre.org/maplibre-gl-js-docs/API/#markers-and-controls). This section describes the user interface elements that you can add to your map. The items in this section exist outside of the map's `canvas` element. This consists of `Marker`, `Popup` and all the controls.
-* [**Geography and geometry**](https://maplibre.org/maplibre-gl-js-docs/API/#geography-and-geometry). This section includes general utilities and types that relate to working with and manipulating geographic information or geometries.
-* [**User interaction handlers**](https://maplibre.org/maplibre-gl-js-docs/API/#handlers). The items in this section relate to the ways in which the map responds to user input.
-* [**Sources**](https://maplibre.org/maplibre-gl-js-docs/API/#sources). This section describes the source types MapLibre GL JS can handle besides the ones described in the [MapLibre Style Specification](https://maplibre.org/maplibre-style-spec/).
-* [**Event Related**](https://maplibre.org/maplibre-gl-js-docs/API/#event-related). This section describes the different types of events that MapLibre GL JS can raise.
+* [**Markers and Controls**](./API//#markers-and-controls). This section describes the user interface elements that you can add to your map. The items in this section exist outside of the map's `canvas` element. This consists of `Marker`, `Popup` and all the controls.
+* [**Geography and geometry**](./API/#geography-and-geometry). This section includes general utilities and types that relate to working with and manipulating geographic information or geometries.
+* [**User interaction handlers**](./API/#handlers). The items in this section relate to the ways in which the map responds to user input.
+* [**Sources**](./API/#sources). This section describes the source types MapLibre GL JS can handle besides the ones described in the [MapLibre Style Specification](https://maplibre.org/maplibre-style-spec/).
+* [**Event Related**](./API/#event-related). This section describes the different types of events that MapLibre GL JS can raise.
 
 Each section describes classes or objects as well as their **properties**, **parameters**, **instance members**, and associated **events**. Many sections also include inline code examples and related resources.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: MapLibre GL JS
-site_url: https://harelm.github.io/maplibre-docs-test/ # HM TODO: change this!
+site_url: https://www.maplibre.org/maplibre-gl-js/docs/
 repo_url: https://github.com/maplibre/maplibre-gl-js/
 theme:
   name: 'material'

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,32 +37,37 @@ const version = packageJSON.version;
 
 export type * from '@maplibre/maplibre-gl-style-spec';
 
-const maplibregl = {
-    Map,
-    NavigationControl,
-    GeolocateControl,
-    AttributionControl,
-    LogoControl,
-    ScaleControl,
-    FullscreenControl,
-    TerrainControl,
-    Popup,
-    Marker,
-    Style,
-    LngLat,
-    LngLatBounds,
-    Point,
-    MercatorCoordinate,
-    Evented,
-    AJAXError,
-    config,
-    CanvasSource,
-    GeoJSONSource,
-    ImageSource,
-    RasterDEMTileSource,
-    RasterTileSource,
-    VectorTileSource,
-    VideoSource,
+/**
+ * `maplibregl` is the global object that allows configurations that are not specific to a map instance
+ *
+ * @group Main
+ */
+class MapLibreGL {
+    static Map = Map;
+    static NavigationControl = NavigationControl;
+    static GeolocateControl = GeolocateControl;
+    static AttributionControl = AttributionControl;
+    static LogoControl = LogoControl;
+    static ScaleControl = ScaleControl;
+    static FullscreenControl = FullscreenControl;
+    static TerrainControl = TerrainControl;
+    static Popup = Popup;
+    static Marker = Marker;
+    static Style = Style;
+    static LngLat = LngLat;
+    static LngLatBounds = LngLatBounds;
+    static Point = Point;
+    static MercatorCoordinate = MercatorCoordinate;
+    static Evented = Evented;
+    static AJAXError = AJAXError;
+    static config = config;
+    static CanvasSource = CanvasSource;
+    static GeoJSONSource = GeoJSONSource;
+    static ImageSource = ImageSource;
+    static RasterDEMTileSource = RasterDEMTileSource;
+    static RasterTileSource = RasterTileSource;
+    static VectorTileSource = VectorTileSource;
+    static VideoSource = VideoSource;
     /**
      * Sets the map's [RTL text plugin](https://www.mapbox.com/mapbox-gl-js/plugins/#mapbox-gl-rtl-text).
      * Necessary for supporting the Arabic and Hebrew languages, which are written right-to-left.
@@ -77,7 +82,7 @@ const maplibregl = {
      * ```
      * @see [Add support for right-to-left scripts](https://maplibre.org/maplibre-gl-js-docs/example/mapbox-gl-rtl-text/)
      */
-    setRTLTextPlugin,
+    static setRTLTextPlugin = setRTLTextPlugin;
     /**
      * Gets the map's [RTL text plugin](https://www.mapbox.com/mapbox-gl-js/plugins/#mapbox-gl-rtl-text) status.
      * The status can be `unavailable` (i.e. not requested or removed), `loading`, `loaded` or `error`.
@@ -88,7 +93,7 @@ const maplibregl = {
      * const pluginStatus = maplibregl.getRTLTextPluginStatus();
      * ```
      */
-    getRTLTextPluginStatus,
+    static getRTLTextPluginStatus = getRTLTextPluginStatus;
     /**
      * Initializes resources like WebWorkers that can be shared across maps to lower load
      * times in some situations. `maplibregl.workerUrl` and `maplibregl.workerCount`, if being
@@ -111,7 +116,7 @@ const maplibregl = {
      * maplibregl.prewarm()
      * ```
      */
-    prewarm,
+    static prewarm = prewarm;
     /**
      * Clears up resources that have previously been created by `maplibregl.prewarm()`.
      * Note that this is typically not necessary. You should only call this function
@@ -123,15 +128,14 @@ const maplibregl = {
      * maplibregl.clearPrewarmedResources()
      * ```
      */
-    clearPrewarmedResources,
-
+    static clearPrewarmedResources = clearPrewarmedResources;
     /**
      * Returns the package version of the library
      * @returns Package version of the library
      */
-    get version(): string {
+    static get version(): string {
         return version;
-    },
+    }
 
     /**
      * Gets and sets the number of web workers instantiated on a page with GL JS maps.
@@ -144,14 +148,13 @@ const maplibregl = {
      * maplibregl.workerCount = 2;
      * ```
      */
-    get workerCount(): number {
+    static get workerCount(): number {
         return WorkerPool.workerCount;
-    },
+    }
 
-    set workerCount(count: number) {
+    static set workerCount(count: number) {
         WorkerPool.workerCount = count;
-    },
-
+    }
     /**
      * Gets and sets the maximum number of images (raster tiles, sprites, icons) to load in parallel,
      * which affects performance in raster-heavy maps. 16 by default.
@@ -162,21 +165,21 @@ const maplibregl = {
      * maplibregl.maxParallelImageRequests = 10;
      * ```
      */
-    get maxParallelImageRequests(): number {
+    static get maxParallelImageRequests(): number {
         return config.MAX_PARALLEL_IMAGE_REQUESTS;
-    },
+    }
 
-    set maxParallelImageRequests(numRequests: number) {
+    static set maxParallelImageRequests(numRequests: number) {
         config.MAX_PARALLEL_IMAGE_REQUESTS = numRequests;
-    },
+    }
 
-    get workerUrl(): string {
+    static get workerUrl(): string {
         return config.WORKER_URL;
-    },
+    }
 
-    set workerUrl(value: string) {
+    static set workerUrl(value: string) {
         config.WORKER_URL = value;
-    },
+    }
 
     /**
      * Sets a custom load tile function that will be called when using a source that starts with a custom url schema.
@@ -212,9 +215,9 @@ const maplibregl = {
      * });
      * ```
      */
-    addProtocol(customProtocol: string, loadFn: (requestParameters: RequestParameters, callback: ResponseCallback<any>) => Cancelable) {
+    static addProtocol(customProtocol: string, loadFn: (requestParameters: RequestParameters, callback: ResponseCallback<any>) => Cancelable) {
         config.REGISTERED_PROTOCOLS[customProtocol] = loadFn;
-    },
+    }
 
     /**
      * Removes a previously added protocol
@@ -225,12 +228,12 @@ const maplibregl = {
      * maplibregl.removeProtocol('custom');
      * ```
      */
-    removeProtocol(customProtocol: string) {
+    static removeProtocol(customProtocol: string) {
         delete config.REGISTERED_PROTOCOLS[customProtocol];
     }
-};
+}
 
 //This gets automatically stripped out in production builds.
-Debug.extend(maplibregl, {isSafari, getPerformanceMetrics: PerformanceUtils.getPerformanceMetrics});
+Debug.extend(MapLibreGL, {isSafari, getPerformanceMetrics: PerformanceUtils.getPerformanceMetrics});
 
-export default maplibregl;
+export default MapLibreGL;

--- a/src/source/rtl_text_plugin.ts
+++ b/src/source/rtl_text_plugin.ts
@@ -16,6 +16,9 @@ export type PluginState = {
     pluginURL: string;
 };
 
+/**
+ * An error callback
+ */
 type ErrorCallback = (error?: Error | null) => void;
 type PluginStateSyncCallback = (state: PluginState) => void;
 let _completionCallback = null;

--- a/src/ui/control/attribution_control.ts
+++ b/src/ui/control/attribution_control.ts
@@ -22,7 +22,7 @@ type AttributionOptions = {
 
 /**
  * An `AttributionControl` control presents the map's attribution information. By default, the attribution control is expanded (regardless of map width).
- * @group Controls
+ * @group Markers and Controls
  * @example
  * ```ts
  * let map = new maplibregl.Map({attributionControl: false})

--- a/src/ui/control/fullscreen_control.ts
+++ b/src/ui/control/fullscreen_control.ts
@@ -22,7 +22,7 @@ type FullscreenOptions = {
  * The map's `cooperativeGestures` option is temporarily disabled while the map
  * is in fullscreen mode, and is restored when the map exist fullscreen mode.
  *
- * @group Controls
+ * @group Markers and Controls
  * @param options - the full screen control options
  *
  * @example

--- a/src/ui/control/geolocate_control.ts
+++ b/src/ui/control/geolocate_control.ts
@@ -75,7 +75,7 @@ let noTimeout = false;
  * * disabled - occurs if Geolocation is not available, disabled or denied.
  *
  * These interaction states can't be controlled programmatically, rather they are set based on user interactions.
- * @group Controls
+ * @group Markers and Controls
  *
  * @example
  * ```ts

--- a/src/ui/control/logo_control.ts
+++ b/src/ui/control/logo_control.ts
@@ -17,7 +17,7 @@ type LogoOptions = {
 /**
  * A `LogoControl` is a control that adds the watermark.
  *
- * @group Controls
+ * @group Markers and Controls
  *
  * @example
  * ```ts

--- a/src/ui/control/navigation_control.ts
+++ b/src/ui/control/navigation_control.ts
@@ -35,7 +35,7 @@ const defaultOptions: NavigationOptions = {
 /**
  * A `NavigationControl` control contains zoom buttons and a compass.
  *
- * @group Controls
+ * @group Markers and Controls
  *
  * @example
  * ```ts

--- a/src/ui/control/scale_control.ts
+++ b/src/ui/control/scale_control.ts
@@ -33,7 +33,7 @@ const defaultOptions: ScaleOptions = {
 /**
  * A `ScaleControl` control displays the ratio of a distance on the map to the corresponding distance on the ground.
  *
- * @group Controls
+ * @group Markers and Controls
  *
  * @example
  * ```ts

--- a/src/ui/control/terrain_control.ts
+++ b/src/ui/control/terrain_control.ts
@@ -7,7 +7,7 @@ import type {TerrainSpecification} from '@maplibre/maplibre-gl-style-spec';
 /**
  * A `TerrainControl` control contains a button for turning the terrain on and off.
  *
- * @group Controls
+ * @group Markers and Controls
  *
  * @example
  * ```ts

--- a/src/ui/events.ts
+++ b/src/ui/events.ts
@@ -35,6 +35,7 @@ export type MapSourceDataType = 'content' | 'metadata' | 'visibility' | 'idle';
  * event action contains a visible portion of the specified layer.
  * The following example can be used for all the events.
  *
+ * @group Event Related
  * @example
  * ```ts
  * // Initialize the map
@@ -133,6 +134,7 @@ export type MapLayerEventType = {
  * When using a `layerId` with {@link Map#on} method, please refer to {@link MapLayerEventType}.
  * The following example can be used for all the events.
  *
+ * @group Event Related
  * @example
  * ```ts
  * // Initialize the map

--- a/src/ui/hash.ts
+++ b/src/ui/hash.ts
@@ -6,7 +6,7 @@ import type {Map} from './map';
  * Adds the map's position to its page's location hash.
  * Passed as an option to the map object.
  *
- * @group Controls
+ * @group Markers and Controls
  */
 export class Hash {
     _map: Map;

--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -421,9 +421,8 @@ const defaultOptions = {
  * and properties that enable you to programmatically change the map,
  * and fires events as users interact with it.
  *
- * You create a `Map` by specifying a `container` and other options.
- * Then MapLibre GL JS initializes the map on the page and returns your `Map`
- * object.
+ * You create a `Map` by specifying a `container` and other options, see {@link MapOptions} for the full list.
+ * Then MapLibre GL JS initializes the map on the page and returns your `Map` object.
  *
  * @group Main
  *

--- a/src/ui/marker.ts
+++ b/src/ui/marker.ts
@@ -78,7 +78,7 @@ type MarkerOptions = {
 /**
  * Creates a marker component
  *
- * @group Main
+ * @group Markers and Controls
  *
  * @example
  * ```ts

--- a/src/ui/popup.ts
+++ b/src/ui/popup.ts
@@ -91,7 +91,7 @@ const focusQuerySelector = [
 /**
  * A popup component.
  *
- * @group Main
+ * @group Markers and Controls
  *
  *
  * @example

--- a/src/util/ajax.ts
+++ b/src/util/ajax.ts
@@ -51,6 +51,9 @@ export type RequestParameters = {
     collectResourceTiming?: boolean;
 };
 
+/**
+ * The response callback used in various places
+ */
 export type ResponseCallback<T> = (
     error?: Error | null,
     data?: T | null,

--- a/src/util/config.ts
+++ b/src/util/config.ts
@@ -1,6 +1,11 @@
 import type {Cancelable} from '../types/cancelable';
 import type {RequestParameters, ResponseCallback} from './ajax';
 
+/**
+ * This is a global config object used to store the configuration
+ * It is available in the workers as well.
+ * Only serializable data should be stored in it.
+ */
 type Config = {
     MAX_PARALLEL_IMAGE_REQUESTS: number;
     MAX_PARALLEL_IMAGE_REQUESTS_PER_FRAME: number;

--- a/test/examples/add-image-animated.html
+++ b/test/examples/add-image-animated.html
@@ -25,7 +25,7 @@
     const size = 200;
 
     // implementation of StyleImageInterface to draw a pulsing dot icon on the map
-    // see https://maplibre.org/maplibre-gl-js-docs/api/properties/#styleimageinterface for more info
+    // Search for StyleImageInterface in https://maplibre.org/maplibre-gl-js-docs/api/
     const pulsingDot = {
         width: size,
         height: size,

--- a/test/examples/custom-style-layer.html
+++ b/test/examples/custom-style-layer.html
@@ -29,7 +29,7 @@
         type: 'custom',
 
         // method called when the layer is added to the map
-        // https://maplibre.org/maplibre-gl-js-docs/api/properties/#styleimageinterface#onadd
+        // Search for StyleImageInterface in https://maplibre.org/maplibre-gl-js-docs/api/
         onAdd (map, gl) {
         // create GLSL source for vertex shader
             const vertexSource = `#version 300 es
@@ -98,7 +98,6 @@
         },
 
         // method fired on each animation frame
-        // https://maplibre.org/maplibre-gl-js-docs/api/map/#map.event:render
         render (gl, matrix) {
             gl.useProgram(this.program);
             gl.uniformMatrix4fv(

--- a/typedoc.json
+++ b/typedoc.json
@@ -3,11 +3,11 @@
     "plugin": ["typedoc-plugin-missing-exports", "typedoc-plugin-markdown"],
     "groupOrder": [
         "Main",
-        "Controls",
-        "Event Related",
+        "Markers and Controls",
         "Geography and Geometry",
+        "Handlers",
         "Sources",
-        "Handlers"
+        "Event Related"
     ],
     "out": "./docs/API",
     "excludeExternals": true,


### PR DESCRIPTION
I've aligned the group to the original doc's structure and fixed the linked in the main readme.
I also changed the main exported const to be a static class - this is mainly so it would show up in the docs with all the relevant information - I'm not super excited about this change so I'll need a second opinion here.

Added also the build to the CI, although I'm not sure what it actually checks...