### PR TITLE
fix: [issue-2868] after enabling terrain, the _update marker method w…

### DIFF
--- a/src/ui/marker.ts
+++ b/src/ui/marker.ts
@@ -297,6 +297,8 @@ export class Marker extends Evented {
         map.getCanvasContainer().appendChild(this._element);
         map.on('move', this._update);
         map.on('moveend', this._update);
+        map.on('terrain', this._update);
+  
         this.setDraggable(this._draggable);
         this._update();
 
@@ -504,7 +506,13 @@ export class Marker extends Evented {
         return this;
     }
 
-    _update = (e?: { type: 'move' | 'moveend' }) => {
+    _update = (e?: { type: 'move' | 'moveend' | 'terrain' }) => {
+        if(e?.type === 'terrain') {
+          setTimeout(() => {
+            this._update();
+          }, 100);
+        }
+
         if (!this._map) return;
 
         if (this._map.transform.renderWorldCopies) {


### PR DESCRIPTION
This pr is a small fix to issue #2868 

This fix has a timeout that could be removed if we have an event terrainEnd, please let me know if  something like that already exists or how it can be added.

https://github.com/maplibre/maplibre-gl-js/assets/10349981/f4e10b6e-3a3c-402c-ba54-f8621c95f829

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [x] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [ ] Add an entry to `CHANGELOG.md` under the `## main` section.
