### PR TITLE
Remove cooperative gesture screen from accessibility tree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### ✨ Features and improvements
 
+- Remove cooperative gesture screen from the accessibility tree since screenreaders cannot interact with the map using gestures
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes
@@ -22,7 +23,8 @@
 - ⚠️ Removed non documented `Marker` constructor parameter ([#2756](https://github.com/maplibre/maplibre-gl-js/pull/2756))
 
 ### 🐞 Bug fixes
-- Return undefined instead of throwing from `Style.serialize()` when the style hasn't loaded yet ([#2712](https://github.com/maplibre/maplibre-gl-js/pull/2712)) 
+
+- Return undefined instead of throwing from `Style.serialize()` when the style hasn't loaded yet ([#2712](https://github.com/maplibre/maplibre-gl-js/pull/2712))
 - Don't throw an exception from `checkMaxAngle` when a label with length 0 is on the last segment of a line ([#2710](https://github.com/maplibre/maplibre-gl-js/pull/2710))
 - Fix the `tap then drag` zoom gesture detection to abort when the two taps are far away ([#2673](https://github.com/maplibre/maplibre-gl-js/pull/2673))
 - Fix regression - update pixel ratio when devicePixelRatio changes, restoring the v1.x behaviour ([#2706](https://github.com/maplibre/maplibre-gl-js/issues/2706))

--- a/src/ui/map.test.ts
+++ b/src/ui/map.test.ts
@@ -2625,6 +2625,14 @@ describe('Map', () => {
         });
     });
 
+    describe('cooperativeGestures option', () => {
+        test('cooperativeGesture container element is hidden from a11y tree', () => {
+            const map = createMap({cooperativeGestures: true});
+
+            expect(map.getContainer().querySelector('.maplibregl-cooperative-gesture-screen').getAttribute('aria-hidden')).toBeTruthy();
+        });
+    });
+
     describe('getCameraTargetElevation', () => {
         test('Elevation is zero without terrain, and matches any given terrain', () => {
             const map = createMap();

--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -2883,7 +2883,7 @@ export class Map extends Camera {
             <div class="maplibregl-mobile-message">${mobileMessage}</div>
         `;
 
-        // Removes cooperative gesture screen from the accessibility tree since screenreaders cannot interact with the map using gestures
+        // Remove cooperative gesture screen from the accessibility tree since screenreaders cannot interact with the map using gestures
         this._cooperativeGesturesScreen.setAttribute('aria-hidden', 'true');
 
         // Add event to canvas container since gesture container is pointer-events: none

--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -2882,6 +2882,10 @@ export class Map extends Camera {
             <div class="maplibregl-desktop-message">${desktopMessage}</div>
             <div class="maplibregl-mobile-message">${mobileMessage}</div>
         `;
+
+        // Removes cooperative gesture screen from the accessibility tree since screenreaders cannot interact with the map using gestures
+        this._cooperativeGesturesScreen.setAttribute('aria-hidden', 'true');
+
         // Add event to canvas container since gesture container is pointer-events: none
         this._canvasContainer.addEventListener('wheel', this._cooperativeGesturesOnWheel, false);
 


### PR DESCRIPTION
## Problem

At the moment the cooperative gesture screen text is read my screenreaders such as VoiceOver on iOS. But screenreader users are not able to use the gestures (Using two fingers or Ctrl + scroll ect.) to interact with the map. Therefore this text doesn't make sense for them.

## Solution

This element should be hidden from the accessibility tree using `aria-hidden="true"` which results in screenreaders not reading the text to the user. 

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [ ] Link to related issues.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [x] Add an entry to `CHANGELOG.md` under the `## main` section.
