### PR TITLE
Revise description of localIdeographFontFamily example

### DIFF
--- a/test/examples/local-ideographs.html
+++ b/test/examples/local-ideographs.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <title>Use locally generated ideographs</title>
-    <meta property="og:description" content="Use the localIdeographFontFamily setting to speed up map load times by using locally available fonts instead of font data fetched from the server." />
+    <meta property="og:description" content="Set localIdeographFontFamily to override the font used for displaying CJK (Chinese, Japanese and Korean) characters, ignoring the map style. This setting must be a CSS font rule specifying fallbacks of on-device fonts. Set localIdeographFontFamily to false to use server-provided fonts, which is much slower." />
     <meta charset='utf-8'>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel='stylesheet' href='../../dist/maplibre-gl.css' />
@@ -22,7 +22,7 @@
             'https://api.maptiler.com/maps/streets/style.json?key=get_your_own_OpIi9ZULNHzrESv6T2vL',
         center: [120.3049, 31.4751],
         zoom: 12,
-        localIdeographFontFamily: '\'Noto Sans\', \'Noto Sans CJK SC\', sans-serif'
+        localIdeographFontFamily: '"Apple LiSung", serif'
     });
 </script>
 </body>


### PR DESCRIPTION
## Launch Checklist

The docs https://maplibre.org/maplibre-gl-js/docs/examples/local-ideographs/ state the opposite of what this setting actually does. Sped-up map load times with local ideographs is the default, and no setting is necessary, but setting it to `false` will disable local ideographs. Finally, setting the value only specifies device font fallbacks that override the style. 

Related to #2990 

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [ ] Add an entry to `CHANGELOG.md` under the `## main` section.
