### PR TITLE
Fix typing of Map.getLayer() and Style.getLayer()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🐞 Bug fixes
 
-- _...Add new stuff here..._
+- Correct declared return type of `Map.getLayer()` and `Style.getLayer()` to be `StyleLayer | undefined` to match the documentation.
 
 ## 3.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### 🐞 Bug fixes
 
 - Correct declared return type of `Map.getLayer()` and `Style.getLayer()` to be `StyleLayer | undefined` to match the documentation.
+- _...Add new stuff here..._
 
 ## 3.3.0
 

--- a/src/style/style.ts
+++ b/src/style/style.ts
@@ -994,7 +994,7 @@ export class Style extends Evented {
      * @param id - id of the desired layer
      * @returns a layer, if one with the given `id` exists
      */
-    getLayer(id: string): StyleLayer {
+    getLayer(id: string): StyleLayer | undefined {
         return this._layers[id];
     }
 

--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -2475,7 +2475,7 @@ export class Map extends Camera {
      * @see [Filter symbols by toggling a list](https://maplibre.org/maplibre-gl-js/docs/examples/filter-markers/)
      * @see [Filter symbols by text input](https://maplibre.org/maplibre-gl-js/docs/examples/filter-markers-by-input/)
      */
-    getLayer(id: string): StyleLayer {
+    getLayer(id: string): StyleLayer | undefined {
         return this.style.getLayer(id);
     }
 


### PR DESCRIPTION
## Launch Checklist

Fixes #2968
<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [X] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [X] Briefly describe the changes in this PR.
 - [X] Link to related issues.  #724 made the equivalent change to `getSource` in December 2021.
 - [ ] ~Include before/after visuals or gifs if this PR includes visual changes.~ N/A
 - [ ] ~Write tests for all new functionality.~ This includes typing changes only.
 - [ ] ~Document any changes to public APIs.~  This change actually makes the advertised API match the documented APIs.
 - [ ] ~Post benchmark scores.~ This does not affect generated code at all, so can't affect performance.
 - [X] Add an entry to `CHANGELOG.md` under the `## main` section.

## Changes

This PR changes the return types of:

* `Map.getLayer()` from returning `StyleLayer` to `StyleLayer | undefined`
* `Style.getLayer()` from returning `StyleLayer` to `StyleLayer | undefined`

Those _declared_ return types are changing to match the existing _documented_ behaviour, and brings them in line with the existing similar `Map.getSource()` and `Style.getSource()` methods.

## Notes

* Does this constitute a (breaking) public API change?

Yes and no. It's making the TypeScript-advertised type match the already-documented and implemented behaviour. It is possible that this could cause existing code to fail to compile if it's calling `getLayer()` and is compiled with a strict type-checking mode that will flag up that the return type is not being checked for `undefined`.

See PR #724 for earlier work which made the same change to the `getSource()` methods.