### PR TITLE
Docs: Replace broken iframe with image

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -4,8 +4,7 @@ MapLibre GL JS is a TypeScript library that uses WebGL to render interactive map
 
 
 ## Quickstart
-
-<iframe src="./examples/simple-map.html" width="100%" style="border:none"></iframe>
+![Display a map](assets/examples/simple-map.png)	
 
 ```html
 <div id="map"></div>


### PR DESCRIPTION
Iframes aren't supported in GH Markdown

# Before:

![image](https://github.com/maplibre/maplibre-gl-js/assets/14878684/09cc0d83-7f85-43cd-92ac-0c64ab49a094)

# After:

![image](https://github.com/maplibre/maplibre-gl-js/assets/14878684/e8534012-ff12-4e51-9cf2-1689fcfe68f2)
