### PR TITLE
Remove unused 'name' parameter from class Program

### DIFF
--- a/src/render/draw_fill.test.ts
+++ b/src/render/draw_fill.test.ts
@@ -28,7 +28,7 @@ describe('drawFill', () => {
         const painterMock: Painter = constructMockPainer();
         const layer: FillStyleLayer = constructMockLayer();
 
-        const programMock = new Program(null as any, null as any, null as any, null as any, null as any, null as any, null as any);
+        const programMock = new Program(null as any, null as any, null as any, null as any, null as any, null as any);
         (painterMock.useProgram as jest.Mock).mockReturnValue(programMock);
 
         const mockTile = constructMockTile(layer);

--- a/src/render/draw_symbol.test.ts
+++ b/src/render/draw_symbol.test.ts
@@ -62,7 +62,7 @@ describe('drawSymbol', () => {
 
         const tileId = new OverscaledTileID(1, 0, 1, 0, 0);
         tileId.posMatrix = mat4.create();
-        const programMock = new Program(null, null, null, null, null, null, null);
+        const programMock = new Program(null, null, null, null, null, null);
         (painterMock.useProgram as jest.Mock).mockReturnValue(programMock);
         const bucketMock = new SymbolBucket(null);
         bucketMock.icon = {
@@ -124,7 +124,7 @@ describe('drawSymbol', () => {
 
         const tileId = new OverscaledTileID(1, 0, 1, 0, 0);
         tileId.posMatrix = mat4.create();
-        const programMock = new Program(null, null, null, null, null, null, null);
+        const programMock = new Program(null, null, null, null, null, null);
         (painterMock.useProgram as jest.Mock).mockReturnValue(programMock);
         const bucketMock = new SymbolBucket(null);
         bucketMock.icon = {
@@ -189,7 +189,7 @@ describe('drawSymbol', () => {
 
         const tileId = new OverscaledTileID(1, 0, 1, 0, 0);
         tileId.posMatrix = mat4.create();
-        const programMock = new Program(null, null, null, null, null, null, null);
+        const programMock = new Program(null, null, null, null, null, null);
         (painterMock.useProgram as jest.Mock).mockReturnValue(programMock);
         const bucketMock = new SymbolBucket(null);
         bucketMock.icon = {

--- a/src/render/painter.ts
+++ b/src/render/painter.ts
@@ -574,7 +574,6 @@ export class Painter {
         if (!this.cache[key]) {
             this.cache[key] = new Program(
                 this.context,
-                name,
                 shaders[name],
                 programConfiguration,
                 programUniforms[name],

--- a/src/render/program.ts
+++ b/src/render/program.ts
@@ -42,7 +42,6 @@ export class Program<Us extends UniformBindings> {
     failedToCreate: boolean;
 
     constructor(context: Context,
-        name: string,
         source: {
             fragmentSource: string;
             vertexSource: string;


### PR DESCRIPTION
The 'name' parameter in the `Program` class is unused. This PR removes this parameter from the constructor and from all invocations.

## Launch Checklist
 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
