### PR TITLE
Exposed the DOM util class to the public

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ import {LngLatBounds} from './geo/lng_lat_bounds';
 import Point from '@mapbox/point-geometry';
 import {MercatorCoordinate} from './geo/mercator_coordinate';
 import {Evented} from './util/evented';
+import {DOM} from './util/dom';
 import {config} from './util/config';
 import {Debug} from './util/debug';
 import {isSafari} from './util/util';
@@ -59,6 +60,7 @@ class MapLibreGL {
     static Point = Point;
     static MercatorCoordinate = MercatorCoordinate;
     static Evented = Evented;
+    static DOM = DOM;
     static AJAXError = AJAXError;
     static config = config;
     static CanvasSource = CanvasSource;


### PR DESCRIPTION
Very small change that only exposes the DOM util class to the public. This will be useful for people wanting to make custom controls, and will allow them to use the same DOM manipulation util class as the bundled controls.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [ ] Link to related issues.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [ ] Add an entry to `CHANGELOG.md` under the `## main` section.
