### PR TITLE
Improve documentation on Map and Camera classes

### DIFF
--- a/src/ui/camera.ts
+++ b/src/ui/camera.ts
@@ -272,9 +272,12 @@ export abstract class Camera extends Evented {
     // so the linear interpolation between start and target keeps smooth and without jumps.
     _elevationStart: number;
 
-    /** Used to track accumulated changes during continuous interaction */
+    /**
+     * @hidden
+     * Used to track accumulated changes during continuous interaction 
+     */
     _requestedCameraState?: Transform;
-    /** A callback used to defer camera updates or apply arbitrary constraints.
+    /**A callback used to defer camera updates or apply arbitrary constraints.
      * If specified, this Camera instance can be used as a stateless component in React etc.
      */
     transformCameraUpdate: CameraUpdateTransformFunction | null;
@@ -313,10 +316,15 @@ export abstract class Camera extends Evented {
     /**
      * Sets the map's geographical centerpoint. Equivalent to `jumpTo({center: center})`.
      *
+     * Events triggered:
+     *
+     * | Event        |
+     * |--------------|
+     * | `movestart`  |
+     * | `moveend`    |
+     *
      * @param center - The centerpoint to set.
      * @param eventData - Additional properties to be added to event objects of events triggered by this method.
-     * @event `movestart`
-     * @event `moveend`
      * @returns `this`
      * @example
      * ```ts
@@ -330,11 +338,16 @@ export abstract class Camera extends Evented {
     /**
      * Pans the map by the specified offset.
      *
+     * Events triggered:
+     *
+     * | Event        |
+     * |--------------|
+     * | `movestart`  |
+     * | `moveend`    |
+     *
      * @param offset - `x` and `y` coordinates by which to pan the map.
      * @param options - Options object
      * @param eventData - Additional properties to be added to event objects of events triggered by this method.
-     * @event `movestart`
-     * @event `moveend`
      * @returns `this`
      * @see [Navigate the map with game-like controls](https://maplibre.org/maplibre-gl-js/docs/examples/game-controls/)
      */
@@ -346,11 +359,16 @@ export abstract class Camera extends Evented {
     /**
      * Pans the map to the specified location with an animated transition.
      *
+     * Events triggered:
+     *
+     * | Event        |
+     * |--------------|
+     * | `movestart`  |
+     * | `moveend`    |
+     *
      * @param lnglat - The location to pan the map to.
      * @param options - Options describing the destination and animation of the transition.
      * @param eventData - Additional properties to be added to event objects of events triggered by this method.
-     * @event `movestart`
-     * @event `moveend`
      * @returns `this`
      * @example
      * ```ts
@@ -380,14 +398,19 @@ export abstract class Camera extends Evented {
     /**
      * Sets the map's zoom level. Equivalent to `jumpTo({zoom: zoom})`.
      *
+     * Events triggered:
+     *
+     * | Event        |
+     * |--------------|
+     * | `movestart`  |
+     * | `zoomstart`  |
+     * | `move`       |
+     * | `zoom`       |
+     * | `moveend`    |
+     * | `zoomend`    |
+     *
      * @param zoom - The zoom level to set (0-20).
      * @param eventData - Additional properties to be added to event objects of events triggered by this method.
-     * @event `movestart`
-     * @event `zoomstart`
-     * @event `move`
-     * @event `zoom`
-     * @event `moveend`
-     * @event `zoomend`
      * @returns `this`
      * @example
      * Zoom to the zoom level 5 without an animated transition
@@ -403,15 +426,20 @@ export abstract class Camera extends Evented {
     /**
      * Zooms the map to the specified zoom level, with an animated transition.
      *
+     * Events triggered:
+     *
+     * | Event        |
+     * |--------------|
+     * | `movestart`  |
+     * | `zoomstart`  |
+     * | `move`       |
+     * | `zoom`       |
+     * | `moveend`    |
+     * | `zoomend`    |
+     *
      * @param zoom - The zoom level to transition to.
      * @param options - Options object
      * @param eventData - Additional properties to be added to event objects of events triggered by this method.
-     * @event `movestart`
-     * @event `zoomstart`
-     * @event `move`
-     * @event `zoom`
-     * @event `moveend`
-     * @event `zoomend`
      * @returns `this`
      * @example
      * ```ts
@@ -433,14 +461,19 @@ export abstract class Camera extends Evented {
     /**
      * Increases the map's zoom level by 1.
      *
+     * Events triggered:
+     *
+     * | Event        |
+     * |--------------|
+     * | `movestart`  |
+     * | `zoomstart`  |
+     * | `move`       |
+     * | `zoom`       |
+     * | `moveend`    |
+     * | `zoomend`    |
+     *
      * @param options - Options object
      * @param eventData - Additional properties to be added to event objects of events triggered by this method.
-     * @event `movestart`
-     * @event `zoomstart`
-     * @event `move`
-     * @event `zoom`
-     * @event `moveend`
-     * @event `zoomend`
      * @returns `this`
      * @example
      * Zoom the map in one level with a custom animation duration
@@ -456,14 +489,19 @@ export abstract class Camera extends Evented {
     /**
      * Decreases the map's zoom level by 1.
      *
+     * Events triggered:
+     *
+     * | Event        |
+     * |--------------|
+     * | `movestart`  |
+     * | `zoomstart`  |
+     * | `move`       |
+     * | `zoom`       |
+     * | `moveend`    |
+     * | `zoomend`    |
+     *
      * @param options - Options object
      * @param eventData - Additional properties to be added to event objects of events triggered by this method.
-     * @event `movestart`
-     * @event `zoomstart`
-     * @event `move`
-     * @event `zoom`
-     * @event `moveend`
-     * @event `zoomend`
      * @returns `this`
      * @example
      * Zoom the map out one level with a custom animation offset
@@ -491,10 +529,16 @@ export abstract class Camera extends Evented {
      *
      * Equivalent to `jumpTo({bearing: bearing})`.
      *
+     * Events triggered:
+     *
+     * | Event        |
+     * |--------------|
+     * | `movestart`  |
+     * | `rotate`     |
+     * | `moveend`    |
+     *
      * @param bearing - The desired bearing.
      * @param eventData - Additional properties to be added to event objects of events triggered by this method.
-     * @event `movestart`
-     * @event `moveend`
      * @returns `this`
      * @example
      * Rotate the map to 90 degrees
@@ -519,10 +563,15 @@ export abstract class Camera extends Evented {
      *
      * Equivalent to `jumpTo({padding: padding})`.
      *
+     * Events triggered:
+     *
+     * | Event        |
+     * |--------------|
+     * | `movestart`  |
+     * | `moveend`    |
+     *
      * @param padding - The desired padding.
      * @param eventData - Additional properties to be added to event objects of events triggered by this method.
-     * @event `movestart`
-     * @event `moveend`
      * @returns `this`
      * @example
      * Sets a left padding of 300px, and a top padding of 50px
@@ -539,11 +588,17 @@ export abstract class Camera extends Evented {
      * Rotates the map to the specified bearing, with an animated transition. The bearing is the compass direction
      * that is "up"; for example, a bearing of 90° orients the map so that east is up.
      *
+     * Events triggered:
+     *
+     * | Event        |
+     * |--------------|
+     * | `movestart`  |
+     * | `rotate`     |
+     * | `moveend`    |
+     *
      * @param bearing - The desired bearing.
      * @param options - Options object
      * @param eventData - Additional properties to be added to event objects of events triggered by this method.
-     * @event `movestart`
-     * @event `moveend`
      * @returns `this`
      */
     rotateTo(bearing: number, options?: AnimationOptions, eventData?: any): this {
@@ -555,10 +610,16 @@ export abstract class Camera extends Evented {
     /**
      * Rotates the map so that north is up (0° bearing), with an animated transition.
      *
+     * Events triggered:
+     *
+     * | Event        |
+     * |--------------|
+     * | `movestart`  |
+     * | `rotate`     |
+     * | `moveend`    |
+     *
      * @param options - Options object
      * @param eventData - Additional properties to be added to event objects of events triggered by this method.
-     * @event `movestart`
-     * @event `moveend`
      * @returns `this`
      */
     resetNorth(options?: AnimationOptions, eventData?: any): this {
@@ -569,10 +630,20 @@ export abstract class Camera extends Evented {
     /**
      * Rotates and pitches the map so that north is up (0° bearing) and pitch is 0°, with an animated transition.
      *
+     * Events triggered:
+     *
+     * | Event        |
+     * |--------------|
+     * | `movestart`  |
+     * | `pitchstart` |
+     * | `move`       |
+     * | `rotate`     |
+     * | `pitch`      |
+     * | `moveend`    |
+     * | `pitchend`   |
+     *
      * @param options - Options object
      * @param eventData - Additional properties to be added to event objects of events triggered by this method.
-     * @event `movestart`
-     * @event `moveend`
      * @returns `this`
      */
     resetNorthPitch(options?: AnimationOptions, eventData?: any): this {
@@ -588,10 +659,16 @@ export abstract class Camera extends Evented {
      * Snaps the map so that north is up (0° bearing), if the current bearing is close enough to it (i.e. within the
      * `bearingSnap` threshold).
      *
+     * Events triggered:
+     *
+     * | Event        |
+     * |--------------|
+     * | `movestart`  |
+     * | `rotate`     |
+     * | `moveend`    |
+     *
      * @param options - Options object
      * @param eventData - Additional properties to be added to event objects of events triggered by this method.
-     * @event `movestart`
-     * @event `moveend`
      * @returns `this`
      */
     snapToNorth(options?: AnimationOptions, eventData?: any): this {
@@ -611,11 +688,16 @@ export abstract class Camera extends Evented {
     /**
      * Sets the map's pitch (tilt). Equivalent to `jumpTo({pitch: pitch})`.
      *
+     * Events triggered:
+     *
+     * | Event        |
+     * |--------------|
+     * | `movestart`  |
+     * | `pitchstart` |
+     * | `moveend`    |
+     *
      * @param pitch - The pitch to set, measured in degrees away from the plane of the screen (0-60).
      * @param eventData - Additional properties to be added to event objects of events triggered by this method.
-     * @event `pitchstart`
-     * @event `movestart`
-     * @event `moveend`
      * @returns `this`
      */
     setPitch(pitch: number, eventData?: any): this {
@@ -738,12 +820,17 @@ export abstract class Camera extends Evented {
      * Pans and zooms the map to contain its visible area within the specified geographical bounds.
      * This function will also reset the map's bearing to 0 if bearing is nonzero.
      *
+     * Events triggered:
+     *
+     * | Event        |
+     * |--------------|
+     * | `movestart`  |
+     * | `moveend`    |
+     *
      * @param bounds - Center these bounds in the viewport and use the highest
      * zoom level up to and including `Map#getMaxZoom()` that fits them in the viewport.
      * @param options- Options supports all properties from {@link AnimationOptions} and {@link CameraOptions} in addition to the fields below.
      * @param eventData - Additional properties to be added to event objects of events triggered by this method.
-     * @event `movestart`
-     * @event `moveend`
      * @returns `this`
      * @example
      * ```ts
@@ -766,13 +853,23 @@ export abstract class Camera extends Evented {
      * once the map is rotated to the specified bearing. To zoom without rotating,
      * pass in the current map bearing.
      *
+     * Events triggered:
+     *
+     * | Event        |
+     * |--------------|
+     * | `movestart`  |
+     * | `zoomstart`  |
+     * | `move`       |
+     * | `zoom`       |
+     * | `rotate`     |
+     * | `moveend`    |
+     * | `zoomend`    |
+     *
      * @param p0 - First point on screen, in pixel coordinates
      * @param p1 - Second point on screen, in pixel coordinates
      * @param bearing - Desired map bearing at end of animation, in degrees
      * @param options - Options object
      * @param eventData - Additional properties to be added to event objects of events triggered by this method.
-     * @event `movestart`
-     * @event `moveend`
      * @returns `this`
      * @example
      * ```ts
@@ -813,18 +910,23 @@ export abstract class Camera extends Evented {
      * an animated transition. The map will retain its current values for any
      * details not specified in `options`.
      *
+     * Events triggered:
+     *
+     * | Event        |
+     * |--------------|
+     * | `movestart`  |
+     * | `zoomstart`  |
+     * | `pitchstart` |
+     * | `move`       |
+     * | `zoom`       |
+     * | `rotate`     |
+     * | `pitch`      |
+     * | `moveend`    |
+     * | `zoomend`    |
+     * | `pitchend`   |
+     *
      * @param options - Options object
      * @param eventData - Additional properties to be added to event objects of events triggered by this method.
-     * @event `movestart`
-     * @event `zoomstart`
-     * @event `pitchstart`
-     * @event `rotate`
-     * @event `move`
-     * @event `zoom`
-     * @event `pitch`
-     * @event `moveend`
-     * @event `zoomend`
-     * @event `pitchend`
      * @returns `this`
      * @example
      * ```ts
@@ -940,19 +1042,24 @@ export abstract class Camera extends Evented {
      * the `reduced motion` accessibility feature enabled in their operating system,
      * unless `options` includes `essential: true`.
      *
+     * Events triggered:
+     *
+     * | Event        |
+     * |--------------|
+     * | `movestart`  |
+     * | `zoomstart`  |
+     * | `pitchstart` |
+     * | `move`       |
+     * | `zoom`       |
+     * | `rotate`     |
+     * | `pitch`      |
+     * | `moveend`    |
+     * | `zoomend`    |
+     * | `pitchend`   |
+     *
      * @param options - Options describing the destination and animation of the transition.
      * Accepts {@link CameraOptions} and {@link AnimationOptions}.
      * @param eventData - Additional properties to be added to event objects of events triggered by this method.
-     * @event `movestart`
-     * @event `zoomstart`
-     * @event `pitchstart`
-     * @event `rotate`
-     * @event `move`
-     * @event `zoom`
-     * @event `pitch`
-     * @event `moveend`
-     * @event `zoomend`
-     * @event `pitchend`
      * @returns `this`
      * @see [Navigate the map with game-like controls](https://maplibre.org/maplibre-gl-js/docs/examples/game-controls/)
      */
@@ -1102,6 +1209,7 @@ export abstract class Camera extends Evented {
      * If `transformCameraUpdate` is specified, a copy of the current transform is created to track the accumulated changes.
      * This underlying transform represents the "desired state" proposed by input handlers / animations / UI controls.
      * It may differ from the state used for rendering (`this.transform`).
+     * @hidden
      * @returns Transform to apply changes to
      */
     _getTransformForUpdate(): Transform {
@@ -1115,6 +1223,7 @@ export abstract class Camera extends Evented {
 
     /**
      * Called after the camera is done being manipulated.
+     * @hidden
      * @param tr - the requested camera end state
      * Call `transformCameraUpdate` if present, and then apply the "approved" changes.
      */
@@ -1188,20 +1297,25 @@ export abstract class Camera extends Evented {
      * if the user has the `reduced motion` accessibility feature enabled in their operating system,
      * unless 'options' includes `essential: true`.
      *
+     * Events triggered:
+     *
+     * | Event        |
+     * |--------------|
+     * | `movestart`  |
+     * | `zoomstart`  |
+     * | `pitchstart` |
+     * | `move`       |
+     * | `zoom`       |
+     * | `rotate`     |
+     * | `pitch`      |
+     * | `moveend`    |
+     * | `zoomend`    |
+     * | `pitchend`   |
+     *
      * @param options - Options describing the destination and animation of the transition.
      * Accepts {@link CameraOptions}, {@link AnimationOptions},
      * and the following additional options.
      * @param eventData - Additional properties to be added to event objects of events triggered by this method.
-     * @event `movestart`
-     * @event `zoomstart`
-     * @event `pitchstart`
-     * @event `move`
-     * @event `zoom`
-     * @event `rotate`
-     * @event `pitch`
-     * @event `moveend`
-     * @event `zoomend`
-     * @event `pitchend`
      * @returns `this`
      * @example
      * ```ts

--- a/src/ui/camera.ts
+++ b/src/ui/camera.ts
@@ -274,7 +274,7 @@ export abstract class Camera extends Evented {
 
     /**
      * @hidden
-     * Used to track accumulated changes during continuous interaction 
+     * Used to track accumulated changes during continuous interaction
      */
     _requestedCameraState?: Transform;
     /**

--- a/src/ui/camera.ts
+++ b/src/ui/camera.ts
@@ -317,12 +317,7 @@ export abstract class Camera extends Evented {
     /**
      * Sets the map's geographical centerpoint. Equivalent to `jumpTo({center: center})`.
      *
-     * Events triggered:
-     *
-     * | Event        |
-     * |--------------|
-     * | `movestart`  |
-     * | `moveend`    |
+     * Triggers the following events: `movestart` and `moveend`.
      *
      * @param center - The centerpoint to set.
      * @param eventData - Additional properties to be added to event objects of events triggered by this method.
@@ -339,12 +334,7 @@ export abstract class Camera extends Evented {
     /**
      * Pans the map by the specified offset.
      *
-     * Events triggered:
-     *
-     * | Event        |
-     * |--------------|
-     * | `movestart`  |
-     * | `moveend`    |
+     * Triggers the following events: `movestart` and `moveend`.
      *
      * @param offset - `x` and `y` coordinates by which to pan the map.
      * @param options - Options object
@@ -360,12 +350,7 @@ export abstract class Camera extends Evented {
     /**
      * Pans the map to the specified location with an animated transition.
      *
-     * Events triggered:
-     *
-     * | Event        |
-     * |--------------|
-     * | `movestart`  |
-     * | `moveend`    |
+     * Triggers the following events: `movestart` and `moveend`.
      *
      * @param lnglat - The location to pan the map to.
      * @param options - Options describing the destination and animation of the transition.
@@ -399,16 +384,7 @@ export abstract class Camera extends Evented {
     /**
      * Sets the map's zoom level. Equivalent to `jumpTo({zoom: zoom})`.
      *
-     * Events triggered:
-     *
-     * | Event        |
-     * |--------------|
-     * | `movestart`  |
-     * | `zoomstart`  |
-     * | `move`       |
-     * | `zoom`       |
-     * | `moveend`    |
-     * | `zoomend`    |
+     * Triggers the following events: `movestart`, `move`, `moveend`, `zoomstart`, `zoom`, and `zoomend`.
      *
      * @param zoom - The zoom level to set (0-20).
      * @param eventData - Additional properties to be added to event objects of events triggered by this method.
@@ -427,16 +403,7 @@ export abstract class Camera extends Evented {
     /**
      * Zooms the map to the specified zoom level, with an animated transition.
      *
-     * Events triggered:
-     *
-     * | Event        |
-     * |--------------|
-     * | `movestart`  |
-     * | `zoomstart`  |
-     * | `move`       |
-     * | `zoom`       |
-     * | `moveend`    |
-     * | `zoomend`    |
+     * Triggers the following events: `movestart`, `move`, `moveend`, `zoomstart`, `zoom`, and `zoomend`.
      *
      * @param zoom - The zoom level to transition to.
      * @param options - Options object
@@ -462,16 +429,7 @@ export abstract class Camera extends Evented {
     /**
      * Increases the map's zoom level by 1.
      *
-     * Events triggered:
-     *
-     * | Event        |
-     * |--------------|
-     * | `movestart`  |
-     * | `zoomstart`  |
-     * | `move`       |
-     * | `zoom`       |
-     * | `moveend`    |
-     * | `zoomend`    |
+     * Triggers the following events: `movestart`, `move`, `moveend`, `zoomstart`, `zoom`, and `zoomend`.
      *
      * @param options - Options object
      * @param eventData - Additional properties to be added to event objects of events triggered by this method.
@@ -490,16 +448,7 @@ export abstract class Camera extends Evented {
     /**
      * Decreases the map's zoom level by 1.
      *
-     * Events triggered:
-     *
-     * | Event        |
-     * |--------------|
-     * | `movestart`  |
-     * | `zoomstart`  |
-     * | `move`       |
-     * | `zoom`       |
-     * | `moveend`    |
-     * | `zoomend`    |
+     * Triggers the following events: `movestart`, `move`, `moveend`, `zoomstart`, `zoom`, and `zoomend`.
      *
      * @param options - Options object
      * @param eventData - Additional properties to be added to event objects of events triggered by this method.
@@ -530,13 +479,7 @@ export abstract class Camera extends Evented {
      *
      * Equivalent to `jumpTo({bearing: bearing})`.
      *
-     * Events triggered:
-     *
-     * | Event        |
-     * |--------------|
-     * | `movestart`  |
-     * | `rotate`     |
-     * | `moveend`    |
+     * Triggers the following events: `movestart`, `moveend`, and `rotate`.
      *
      * @param bearing - The desired bearing.
      * @param eventData - Additional properties to be added to event objects of events triggered by this method.
@@ -564,12 +507,7 @@ export abstract class Camera extends Evented {
      *
      * Equivalent to `jumpTo({padding: padding})`.
      *
-     * Events triggered:
-     *
-     * | Event        |
-     * |--------------|
-     * | `movestart`  |
-     * | `moveend`    |
+     * Triggers the following events: `movestart` and `moveend`.
      *
      * @param padding - The desired padding.
      * @param eventData - Additional properties to be added to event objects of events triggered by this method.
@@ -589,13 +527,7 @@ export abstract class Camera extends Evented {
      * Rotates the map to the specified bearing, with an animated transition. The bearing is the compass direction
      * that is "up"; for example, a bearing of 90° orients the map so that east is up.
      *
-     * Events triggered:
-     *
-     * | Event        |
-     * |--------------|
-     * | `movestart`  |
-     * | `rotate`     |
-     * | `moveend`    |
+     * Triggers the following events: `movestart`, `moveend`, and `rotate`.
      *
      * @param bearing - The desired bearing.
      * @param options - Options object
@@ -611,13 +543,7 @@ export abstract class Camera extends Evented {
     /**
      * Rotates the map so that north is up (0° bearing), with an animated transition.
      *
-     * Events triggered:
-     *
-     * | Event        |
-     * |--------------|
-     * | `movestart`  |
-     * | `rotate`     |
-     * | `moveend`    |
+     * Triggers the following events: `movestart`, `moveend`, and `rotate`.
      *
      * @param options - Options object
      * @param eventData - Additional properties to be added to event objects of events triggered by this method.
@@ -631,17 +557,7 @@ export abstract class Camera extends Evented {
     /**
      * Rotates and pitches the map so that north is up (0° bearing) and pitch is 0°, with an animated transition.
      *
-     * Events triggered:
-     *
-     * | Event        |
-     * |--------------|
-     * | `movestart`  |
-     * | `pitchstart` |
-     * | `move`       |
-     * | `rotate`     |
-     * | `pitch`      |
-     * | `moveend`    |
-     * | `pitchend`   |
+     * Triggers the following events: `movestart`, `move`, `moveend`, `pitchstart`, `pitch`, `pitchend`, and `rotate`.
      *
      * @param options - Options object
      * @param eventData - Additional properties to be added to event objects of events triggered by this method.
@@ -660,13 +576,7 @@ export abstract class Camera extends Evented {
      * Snaps the map so that north is up (0° bearing), if the current bearing is close enough to it (i.e. within the
      * `bearingSnap` threshold).
      *
-     * Events triggered:
-     *
-     * | Event        |
-     * |--------------|
-     * | `movestart`  |
-     * | `rotate`     |
-     * | `moveend`    |
+     * Triggers the following events: `movestart`, `moveend`, and `rotate`.
      *
      * @param options - Options object
      * @param eventData - Additional properties to be added to event objects of events triggered by this method.
@@ -689,13 +599,7 @@ export abstract class Camera extends Evented {
     /**
      * Sets the map's pitch (tilt). Equivalent to `jumpTo({pitch: pitch})`.
      *
-     * Events triggered:
-     *
-     * | Event        |
-     * |--------------|
-     * | `movestart`  |
-     * | `pitchstart` |
-     * | `moveend`    |
+     * Triggers the following events: `movestart`, `moveend`, `pitchstart`, and `pitchend`.
      *
      * @param pitch - The pitch to set, measured in degrees away from the plane of the screen (0-60).
      * @param eventData - Additional properties to be added to event objects of events triggered by this method.
@@ -821,12 +725,7 @@ export abstract class Camera extends Evented {
      * Pans and zooms the map to contain its visible area within the specified geographical bounds.
      * This function will also reset the map's bearing to 0 if bearing is nonzero.
      *
-     * Events triggered:
-     *
-     * | Event        |
-     * |--------------|
-     * | `movestart`  |
-     * | `moveend`    |
+     * Triggers the following events: `movestart` and `moveend`.
      *
      * @param bounds - Center these bounds in the viewport and use the highest
      * zoom level up to and including `Map#getMaxZoom()` that fits them in the viewport.
@@ -854,17 +753,7 @@ export abstract class Camera extends Evented {
      * once the map is rotated to the specified bearing. To zoom without rotating,
      * pass in the current map bearing.
      *
-     * Events triggered:
-     *
-     * | Event        |
-     * |--------------|
-     * | `movestart`  |
-     * | `zoomstart`  |
-     * | `move`       |
-     * | `zoom`       |
-     * | `rotate`     |
-     * | `moveend`    |
-     * | `zoomend`    |
+     * Triggers the following events: `movestart`, `move`, `moveend`, `zoomstart`, `zoom`, `zoomend` and `rotate`.
      *
      * @param p0 - First point on screen, in pixel coordinates
      * @param p1 - Second point on screen, in pixel coordinates
@@ -911,20 +800,8 @@ export abstract class Camera extends Evented {
      * an animated transition. The map will retain its current values for any
      * details not specified in `options`.
      *
-     * Events triggered:
-     *
-     * | Event        |
-     * |--------------|
-     * | `movestart`  |
-     * | `zoomstart`  |
-     * | `pitchstart` |
-     * | `move`       |
-     * | `zoom`       |
-     * | `rotate`     |
-     * | `pitch`      |
-     * | `moveend`    |
-     * | `zoomend`    |
-     * | `pitchend`   |
+     * Triggers the following events: `movestart`, `move`, `moveend`, `zoomstart`, `zoom`, `zoomend`, `pitchstart`,
+     * `pitch`, `pitchend`, and `rotate`.
      *
      * @param options - Options object
      * @param eventData - Additional properties to be added to event objects of events triggered by this method.
@@ -1043,20 +920,8 @@ export abstract class Camera extends Evented {
      * the `reduced motion` accessibility feature enabled in their operating system,
      * unless `options` includes `essential: true`.
      *
-     * Events triggered:
-     *
-     * | Event        |
-     * |--------------|
-     * | `movestart`  |
-     * | `zoomstart`  |
-     * | `pitchstart` |
-     * | `move`       |
-     * | `zoom`       |
-     * | `rotate`     |
-     * | `pitch`      |
-     * | `moveend`    |
-     * | `zoomend`    |
-     * | `pitchend`   |
+     * Triggers the following events: `movestart`, `move`, `moveend`, `zoomstart`, `zoom`, `zoomend`, `pitchstart`,
+     * `pitch`, `pitchend`, and `rotate`.
      *
      * @param options - Options describing the destination and animation of the transition.
      * Accepts {@link CameraOptions} and {@link AnimationOptions}.
@@ -1298,20 +1163,8 @@ export abstract class Camera extends Evented {
      * if the user has the `reduced motion` accessibility feature enabled in their operating system,
      * unless 'options' includes `essential: true`.
      *
-     * Events triggered:
-     *
-     * | Event        |
-     * |--------------|
-     * | `movestart`  |
-     * | `zoomstart`  |
-     * | `pitchstart` |
-     * | `move`       |
-     * | `zoom`       |
-     * | `rotate`     |
-     * | `pitch`      |
-     * | `moveend`    |
-     * | `zoomend`    |
-     * | `pitchend`   |
+     * Triggers the following events: `movestart`, `move`, `moveend`, `zoomstart`, `zoom`, `zoomend`, `pitchstart`,
+     * `pitch`, `pitchend`, and `rotate`.
      *
      * @param options - Options describing the destination and animation of the transition.
      * Accepts {@link CameraOptions}, {@link AnimationOptions},

--- a/src/ui/camera.ts
+++ b/src/ui/camera.ts
@@ -277,7 +277,8 @@ export abstract class Camera extends Evented {
      * Used to track accumulated changes during continuous interaction 
      */
     _requestedCameraState?: Transform;
-    /**A callback used to defer camera updates or apply arbitrary constraints.
+    /**
+     * A callback used to defer camera updates or apply arbitrary constraints.
      * If specified, this Camera instance can be used as a stateless component in React etc.
      */
     transformCameraUpdate: CameraUpdateTransformFunction | null;

--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -505,7 +505,7 @@ export class Map extends Camera {
 
     /**
      * @hidden
-     * image queue throttling handle. To be used later when clean up 
+     * image queue throttling handle. To be used later when clean up
      */
     _imageQueueHandle: number;
 

--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -818,14 +818,7 @@ export class Map extends Camera {
      * This method must be called after the map's `container` is resized programmatically
      * or when the map is shown after being initially hidden with CSS.
      *
-     * Events triggered:
-     *
-     * | Event       |
-     * |-------------|
-     * | `move`      |
-     * | `moveend`   |
-     * | `movestart` |
-     * | `reside`    |
+     * Triggers the following events: `movestart`, `move`, `moveend`, and `resize`.
      *
      * @param eventData - Additional properties to be passed to `movestart`, `move`, `resize`, and `moveend`
      * events that get triggered as a result of resize. This can be useful for differentiating the
@@ -1862,9 +1855,7 @@ export class Map extends Camera {
      *
      * Events triggered:
      *
-     * | Event                  |
-     * |------------------------|
-     * | `source.add`           |
+     * Triggers the `source.add` event.
      *
      * @param id - The ID of the source to add. Must not conflict with existing sources.
      * @param source - The source object, conforming to the
@@ -1928,11 +1919,7 @@ export class Map extends Camera {
     /**
      * Loads a 3D terrain mesh, based on a "raster-dem" source.
      *
-     * Events triggered:
-     *
-     * | Event     | Condition              |
-     * |-----------|------------------------|
-     * | `terrain` | Success loading source |
+     * Triggers the `terrain` event.
      *
      * @param options - Options object.
      * @returns `this`

--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -412,7 +412,7 @@ const defaultOptions = {
     fadeDuration: 300,
     crossSourceCollisions: true,
     validateStyle: true,
-    /** Because GL MAX_TEXTURE_SIZE is usually at least 4096px. */
+    /**Because GL MAX_TEXTURE_SIZE is usually at least 4096px. */
     maxCanvasSize: [4096, 4096]
 } as CompleteMapOptions;
 
@@ -503,7 +503,10 @@ export class Map extends Camera {
     _maxCanvasSize: [number, number];
     _terrainDataCallback: (e: MapStyleDataEvent | MapSourceDataEvent) => void;
 
-    /** image queue throttling handle. To be used later when clean up */
+    /**
+     * @hidden
+     * image queue throttling handle. To be used later when clean up 
+     */
     _imageQueueHandle: number;
 
     /**
@@ -706,6 +709,7 @@ export class Map extends Camera {
     /**
      * Returns a unique number for this map instance which is used for the MapLoadEvent
      * to make sure we only fire one event per instantiated map object.
+     * @hidden
      * @returns the uniq map ID
      */
     _getMapId() {
@@ -714,6 +718,12 @@ export class Map extends Camera {
 
     /**
      * Adds an {@link IControl} to the map, calling `control.onAdd(this)`.
+     *
+     * Events triggered:
+     *
+     * | Event   | Condition                           |
+     * |---------|-------------------------------------|
+     * | `error` | Null, undefined, or invalid control |
      *
      * @param control - The {@link IControl} to add.
      * @param position - position on the map to which the control will be added.
@@ -753,6 +763,12 @@ export class Map extends Camera {
     /**
      * Removes the control from the map.
      *
+     * Events triggered:
+     *
+     * | Event   | Condition                           |
+     * |---------|-------------------------------------|
+     * | `error` | Null, undefined, or invalid control |
+     *
      * @param control - The {@link IControl} to remove.
      * @returns `this`
      * @example
@@ -791,7 +807,7 @@ export class Map extends Camera {
      * map.hasControl(navigation);
      * ```
      */
-    hasControl(control: IControl) {
+    hasControl(control: IControl): boolean {
         return this._controls.indexOf(control) > -1;
     }
 
@@ -809,6 +825,15 @@ export class Map extends Camera {
      * Checks if the map container size changed and updates the map if it has changed.
      * This method must be called after the map's `container` is resized programmatically
      * or when the map is shown after being initially hidden with CSS.
+     *
+     * Events triggered:
+     *
+     * | Event       |
+     * |-------------|
+     * | `move`      |
+     * | `moveend`   |
+     * | `movestart` |
+     * | `reside`    |
      *
      * @param eventData - Additional properties to be passed to `movestart`, `move`, `resize`, and `moveend`
      * events that get triggered as a result of resize. This can be useful for differentiating the
@@ -857,9 +882,10 @@ export class Map extends Camera {
         return this;
     }
 
-    /*
+    /**
      * Return the map's pixel ratio eventually scaled down to respect maxCanvasSize.
      * Internally you should use this and not getPixelRatio().
+     * @hidden
      */
     _getClampedPixelRatio(width: number, height: number): number {
         const {0: maxCanvasWidth, 1: maxCanvasHeight} = this._maxCanvasSize;
@@ -958,6 +984,12 @@ export class Map extends Camera {
      * if the map is 512px tall it will not be possible to zoom below zoom 0
      * no matter what the `minZoom` is set to.
      *
+     * Events triggered:
+     *
+     * | Event   | Condition             |
+     * |---------|-----------------------|
+     * | `error` | minZoom out of bounds |
+     *
      * @param minZoom - The minimum zoom level to set (-2 - 24).
      * If `null` or `undefined` is provided, the function removes the current minimum zoom (i.e. sets it to -2).
      * @returns `this`
@@ -996,6 +1028,12 @@ export class Map extends Camera {
      * Sets or clears the map's maximum zoom level.
      * If the map's current zoom level is higher than the new maximum,
      * the map will zoom to the new maximum.
+     *
+     * Events triggered:
+     *
+     * | Event   | Condition             |
+     * |---------|-----------------------|
+     * | `error` | maxZoom out of bounds |
      *
      * @param maxZoom - The maximum zoom level to set.
      * If `null` or `undefined` is provided, the function removes the current maximum zoom (sets it to 22).
@@ -1036,6 +1074,12 @@ export class Map extends Camera {
      * If the map's current pitch is lower than the new minimum,
      * the map will pitch to the new minimum.
      *
+     * Events triggered:
+     *
+     * | Event   | Condition               |
+     * |---------|-------------------------|
+     * | `error` | minPitch out ouf bounds |
+     *
      * @param minPitch - The minimum pitch to set (0-85). Values greater than 60 degrees are experimental and may result in rendering issues. If you encounter any, please raise an issue with details in the MapLibre project.
      * If `null` or `undefined` is provided, the function removes the current minimum pitch (i.e. sets it to 0).
      * @returns `this`
@@ -1070,6 +1114,12 @@ export class Map extends Camera {
      * Sets or clears the map's maximum pitch.
      * If the map's current pitch is higher than the new maximum,
      * the map will pitch to the new maximum.
+     *
+     * Events triggered:
+     *
+     * | Event   | Condition               |
+     * |---------|-------------------------|
+     * | `error` | maxPitch out ouf bounds |
      *
      * @param maxPitch - The maximum pitch to set (0-85). Values greater than 60 degrees are experimental and may result in rendering issues. If you encounter any, please raise an issue with details in the MapLibre project.
      * If `null` or `undefined` is provided, the function removes the current maximum pitch (sets it to 60).
@@ -1287,6 +1337,7 @@ export class Map extends Camera {
     }
 
     /**
+     * @event
      * Adds a listener for events of a specified type, optionally limited to features in a specified style layer.
      * See {@link MapEventType} and {@link MapLayerEventType} for a full list of events and their description.
      *
@@ -1400,6 +1451,7 @@ export class Map extends Camera {
     on<T extends keyof MapEventType>(type: T, listener: (ev: MapEventType[T] & Object) => void): this;
     /**
      * This is an overload of the `on` method that allows to listen to events based on the `layerId`
+     * @event
      * @param type - The type of the event.
      * @param layerIdOrListener - The ID of the layer.
      * @param listener - The listener callback.
@@ -1426,6 +1478,7 @@ export class Map extends Camera {
     /**
      * Adds a listener that will be called only once to a specified event type occurring on features in a specified style layer.
      *
+     * @event
      * @param type - The event type to listen for; one of `'mousedown'`, `'mouseup'`, `'click'`, `'dblclick'`,
      * `'mousemove'`, `'mouseenter'`, `'mouseleave'`, `'mouseover'`, `'mouseout'`, `'contextmenu'`, `'touchstart'`,
      * `'touchend'`, or `'touchcancel'`. `mouseenter` and `mouseover` events are triggered when the cursor enters
@@ -1463,6 +1516,7 @@ export class Map extends Camera {
     /**
      * Removes an event listener for layer-specific events previously added with `Map#on`.
      *
+     * @event
      * @param type - The event type previously used to install the listener.
      * @param layerIdOrListener - The layer ID or listener previously used to install the listener.
      * @param listener - (optional) The function previously installed as a listener.
@@ -1830,11 +1884,16 @@ export class Map extends Camera {
     /**
      * Adds a source to the map's style.
      *
+     * Events triggered:
+     *
+     * | Event                  |
+     * |------------------------|
+     * | `source.add`           |
+     *
      * @param id - The ID of the source to add. Must not conflict with existing sources.
      * @param source - The source object, conforming to the
      * MapLibre Style Specification's [source definition](https://maplibre.org/maplibre-style-spec/#sources) or
      * {@link CanvasSourceSpecification}.
-     * @event `source.add`
      * @returns `this`
      * @example
      * ```ts
@@ -1872,6 +1931,12 @@ export class Map extends Camera {
      * Returns a Boolean indicating whether the source is loaded. Returns `true` if the source with
      * the given ID in the map's style has no outstanding network requests, otherwise `false`.
      *
+     * Events triggered:
+     *
+     * | Event   | Condition              |
+     * |---------|------------------------|
+     * | `error` | No source with this ID |
+     *
      * @param id - The ID of the source to be checked.
      * @returns A Boolean indicating whether the source is loaded.
      * @example
@@ -1890,6 +1955,14 @@ export class Map extends Camera {
 
     /**
      * Loads a 3D terrain mesh, based on a "raster-dem" source.
+     *
+     * Events triggered:
+     *
+     * | Event     | Condition              |
+     * |-----------|------------------------|
+     * | `error`   | Failed to load source  |
+     * | `terrain` | Success loading source |
+     *
      * @param options - Options object.
      * @returns `this`
      * @example
@@ -2036,6 +2109,12 @@ export class Map extends Camera {
      * or [`line-pattern`](https://maplibre.org/maplibre-style-spec/#paint-line-line-pattern).
      * A {@link ErrorEvent} event will be fired if there is not enough space in the sprite to add this image.
      *
+     * Events triggered:
+     *
+     * | Event     | Condition                |
+     * |-----------|--------------------------|
+     * | `error`   | Invalid image parameter  |
+     *
      * @param id - The ID of the image.
      * @param image - The image as an `HTMLImageElement`, `ImageData`, `ImageBitmap` or object with `width`, `height`, and `data`
      * properties with the same format as `ImageData`.
@@ -2120,6 +2199,12 @@ export class Map extends Camera {
      * [`fill-pattern`](https://maplibre.org/maplibre-style-spec/#paint-fill-fill-pattern),
      * or [`line-pattern`](https://maplibre.org/maplibre-style-spec/#paint-line-line-pattern).
      *
+     * Events triggered:
+     *
+     * | Event     | Condition                |
+     * |-----------|--------------------------|
+     * | `error`   | Invalid image parameter  |
+     *
      * @param id - The ID of the image.
      * @param image - The image as an `HTMLImageElement`, `ImageData`, `ImageBitmap` or object with `width`, `height`, and `data`
      * properties with the same format as `ImageData`.
@@ -2189,6 +2274,12 @@ export class Map extends Camera {
      * that have been added at runtime using {@link Map#addImage}.
      *
      * @param id - The ID of the image.
+     *
+     * Events triggered:
+     *
+     * | Event     | Condition                |
+     * |-----------|--------------------------|
+     * | `error`   | Invalid image parameter  |
      *
      * @returns A Boolean indicating whether the image exists.
      * @example
@@ -2370,10 +2461,13 @@ export class Map extends Camera {
     /**
      * Removes the layer with the given ID from the map's style.
      *
-     * If no such layer exists, an `error` event is fired.
+     * Events triggered:
+     *
+     * | Event   | Condition            |
+     * |---------|----------------------|
+     * | `error` | No such layer exists |
      *
      * @param id - The ID of the layer to remove
-     * @event `error`
      * @returns `this`
      *
      * @example
@@ -2568,12 +2662,11 @@ export class Map extends Camera {
     }
 
     /**
-     * Adds a sprite to the map's style.
+     * Adds a sprite to the map's style. Fires the `style` event.
      *
      * @param id - The ID of the sprite to add. Must not conflict with existing sprites.
      * @param url - The URL to load the sprite from
      * @param options - Options object.
-     * @event `style`
      * @returns `this`
      * @example
      * ```ts
@@ -2591,10 +2684,9 @@ export class Map extends Camera {
     }
 
     /**
-     * Removes the sprite from the map's style.
+     * Removes the sprite from the map's style. Fires the `style` event.
      *
      * @param id - The ID of the sprite to remove. If the sprite is declared as a single URL, the ID must be "default".
-     * @event `style`
      * @returns `this`
      * @example
      * ```ts
@@ -2996,6 +3088,7 @@ export class Map extends Camera {
     /**
      * Update this map's style and sources, and re-render the map.
      *
+     * @hidden
      * @param updateStyle - mark the map's style for reprocessing as
      * well as its sources
      * @returns `this`
@@ -3013,6 +3106,7 @@ export class Map extends Camera {
     /**
      * Request that the given callback be executed during the next render
      * frame.  Schedule a render frame if one is not already scheduled.
+     * @hidden
      * @returns An id that can be used to cancel the callback
      */
     _requestRenderFrame(callback: () => void): TaskID {
@@ -3032,6 +3126,7 @@ export class Map extends Camera {
      * - A transition is in progress
      *
      * @param paintStartTimeStamp - The time when the animation frame began executing.
+     * @hidden
      *
      * @returns `this`
      */

--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -719,11 +719,7 @@ export class Map extends Camera {
     /**
      * Adds an {@link IControl} to the map, calling `control.onAdd(this)`.
      *
-     * Events triggered:
-     *
-     * | Event   | Condition                           |
-     * |---------|-------------------------------------|
-     * | `error` | Null, undefined, or invalid control |
+     * An {@link ErrorEvent} will be fired if the image parameter is invald.
      *
      * @param control - The {@link IControl} to add.
      * @param position - position on the map to which the control will be added.
@@ -763,12 +759,8 @@ export class Map extends Camera {
     /**
      * Removes the control from the map.
      *
-     * Events triggered:
-     *
-     * | Event   | Condition                           |
-     * |---------|-------------------------------------|
-     * | `error` | Null, undefined, or invalid control |
-     *
+     * An {@link ErrorEvent} will be fired if the image parameter is invald.
+     * 
      * @param control - The {@link IControl} to remove.
      * @returns `this`
      * @example
@@ -984,11 +976,7 @@ export class Map extends Camera {
      * if the map is 512px tall it will not be possible to zoom below zoom 0
      * no matter what the `minZoom` is set to.
      *
-     * Events triggered:
-     *
-     * | Event   | Condition             |
-     * |---------|-----------------------|
-     * | `error` | minZoom out of bounds |
+     * A {@link ErrorEvent} event will be fired if minZoom is out of bounds.
      *
      * @param minZoom - The minimum zoom level to set (-2 - 24).
      * If `null` or `undefined` is provided, the function removes the current minimum zoom (i.e. sets it to -2).
@@ -1029,11 +1017,7 @@ export class Map extends Camera {
      * If the map's current zoom level is higher than the new maximum,
      * the map will zoom to the new maximum.
      *
-     * Events triggered:
-     *
-     * | Event   | Condition             |
-     * |---------|-----------------------|
-     * | `error` | maxZoom out of bounds |
+     * A {@link ErrorEvent} event will be fired if minZoom is out of bounds.
      *
      * @param maxZoom - The maximum zoom level to set.
      * If `null` or `undefined` is provided, the function removes the current maximum zoom (sets it to 22).
@@ -1074,11 +1058,7 @@ export class Map extends Camera {
      * If the map's current pitch is lower than the new minimum,
      * the map will pitch to the new minimum.
      *
-     * Events triggered:
-     *
-     * | Event   | Condition               |
-     * |---------|-------------------------|
-     * | `error` | minPitch out ouf bounds |
+     * A {@link ErrorEvent} event will be fired if minPitch is out of bounds.
      *
      * @param minPitch - The minimum pitch to set (0-85). Values greater than 60 degrees are experimental and may result in rendering issues. If you encounter any, please raise an issue with details in the MapLibre project.
      * If `null` or `undefined` is provided, the function removes the current minimum pitch (i.e. sets it to 0).
@@ -1115,11 +1095,7 @@ export class Map extends Camera {
      * If the map's current pitch is higher than the new maximum,
      * the map will pitch to the new maximum.
      *
-     * Events triggered:
-     *
-     * | Event   | Condition               |
-     * |---------|-------------------------|
-     * | `error` | maxPitch out ouf bounds |
+     * A {@link ErrorEvent} event will be fired if maxPitch is out of bounds.
      *
      * @param maxPitch - The maximum pitch to set (0-85). Values greater than 60 degrees are experimental and may result in rendering issues. If you encounter any, please raise an issue with details in the MapLibre project.
      * If `null` or `undefined` is provided, the function removes the current maximum pitch (sets it to 60).
@@ -1931,11 +1907,7 @@ export class Map extends Camera {
      * Returns a Boolean indicating whether the source is loaded. Returns `true` if the source with
      * the given ID in the map's style has no outstanding network requests, otherwise `false`.
      *
-     * Events triggered:
-     *
-     * | Event   | Condition              |
-     * |---------|------------------------|
-     * | `error` | No source with this ID |
+     * A {@link ErrorEvent} event will be fired if there is no source wit the specified ID.
      *
      * @param id - The ID of the source to be checked.
      * @returns A Boolean indicating whether the source is loaded.
@@ -2106,13 +2078,8 @@ export class Map extends Camera {
      * [`background-pattern`](https://maplibre.org/maplibre-style-spec/#paint-background-background-pattern),
      * [`fill-pattern`](https://maplibre.org/maplibre-style-spec/#paint-fill-fill-pattern),
      * or [`line-pattern`](https://maplibre.org/maplibre-style-spec/#paint-line-line-pattern).
-     * A {@link ErrorEvent} event will be fired if there is not enough space in the sprite to add this image.
-     *
-     * Events triggered:
-     *
-     * | Event     | Condition                |
-     * |-----------|--------------------------|
-     * | `error`   | Invalid image parameter  |
+     * 
+     * A {@link ErrorEvent} event will be fired if the image parameter is invalid or there is not enough space in the sprite to add this image.
      *
      * @param id - The ID of the image.
      * @param image - The image as an `HTMLImageElement`, `ImageData`, `ImageBitmap` or object with `width`, `height`, and `data`
@@ -2197,12 +2164,8 @@ export class Map extends Camera {
      * [`background-pattern`](https://maplibre.org/maplibre-style-spec/#paint-background-background-pattern),
      * [`fill-pattern`](https://maplibre.org/maplibre-style-spec/#paint-fill-fill-pattern),
      * or [`line-pattern`](https://maplibre.org/maplibre-style-spec/#paint-line-line-pattern).
-     *
-     * Events triggered:
-     *
-     * | Event     | Condition                |
-     * |-----------|--------------------------|
-     * | `error`   | Invalid image parameter  |
+     * 
+     * An {@link ErrorEvent} will be fired if the image parameter is invald.
      *
      * @param id - The ID of the image.
      * @param image - The image as an `HTMLImageElement`, `ImageData`, `ImageBitmap` or object with `width`, `height`, and `data`
@@ -2272,13 +2235,9 @@ export class Map extends Camera {
      * in the style's original sprite and any images
      * that have been added at runtime using {@link Map#addImage}.
      *
+     * An {@link ErrorEvent} will be fired if the image parameter is invald.
+     *
      * @param id - The ID of the image.
-     *
-     * Events triggered:
-     *
-     * | Event     | Condition                |
-     * |-----------|--------------------------|
-     * | `error`   | Invalid image parameter  |
      *
      * @returns A Boolean indicating whether the image exists.
      * @example
@@ -2460,11 +2419,7 @@ export class Map extends Camera {
     /**
      * Removes the layer with the given ID from the map's style.
      *
-     * Events triggered:
-     *
-     * | Event   | Condition            |
-     * |---------|----------------------|
-     * | `error` | No such layer exists |
+     * An {@link ErrorEvent} will be fired if the image parameter is invald.
      *
      * @param id - The ID of the layer to remove
      * @returns `this`

--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -1960,7 +1960,6 @@ export class Map extends Camera {
      *
      * | Event     | Condition              |
      * |-----------|------------------------|
-     * | `error`   | Failed to load source  |
      * | `terrain` | Success loading source |
      *
      * @param options - Options object.

--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -760,7 +760,7 @@ export class Map extends Camera {
      * Removes the control from the map.
      *
      * An {@link ErrorEvent} will be fired if the image parameter is invald.
-     * 
+     *
      * @param control - The {@link IControl} to remove.
      * @returns `this`
      * @example
@@ -2078,7 +2078,7 @@ export class Map extends Camera {
      * [`background-pattern`](https://maplibre.org/maplibre-style-spec/#paint-background-background-pattern),
      * [`fill-pattern`](https://maplibre.org/maplibre-style-spec/#paint-fill-fill-pattern),
      * or [`line-pattern`](https://maplibre.org/maplibre-style-spec/#paint-line-line-pattern).
-     * 
+     *
      * A {@link ErrorEvent} event will be fired if the image parameter is invalid or there is not enough space in the sprite to add this image.
      *
      * @param id - The ID of the image.
@@ -2164,7 +2164,7 @@ export class Map extends Camera {
      * [`background-pattern`](https://maplibre.org/maplibre-style-spec/#paint-background-background-pattern),
      * [`fill-pattern`](https://maplibre.org/maplibre-style-spec/#paint-fill-fill-pattern),
      * or [`line-pattern`](https://maplibre.org/maplibre-style-spec/#paint-line-line-pattern).
-     * 
+     *
      * An {@link ErrorEvent} will be fired if the image parameter is invald.
      *
      * @param id - The ID of the image.


### PR DESCRIPTION
This improves the Map/Camera class documentation in the following ways:
- Private functions and properties are suppressed from the output
- Event annotations are constrained only to event listeners, and lists of events are added to each method that fires events.
- Some events were added to the Camera class where they seemed to be missing/wrong/copy-paste-errored, for example, adding pitch and rotate to functions that pitch and rotate the map.

If the table takes up too much white space to list the Camera class events, it can be changed to a simple, more compact list.

Related to #2861, however, this changes documentation only and does not fire warnings.

## Launch Checklist

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Document any changes to public APIs.