### PR TITLE
Throttle ResizeObserver's call to map.resize()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,9 @@
 
 ### 🐞 Bug fixes
 
-- Correct declared return type of `Map.getLayer()` and `Style.getLayer()` to be `StyleLayer | undefined` to match the documentation. ([#2969](https://github.com/maplibre/maplibre-gl-js/pull/2969))
-- Correct type of `Map.addLayer()` and `Style.addLayer()` to allow adding a layer with an embedded source, matching the documentation. ([#2966](https://github.com/maplibre/maplibre-gl-js/pull/2966))
-- Throttle map resizes from ResizeObserver to reduce flicker
+- Correct declared return type of `Map.getLayer()` and `Style.getLayer()` to be `StyleLayer | undefined` to match the documentation ([#2969](https://github.com/maplibre/maplibre-gl-js/pull/2969))
+- Correct type of `Map.addLayer()` and `Style.addLayer()` to allow adding a layer with an embedded source, matching the documentation ([#2966](https://github.com/maplibre/maplibre-gl-js/pull/2966))
+- Throttle map resizes from ResizeObserver to reduce flicker ([#2986](https://github.com/maplibre/maplibre-gl-js/pull/2986))
 - _...Add new stuff here..._
 
 ## 3.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,9 @@
 
 ### 🐞 Bug fixes
 
-- Correct declared return type of `Map.getLayer()` and `Style.getLayer()` to be `StyleLayer | undefined` to match the documentation.
-- Correct type of `Map.addLayer()` and `Style.addLayer()` to allow adding a layer with an embedded source, matching the documentation.
+- Correct declared return type of `Map.getLayer()` and `Style.getLayer()` to be `StyleLayer | undefined` to match the documentation. ([#2969](https://github.com/maplibre/maplibre-gl-js/pull/2969))
+- Correct type of `Map.addLayer()` and `Style.addLayer()` to allow adding a layer with an embedded source, matching the documentation. ([#2966](https://github.com/maplibre/maplibre-gl-js/pull/2966))
+- Throttle map resizes from ResizeObserver to reduce flicker
 - _...Add new stuff here..._
 
 ## 3.3.0

--- a/src/ui/map.test.ts
+++ b/src/ui/map.test.ts
@@ -861,21 +861,30 @@ describe('Map', () => {
 
             const map = createMap();
 
-            const spyA = jest.spyOn(map, '_update');
-            const spyB = jest.spyOn(map, 'resize');
+            const updateSpy = jest.spyOn(map, '_update');
+            const resizeSpy = jest.spyOn(map, 'resize');
 
             // The initial "observe" event fired by ResizeObserver should be captured/muted
             // in the map constructor
 
             observerCallback();
-            expect(spyA).not.toHaveBeenCalled();
-            expect(spyB).not.toHaveBeenCalled();
+            expect(updateSpy).not.toHaveBeenCalled();
+            expect(resizeSpy).not.toHaveBeenCalled();
 
-            // Following "observe" events should fire a resize / _update
+            // The next "observe" event should fire a resize / _update
 
             observerCallback();
-            expect(spyA).toHaveBeenCalled();
-            expect(spyB).toHaveBeenCalled();
+            expect(updateSpy).toHaveBeenCalled();
+            expect(resizeSpy).toHaveBeenCalledTimes(1);
+
+            // Additional "observe" events should be throttled
+            observerCallback();
+            observerCallback();
+            observerCallback();
+            observerCallback();
+            expect(resizeSpy).toHaveBeenCalledTimes(1);
+            await new Promise((resolve) => { setTimeout(resolve, 100); });
+            expect(resizeSpy).toHaveBeenCalledTimes(2);
         });
 
         test('width and height correctly rounded', () => {

--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -639,12 +639,12 @@ export class Map extends Camera {
         if (typeof window !== 'undefined') {
             addEventListener('online', this._onWindowOnline, false);
             let initialResizeEventCaptured = false;
-            const throttledResizeCallback = throttle((entries) => {
+            const throttledResizeCallback = throttle((entries: ResizeObserverEntry[]) => {
                 if (this._trackResize && !this._removed) {
                     this.resize(entries)._update();
                 }
             }, 50);
-            this._resizeObserver = new ResizeObserver((entries: ResizeObserverEntry[]) => {
+            this._resizeObserver = new ResizeObserver((entries) => {
                 if (!initialResizeEventCaptured) {
                     initialResizeEventCaptured = true;
                     return;

--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -25,6 +25,7 @@ import {RGBAImage} from '../util/image';
 import {Event, ErrorEvent, Listener} from '../util/evented';
 import {MapEventType, MapLayerEventType, MapMouseEvent, MapSourceDataEvent, MapStyleDataEvent} from './events';
 import {TaskQueue} from '../util/task_queue';
+import {throttle} from '../util/throttle';
 import {webpSupported} from '../util/webp_supported';
 import {PerformanceMarkers, PerformanceUtils} from '../util/performance';
 import {Source, SourceClass} from '../source/source';
@@ -638,15 +639,17 @@ export class Map extends Camera {
         if (typeof window !== 'undefined') {
             addEventListener('online', this._onWindowOnline, false);
             let initialResizeEventCaptured = false;
-            this._resizeObserver = new ResizeObserver((entries) => {
+            const throttledResizeCallback = throttle((entries) => {
+                if (this._trackResize && !this._removed) {
+                    this.resize(entries)._update();
+                }
+            }, 50);
+            this._resizeObserver = new ResizeObserver((entries: ResizeObserverEntry[]) => {
                 if (!initialResizeEventCaptured) {
                     initialResizeEventCaptured = true;
                     return;
                 }
-
-                if (this._trackResize) {
-                    this.resize(entries)._update();
-                }
+                throttledResizeCallback(entries);
             });
             this._resizeObserver.observe(this._container);
         }

--- a/src/util/throttle.ts
+++ b/src/util/throttle.ts
@@ -1,21 +1,25 @@
 /**
  * Throttle the given function to run at most every `period` milliseconds.
  */
-export function throttle(fn: () => void, time: number): () => ReturnType<typeof setTimeout> {
+export function throttle<T extends (...args: any) => any>(fn: T, time: number): (...args: Parameters<T>) => ReturnType<typeof setTimeout> {
     let pending = false;
     let timerId: ReturnType<typeof setTimeout> = null;
+    let lastCallContext = null;
+    let lastCallArgs: Parameters<T>;
 
     const later = () => {
         timerId = null;
         if (pending) {
-            fn();
+            fn.apply(lastCallContext, lastCallArgs);
             timerId = setTimeout(later, time);
             pending = false;
         }
     };
 
-    return () => {
+    return (...args: Parameters<T>) => {
         pending = true;
+        lastCallContext = this;
+        lastCallArgs = args;
         if (!timerId) {
             later();
         }

--- a/src/util/throttle.ts
+++ b/src/util/throttle.ts
@@ -1,7 +1,7 @@
 /**
  * Throttle the given function to run at most every `period` milliseconds.
  */
-export function throttle<T extends (...args: any) => any>(fn: T, time: number): (...args: Parameters<T>) => ReturnType<typeof setTimeout> {
+export function throttle<T extends (...args: any) => void>(fn: T, time: number): (...args: Parameters<T>) => ReturnType<typeof setTimeout> {
     let pending = false;
     let timerId: ReturnType<typeof setTimeout> = null;
     let lastCallContext = null;


### PR DESCRIPTION
- Closes https://github.com/maplibre/maplibre-gl-js/issues/2971
- Replaces https://github.com/maplibre/maplibre-gl-js/pull/2973 - I think throttle probably turned out better anyway!
- Throttles the map's ResizeObserver's call to map.resize(), to 50 milliseconds
- Adds argument support to existing throttle() utility
- Still ignores ResizeObserver's initial call, with subsequent calls throttled
- Resizing in Chrome and Firefox behaves considerably better, with much less flicker

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [X] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [X] Briefly describe the changes in this PR.
 - [X] Link to related issues.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [X] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [X] Add an entry to `CHANGELOG.md` under the `## main` section.
