### PR TITLE
VectorTileWorkerSource: fix reload for original's load parse would not pass the rawTileData and meta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### 🐞 Bug fixes
 
+- VectorTileWorkerSource: fix reload for original's load parse would not pass the rawTileData and meta. ([#2941](https://github.com/maplibre/maplibre-gl-js/pull/2941))
 - _...Add new stuff here..._
 
 ## 3.2.1

--- a/src/source/vector_tile_worker_source.test.ts
+++ b/src/source/vector_tile_worker_source.test.ts
@@ -6,7 +6,7 @@ import {VectorTileWorkerSource} from '../source/vector_tile_worker_source';
 import {StyleLayerIndex} from '../style/style_layer_index';
 import {fakeServer, FakeServer} from 'nise';
 import {Actor} from '../util/actor';
-import {TileParameters, WorkerTileParameters, WorkerTileResult} from './worker_source';
+import {TileParameters, WorkerTileParameters} from './worker_source';
 import {WorkerTile} from './worker_tile';
 import {setPerformance} from '../util/test/util';
 

--- a/src/source/vector_tile_worker_source.ts
+++ b/src/source/vector_tile_worker_source.ts
@@ -24,6 +24,12 @@ export type LoadVectorTileResult = {
     resourceTiming?: Array<PerformanceResourceTiming>;
 } & ExpiryData;
 
+type FetchingState = {
+    rawTileData: ArrayBuffer;
+    cacheControl: ExpiryData;
+    resourceTiming: any;
+}
+
 /**
  * The callback when finished loading vector data
  */
@@ -52,12 +58,6 @@ function loadVectorTile(params: WorkerTileParameters, callback: LoadVectorDataCa
         request.cancel();
         callback();
     };
-}
-
-interface FetchingState {
-    rawTileData: ArrayBuffer;
-    cacheControl: ExpiryData;
-    resourceTiming: any;
 }
 
 /**

--- a/src/source/vector_tile_worker_source.ts
+++ b/src/source/vector_tile_worker_source.ts
@@ -132,6 +132,7 @@ export class VectorTileWorkerSource implements WorkerSource {
 
             workerTile.vectorTile = response.vectorTile;
             workerTile.parse(response.vectorTile, this.layerIndex, this.availableImages, this.actor, (err, result) => {
+                delete this.fetching[uid];
                 if (err || !result) return callback(err);
 
                 // Transferring a copy of rawTileData because the worker needs to retain its copy.


### PR DESCRIPTION
## Launch Checklist

Fixes #2923.

An unfortunate regression has been introduced in #1874, where when `reloadTile`  would get called before the original load completes, the `rawTileData` won't get passed to the main thread, leading to #2923. The base `loadTile` will extend the parse result with previously fetched data at https://github.com/maplibre/maplibre-gl-js/blob/01e5f51cf15421cb40ad0ff4798f8f536f816a0c/src/source/vector_tile_worker_source.ts#L130

This PR will keep the original fetching state until the first parse completes and will pass it along as expected.

 - [X] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [X] Briefly describe the changes in this PR.
 - [X] Link to related issues.
 - [x] Write tests for all new functionality.
 - [x] Add an entry to `CHANGELOG.md` under the `## main` section.
