### PR TITLE
Added hidden modifier to "non interesting" classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### ✨ Features and improvements
 
 - Add `cache` parameter to [`RequestParameters`](https://maplibre.org/maplibre-gl-js/docs/API/types/maplibregl.RequestParameters/) ([#2910](https://github.com/maplibre/maplibre-gl-js/pull/2910))
+- Removed some classed from the docs to better define the public API ([#2945](https://github.com/maplibre/maplibre-gl-js/pull/2945))
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes

--- a/build/generate-struct-arrays.ts
+++ b/build/generate-struct-arrays.ts
@@ -227,6 +227,7 @@ function emitStructArrayLayout(locals) {
 
     output.push(
         `/**
+ * @hidden
  * Implementation of the StructArray layout:`);
 
     for (const member of members) {
@@ -348,7 +349,7 @@ function emitStructArray(locals) {
 
     if (includeStructAccessors && !useComponentGetters) {
         output.push(
-            `/** */
+            `/** @hidden */
 class ${structTypeClass} extends Struct {
     _structArray: ${structArrayClass};`);
 
@@ -384,7 +385,7 @@ export type ${structTypeClass.replace('Struct', '')} = ${structTypeClass};
     } // end 'if (includeStructAccessors)'
 
     output.push(
-        `/** */
+        `/** @hidden */
 export class ${structArrayClass} extends ${structArrayLayoutClass} {`);
 
     if (useComponentGetters) {

--- a/build/generate-struct-arrays.ts
+++ b/build/generate-struct-arrays.ts
@@ -227,7 +227,7 @@ function emitStructArrayLayout(locals) {
 
     output.push(
         `/**
- * @hidden
+ * @internal
  * Implementation of the StructArray layout:`);
 
     for (const member of members) {
@@ -349,7 +349,7 @@ function emitStructArray(locals) {
 
     if (includeStructAccessors && !useComponentGetters) {
         output.push(
-            `/** @hidden */
+            `/** @internal */
 class ${structTypeClass} extends Struct {
     _structArray: ${structArrayClass};`);
 
@@ -385,7 +385,7 @@ export type ${structTypeClass.replace('Struct', '')} = ${structTypeClass};
     } // end 'if (includeStructAccessors)'
 
     output.push(
-        `/** @hidden */
+        `/** @internal */
 export class ${structArrayClass} extends ${structArrayLayoutClass} {`);
 
     if (useComponentGetters) {

--- a/src/data/bucket/circle_bucket.ts
+++ b/src/data/bucket/circle_bucket.ts
@@ -35,6 +35,7 @@ function addCircleVertex(layoutVertexArray, x, y, extrudeX, extrudeY) {
 }
 
 /**
+ * @hidden
  * Circles are represented by two triangles.
  *
  * Each corner has a pos that is the center of the circle and an extrusion

--- a/src/data/bucket/circle_bucket.ts
+++ b/src/data/bucket/circle_bucket.ts
@@ -35,7 +35,7 @@ function addCircleVertex(layoutVertexArray, x, y, extrudeX, extrudeY) {
 }
 
 /**
- * @hidden
+ * @internal
  * Circles are represented by two triangles.
  *
  * Each corner has a pos that is the center of the circle and an extrusion

--- a/src/data/bucket/line_bucket.ts
+++ b/src/data/bucket/line_bucket.ts
@@ -82,6 +82,7 @@ type GradientTexture = {
 };
 
 /**
+ * @hidden
  * Line bucket class
  */
 export class LineBucket implements Bucket {

--- a/src/data/bucket/line_bucket.ts
+++ b/src/data/bucket/line_bucket.ts
@@ -82,7 +82,7 @@ type GradientTexture = {
 };
 
 /**
- * @hidden
+ * @internal
  * Line bucket class
  */
 export class LineBucket implements Bucket {

--- a/src/data/bucket/symbol_bucket.ts
+++ b/src/data/bucket/symbol_bucket.ts
@@ -276,7 +276,7 @@ class CollisionBuffers {
 register('CollisionBuffers', CollisionBuffers);
 
 /**
- * @hidden
+ * @internal
  * Unlike other buckets, which simply implement #addFeature with type-specific
  * logic for (essentially) triangulating feature geometries, SymbolBucket
  * requires specialized behavior:

--- a/src/data/bucket/symbol_bucket.ts
+++ b/src/data/bucket/symbol_bucket.ts
@@ -276,6 +276,7 @@ class CollisionBuffers {
 register('CollisionBuffers', CollisionBuffers);
 
 /**
+ * @hidden
  * Unlike other buckets, which simply implement #addFeature with type-specific
  * logic for (essentially) triangulating feature geometries, SymbolBucket
  * requires specialized behavior:

--- a/src/data/feature_index.ts
+++ b/src/data/feature_index.ts
@@ -40,6 +40,7 @@ type QueryParameters = {
 };
 
 /**
+ * @hidden
  * An in memory index class to allow fast interaction with features
  */
 export class FeatureIndex {

--- a/src/data/feature_index.ts
+++ b/src/data/feature_index.ts
@@ -40,7 +40,7 @@ type QueryParameters = {
 };
 
 /**
- * @hidden
+ * @internal
  * An in memory index class to allow fast interaction with features
  */
 export class FeatureIndex {

--- a/src/data/program_configuration.ts
+++ b/src/data/program_configuration.ts
@@ -393,7 +393,7 @@ class CrossFadedCompositeBinder implements AttributeBinder {
 }
 
 /**
- * @hidden
+ * @internal
  * ProgramConfiguration contains the logic for binding style layer properties and tile
  * layer feature data into GL program uniforms and vertex attributes.
  *

--- a/src/data/program_configuration.ts
+++ b/src/data/program_configuration.ts
@@ -393,6 +393,7 @@ class CrossFadedCompositeBinder implements AttributeBinder {
 }
 
 /**
+ * @hidden
  * ProgramConfiguration contains the logic for binding style layer properties and tile
  * layer feature data into GL program uniforms and vertex attributes.
  *

--- a/src/data/segment.ts
+++ b/src/data/segment.ts
@@ -6,6 +6,7 @@ import type {VertexArrayObject} from '../render/vertex_array_object';
 import type {StructArray} from '../util/struct_array';
 
 /**
+ * @hidden
  * A single segment of a vector
  */
 export type Segment = {
@@ -18,6 +19,7 @@ export type Segment = {
 };
 
 /**
+ * @hidden
  * Used for calculations on vector segments
  */
 export class SegmentVector {

--- a/src/data/segment.ts
+++ b/src/data/segment.ts
@@ -6,7 +6,7 @@ import type {VertexArrayObject} from '../render/vertex_array_object';
 import type {StructArray} from '../util/struct_array';
 
 /**
- * @hidden
+ * @internal
  * A single segment of a vector
  */
 export type Segment = {
@@ -19,7 +19,7 @@ export type Segment = {
 };
 
 /**
- * @hidden
+ * @internal
  * Used for calculations on vector segments
  */
 export class SegmentVector {

--- a/src/geo/transform.ts
+++ b/src/geo/transform.ts
@@ -14,6 +14,7 @@ import type {PaddingOptions} from './edge_insets';
 import {Terrain} from '../render/terrain';
 
 /**
+ * @hidden
  * A single transform, generally used for a single tile to be
  * scaled, rotated, and zoomed.
  */

--- a/src/geo/transform.ts
+++ b/src/geo/transform.ts
@@ -14,7 +14,7 @@ import type {PaddingOptions} from './edge_insets';
 import {Terrain} from '../render/terrain';
 
 /**
- * @hidden
+ * @internal
  * A single transform, generally used for a single tile to be
  * scaled, rotated, and zoomed.
  */

--- a/src/gl/context.ts
+++ b/src/gl/context.ts
@@ -24,6 +24,7 @@ type ClearArgs = {
 };
 
 /**
+ * @hidden
  * A webgl wrapper class to allow injection, mocking and abstaction
  */
 export class Context {

--- a/src/gl/context.ts
+++ b/src/gl/context.ts
@@ -24,7 +24,7 @@ type ClearArgs = {
 };
 
 /**
- * @hidden
+ * @internal
  * A webgl wrapper class to allow injection, mocking and abstaction
  */
 export class Context {

--- a/src/gl/framebuffer.ts
+++ b/src/gl/framebuffer.ts
@@ -3,7 +3,7 @@ import {ColorAttachment, DepthAttachment, DepthStencilAttachment} from './value'
 import type {Context} from './context';
 
 /**
- * @hidden
+ * @internal
  * A framebuffer holder object
  */
 export class Framebuffer {

--- a/src/gl/framebuffer.ts
+++ b/src/gl/framebuffer.ts
@@ -3,6 +3,7 @@ import {ColorAttachment, DepthAttachment, DepthStencilAttachment} from './value'
 import type {Context} from './context';
 
 /**
+ * @hidden
  * A framebuffer holder object
  */
 export class Framebuffer {

--- a/src/gl/index_buffer.ts
+++ b/src/gl/index_buffer.ts
@@ -4,6 +4,7 @@ import type {TriangleIndexArray, LineIndexArray, LineStripIndexArray} from '../d
 import type {Context} from '../gl/context';
 
 /**
+ * @hidden
  * an index buffer class
  */
 export class IndexBuffer {

--- a/src/gl/index_buffer.ts
+++ b/src/gl/index_buffer.ts
@@ -4,7 +4,7 @@ import type {TriangleIndexArray, LineIndexArray, LineStripIndexArray} from '../d
 import type {Context} from '../gl/context';
 
 /**
- * @hidden
+ * @internal
  * an index buffer class
  */
 export class IndexBuffer {

--- a/src/gl/render_pool.ts
+++ b/src/gl/render_pool.ts
@@ -10,7 +10,8 @@ export type PoolObject = {
     inUse: boolean;
 };
 /**
- * RenderPool a resource pool for textures and framebuffers
+ * @hidden
+ * `RenderPool` is a resource pool for textures and framebuffers
  */
 export class RenderPool {
     private _objects: Array<PoolObject>;

--- a/src/gl/render_pool.ts
+++ b/src/gl/render_pool.ts
@@ -10,7 +10,7 @@ export type PoolObject = {
     inUse: boolean;
 };
 /**
- * @hidden
+ * @internal
  * `RenderPool` is a resource pool for textures and framebuffers
  */
 export class RenderPool {

--- a/src/gl/vertex_buffer.ts
+++ b/src/gl/vertex_buffer.ts
@@ -21,7 +21,7 @@ const AttributeType = {
 };
 
 /**
- * @hidden
+ * @internal
  * The `VertexBuffer` class turns a `StructArray` into a WebGL buffer. Each member of the StructArray's
  * Struct type is converted to a WebGL attribute.
  */

--- a/src/gl/vertex_buffer.ts
+++ b/src/gl/vertex_buffer.ts
@@ -21,6 +21,7 @@ const AttributeType = {
 };
 
 /**
+ * @hidden
  * The `VertexBuffer` class turns a `StructArray` into a WebGL buffer. Each member of the StructArray's
  * Struct type is converted to a WebGL attribute.
  */

--- a/src/render/image_atlas.ts
+++ b/src/render/image_atlas.ts
@@ -61,7 +61,7 @@ export class ImagePosition {
 }
 
 /**
- * @hidden
+ * @internal
  * A class holding all the images
  */
 export class ImageAtlas {

--- a/src/render/image_atlas.ts
+++ b/src/render/image_atlas.ts
@@ -61,6 +61,7 @@ export class ImagePosition {
 }
 
 /**
+ * @hidden
  * A class holding all the images
  */
 export class ImageAtlas {

--- a/src/render/line_atlas.ts
+++ b/src/render/line_atlas.ts
@@ -12,6 +12,7 @@ type DashEntry = {
 }
 
 /**
+ * @hidden
  * A LineAtlas lets us reuse rendered dashed lines
  * by writing many of them to a texture and then fetching their positions
  * using {@link LineAtlas#getDash}.

--- a/src/render/line_atlas.ts
+++ b/src/render/line_atlas.ts
@@ -12,7 +12,7 @@ type DashEntry = {
 }
 
 /**
- * @hidden
+ * @internal
  * A LineAtlas lets us reuse rendered dashed lines
  * by writing many of them to a texture and then fetching their positions
  * using {@link LineAtlas#getDash}.

--- a/src/render/painter.ts
+++ b/src/render/painter.ts
@@ -61,7 +61,7 @@ type PainterOptions = {
 };
 
 /**
- * @hidden
+ * @internal
  * Initialize a new painter object.
  */
 export class Painter {

--- a/src/render/painter.ts
+++ b/src/render/painter.ts
@@ -61,6 +61,7 @@ type PainterOptions = {
 };
 
 /**
+ * @hidden
  * Initialize a new painter object.
  */
 export class Painter {

--- a/src/render/program.ts
+++ b/src/render/program.ts
@@ -30,7 +30,7 @@ function getTokenizedAttributesAndUniforms(array: Array<string>): Array<string> 
 }
 
 /**
- * @hidden
+ * @internal
  * A webgl program to execute in the GPU space
  */
 export class Program<Us extends UniformBindings> {

--- a/src/render/program.ts
+++ b/src/render/program.ts
@@ -30,6 +30,7 @@ function getTokenizedAttributesAndUniforms(array: Array<string>): Array<string> 
 }
 
 /**
+ * @hidden
  * A webgl program to execute in the GPU space
  */
 export class Program<Us extends UniformBindings> {

--- a/src/render/render_to_texture.ts
+++ b/src/render/render_to_texture.ts
@@ -9,7 +9,9 @@ import {RenderPool} from '../gl/render_pool';
 import {Texture} from './texture';
 import type {StyleLayer} from '../style/style_layer';
 
-// lookup table which layers should rendered to texture
+/**
+ * lookup table which layers should rendered to texture
+ */
 const LAYERS: { [keyof in StyleLayer['type']]?: boolean } = {
     background: true,
     fill: true,
@@ -19,30 +21,45 @@ const LAYERS: { [keyof in StyleLayer['type']]?: boolean } = {
 };
 
 /**
- * RenderToTexture
+ * @hidden
+ * A helper class to help define what should be rendered to texture and how
  */
 export class RenderToTexture {
     painter: Painter;
     terrain: Terrain;
     pool: RenderPool;
-    // coordsDescendingInv contains a list of all tiles which should be rendered for one render-to-texture tile
-    // e.g. render 4 raster-tiles with size 256px to the 512px render-to-texture tile
+    /**
+     * coordsDescendingInv contains a list of all tiles which should be rendered for one render-to-texture tile
+     * e.g. render 4 raster-tiles with size 256px to the 512px render-to-texture tile
+     */
     _coordsDescendingInv: {[_: string]: {[_:string]: Array<OverscaledTileID>}};
-    // create a string representation of all to tiles rendered to render-to-texture tiles
-    // this string representation is used to check if tile should be re-rendered.
+    /**
+     * create a string representation of all to tiles rendered to render-to-texture tiles
+     * this string representation is used to check if tile should be re-rendered.
+     */
     _coordsDescendingInvStr: {[_: string]: {[_:string]: string}};
-    // store for render-stacks
-    // a render stack is a set of layers which should be rendered into one texture
-    // every stylesheet can have multiple stacks. A new stack is created if layers which should
-    // not rendered to texture sit inbetween layers which should rendered to texture. e.g. hillshading or symbols
+    /**
+     * store for render-stacks
+     * a render stack is a set of layers which should be rendered into one texture
+     * every stylesheet can have multiple stacks. A new stack is created if layers which should
+     * not rendered to texture sit inbetween layers which should rendered to texture. e.g. hillshading or symbols
+     */
     _stacks: Array<Array<string>>;
-    // remember the previous processed layer to check if a new stack is needed
+    /**
+     * remember the previous processed layer to check if a new stack is needed
+     */
     _prevType: string;
-    // a list of tiles that can potentially rendered
+    /**
+     * a list of tiles that can potentially rendered
+     */
     _renderableTiles: Array<Tile>;
-    // a list of tiles that should be rendered to screen in the next render-call
+    /**
+     * a list of tiles that should be rendered to screen in the next render-call
+     */
     _rttTiles: Array<Tile>;
-    // a list of all layer-ids which should be rendered
+    /**
+     * a list of all layer-ids which should be rendered
+     */
     _renderableLayerIds: Array<string>;
 
     constructor(painter: Painter, terrain: Terrain) {

--- a/src/render/render_to_texture.ts
+++ b/src/render/render_to_texture.ts
@@ -21,7 +21,7 @@ const LAYERS: { [keyof in StyleLayer['type']]?: boolean } = {
 };
 
 /**
- * @hidden
+ * @internal
  * A helper class to help define what should be rendered to texture and how
  */
 export class RenderToTexture {

--- a/src/render/terrain.ts
+++ b/src/render/terrain.ts
@@ -21,7 +21,7 @@ import type {TerrainSpecification} from '@maplibre/maplibre-gl-style-spec';
 import {LngLat, earthRadius} from '../geo/lng_lat';
 
 /**
- * @hidden
+ * @internal
  * A terrain GPU related object
  */
 export type TerrainData = {
@@ -37,7 +37,7 @@ export type TerrainData = {
 }
 
 /**
- * @hidden
+ * @internal
  * A terrain mesh object
  */
 export type TerrainMesh = {
@@ -47,7 +47,7 @@ export type TerrainMesh = {
 }
 
 /**
- * @hidden
+ * @internal
  * This is the main class which handles most of the 3D Terrain logic. It has the following topics:
  *    1) loads raster-dem tiles via the internal sourceCache this.sourceCache
  *    2) creates a depth-framebuffer, which is used to calculate the visibility of coordinates

--- a/src/render/terrain.ts
+++ b/src/render/terrain.ts
@@ -21,6 +21,7 @@ import type {TerrainSpecification} from '@maplibre/maplibre-gl-style-spec';
 import {LngLat, earthRadius} from '../geo/lng_lat';
 
 /**
+ * @hidden
  * A terrain GPU related object
  */
 export type TerrainData = {
@@ -36,6 +37,7 @@ export type TerrainData = {
 }
 
 /**
+ * @hidden
  * A terrain mesh object
  */
 export type TerrainMesh = {
@@ -45,6 +47,7 @@ export type TerrainMesh = {
 }
 
 /**
+ * @hidden
  * This is the main class which handles most of the 3D Terrain logic. It has the following topics:
  *    1) loads raster-dem tiles via the internal sourceCache this.sourceCache
  *    2) creates a depth-framebuffer, which is used to calculate the visibility of coordinates

--- a/src/render/texture.ts
+++ b/src/render/texture.ts
@@ -16,6 +16,7 @@ type DataTextureImage = RGBAImage | AlphaImage | EmptyImage;
 export type TextureImage = TexImageSource | DataTextureImage;
 
 /**
+ * @hidden
  * A `Texture` GL related object
  */
 export class Texture {

--- a/src/render/texture.ts
+++ b/src/render/texture.ts
@@ -16,7 +16,7 @@ type DataTextureImage = RGBAImage | AlphaImage | EmptyImage;
 export type TextureImage = TexImageSource | DataTextureImage;
 
 /**
- * @hidden
+ * @internal
  * A `Texture` GL related object
  */
 export class Texture {

--- a/src/render/uniform_binding.ts
+++ b/src/render/uniform_binding.ts
@@ -11,7 +11,7 @@ export type UniformValues<Us extends {}> = $ObjMap<Us, <V>(u: Uniform<V>) => V>;
 export type UniformLocations = {[_: string]: WebGLUniformLocation};
 
 /**
- * @hidden
+ * @internal
  * A base uniform abstract class
  */
 abstract class Uniform<T> {
@@ -151,7 +151,7 @@ export {
 };
 
 /**
- * @hidden
+ * @internal
  * A uniform bindings
  */
 export type UniformBindings = {[_: string]: Uniform<any>};

--- a/src/render/uniform_binding.ts
+++ b/src/render/uniform_binding.ts
@@ -11,6 +11,7 @@ export type UniformValues<Us extends {}> = $ObjMap<Us, <V>(u: Uniform<V>) => V>;
 export type UniformLocations = {[_: string]: WebGLUniformLocation};
 
 /**
+ * @hidden
  * A base uniform abstract class
  */
 abstract class Uniform<T> {
@@ -150,6 +151,7 @@ export {
 };
 
 /**
+ * @hidden
  * A uniform bindings
  */
 export type UniformBindings = {[_: string]: Uniform<any>};

--- a/src/render/vertex_array_object.ts
+++ b/src/render/vertex_array_object.ts
@@ -5,7 +5,7 @@ import type {IndexBuffer} from '../gl/index_buffer';
 import type {Context} from '../gl/context';
 
 /**
- * @hidden
+ * @internal
  * A vertex array object used to pass data to the webgl code
  */
 export class VertexArrayObject {

--- a/src/render/vertex_array_object.ts
+++ b/src/render/vertex_array_object.ts
@@ -5,6 +5,7 @@ import type {IndexBuffer} from '../gl/index_buffer';
 import type {Context} from '../gl/context';
 
 /**
+ * @hidden
  * A vertex array object used to pass data to the webgl code
  */
 export class VertexArrayObject {

--- a/src/source/canvas_source.ts
+++ b/src/source/canvas_source.ts
@@ -81,9 +81,7 @@ export class CanvasSource extends ImageSource {
     pause: () => void;
     _playing: boolean;
 
-    /**
-     * @hidden
-     */
+    /** @internal */
     constructor(id: string, options: CanvasSourceSpecification, dispatcher: Dispatcher, eventedParent: Evented) {
         super(id, options, dispatcher, eventedParent);
 

--- a/src/source/geojson_source.ts
+++ b/src/source/geojson_source.ts
@@ -138,9 +138,7 @@ export class GeoJSONSource extends Evented implements Source {
     _collectResourceTiming: boolean;
     _removed: boolean;
 
-    /**
-     * @hidden
-     */
+    /** @internal */
     constructor(id: string, options: GeoJSONSourceOptions, dispatcher: Dispatcher, eventedParent: Evented) {
         super();
 

--- a/src/source/image_source.ts
+++ b/src/source/image_source.ts
@@ -109,9 +109,7 @@ export class ImageSource extends Evented implements Source {
     _loaded: boolean;
     _request: Cancelable;
 
-    /**
-     * @hidden
-     */
+    /** @internal */
     constructor(id: string, options: ImageSourceSpecification | VideoSourceSpecification | CanvasSourceSpecification, dispatcher: Dispatcher, eventedParent: Evented) {
         super();
         this.id = id;
@@ -317,7 +315,7 @@ export class ImageSource extends Evented implements Source {
  * Given a list of coordinates, get their center as a coordinate.
  *
  * @returns centerpoint
- * @hidden
+ * @internal
  */
 export function getCoordinatesCenterTileID(coords: Array<MercatorCoordinate>) {
     let minX = Infinity;

--- a/src/source/source_cache.ts
+++ b/src/source/source_cache.ts
@@ -25,7 +25,7 @@ import {Terrain} from '../render/terrain';
 import {config} from '../util/config';
 
 /**
- * @hidden
+ * @internal
  * `SourceCache` is responsible for
  *
  *  - creating an instance of `Source`

--- a/src/source/source_cache.ts
+++ b/src/source/source_cache.ts
@@ -25,6 +25,7 @@ import {Terrain} from '../render/terrain';
 import {config} from '../util/config';
 
 /**
+ * @hidden
  * `SourceCache` is responsible for
  *
  *  - creating an instance of `Source`

--- a/src/source/source_state.ts
+++ b/src/source/source_state.ts
@@ -6,7 +6,7 @@ export type FeatureStates = {[featureId: string]: FeatureState};
 export type LayerFeatureStates = {[layer: string]: FeatureStates};
 
 /**
- * @hidden
+ * @internal
  * SourceFeatureState manages the state and pending changes
  * to features in a source, separated by source layer.
  * stateChanges and deletedStates batch all changes to the tile (updates and removes, respectively)

--- a/src/source/source_state.ts
+++ b/src/source/source_state.ts
@@ -6,6 +6,7 @@ export type FeatureStates = {[featureId: string]: FeatureState};
 export type LayerFeatureStates = {[layer: string]: FeatureStates};
 
 /**
+ * @hidden
  * SourceFeatureState manages the state and pending changes
  * to features in a source, separated by source layer.
  * stateChanges and deletedStates batch all changes to the tile (updates and removes, respectively)

--- a/src/source/terrain_source_cache.ts
+++ b/src/source/terrain_source_cache.ts
@@ -8,6 +8,7 @@ import type {SourceCache} from '../source/source_cache';
 import {Terrain} from '../render/terrain';
 
 /**
+ * @hidden
  * This class is a helper for the Terrain-class, it:
  *   - loads raster-dem tiles
  *   - manages all renderToTexture tiles.

--- a/src/source/terrain_source_cache.ts
+++ b/src/source/terrain_source_cache.ts
@@ -8,7 +8,7 @@ import type {SourceCache} from '../source/source_cache';
 import {Terrain} from '../render/terrain';
 
 /**
- * @hidden
+ * @internal
  * This class is a helper for the Terrain-class, it:
  *   - loads raster-dem tiles
  *   - manages all renderToTexture tiles.

--- a/src/source/tile.ts
+++ b/src/source/tile.ts
@@ -47,7 +47,7 @@ import {ExpiryData} from '../util/ajax';
 export type TileState = 'loading' | 'loaded' | 'reloading' | 'unloaded' | 'errored' | 'expired';
 
 /**
- * @hidden
+ * @internal
  * A tile object is the combination of a Coordinate, which defines
  * its place, as well as a unique ID and data tracking for its content
  */

--- a/src/source/tile.ts
+++ b/src/source/tile.ts
@@ -47,6 +47,7 @@ import {ExpiryData} from '../util/ajax';
 export type TileState = 'loading' | 'loaded' | 'reloading' | 'unloaded' | 'errored' | 'expired';
 
 /**
+ * @hidden
  * A tile object is the combination of a Coordinate, which defines
  * its place, as well as a unique ID and data tracking for its content
  */

--- a/src/source/tile_cache.ts
+++ b/src/source/tile_cache.ts
@@ -2,11 +2,10 @@ import {OverscaledTileID} from './tile_id';
 import type {Tile} from './tile';
 
 /**
- * @hidden
+ * @internal
  * A [least-recently-used cache](http://en.wikipedia.org/wiki/Cache_algorithms)
  * with hash lookup made possible by keeping a list of keys in parallel to
  * an array of dictionary of values
- *
  */
 export class TileCache {
     max: number;

--- a/src/source/tile_cache.ts
+++ b/src/source/tile_cache.ts
@@ -2,6 +2,7 @@ import {OverscaledTileID} from './tile_id';
 import type {Tile} from './tile';
 
 /**
+ * @hidden
  * A [least-recently-used cache](http://en.wikipedia.org/wiki/Cache_algorithms)
  * with hash lookup made possible by keeping a list of keys in parallel to
  * an array of dictionary of values

--- a/src/source/tile_id.ts
+++ b/src/source/tile_id.ts
@@ -64,6 +64,7 @@ export class CanonicalTileID implements ICanonicalTileID {
 }
 
 /**
+ * @hidden
  * An unwrapped tile identifier
  */
 export class UnwrappedTileID {

--- a/src/source/tile_id.ts
+++ b/src/source/tile_id.ts
@@ -64,7 +64,7 @@ export class CanonicalTileID implements ICanonicalTileID {
 }
 
 /**
- * @hidden
+ * @internal
  * An unwrapped tile identifier
  */
 export class UnwrappedTileID {

--- a/src/source/worker_source.ts
+++ b/src/source/worker_source.ts
@@ -41,7 +41,7 @@ export type WorkerDEMTileParameters = TileParameters & {
 };
 
 /**
- * @hidden
+ * @internal
  * The worker tile's result type
  */
 export type WorkerTileResult = {

--- a/src/source/worker_source.ts
+++ b/src/source/worker_source.ts
@@ -41,6 +41,7 @@ export type WorkerDEMTileParameters = TileParameters & {
 };
 
 /**
+ * @hidden
  * The worker tile's result type
  */
 export type WorkerTileResult = {

--- a/src/style/evaluation_parameters.ts
+++ b/src/style/evaluation_parameters.ts
@@ -11,6 +11,7 @@ export type CrossfadeParameters = {
 };
 
 /**
+ * @hidden
  * A parameter that can be evaluated to a value
  */
 export class EvaluationParameters {

--- a/src/style/evaluation_parameters.ts
+++ b/src/style/evaluation_parameters.ts
@@ -11,7 +11,7 @@ export type CrossfadeParameters = {
 };
 
 /**
- * @hidden
+ * @internal
  * A parameter that can be evaluated to a value
  */
 export class EvaluationParameters {

--- a/src/style/properties.ts
+++ b/src/style/properties.ts
@@ -50,6 +50,7 @@ export interface Property<T, R> {
 }
 
 /**
+ * @hidden
  *  `PropertyValue` represents the value part of a property key-value unit. It's used to represent both
  *  paint and layout property values, and regardless of whether or not their property supports data-driven
  *  expressions.

--- a/src/style/properties.ts
+++ b/src/style/properties.ts
@@ -22,7 +22,7 @@ export type CrossFaded<T> = {
 };
 
 /**
- * @hidden
+ * @internal
  *  Implementations of the `Property` interface:
  *
  *  * Hold metadata about a property that's independent of any specific value: stuff like the type of the value,
@@ -50,7 +50,7 @@ export interface Property<T, R> {
 }
 
 /**
- * @hidden
+ * @internal
  *  `PropertyValue` represents the value part of a property key-value unit. It's used to represent both
  *  paint and layout property values, and regardless of whether or not their property supports data-driven
  *  expressions.
@@ -97,7 +97,7 @@ export type TransitionParameters = {
 };
 
 /**
- * @hidden
+ * @internal
  * Paint properties are _transitionable_: they can change in a fluid manner, interpolating or cross-fading between
  * old and new value. The duration of the transition, and the delay before it begins, is configurable.
  *
@@ -128,7 +128,7 @@ class TransitionablePropertyValue<T, R> {
 }
 
 /**
- * @hidden
+ * @internal
  * `Transitionable` stores a map of all (property name, `TransitionablePropertyValue`) pairs for paint properties of a
  * given layer type. It can calculate the `TransitioningPropertyValue`s for all of them at once, producing a
  * `Transitioning` instance for the same set of properties.
@@ -200,7 +200,7 @@ export class Transitionable<Props> {
 }
 
 /**
- * @hidden
+ * @internal
  * `TransitioningPropertyValue` implements the first of two intermediate steps in the evaluation chain of a paint
  * property value. In this step, transitions between old and new values are handled: as long as the transition is in
  * progress, `TransitioningPropertyValue` maintains a reference to the prior value, and interpolates between it and
@@ -261,7 +261,7 @@ class TransitioningPropertyValue<T, R> {
 }
 
 /**
- * @hidden
+ * @internal
  * `Transitioning` stores a map of all (property name, `TransitioningPropertyValue`) pairs for paint properties of a
  * given layer type. It can calculate the possibly-evaluated values for all of them at once, producing a
  * `PossiblyEvaluated` instance for the same set of properties.
@@ -376,7 +376,7 @@ type PossiblyEvaluatedValue<T> = {
 } | SourceExpression | CompositeExpression;
 
 /**
- * @hidden
+ * @internal
  * `PossiblyEvaluatedPropertyValue` is used for data-driven paint and layout property values. It holds a
  * `PossiblyEvaluatedValue` and the `GlobalProperties` that were used to generate it. You're not allowed to supply
  * a different set of `GlobalProperties` when performing the final evaluation because they would be ignored in the
@@ -416,7 +416,7 @@ export class PossiblyEvaluatedPropertyValue<T> {
 }
 
 /**
- * @hidden
+ * @internal
  * `PossiblyEvaluated` stores a map of all (property name, `R`) pairs for paint or layout properties of a
  * given layer type.
  */
@@ -435,7 +435,7 @@ export class PossiblyEvaluated<Props, PossibleEvaluatedProps> {
 }
 
 /**
- * @hidden
+ * @internal
  * An implementation of `Property` for properties that do not permit data-driven (source or composite) expressions.
  * This restriction allows us to declare statically that the result of possibly evaluating this kind of property
  * is in fact always the scalar type `T`, and can be used without further evaluating the value on a per-feature basis.
@@ -464,7 +464,7 @@ export class DataConstantProperty<T> implements Property<T, T> {
 }
 
 /**
- * @hidden
+ * @internal
  * An implementation of `Property` for properties that permit data-driven (source or composite) expressions.
  * The result of possibly evaluating this kind of property is `PossiblyEvaluatedPropertyValue<T>`; obtaining
  * a scalar value `T` requires further evaluation on a per-feature basis.
@@ -539,7 +539,7 @@ export class DataDrivenProperty<T> implements Property<T, PossiblyEvaluatedPrope
 }
 
 /**
- * @hidden
+ * @internal
  * An implementation of `Property` for  data driven `line-pattern` which are transitioned by cross-fading
  * rather than interpolation.
  */
@@ -605,7 +605,7 @@ export class CrossFadedDataDrivenProperty<T> extends DataDrivenProperty<CrossFad
     }
 }
 /**
- * @hidden
+ * @internal
  * An implementation of `Property` for `*-pattern` and `line-dasharray`, which are transitioned by cross-fading
  * rather than interpolation.
  */
@@ -647,7 +647,7 @@ export class CrossFadedProperty<T> implements Property<T, CrossFaded<T>> {
 }
 
 /**
- * @hidden
+ * @internal
  * An implementation of `Property` for `heatmap-color` and `line-gradient`. Interpolation is a no-op, and
  * evaluation returns a boolean value in order to indicate its presence, but the real
  * evaluation happens in StyleLayer classes.
@@ -673,7 +673,7 @@ export class ColorRampProperty implements Property<Color, boolean> {
 }
 
 /**
- * @hidden
+ * @internal
  * `Properties` holds objects containing default values for the layout or paint property set of a given
  * layer type. These objects are immutable, and they are used as the prototypes for the `_values` members of
  * `Transitionable`, `Transitioning`, `Layout`, and `PossiblyEvaluated`. This allows these classes to avoid

--- a/src/style/properties.ts
+++ b/src/style/properties.ts
@@ -22,6 +22,7 @@ export type CrossFaded<T> = {
 };
 
 /**
+ * @hidden
  *  Implementations of the `Property` interface:
  *
  *  * Hold metadata about a property that's independent of any specific value: stuff like the type of the value,
@@ -95,6 +96,7 @@ export type TransitionParameters = {
 };
 
 /**
+ * @hidden
  * Paint properties are _transitionable_: they can change in a fluid manner, interpolating or cross-fading between
  * old and new value. The duration of the transition, and the delay before it begins, is configurable.
  *
@@ -125,6 +127,7 @@ class TransitionablePropertyValue<T, R> {
 }
 
 /**
+ * @hidden
  * `Transitionable` stores a map of all (property name, `TransitionablePropertyValue`) pairs for paint properties of a
  * given layer type. It can calculate the `TransitioningPropertyValue`s for all of them at once, producing a
  * `Transitioning` instance for the same set of properties.
@@ -196,6 +199,7 @@ export class Transitionable<Props> {
 }
 
 /**
+ * @hidden
  * `TransitioningPropertyValue` implements the first of two intermediate steps in the evaluation chain of a paint
  * property value. In this step, transitions between old and new values are handled: as long as the transition is in
  * progress, `TransitioningPropertyValue` maintains a reference to the prior value, and interpolates between it and
@@ -256,6 +260,7 @@ class TransitioningPropertyValue<T, R> {
 }
 
 /**
+ * @hidden
  * `Transitioning` stores a map of all (property name, `TransitioningPropertyValue`) pairs for paint properties of a
  * given layer type. It can calculate the possibly-evaluated values for all of them at once, producing a
  * `PossiblyEvaluated` instance for the same set of properties.
@@ -370,6 +375,7 @@ type PossiblyEvaluatedValue<T> = {
 } | SourceExpression | CompositeExpression;
 
 /**
+ * @hidden
  * `PossiblyEvaluatedPropertyValue` is used for data-driven paint and layout property values. It holds a
  * `PossiblyEvaluatedValue` and the `GlobalProperties` that were used to generate it. You're not allowed to supply
  * a different set of `GlobalProperties` when performing the final evaluation because they would be ignored in the
@@ -409,6 +415,7 @@ export class PossiblyEvaluatedPropertyValue<T> {
 }
 
 /**
+ * @hidden
  * `PossiblyEvaluated` stores a map of all (property name, `R`) pairs for paint or layout properties of a
  * given layer type.
  */
@@ -427,6 +434,7 @@ export class PossiblyEvaluated<Props, PossibleEvaluatedProps> {
 }
 
 /**
+ * @hidden
  * An implementation of `Property` for properties that do not permit data-driven (source or composite) expressions.
  * This restriction allows us to declare statically that the result of possibly evaluating this kind of property
  * is in fact always the scalar type `T`, and can be used without further evaluating the value on a per-feature basis.
@@ -455,6 +463,7 @@ export class DataConstantProperty<T> implements Property<T, T> {
 }
 
 /**
+ * @hidden
  * An implementation of `Property` for properties that permit data-driven (source or composite) expressions.
  * The result of possibly evaluating this kind of property is `PossiblyEvaluatedPropertyValue<T>`; obtaining
  * a scalar value `T` requires further evaluation on a per-feature basis.
@@ -529,6 +538,7 @@ export class DataDrivenProperty<T> implements Property<T, PossiblyEvaluatedPrope
 }
 
 /**
+ * @hidden
  * An implementation of `Property` for  data driven `line-pattern` which are transitioned by cross-fading
  * rather than interpolation.
  */
@@ -594,6 +604,7 @@ export class CrossFadedDataDrivenProperty<T> extends DataDrivenProperty<CrossFad
     }
 }
 /**
+ * @hidden
  * An implementation of `Property` for `*-pattern` and `line-dasharray`, which are transitioned by cross-fading
  * rather than interpolation.
  */
@@ -635,6 +646,7 @@ export class CrossFadedProperty<T> implements Property<T, CrossFaded<T>> {
 }
 
 /**
+ * @hidden
  * An implementation of `Property` for `heatmap-color` and `line-gradient`. Interpolation is a no-op, and
  * evaluation returns a boolean value in order to indicate its presence, but the real
  * evaluation happens in StyleLayer classes.
@@ -660,6 +672,7 @@ export class ColorRampProperty implements Property<Color, boolean> {
 }
 
 /**
+ * @hidden
  * `Properties` holds objects containing default values for the layout or paint property set of a given
  * layer type. These objects are immutable, and they are used as the prototypes for the `_values` members of
  * `Transitionable`, `Transitioning`, `Layout`, and `PossiblyEvaluated`. This allows these classes to avoid

--- a/src/style/style.ts
+++ b/src/style/style.ts
@@ -562,6 +562,7 @@ export class Style extends Evented {
     }
 
     /**
+     * @hidden
      * Apply queued style updates in a batch and recalculate zoom-dependent paint properties.
      */
     update(parameters: EvaluationParameters) {

--- a/src/style/style.ts
+++ b/src/style/style.ts
@@ -562,7 +562,7 @@ export class Style extends Evented {
     }
 
     /**
-     * @hidden
+     * @internal
      * Apply queued style updates in a batch and recalculate zoom-dependent paint properties.
      */
     update(parameters: EvaluationParameters) {

--- a/src/style/style_glyph.ts
+++ b/src/style/style_glyph.ts
@@ -12,7 +12,7 @@ export type GlyphMetrics = {
 };
 
 /**
- * @hidden
+ * @internal
  * A style glyph type
  */
 export type StyleGlyph = {

--- a/src/style/style_glyph.ts
+++ b/src/style/style_glyph.ts
@@ -12,6 +12,7 @@ export type GlyphMetrics = {
 };
 
 /**
+ * @hidden
  * A style glyph type
  */
 export type StyleGlyph = {

--- a/src/symbol/collision_index.ts
+++ b/src/symbol/collision_index.ts
@@ -33,7 +33,7 @@ export type FeatureKey = {
 };
 
 /**
- * @hidden
+ * @internal
  * A collision index used to prevent symbols from overlapping. It keep tracks of
  * where previous symbols have been placed and is used to check if a new
  * symbol overlaps with any previously added symbols.

--- a/src/symbol/collision_index.ts
+++ b/src/symbol/collision_index.ts
@@ -33,6 +33,7 @@ export type FeatureKey = {
 };
 
 /**
+ * @hidden
  * A collision index used to prevent symbols from overlapping. It keep tracks of
  * where previous symbols have been placed and is used to check if a new
  * symbol overlaps with any previously added symbols.

--- a/src/symbol/grid_index.ts
+++ b/src/symbol/grid_index.ts
@@ -48,6 +48,7 @@ function overlapAllowed(overlapA: OverlapMode, overlapB: OverlapMode): boolean {
 }
 
 /**
+ * @hidden
  * GridIndex is a data structure for testing the intersection of
  * circles and rectangles in a 2d plane.
  * It is optimized for rapid insertion and querying.

--- a/src/symbol/grid_index.ts
+++ b/src/symbol/grid_index.ts
@@ -48,7 +48,7 @@ function overlapAllowed(overlapA: OverlapMode, overlapB: OverlapMode): boolean {
 }
 
 /**
- * @hidden
+ * @internal
  * GridIndex is a data structure for testing the intersection of
  * circles and rectangles in a 2d plane.
  * It is optimized for rapid insertion and querying.

--- a/src/ui/camera.ts
+++ b/src/ui/camera.ts
@@ -263,30 +263,30 @@ export abstract class Camera extends Evented {
     _easeFrameId: TaskID;
 
     /**
-     * @hidden
+     * @internal
      * holds the geographical coordinate of the target
      */
     _elevationCenter: LngLat;
     /**
-     * @hidden
+     * @internal
      * holds the targ altitude value, = center elevation of the target.
      * This value may changes during flight, because new terrain-tiles loads during flight.
      */
     _elevationTarget: number;
     /**
-     * @hidden
+     * @internal
      * holds the start altitude value, = center elevation before animation begins
      * this value will recalculated during flight in respect of changing _elevationTarget values,
      * so the linear interpolation between start and target keeps smooth and without jumps.
      */
     _elevationStart: number;
     /**
-     * @hidden
+     * @internal
      * Saves the current state of the elevation freeze - this is used during map movement to prevent "rocky" camera movement.
      */
     _elevationFreeze: boolean;
     /**
-     * @hidden
+     * @internal
      * Used to track accumulated changes during continuous interaction
      */
     _requestedCameraState?: Transform;
@@ -645,6 +645,7 @@ export abstract class Camera extends Evented {
     }
 
     /**
+     * @internal
      * Calculate the center of these two points in the viewport and use
      * the highest zoom level up to and including `Map#getMaxZoom()` that fits
      * the points in the viewport at the specified bearing.
@@ -654,7 +655,6 @@ export abstract class Camera extends Evented {
      * @param options - the camera options
      * @returns If map is able to fit to provided bounds, returns `center`, `zoom`, and `bearing`.
      *      If map is unable to fit, method will warn and return undefined.
-     * @hidden
      * @example
      * ```ts
      * let p0 = [-79, 43];
@@ -1085,11 +1085,11 @@ export abstract class Camera extends Evented {
     }
 
     /**
+     * @internal
      * Called when the camera is about to be manipulated.
      * If `transformCameraUpdate` is specified, a copy of the current transform is created to track the accumulated changes.
      * This underlying transform represents the "desired state" proposed by input handlers / animations / UI controls.
      * It may differ from the state used for rendering (`this.transform`).
-     * @hidden
      * @returns Transform to apply changes to
      */
     _getTransformForUpdate(): Transform {
@@ -1102,8 +1102,8 @@ export abstract class Camera extends Evented {
     }
 
     /**
+     * @internal
      * Called after the camera is done being manipulated.
-     * @hidden
      * @param tr - the requested camera end state
      * Call `transformCameraUpdate` if present, and then apply the "approved" changes.
      */

--- a/src/ui/handler/box_zoom.ts
+++ b/src/ui/handler/box_zoom.ts
@@ -25,9 +25,7 @@ export class BoxZoomHandler implements Handler {
     _box: HTMLElement;
     _clickTolerance: number;
 
-    /**
-     * @hidden
-     */
+    /** @internal */
     constructor(map: Map, options: {
         clickTolerance: number;
     }) {

--- a/src/ui/handler/click_zoom.ts
+++ b/src/ui/handler/click_zoom.ts
@@ -13,9 +13,7 @@ export class ClickZoomHandler implements Handler {
     _enabled: boolean;
     _active: boolean;
 
-    /**
-     * @hidden
-    */
+    /** @internal */
     constructor(map: Map) {
         this._tr = new TransformProvider(map);
         this.reset();

--- a/src/ui/handler/keyboard.ts
+++ b/src/ui/handler/keyboard.ts
@@ -33,9 +33,7 @@ export class KeyboardHandler implements Handler {
     _pitchStep: number;
     _rotationDisabled: boolean;
 
-    /**
-    * @hidden
-    */
+    /** @internal */
     constructor(map: Map) {
         this._tr = new TransformProvider(map);
         const stepOptions = defaultOptions;

--- a/src/ui/handler/scroll_zoom.ts
+++ b/src/ui/handler/scroll_zoom.ts
@@ -62,9 +62,7 @@ export class ScrollZoomHandler implements Handler {
     _defaultZoomRate: number;
     _wheelZoomRate: number;
 
-    /**
-     * @hidden
-     */
+    /** @internal */
     constructor(map: Map, triggerRenderFrame: () => void) {
         this._map = map;
         this._tr = new TransformProvider(map);

--- a/src/ui/handler/shim/dblclick_zoom.ts
+++ b/src/ui/handler/shim/dblclick_zoom.ts
@@ -12,9 +12,7 @@ export class DoubleClickZoomHandler {
     _clickZoom: ClickZoomHandler;
     _tapZoom: TapZoomHandler;
 
-    /**
-     * @hidden
-    */
+    /** @internal */
     constructor(clickZoom: ClickZoomHandler, TapZoom: TapZoomHandler) {
         this._clickZoom = clickZoom;
         this._tapZoom = TapZoom;

--- a/src/ui/handler/shim/drag_pan.ts
+++ b/src/ui/handler/shim/drag_pan.ts
@@ -41,9 +41,7 @@ export class DragPanHandler {
     _touchPan: TouchPanHandler;
     _inertiaOptions: DragPanOptions | boolean;
 
-    /**
-     * @hidden
-    */
+    /** @internal */
     constructor(el: HTMLElement, mousePan: MousePanHandler, touchPan: TouchPanHandler) {
         this._el = el;
         this._mousePan = mousePan;

--- a/src/ui/handler/shim/drag_rotate.ts
+++ b/src/ui/handler/shim/drag_rotate.ts
@@ -20,9 +20,7 @@ export class DragRotateHandler {
     _mousePitch: MousePitchHandler;
     _pitchWithRotate: boolean;
 
-    /**
-     * @hidden
-    */
+    /** @internal */
     constructor(options: DragRotateHandlerOptions, mouseRotate: MouseRotateHandler, mousePitch: MousePitchHandler) {
         this._pitchWithRotate = options.pitchWithRotate;
         this._mouseRotate = mouseRotate;

--- a/src/ui/handler/shim/two_fingers_touch.ts
+++ b/src/ui/handler/shim/two_fingers_touch.ts
@@ -19,9 +19,7 @@ export class TwoFingersTouchZoomRotateHandler {
     _rotationDisabled: boolean;
     _enabled: boolean;
 
-    /**
-     * @hidden
-    */
+    /** @internal */
     constructor(el: HTMLElement, touchZoom: TwoFingersTouchZoomHandler, touchRotate: TwoFingersTouchRotateHandler, tapDragZoom: TapDragZoomHandler) {
         this._el = el;
         this._touchZoom = touchZoom;

--- a/src/ui/handler/transform-provider.ts
+++ b/src/ui/handler/transform-provider.ts
@@ -5,6 +5,7 @@ import Point from '@mapbox/point-geometry';
 import {LngLat} from '../../geo/lng_lat';
 
 /**
+ * @hidden
  * Shared utilities for the Handler classes to access the correct camera state.
  * If Camera.transformCameraUpdate is specified, the "desired state" of camera may differ from the state used for rendering.
  * The handlers need the "desired state" to track accumulated changes.

--- a/src/ui/handler/transform-provider.ts
+++ b/src/ui/handler/transform-provider.ts
@@ -5,7 +5,7 @@ import Point from '@mapbox/point-geometry';
 import {LngLat} from '../../geo/lng_lat';
 
 /**
- * @hidden
+ * @internal
  * Shared utilities for the Handler classes to access the correct camera state.
  * If Camera.transformCameraUpdate is specified, the "desired state" of camera may differ from the state used for rendering.
  * The handlers need the "desired state" to track accumulated changes.

--- a/src/ui/handler/two_fingers_touch.ts
+++ b/src/ui/handler/two_fingers_touch.ts
@@ -27,9 +27,7 @@ abstract class TwoFingersTouchHandler implements Handler {
     _startVector: Point;
     _aroundCenter: boolean;
 
-    /**
-     * @hidden
-     */
+    /** @internal */
     constructor() {
         this.reset();
     }

--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -504,7 +504,7 @@ export class Map extends Camera {
     _terrainDataCallback: (e: MapStyleDataEvent | MapSourceDataEvent) => void;
 
     /**
-     * @hidden
+     * @internal
      * image queue throttling handle. To be used later when clean up
      */
     _imageQueueHandle: number;
@@ -707,9 +707,9 @@ export class Map extends Camera {
     }
 
     /**
+     * @internal
      * Returns a unique number for this map instance which is used for the MapLoadEvent
      * to make sure we only fire one event per instantiated map object.
-     * @hidden
      * @returns the uniq map ID
      */
     _getMapId() {
@@ -868,9 +868,9 @@ export class Map extends Camera {
     }
 
     /**
+     * @internal
      * Return the map's pixel ratio eventually scaled down to respect maxCanvasSize.
      * Internally you should use this and not getPixelRatio().
-     * @hidden
      */
     _getClampedPixelRatio(width: number, height: number): number {
         const {0: maxCanvasWidth, 1: maxCanvasHeight} = this._maxCanvasSize;
@@ -3070,9 +3070,9 @@ export class Map extends Camera {
     }
 
     /**
+     * @internal
      * Update this map's style and sources, and re-render the map.
      *
-     * @hidden
      * @param updateStyle - mark the map's style for reprocessing as
      * well as its sources
      * @returns `this`
@@ -3088,9 +3088,10 @@ export class Map extends Camera {
     }
 
     /**
+     * @internal
      * Request that the given callback be executed during the next render
      * frame.  Schedule a render frame if one is not already scheduled.
-     * @hidden
+     * 
      * @returns An id that can be used to cancel the callback
      */
     _requestRenderFrame(callback: () => void): TaskID {
@@ -3103,6 +3104,7 @@ export class Map extends Camera {
     }
 
     /**
+     * @internal
      * Call when a (re-)render of the map is required:
      * - The style has changed (`setPaintProperty()`, etc.)
      * - Source data has changed (e.g. tiles have finished loading)
@@ -3110,7 +3112,6 @@ export class Map extends Camera {
      * - A transition is in progress
      *
      * @param paintStartTimeStamp - The time when the animation frame began executing.
-     * @hidden
      *
      * @returns `this`
      */

--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -3091,7 +3091,7 @@ export class Map extends Camera {
      * @internal
      * Request that the given callback be executed during the next render
      * frame.  Schedule a render frame if one is not already scheduled.
-     * 
+     *
      * @returns An id that can be used to cancel the callback
      */
     _requestRenderFrame(callback: () => void): TaskID {

--- a/src/util/image.ts
+++ b/src/util/image.ts
@@ -83,6 +83,7 @@ function copyImage(srcImg: any, dstImg: any, srcPt: Point2D, dstPt: Point2D, siz
 
 /**
  * An image with alpha color value
+ * @hidden
  */
 export class AlphaImage {
     width: number;

--- a/src/util/image.ts
+++ b/src/util/image.ts
@@ -82,8 +82,8 @@ function copyImage(srcImg: any, dstImg: any, srcPt: Point2D, dstPt: Point2D, siz
 }
 
 /**
+ * @internal
  * An image with alpha color value
- * @hidden
  */
 export class AlphaImage {
     width: number;

--- a/src/util/performance.ts
+++ b/src/util/performance.ts
@@ -75,9 +75,8 @@ export const PerformanceUtils = {
 };
 
 /**
+ * @internal
  * Safe wrapper for the performance resource timing API in web workers with graceful degradation
- *
- * @hidden
  */
 export class RequestPerformance {
     _marks: {

--- a/src/util/struct_array.ts
+++ b/src/util/struct_array.ts
@@ -3,6 +3,7 @@
 import type {Transferable} from '../types/transferable';
 
 /**
+ * @hidden
  * A view type size
  */
 const viewTypes = {
@@ -16,11 +17,12 @@ const viewTypes = {
 };
 
 /**
+ * @hidden
  * A view type size
  */
 export type ViewType = keyof typeof viewTypes;
 
-/** */
+/** @hidden */
 class Struct {
     _pos1: number;
     _pos2: number;
@@ -48,6 +50,7 @@ const DEFAULT_CAPACITY = 128;
 const RESIZE_MULTIPLIER = 5;
 
 /**
+ * @hidden
  * A struct array memeber
  */
 export type StructArrayMember = {
@@ -72,6 +75,7 @@ export type SerializedStructArray = {
 };
 
 /**
+ * @hidden
  * `StructArray` provides an abstraction over `ArrayBuffer` and `TypedArray`
  * making it behave like an array of typed structs.
  *

--- a/src/util/struct_array.ts
+++ b/src/util/struct_array.ts
@@ -3,7 +3,7 @@
 import type {Transferable} from '../types/transferable';
 
 /**
- * @hidden
+ * @internal
  * A view type size
  */
 const viewTypes = {
@@ -17,12 +17,12 @@ const viewTypes = {
 };
 
 /**
- * @hidden
+ * @internal
  * A view type size
  */
 export type ViewType = keyof typeof viewTypes;
 
-/** @hidden */
+/** @internal */
 class Struct {
     _pos1: number;
     _pos2: number;
@@ -50,7 +50,7 @@ const DEFAULT_CAPACITY = 128;
 const RESIZE_MULTIPLIER = 5;
 
 /**
- * @hidden
+ * @internal
  * A struct array memeber
  */
 export type StructArrayMember = {
@@ -75,7 +75,7 @@ export type SerializedStructArray = {
 };
 
 /**
- * @hidden
+ * @internal
  * `StructArray` provides an abstraction over `ArrayBuffer` and `TypedArray`
  * making it behave like an array of typed structs.
  *

--- a/typedoc.json
+++ b/typedoc.json
@@ -11,6 +11,7 @@
     ],
     "out": "./docs/API",
     "excludeExternals": true,
+    "excludeInternal": true,
     "excludeNotDocumented": true,
     "internalModule": "maplibregl",
     "entryPoints": ["./src/index.ts"],


### PR DESCRIPTION
Fixes #2916

I've went trough the current docs and removed the classes which didn't seem relevant.
I made sure the docs generation is warning free so that there will not be missing classes in the docs.

Partial list after this PR:
![image](https://github.com/maplibre/maplibre-gl-js/assets/3269297/150f0920-730d-4873-8afd-ee48a1fc20be)

