### PR TITLE
Move docs examples to examples folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /dist_type/
 /test/bench/results/
 /docs/API
+/docs/examples
 /docs/example
 *.es.js
 *.js.map

--- a/build/generate-docs.ts
+++ b/build/generate-docs.ts
@@ -37,7 +37,7 @@ ${htmlContent}
 }
 
 function generateMarkdownIndexFileOfAllExamples(indexArray: HtmlDoc[]): string {
-    let indexMarkdown = '# Exmaples \n\n';
+    let indexMarkdown = '# Overview \n\n';
     for (const indexArrayItem of indexArray) {
         indexMarkdown += `
 ## [${indexArrayItem.title}](./${indexArrayItem.mdFileName})
@@ -66,7 +66,7 @@ const contentString = generateAPIIntroMarkdown(lines);
 fs.writeFileSync(path.join(typedocConfig.out, 'README.md'), contentString);
 
 // Examples manupilation
-const examplesDocsFolder = path.join('docs', 'example');
+const examplesDocsFolder = path.join('docs', 'examples');
 if (fs.existsSync(examplesDocsFolder)) {
     fs.rmSync(examplesDocsFolder, {recursive: true, force: true});
 }


### PR DESCRIPTION
It seems quite straightforward in cloudflare to forwarding all existing examples to the new route.

https://maplibre.org/maplibre-gl-js-docs/example/ -> https://maplibre.org/maplibre-gl-js/docs/examples/

Alternatively, if a direct forward of everything from old to new docs page is setup, this could also be fixed with a redirect:

https://maplibre.org/maplibre-gl-js/docs/example/ -> https://maplibre.org/maplibre-gl-js/docs/examples/