### PR TITLE
Debounce ResizeObserver's call to map.resize()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,9 @@
 
 ### 🐞 Bug fixes
 
-- Correct declared return type of `Map.getLayer()` and `Style.getLayer()` to be `StyleLayer | undefined` to match the documentation.
-- Correct type of `Map.addLayer()` and `Style.addLayer()` to allow adding a layer with an embedded source, matching the documentation.
+- Correct declared return type of `Map.getLayer()` and `Style.getLayer()` to be `StyleLayer | undefined` to match the documentation. ([#2969](https://github.com/maplibre/maplibre-gl-js/pull/2969))
+- Correct type of `Map.addLayer()` and `Style.addLayer()` to allow adding a layer with an embedded source, matching the documentation. ([#2966](https://github.com/maplibre/maplibre-gl-js/pull/2966))
+- Debounce map resizes from ResizeObserver to reduce flicker ([#2973](https://github.com/maplibre/maplibre-gl-js/pull/2973))
 - _...Add new stuff here..._
 
 ## 3.3.0

--- a/src/ui/map.test.ts
+++ b/src/ui/map.test.ts
@@ -861,21 +861,30 @@ describe('Map', () => {
 
             const map = createMap();
 
-            const spyA = jest.spyOn(map, '_update');
-            const spyB = jest.spyOn(map, 'resize');
+            const updateSpy = jest.spyOn(map, '_update');
+            const resizeSpy = jest.spyOn(map, 'resize');
 
             // The initial "observe" event fired by ResizeObserver should be captured/muted
             // in the map constructor
 
             observerCallback();
-            expect(spyA).not.toHaveBeenCalled();
-            expect(spyB).not.toHaveBeenCalled();
+            expect(updateSpy).not.toHaveBeenCalled();
+            expect(resizeSpy).not.toHaveBeenCalled();
 
-            // Following "observe" events should fire a resize / _update
+            // The next "observe" event should fire a resize / _update
 
             observerCallback();
-            expect(spyA).toHaveBeenCalled();
-            expect(spyB).toHaveBeenCalled();
+            expect(updateSpy).toHaveBeenCalled();
+            expect(resizeSpy).toHaveBeenCalledTimes(1);
+
+            // Additional "observe" events should be debounced
+            observerCallback();
+            observerCallback();
+            observerCallback();
+            observerCallback();
+            expect(resizeSpy).toHaveBeenCalledTimes(1);
+            await new Promise((resolve) => { setTimeout(resolve, 50); });
+            expect(resizeSpy).toHaveBeenCalledTimes(2);
         });
 
         test('width and height correctly rounded', () => {

--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -414,6 +414,16 @@ const defaultOptions = {
     maxCanvasSize: [4096, 4096]
 } as CompleteMapOptions;
 
+function throttleResizeObserver(func: ResizeObserverCallback, delay: number): ResizeObserverCallback {
+    let timer: ReturnType<typeof setTimeout>;
+    return function(...args) {
+        if (timer) {
+            clearTimeout(timer);
+        }
+        timer = setTimeout(() => func.apply(this, args), delay);
+    };
+}
+
 /**
  * The `Map` object represents the map on your page. It exposes methods
  * and properties that enable you to programmatically change the map,
@@ -638,14 +648,19 @@ export class Map extends Camera {
         if (typeof window !== 'undefined') {
             addEventListener('online', this._onWindowOnline, false);
             let initialResizeEventCaptured = false;
-            this._resizeObserver = new ResizeObserver((entries) => {
+            let resizeDebounceTimer: ReturnType<typeof setTimeout>;
+            const resizeDebounceTime = 30;
+            this._resizeObserver = new ResizeObserver((entries: ResizeObserverEntry[]) => {
                 if (!initialResizeEventCaptured) {
                     initialResizeEventCaptured = true;
                     return;
                 }
 
-                if (this._trackResize) {
-                    this.resize(entries)._update();
+                if (resizeDebounceTimer) {
+                    clearTimeout(resizeDebounceTimer);
+                }
+                if (this._trackResize && !this._removed) {
+                    resizeDebounceTimer = setTimeout(() => this.resize(entries)._update(), resizeDebounceTime);
                 }
             });
             this._resizeObserver.observe(this._container);

--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -414,16 +414,6 @@ const defaultOptions = {
     maxCanvasSize: [4096, 4096]
 } as CompleteMapOptions;
 
-function throttleResizeObserver(func: ResizeObserverCallback, delay: number): ResizeObserverCallback {
-    let timer: ReturnType<typeof setTimeout>;
-    return function(...args) {
-        if (timer) {
-            clearTimeout(timer);
-        }
-        timer = setTimeout(() => func.apply(this, args), delay);
-    };
-}
-
 /**
  * The `Map` object represents the map on your page. It exposes methods
  * and properties that enable you to programmatically change the map,


### PR DESCRIPTION
- Closes https://github.com/maplibre/maplibre-gl-js/issues/2971
- Debounces the map's ResizeObserver's call to map.resize(), to 30 milliseconds
- Leaves ResizeObserver's leading edge calls (i.e. initial calls before debouncing) to map.resize() in place, meaning that the first resizes before debouncing are immediate
- Resizing in Chrome and Firefox behaves considerably better, with much less flicker

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [X] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [X] Briefly describe the changes in this PR.
 - [X] Link to related issues.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [X] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [X] Add an entry to `CHANGELOG.md` under the `## main` section.
