### PR TITLE
Feature/support cache parameter in fetch request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Remove cooperative gesture screen from the accessibility tree since screenreaders cannot interact with the map using gestures
 - Add `cooperated gestures` example to the doc.([#2860](https://github.com/maplibre/maplibre-gl-js/pull/2860))
-- Add `fetchCache` to [`RequestParameters`](https://maplibre.org/maplibre-gl-js/docs/API/types/maplibregl.RequestParameters/)
+- Add `cache` parameter to [`RequestParameters`](https://maplibre.org/maplibre-gl-js/docs/API/types/maplibregl.RequestParameters/) ([#2910](https://github.com/maplibre/maplibre-gl-js/pull/2910))
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Remove cooperative gesture screen from the accessibility tree since screenreaders cannot interact with the map using gestures
 - Add `cooperated gestures` example to the doc.([#2860](https://github.com/maplibre/maplibre-gl-js/pull/2860))
+- Add `fetchCache` to [`RequestParameters`](https://maplibre.org/maplibre-gl-js/docs/API/types/maplibregl.RequestParameters/)
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes

--- a/src/util/ajax.test.ts
+++ b/src/util/ajax.test.ts
@@ -7,7 +7,7 @@ import {
 } from './ajax';
 
 import {fakeServer, FakeServer} from 'nise';
-import {fetchMock, RequestMock, setupFetchMock} from './test/mock_fetch';
+import {RequestMock, setupFetchMock} from './test/mock_fetch';
 
 function readAsText(blob) {
     return new Promise((resolve, reject) => {

--- a/src/util/ajax.test.ts
+++ b/src/util/ajax.test.ts
@@ -7,6 +7,7 @@ import {
 } from './ajax';
 
 import {fakeServer, FakeServer} from 'nise';
+import {setupFetchMock} from './test/mock_fetch';
 
 function readAsText(blob) {
     return new Promise((resolve, reject) => {
@@ -41,6 +42,26 @@ describe('ajax', () => {
             done();
         });
         server.respond();
+    });
+
+    test('getJSON set request parameters', (done) => {
+        setupFetchMock();
+
+        jest.spyOn(global, 'fetch').mockImplementation((requestInfo: Request) => {
+            expect(requestInfo.url).toBe('http://example.com/test-params.json');
+            expect(requestInfo.cache).toBe('force-cache');
+            expect(requestInfo.method).toBe('GET');
+            expect(requestInfo.headers.get('Authorization')).toBe('Bearer 123');
+            expect(requestInfo.body).toBeUndefined();
+
+            done();
+
+            return Promise.resolve(<Response>{
+                json: () => null,
+            });
+        });
+
+        getJSON({url: 'http://example.com/test-params.json', fetchCache: 'force-cache', headers: {'Authorization': 'Bearer 123'}}, () => {});
     });
 
     test('getJSON', done => {

--- a/src/util/ajax.test.ts
+++ b/src/util/ajax.test.ts
@@ -7,7 +7,7 @@ import {
 } from './ajax';
 
 import {fakeServer, FakeServer} from 'nise';
-import {RequestMock, setupFetchMock} from './test/mock_fetch';
+import {destroyFetchMock, RequestMock, setupFetchMock} from './test/mock_fetch';
 
 function readAsText(blob) {
     return new Promise((resolve, reject) => {
@@ -26,6 +26,7 @@ describe('ajax', () => {
     });
     afterEach(() => {
         server.restore();
+        destroyFetchMock();
     });
 
     test('getArrayBuffer set correct request parameters', (done) => {

--- a/src/util/ajax.test.ts
+++ b/src/util/ajax.test.ts
@@ -44,24 +44,29 @@ describe('ajax', () => {
         server.respond();
     });
 
-    test('getJSON set request parameters', (done) => {
-        setupFetchMock();
+    [
+        {functionName: 'getJSON', targetFunction: getJSON},
+        {functionName: 'getArrayBuffer', targetFunction: getArrayBuffer}
+    ].forEach(({targetFunction, functionName}) => {
+        test(`${functionName} set correct request parameters`, (done) => {
+            setupFetchMock();
 
-        jest.spyOn(global, 'fetch').mockImplementation((requestInfo: Request) => {
-            expect(requestInfo.url).toBe('http://example.com/test-params.json');
-            expect(requestInfo.cache).toBe('force-cache');
-            expect(requestInfo.method).toBe('GET');
-            expect(requestInfo.headers.get('Authorization')).toBe('Bearer 123');
-            expect(requestInfo.body).toBeUndefined();
+            jest.spyOn(global, 'fetch').mockImplementation((requestInfo: Request) => {
+                expect(requestInfo.url).toBe('http://example.com/test-params.json');
+                expect(requestInfo.cache).toBe('force-cache');
+                expect(requestInfo.method).toBe('GET');
+                expect(requestInfo.headers.get('Authorization')).toBe('Bearer 123');
+                expect(requestInfo.body).toBeUndefined();
 
-            done();
+                done();
 
-            return Promise.resolve(<Response>{
-                json: () => null,
+                return Promise.resolve(<Response>{
+                    json: () => null,
+                });
             });
-        });
 
-        getJSON({url: 'http://example.com/test-params.json', fetchCache: 'force-cache', headers: {'Authorization': 'Bearer 123'}}, () => {});
+            targetFunction({url: 'http://example.com/test-params.json', fetchCache: 'force-cache', headers: {'Authorization': 'Bearer 123'}}, () => {});
+        });
     });
 
     test('getJSON', done => {

--- a/src/util/ajax.test.ts
+++ b/src/util/ajax.test.ts
@@ -7,7 +7,7 @@ import {
 } from './ajax';
 
 import {fakeServer, FakeServer} from 'nise';
-import {destroyFetchMock, RequestMock, setupFetchMock} from './test/mock_fetch';
+import {destroyFetchMock, FetchMock, RequestMock, setupFetchMock} from './test/mock_fetch';
 
 function readAsText(blob) {
     return new Promise((resolve, reject) => {
@@ -26,19 +26,6 @@ describe('ajax', () => {
     });
     afterEach(() => {
         server.restore();
-        destroyFetchMock();
-    });
-
-    test('getArrayBuffer set correct request parameters', (done) => {
-        const fetch = setupFetchMock();
-
-        getArrayBuffer({url: 'http://example.com/test-params.json', cache: 'force-cache', headers: {'Authorization': 'Bearer 123'}}, () => {
-            expect(fetch).toHaveBeenCalledTimes(1);
-            expect(fetch).toHaveBeenCalledWith(expect.objectContaining({url: 'http://example.com/test-params.json', method: 'GET', cache: 'force-cache'}));
-            expect((fetch.mock.calls[0][0] as RequestMock).headers.get('Authorization')).toBe('Bearer 123');
-
-            done();
-        });
     });
 
     test('getArrayBuffer, 404', done => {
@@ -55,18 +42,6 @@ describe('ajax', () => {
             done();
         });
         server.respond();
-    });
-
-    test('getJSON set correct request parameters', (done) => {
-        const fetch = setupFetchMock();
-
-        getJSON({url: 'http://example.com/test-params.json', cache: 'force-cache', headers: {'Authorization': 'Bearer 123'}}, () => {
-            expect(fetch).toHaveBeenCalledTimes(1);
-            expect(fetch).toHaveBeenCalledWith(expect.objectContaining({url: 'http://example.com/test-params.json', method: 'GET', cache: 'force-cache'}));
-            expect((fetch.mock.calls[0][0] as RequestMock).headers.get('Authorization')).toBe('Bearer 123');
-
-            done();
-        });
     });
 
     test('getJSON', done => {
@@ -166,5 +141,37 @@ describe('ajax', () => {
 
         // edge case
         expect(sameOrigin('://foo')).toBe(true);
+    });
+
+    describe('requests parameters', () => {
+        let fetch: FetchMock;
+
+        beforeEach(() => {
+            fetch = setupFetchMock();
+        });
+
+        afterEach(() => {
+            destroyFetchMock();
+        });
+
+        test('should be provided to fetch API in getArrayBuffer function', (done) => {
+            getArrayBuffer({url: 'http://example.com/test-params.json', cache: 'force-cache', headers: {'Authorization': 'Bearer 123'}}, () => {
+                expect(fetch).toHaveBeenCalledTimes(1);
+                expect(fetch).toHaveBeenCalledWith(expect.objectContaining({url: 'http://example.com/test-params.json', method: 'GET', cache: 'force-cache'}));
+                expect((fetch.mock.calls[0][0] as RequestMock).headers.get('Authorization')).toBe('Bearer 123');
+
+                done();
+            });
+        });
+
+        test('should be provided to fetch API in getJSON function', (done) => {
+            getJSON({url: 'http://example.com/test-params.json', cache: 'force-cache', headers: {'Authorization': 'Bearer 123'}}, () => {
+                expect(fetch).toHaveBeenCalledTimes(1);
+                expect(fetch).toHaveBeenCalledWith(expect.objectContaining({url: 'http://example.com/test-params.json', method: 'GET', cache: 'force-cache'}));
+                expect((fetch.mock.calls[0][0] as RequestMock).headers.get('Authorization')).toBe('Bearer 123');
+
+                done();
+            });
+        });
     });
 });

--- a/src/util/ajax.ts
+++ b/src/util/ajax.ts
@@ -52,7 +52,7 @@ export type RequestParameters = {
     /**
      * Parameters supported only by browser fetch API. Property of the Request interface contains the cache mode of the request. It controls how the request will interact with the browser's HTTP cache. (https://developer.mozilla.org/en-US/docs/Web/API/Request/cache)
      */
-    fetchCache?: RequestCache;
+    cache?: RequestCache;
 };
 
 /**
@@ -127,7 +127,7 @@ function makeFetchRequest(requestParameters: RequestParameters, callback: Respon
         body: requestParameters.body,
         credentials: requestParameters.credentials,
         headers: requestParameters.headers,
-        cache: requestParameters.fetchCache,
+        cache: requestParameters.cache,
         referrer: getReferrer(),
         signal: controller.signal
     });

--- a/src/util/ajax.ts
+++ b/src/util/ajax.ts
@@ -49,6 +49,15 @@ export type RequestParameters = {
      * If `true`, Resource Timing API information will be collected for these transformed requests and returned in a resourceTiming property of relevant data events.
      */
     collectResourceTiming?: boolean;
+    /**
+     * Parameters supported only by browser fetch API
+     */
+    fetchParameters?: {
+        /**
+         * Property of the Request interface contains the cache mode of the request. It controls how the request will interact with the browser's HTTP cache. (https://developer.mozilla.org/en-US/docs/Web/API/Request/cache)
+         */
+        cache?: RequestCache;
+    };
 };
 
 /**
@@ -123,6 +132,7 @@ function makeFetchRequest(requestParameters: RequestParameters, callback: Respon
         body: requestParameters.body,
         credentials: requestParameters.credentials,
         headers: requestParameters.headers,
+        cache: requestParameters?.fetchParameters?.cache,
         referrer: getReferrer(),
         signal: controller.signal
     });

--- a/src/util/ajax.ts
+++ b/src/util/ajax.ts
@@ -50,14 +50,9 @@ export type RequestParameters = {
      */
     collectResourceTiming?: boolean;
     /**
-     * Parameters supported only by browser fetch API
+     * Parameters supported only by browser fetch API. Property of the Request interface contains the cache mode of the request. It controls how the request will interact with the browser's HTTP cache. (https://developer.mozilla.org/en-US/docs/Web/API/Request/cache)
      */
-    fetchParameters?: {
-        /**
-         * Property of the Request interface contains the cache mode of the request. It controls how the request will interact with the browser's HTTP cache. (https://developer.mozilla.org/en-US/docs/Web/API/Request/cache)
-         */
-        cache?: RequestCache;
-    };
+    fetchCache?: RequestCache;
 };
 
 /**
@@ -132,7 +127,7 @@ function makeFetchRequest(requestParameters: RequestParameters, callback: Respon
         body: requestParameters.body,
         credentials: requestParameters.credentials,
         headers: requestParameters.headers,
-        cache: requestParameters?.fetchParameters?.cache,
+        cache: requestParameters.fetchCache,
         referrer: getReferrer(),
         signal: controller.signal
     });

--- a/src/util/test/mock_fetch.ts
+++ b/src/util/test/mock_fetch.ts
@@ -19,7 +19,7 @@ export class RequestMock implements Partial<Request> {
 class AbortControllerMock {
     public signal: AbortSignal;
 
-    public abort() {}
+    public abort(): void {}
 }
 
 export type FetchMock = jest.Mock<Promise<Response>, [input: RequestInfo | URL, init?: RequestInit], any>;
@@ -40,11 +40,7 @@ export function setupFetchMock(): FetchMock {
     _fetch = _fetch ?? global.fetch;
 
     const fetchMock = jest.fn(async (_input: RequestInfo | URL, _init?: RequestInit): Promise<Response> => {
-        return <Response>{
-            json: async () => null,
-            arrayBuffer: async () => null,
-            text: async () => null,
-        };
+        return <Response>{};
     });
 
     global.AbortController = AbortControllerMock;

--- a/src/util/test/mock_fetch.ts
+++ b/src/util/test/mock_fetch.ts
@@ -1,4 +1,4 @@
-class RequestMock implements Partial<Request> {
+export class RequestMock implements Partial<Request> {
     public readonly cache: RequestCache;
     public readonly headers: Headers = new Headers();
     public readonly method?: string;
@@ -16,19 +16,24 @@ class RequestMock implements Partial<Request> {
     }
 }
 
-class AbortController {
+class AbortControllerMock {
     public signal: AbortSignal;
 
     public abort() {}
 }
 
-export function setupFetchMock() {
-    global.AbortController = AbortController;
-    global.Request = RequestMock as unknown as typeof Request;
-
-    global.fetch = jest.fn(() => {
-        return Promise.resolve(<Response>{
-            json: () => null,
-        });
+export function setupFetchMock(): jest.Mock<Promise<Response>, [input: RequestInfo | URL, init?: RequestInit], any> {
+    const fetchMock = jest.fn(async (_input: RequestInfo | URL, _init?: RequestInit): Promise<Response> => {
+        return <Response>{
+            json: async () => null,
+            arrayBuffer: async () => null,
+            text: async () => null,
+        };
     });
+
+    global.AbortController = AbortControllerMock;
+    global.Request = RequestMock as unknown as typeof Request;
+    global.fetch = fetchMock;
+
+    return fetchMock;
 }

--- a/src/util/test/mock_fetch.ts
+++ b/src/util/test/mock_fetch.ts
@@ -1,4 +1,3 @@
-
 class RequestMock implements Partial<Request> {
     public readonly cache: RequestCache;
     public readonly headers: Headers = new Headers();
@@ -13,7 +12,7 @@ class RequestMock implements Partial<Request> {
         this.cache = typeof input === 'object' && 'cache' in input ? input.cache : init.cache;
         this.method = typeof input === 'object' && 'method' in input ? input.method : init.method;
         this.url = typeof input === 'object' && 'url' in input ? input.url : input.toString();
-        this.headers = typeof input === 'object' && 'headers' in input ? new Headers(input.headers) : new Headers(init.headers);
+        this.headers = typeof input === 'object' && 'headers' in input ? new Headers(input.headers) : new Headers(init.headers || {});
     }
 }
 

--- a/src/util/test/mock_fetch.ts
+++ b/src/util/test/mock_fetch.ts
@@ -22,7 +22,23 @@ class AbortControllerMock {
     public abort() {}
 }
 
-export function setupFetchMock(): jest.Mock<Promise<Response>, [input: RequestInfo | URL, init?: RequestInit], any> {
+export type FetchMock = jest.Mock<Promise<Response>, [input: RequestInfo | URL, init?: RequestInit], any>;
+
+let _AbortController: typeof AbortController;
+let _Request: typeof Request;
+let _fetch: typeof fetch;
+
+export function destroyFetchMock(): void {
+    global.AbortController = _AbortController ?? global.AbortController;
+    global.Request = _Request ?? global.Request;
+    global.fetch = _fetch ?? global.fetch;
+}
+
+export function setupFetchMock(): FetchMock {
+    _AbortController = _AbortController ?? global.AbortController;
+    _Request = _Request ?? global.Request;
+    _fetch = _fetch ?? global.fetch;
+
     const fetchMock = jest.fn(async (_input: RequestInfo | URL, _init?: RequestInit): Promise<Response> => {
         return <Response>{
             json: async () => null,

--- a/src/util/test/mock_fetch.ts
+++ b/src/util/test/mock_fetch.ts
@@ -1,0 +1,35 @@
+
+class RequestMock implements Partial<Request> {
+    public readonly cache: RequestCache;
+    public readonly headers: Headers = new Headers();
+    public readonly method?: string;
+    public readonly url?: string;
+
+    public get signal(): AbortSignal {
+        return null;
+    }
+
+    constructor(input: RequestInfo | URL, init?: RequestInit) {
+        this.cache = typeof input === 'object' && 'cache' in input ? input.cache : init.cache;
+        this.method = typeof input === 'object' && 'method' in input ? input.method : init.method;
+        this.url = typeof input === 'object' && 'url' in input ? input.url : input.toString();
+        this.headers = typeof input === 'object' && 'headers' in input ? new Headers(input.headers) : new Headers(init.headers);
+    }
+}
+
+class AbortController {
+    public signal: AbortSignal;
+
+    public abort() {}
+}
+
+export function setupFetchMock() {
+    global.AbortController = AbortController;
+    global.Request = RequestMock as unknown as typeof Request;
+
+    global.fetch = jest.fn(() => {
+        return Promise.resolve(<Response>{
+            json: () => null,
+        });
+    });
+}


### PR DESCRIPTION
## Launch Checklist

In my case, I need it to use a **force-cache** strategy in **fetch** API when downloading map tiles. 

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [ ] Link to related issues.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality.
 - [x] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [x] Add an entry to `CHANGELOG.md` under the `## main` section.
