### PR TITLE
Copy LICENSE.txt to dist folder so it's included in 3rdpartylicenses by webpack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### ✨ Features and improvements
 
+- Copy LICENSE.txt to dist folder so it's included in 3rdpartylicenses.txt by webpack ([#3021](https://github.com/maplibre/maplibre-gl-js/pull/3021))
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2020, MapLibre contributors
+Copyright (c) 2023, MapLibre contributors
 
 All rights reserved.
 

--- a/build/generate-dist-package.js
+++ b/build/generate-dist-package.js
@@ -3,7 +3,7 @@
 /// This package.json ensures that node imports from outside see them as such
 // https://nodejs.org/api/packages.html#type
 
-import { writeFile, mkdir } from "node:fs/promises"
+import { writeFile, mkdir, copyFile } from "node:fs/promises"
 
 async function ensureDist() {
   const dist = new URL("../dist/", import.meta.url);
@@ -18,4 +18,9 @@ await writeFile(
     type: "commonjs",
     deprecated: "Please install maplibre-gl from parent directory instead",
   })
+)
+
+await copyFile(
+  "./LICENSE.txt",
+  new URL("LICENSE.txt", await ensureDist())
 )

--- a/build/generate-dist-package.js
+++ b/build/generate-dist-package.js
@@ -14,7 +14,7 @@ async function ensureDist() {
 await writeFile(
   new URL("package.json", await ensureDist()),
   JSON.stringify({
-    name: "@maplibre/distfiles",
+    name: "maplibre-gl",
     type: "commonjs",
     deprecated: "Please install maplibre-gl from parent directory instead",
   })


### PR DESCRIPTION
Fixes #2865 

This PR consists of three changes:
- [when creating dist/package.json, also copy LICENSE.txt from repo root](https://github.com/maplibre/maplibre-gl-js/commit/6b827479cad87a87cd04d6212fcfdd2a58c402c0)
  - This is achieved by modifying `generate-dist-package.js`. I assume this file must be run during build, but couldn't see where in the GitHub actions. This seemed like the best place without adding a rollup plugin or relying on an OS specific command.
  - I tested with local npm installation and upon `ng build` the license was included in 3rdpartylicenses.txt.
- [set name in dist/package.json to maplibre-gl](https://github.com/maplibre/maplibre-gl-js/commit/9213b1f0678f1d26d4e4409484640e515496b6ec)
  - This will ensure that the package name as listed in 3rdpartylicenses.txt is correct, though I am not sure if this carries any risk - local testing was fine.
- [bump license year to 2023](https://github.com/maplibre/maplibre-gl-js/commit/a921a5a7faf113765751cd08dbbc5c8bb0c24162)
  - Since the website mentions Copyright © 2023 Maplibre, I took the liberty of bumping the year here.

Please let me know if there's any feedback or a way I can test more thoroughly than via `npm install ~/repos/maplibre-gl-js`.

