### PR TITLE
Fix image links in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ Check out the features through [examples](https://maplibre.org/maplibre-gl-js/do
 
 | Showcases |      |
 | ---- | ---- |
-|![Display a map](https://maplibre.org/maplibre-gl-js/docs/assets/simple-map.png)	|![Third party vector tile source](https://maplibre.org/maplibre-gl-js/docs/assets/3d-terrain.png)	|
-|![Animate a series of images](https://maplibre.org/maplibre-gl-js/docs/assets/animate-images.png)	|![Create a heatmap layer](https://maplibre.org/maplibre-gl-js/docs/assets/heatmap-layer.png)	|
-|![3D buildings](https://maplibre.org/maplibre-gl-js/docs/assets/3d-buildings.png)	|![Visualize population density](https://maplibre.org/maplibre-gl-js/docs/assets/visualize-population-density.png)	|
+|![Display a map](https://maplibre.org/maplibre-gl-js/docs/assets/examples/simple-map.png)	|![Third party vector tile source](https://maplibre.org/maplibre-gl-js/docs/assets/examples/3d-terrain.png)	|
+|![Animate a series of images](https://maplibre.org/maplibre-gl-js/docs/assets/examples/animate-images.png)	|![Create a heatmap layer](https://maplibre.org/maplibre-gl-js/docs/assets/examples/heatmap-layer.png)	|
+|![3D buildings](https://maplibre.org/maplibre-gl-js/docs/assets/examples/3d-buildings.png)	|![Visualize population density](https://maplibre.org/maplibre-gl-js/docs/assets/examples/visualize-population-density.png)	|
 
 <br />
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,7 +27,7 @@ This documentation is divided into several sections:
 * [**Main**](./API/#main) - The Main section holds the following classes
     * [`Map`](./API/classes/maplibregl.Map/) object is the map on your page. It lets you access methods and properties for interacting with the map's style and layers, respond to events, and manipulate the user's perspective with the camera.
     * [`MaplibreGL`](./API/classes/default/) object is MapLibre GL JS's global properties and options that you might want to access while initializing your map or accessing information about its status.
-* [**Markers and Controls**](./API//#markers-and-controls) - This section describes the user interface elements that you can add to your map. The items in this section exist outside of the map's `canvas` element. This consists of `Marker`, `Popup` and all the controls.
+* [**Markers and Controls**](./API/#markers-and-controls) - This section describes the user interface elements that you can add to your map. The items in this section exist outside of the map's `canvas` element. This consists of `Marker`, `Popup` and all the controls.
 * [**Geography and geometry**](./API/#geography-and-geometry) - This section includes general utilities and types that relate to working with and manipulating geographic information or geometries.
 * [**User interaction handlers**](./API/#handlers) - The items in this section relate to the ways in which the map responds to user input.
 * [**Sources**](./API/#sources) - This section describes the source types MapLibre GL JS can handle besides the ones described in the [MapLibre Style Specification](https://maplibre.org/maplibre-style-spec/).


### PR DESCRIPTION
Images in readme now point to where they are in the new docs site.