### PR TITLE
Bump version to 3.2.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,6 +127,7 @@ jobs:
           docker run --rm -v ${PWD}:/docs squidfunk/mkdocs-material build
 
       - name: Publish the docs
+        if: ${{ steps.prepare_release.outputs.release_type == 'regular' }}
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 - _...Add new stuff here..._
 
-## 3.2.0-pre.3
+## 3.2.0
 
 ### ✨ Features and improvements
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "maplibre-gl",
-  "version": "3.2.0-pre.3",
+  "version": "3.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "maplibre-gl",
-      "version": "3.2.0-pre.3",
+      "version": "3.2.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@mapbox/geojson-rewind": "^0.5.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "maplibre-gl",
   "description": "BSD licensed community fork of mapbox-gl, a WebGL interactive maps library",
-  "version": "3.2.0-pre.3",
+  "version": "3.2.0",
   "main": "dist/maplibre-gl.js",
   "style": "dist/maplibre-gl.css",
   "license": "BSD-3-Clause",


### PR DESCRIPTION
Release version 3.2.

I believe I fixes most of the docs issues.
I'm fairly pleased with it.
I've added a condition to the release.yml to avoid publishing the docs when publishing a pre-release.

