### PR TITLE
Fix Raster DEM source serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Incorrect distance field of view calculation for negative elevation, fixed by storing min elevation for the tile in view ([#1655](https://github.com/maplibre/maplibre-gl-js/issues/1655), [#2858](https://github.com/maplibre/maplibre-gl-js/pull/2858))
 - Fix reloadCallback not firing on VectorTileWorkerSource.reloadTile ([#1874](https://github.com/maplibre/maplibre-gl-js/pull/1874))
+- Fix RasterDEMTileSource not serializing its options correctly ([#2895](https://github.com/maplibre/maplibre-gl-js/pull/2895))
 - _...Add new stuff here..._
 
 ## 3.2.0

--- a/src/source/raster_dem_tile_source.test.ts
+++ b/src/source/raster_dem_tile_source.test.ts
@@ -150,4 +150,18 @@ describe('RasterTileSource', () => {
         });
         server.respond();
     });
+
+    it('serializes options', () => {
+        const source = createSource({
+            tiles: ['http://localhost:2900/raster-dem/{z}/{x}/{y}.png'],
+            minzoom: 2,
+            maxzoom: 10
+        });
+        expect(source.serialize()).toStrictEqual({
+            type: 'raster-dem',
+            tiles: ['http://localhost:2900/raster-dem/{z}/{x}/{y}.png'],
+            minzoom: 2,
+            maxzoom: 10
+        });
+    });
 });

--- a/src/source/raster_dem_tile_source.ts
+++ b/src/source/raster_dem_tile_source.ts
@@ -43,17 +43,6 @@ export class RasterDEMTileSource extends RasterTileSource implements Source {
         this.encoding = options.encoding || 'mapbox';
     }
 
-    serialize() {
-        return {
-            type: 'raster-dem',
-            url: this.url,
-            tileSize: this.tileSize,
-            tiles: this.tiles,
-            bounds: this.bounds,
-            encoding: this.encoding
-        };
-    }
-
     loadTile(tile: Tile, callback: Callback<void>) {
         const url = tile.tileID.canonical.url(this.tiles, this.map.getPixelRatio(), this.scheme);
         tile.request = ImageRequest.getImage(this.map._requestManager.transformRequest(url, ResourceType.Tile), imageLoaded.bind(this), this.map._refreshExpiredTiles);

--- a/src/source/raster_tile_source.test.ts
+++ b/src/source/raster_tile_source.test.ts
@@ -170,4 +170,17 @@ describe('RasterTileSource', () => {
         expect((server.requests.pop() as any).aborted).toBe(true);
     });
 
+    it('serializes options', () => {
+        const source = createSource({
+            tiles: ['http://localhost:2900/raster/{z}/{x}/{y}.png'],
+            minzoom: 2,
+            maxzoom: 10
+        });
+        expect(source.serialize()).toStrictEqual({
+            type: 'raster',
+            tiles: ['http://localhost:2900/raster/{z}/{x}/{y}.png'],
+            minzoom: 2,
+            maxzoom: 10
+        });
+    });
 });


### PR DESCRIPTION
Closes https://github.com/maplibre/maplibre-gl-js/issues/2889.

While investigating the issue, I determined that not only are undefined properties included when serializing, but not all relevant properties are included either (e.g. minzoom and maxzoom). However, I can see no reason to not just use the base class [RasterTileSource's serialize() function](https://github.com/maplibre/maplibre-gl-js/blob/8c351c401b72e69bb3d5156a6101d281d18f44cb/src/source/raster_tile_source.ts#L127) directly. So, I've removed the function from RasterDEMTileSource, and added a test for both RasterTileSource and RasterDEMTileSource.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [X] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [X] Briefly describe the changes in this PR.
 - [X] Link to related issues.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [X] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [X] Add an entry to `CHANGELOG.md` under the `## main` section.
