### PR TITLE
Fix setting line-gradient to null/undefined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Fixed Interrupting a scroll zoom causes the next scroll zoom to return to the prior zoom level by reseting scroll handler state properly ([#2709](https://github.com/maplibre/maplibre-gl-js/issues/2709), [#3051](https://github.com/maplibre/maplibre-gl-js/pull/305))
 - Fix unit test warning about duplicate module names ([#3049](https://github.com/maplibre/maplibre-gl-js/pull/3049))
 - Correct marker position when switching between 2D and 3D view ([#2996](https://github.com/maplibre/maplibre-gl-js/pull/2996))
+- Fix error thrown when unsetting line-gradient [#2683]
 - _...Add new stuff here..._
 
 ## 3.3.1

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@mapbox/unitbezier": "^0.0.1",
         "@mapbox/vector-tile": "^1.3.1",
         "@mapbox/whoots-js": "^3.1.0",
-        "@maplibre/maplibre-gl-style-spec": "^19.3.0",
+        "@maplibre/maplibre-gl-style-spec": "^19.3.1",
         "@types/geojson": "^7946.0.10",
         "@types/mapbox__point-geometry": "^0.1.2",
         "@types/mapbox__vector-tile": "^1.3.0",
@@ -1403,9 +1403,9 @@
       }
     },
     "node_modules/@maplibre/maplibre-gl-style-spec": {
-      "version": "19.3.0",
-      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-19.3.0.tgz",
-      "integrity": "sha512-ZbhX9CTV+Z7vHwkRIasDOwTSzr76e8Q6a55RMsAibjyX6+P0ZNL1qAKNzOjjBDP3+aEfNMl7hHo5knuY6pTAUQ==",
+      "version": "19.3.1",
+      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-19.3.1.tgz",
+      "integrity": "sha512-ss5+b3/a8I1wD5PYmAYPYxg0Nag0cxvw4GGOnQroTP59sobTPI3KeHP9OjUr/es7uNtYEodr54fgoEnCBF6gaQ==",
       "dependencies": {
         "@mapbox/jsonlint-lines-primitives": "~2.0.2",
         "@mapbox/unitbezier": "^0.0.1",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@mapbox/unitbezier": "^0.0.1",
     "@mapbox/vector-tile": "^1.3.1",
     "@mapbox/whoots-js": "^3.1.0",
-    "@maplibre/maplibre-gl-style-spec": "^19.3.0",
+    "@maplibre/maplibre-gl-style-spec": "^19.3.1",
     "@types/geojson": "^7946.0.10",
     "@types/mapbox__point-geometry": "^0.1.2",
     "@types/mapbox__vector-tile": "^1.3.0",

--- a/src/style/style_layer.test.ts
+++ b/src/style/style_layer.test.ts
@@ -6,7 +6,7 @@ import {EvaluationParameters} from './evaluation_parameters';
 import {TransitionParameters} from './properties';
 import {BackgroundStyleLayer} from './style_layer/background_style_layer';
 import {SymbolStyleLayer} from './style_layer/symbol_style_layer';
-import { LineStyleLayer } from './style_layer/line_style_layer';
+import {LineStyleLayer} from './style_layer/line_style_layer';
 
 describe('StyleLayer', () => {
     test('instantiates the correct subclass', () => {
@@ -392,7 +392,7 @@ describe('StyleLayer->LineStyleLayer', () => {
                 ]
             }
         }, layer);
-    };
+    }
 
     test('updating with valid line-gradient updates this.gradientVersion', () => {
         const lineLayer = createStyleLayer(createLineLayer()) as LineStyleLayer;
@@ -417,4 +417,4 @@ describe('StyleLayer->LineStyleLayer', () => {
         lineLayer.setPaintProperty('line-gradient', null);
         expect(lineLayer.gradientVersion).toBeGreaterThan(gradientVersion);
     });
-})
+});

--- a/src/style/style_layer.test.ts
+++ b/src/style/style_layer.test.ts
@@ -6,7 +6,6 @@ import {EvaluationParameters} from './evaluation_parameters';
 import {TransitionParameters} from './properties';
 import {BackgroundStyleLayer} from './style_layer/background_style_layer';
 import {SymbolStyleLayer} from './style_layer/symbol_style_layer';
-import {LineStyleLayer} from './style_layer/line_style_layer';
 
 describe('StyleLayer', () => {
     test('instantiates the correct subclass', () => {
@@ -369,52 +368,5 @@ describe('StyleLayer#serialize', () => {
         const layer = createStyleLayer({type: 'fill'} as LayerSpecification);
         // paint is never undefined
         expect(layer.paint).toBeTruthy();
-    });
-});
-
-describe('StyleLayer->LineStyleLayer', () => {
-    function createLineLayer(layer?) {
-        return extend({
-            type: 'line',
-            source: 'line',
-            id: 'line',
-            paint: {
-                'line-color': 'red',
-                'line-width': 14,
-                'line-gradient': [
-                    'interpolate',
-                    ['linear'],
-                    ['line-progress'],
-                    0,
-                    'blue',
-                    1,
-                    'red'
-                ]
-            }
-        }, layer);
-    }
-
-    test('updating with valid line-gradient updates this.gradientVersion', () => {
-        const lineLayer = createStyleLayer(createLineLayer()) as LineStyleLayer;
-        const gradientVersion = lineLayer.gradientVersion;
-
-        lineLayer.setPaintProperty('line-gradient', [
-            'interpolate',
-            ['linear'],
-            ['line-progress'],
-            0,
-            'red',
-            1,
-            'blue'
-        ]);
-        expect(lineLayer.gradientVersion).toBeGreaterThan(gradientVersion);
-    });
-
-    test('updating with invalid line-gradient updates this.gradientVersion', () => {
-        const lineLayer = createStyleLayer(createLineLayer()) as LineStyleLayer;
-        const gradientVersion = lineLayer.gradientVersion;
-
-        lineLayer.setPaintProperty('line-gradient', null);
-        expect(lineLayer.gradientVersion).toBeGreaterThan(gradientVersion);
     });
 });

--- a/src/style/style_layer.test.ts
+++ b/src/style/style_layer.test.ts
@@ -6,6 +6,7 @@ import {EvaluationParameters} from './evaluation_parameters';
 import {TransitionParameters} from './properties';
 import {BackgroundStyleLayer} from './style_layer/background_style_layer';
 import {SymbolStyleLayer} from './style_layer/symbol_style_layer';
+import { LineStyleLayer } from './style_layer/line_style_layer';
 
 describe('StyleLayer', () => {
     test('instantiates the correct subclass', () => {
@@ -370,3 +371,50 @@ describe('StyleLayer#serialize', () => {
         expect(layer.paint).toBeTruthy();
     });
 });
+
+describe('StyleLayer->LineStyleLayer', () => {
+    function createLineLayer(layer?) {
+        return extend({
+            type: 'line',
+            source: 'line',
+            id: 'line',
+            paint: {
+                'line-color': 'red',
+                'line-width': 14,
+                'line-gradient': [
+                    'interpolate',
+                    ['linear'],
+                    ['line-progress'],
+                    0,
+                    'blue',
+                    1,
+                    'red'
+                ]
+            }
+        }, layer);
+    };
+
+    test('updating with valid line-gradient updates this.gradientVersion', () => {
+        const lineLayer = createStyleLayer(createLineLayer()) as LineStyleLayer;
+        const gradientVersion = lineLayer.gradientVersion;
+
+        lineLayer.setPaintProperty('line-gradient', [
+            'interpolate',
+            ['linear'],
+            ['line-progress'],
+            0,
+            'red',
+            1,
+            'blue'
+        ]);
+        expect(lineLayer.gradientVersion).toBeGreaterThan(gradientVersion);
+    });
+
+    test('updating with invalid line-gradient updates this.gradientVersion', () => {
+        const lineLayer = createStyleLayer(createLineLayer()) as LineStyleLayer;
+        const gradientVersion = lineLayer.gradientVersion;
+
+        lineLayer.setPaintProperty('line-gradient', null);
+        expect(lineLayer.gradientVersion).toBeGreaterThan(gradientVersion);
+    });
+})

--- a/src/style/style_layer/line_style_layer.test.ts
+++ b/src/style/style_layer/line_style_layer.test.ts
@@ -1,0 +1,50 @@
+import {createStyleLayer} from '../create_style_layer';
+import {extend} from '../../util/util';
+import {LineStyleLayer} from './line_style_layer';
+
+describe('LineStyleLayer', () => {
+    function createLineLayer(layer?) {
+        return extend({
+            type: 'line',
+            source: 'line',
+            id: 'line',
+            paint: {
+                'line-color': 'red',
+                'line-width': 14,
+                'line-gradient': [
+                    'interpolate',
+                    ['linear'],
+                    ['line-progress'],
+                    0,
+                    'blue',
+                    1,
+                    'red'
+                ]
+            }
+        }, layer);
+    }
+
+    test('updating with valid line-gradient updates this.gradientVersion', () => {
+        const lineLayer = createStyleLayer(createLineLayer()) as LineStyleLayer;
+        const gradientVersion = lineLayer.gradientVersion;
+
+        lineLayer.setPaintProperty('line-gradient', [
+            'interpolate',
+            ['linear'],
+            ['line-progress'],
+            0,
+            'red',
+            1,
+            'blue'
+        ]);
+        expect(lineLayer.gradientVersion).toBeGreaterThan(gradientVersion);
+    });
+
+    test('updating with invalid line-gradient updates this.gradientVersion', () => {
+        const lineLayer = createStyleLayer(createLineLayer()) as LineStyleLayer;
+        const gradientVersion = lineLayer.gradientVersion;
+
+        lineLayer.setPaintProperty('line-gradient', null);
+        expect(lineLayer.gradientVersion).toBeGreaterThan(gradientVersion);
+    });
+});

--- a/src/style/style_layer/line_style_layer.ts
+++ b/src/style/style_layer/line_style_layer.ts
@@ -61,7 +61,8 @@ export class LineStyleLayer extends StyleLayer {
     _handleSpecialPaintPropertyUpdate(name: string) {
         if (name === 'line-gradient') {
             const expression = this.gradientExpression();
-            if (Object.prototype.hasOwnProperty.call(expression, '_styleExpression')) {
+            if (expression._styleExpression) {
+                // presence of ._styleExpression implies expression is a ZoonConstantExpression
                 const zoomConstantExpression = expression as ZoomConstantExpression<'source'>;
                 this.stepInterpolant = zoomConstantExpression._styleExpression.expression instanceof Step;
             } else {

--- a/src/style/style_layer/line_style_layer.ts
+++ b/src/style/style_layer/line_style_layer.ts
@@ -60,8 +60,13 @@ export class LineStyleLayer extends StyleLayer {
 
     _handleSpecialPaintPropertyUpdate(name: string) {
         if (name === 'line-gradient') {
-            const expression: ZoomConstantExpression<'source'> = (this._transitionablePaint._values['line-gradient'].value.expression as any);
-            this.stepInterpolant = expression._styleExpression.expression instanceof Step;
+            if (Object.prototype.hasOwnProperty.call(this.gradientExpression(), '_styleExpression')) {
+                const expression: ZoomConstantExpression<'source'> = this.gradientExpression() as any;
+                this.stepInterpolant = expression._styleExpression.expression instanceof Step;
+            } else {
+                this.stepInterpolant = false;
+            }
+            
             this.gradientVersion = (this.gradientVersion + 1) % Number.MAX_SAFE_INTEGER;
         }
     }

--- a/src/style/style_layer/line_style_layer.ts
+++ b/src/style/style_layer/line_style_layer.ts
@@ -9,8 +9,8 @@ import {extend} from '../../util/util';
 import {EvaluationParameters} from '../evaluation_parameters';
 import {Transitionable, Transitioning, Layout, PossiblyEvaluated, DataDrivenProperty} from '../properties';
 
-import {Step} from '@maplibre/maplibre-gl-style-spec';
-import type {FeatureState, ZoomConstantExpression, LayerSpecification} from '@maplibre/maplibre-gl-style-spec';
+import {isZoomExpression, Step} from '@maplibre/maplibre-gl-style-spec';
+import type {FeatureState, LayerSpecification} from '@maplibre/maplibre-gl-style-spec';
 import type {Bucket, BucketParameters} from '../../data/bucket';
 import type {LineLayoutProps, LinePaintProps} from './line_style_layer_properties.g';
 import type {Transform} from '../../geo/transform';
@@ -61,10 +61,8 @@ export class LineStyleLayer extends StyleLayer {
     _handleSpecialPaintPropertyUpdate(name: string) {
         if (name === 'line-gradient') {
             const expression = this.gradientExpression();
-            if (expression._styleExpression) {
-                // presence of ._styleExpression implies expression is a ZoonConstantExpression
-                const zoomConstantExpression = expression as ZoomConstantExpression<'source'>;
-                this.stepInterpolant = zoomConstantExpression._styleExpression.expression instanceof Step;
+            if (isZoomExpression(expression)) {
+                this.stepInterpolant = expression._styleExpression.expression instanceof Step;
             } else {
                 this.stepInterpolant = false;
             }

--- a/src/style/style_layer/line_style_layer.ts
+++ b/src/style/style_layer/line_style_layer.ts
@@ -60,9 +60,10 @@ export class LineStyleLayer extends StyleLayer {
 
     _handleSpecialPaintPropertyUpdate(name: string) {
         if (name === 'line-gradient') {
-            if (Object.prototype.hasOwnProperty.call(this.gradientExpression(), '_styleExpression')) {
-                const expression: ZoomConstantExpression<'source'> = this.gradientExpression() as any;
-                this.stepInterpolant = expression._styleExpression.expression instanceof Step;
+            const expression = this.gradientExpression();
+            if (Object.prototype.hasOwnProperty.call(expression, '_styleExpression')) {
+                const zoomConstantExpression = expression as ZoomConstantExpression<'source'>;
+                this.stepInterpolant = zoomConstantExpression._styleExpression.expression instanceof Step;
             } else {
                 this.stepInterpolant = false;
             }

--- a/src/style/style_layer/line_style_layer.ts
+++ b/src/style/style_layer/line_style_layer.ts
@@ -66,7 +66,6 @@ export class LineStyleLayer extends StyleLayer {
             } else {
                 this.stepInterpolant = false;
             }
-            
             this.gradientVersion = (this.gradientVersion + 1) % Number.MAX_SAFE_INTEGER;
         }
     }

--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -2562,6 +2562,7 @@ export class Map extends Camera {
      * @param name - The name of the paint property to set.
      * @param value - The value of the paint property to set.
      * Must be of a type appropriate for the property, as defined in the [MapLibre Style Specification](https://maplibre.org/maplibre-style-spec/).
+     * Pass `null` to unset the existing value.
      * @param options - Options object.
      * @returns `this`
      * @example


### PR DESCRIPTION
This PR fixes #2683

## Problem
A `StyleLayer` is added to a map by calling [`map.addLayer`](https://maplibre.org/maplibre-gl-js/docs/API/classes/maplibregl.Map/#addlayer). In particular, we can add a `LineStyleLayer` that adds a color gradient (`line-gradient`) as follows:
```
    map.addLayer({
        type: 'line',
        source: 'line',
        id: 'line',
        paint: {
            'line-color': 'red',
            'line-width': 14,
            'line-gradient': [
                'interpolate',
                ['linear'],
                ['line-progress'],
                0,
                'blue',
                1,
                'red'
            ]
        }
    });
```
Our problem comes when we try to unset the `line-gradient` using [`Map.setPaintProperty`](https://maplibre.org/maplibre-gl-js/docs/API/classes/maplibregl.Map/#setpaintproperty):
```
map.setPaintProperty('line', 'line-gradient', null)
```
Note the third argument, `null`, which is meant to unset the property. (Note that `null` and `undefined` have same behavior in this case)
Our app crashes and we see an error in console:
<img width="904" alt="Screen Shot 2023-07-09 at 3 59 12 PM" src="https://github.com/maplibre/maplibre-gl-js/assets/83888516/8a3afe0b-9ff1-4f71-afc1-25778578673a">

## Explanation
When we call `map.setPaintProperty('line', 'line-gradient', null)`, our callstack is:

-->[`LineStyleLayer._handleSpecialPaintPropertyUpdate`](https://github.com/maplibre/maplibre-gl-js/blob/main/src/style/style_layer/line_style_layer.ts#L61)
->[`StyleLayer.setPaintProperty`](https://github.com/maplibre/maplibre-gl-js/blob/main/src/style/style_layer.ts#L150)
[`Map.setPaintProperty`](https://maplibre.org/maplibre-gl-js/docs/API/classes/maplibregl.Map/#setpaintproperty)

In `LineStyleLayer._handleSpecialPaintPropertyUpdate`, there is a special case for `line-gradient`.
```
        if (name === 'line-gradient') {
            const expression: ZoomConstantExpression<'source'> = (this._transitionablePaint._values['line-gradient'].value.expression as any);
            this.stepInterpolant = expression._styleExpression.expression instanceof Step;
            this.gradientVersion = (this.gradientVersion + 1) % Number.MAX_SAFE_INTEGER;
        }
```
You can see that this code assumes the existence of `expression._styleExpression`. This assumption is broken when we're setting the property to `null`.

## Solution
Check for the existence of `_styleExpression` before trying to access it.

## Bonus
`Map.setPaintProperty` expects you to pass `null` when unsetting the existing value, not `undefined`. This is what we test for. I added this info to the documentation for this method.

## Potential future work
1. Do we want to enforce the use of `null` over `undefined` for unsetting? I'd imagine we would do this using Typescript. If so I can make ticket.
2.  [Casting as `ZoomConstantExpression`](https://github.com/maplibre/maplibre-gl-js/blob/main/src/style/style_layer/line_style_layer.ts#L63) doesn't seem ideal, especially since `ZoomConstantExpression` isn't even one of the possible types for `this._transitionablePaint._values['line-gradient'].value.expression`. We should probably clean up the typing here? If so I can make ticket.


## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [x] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [x] Add an entry to `CHANGELOG.md` under the `## main` section.
