### PR TITLE
jest ignore dist folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### 🐞 Bug fixes
 
+- Fix unit test warning about duplicate module names ([#3049](https://github.com/maplibre/maplibre-gl-js/pull/3049))
 - _...Add new stuff here..._
 
 ## 3.3.1

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -9,7 +9,7 @@ const sharedConfig = {
     },
     // any tests that operate on dist files shouldn't compile them again.
     transformIgnorePatterns: ['<rootDir>/dist'],
-    modulePathIgnorePatterns : ['<rootDir>/dist'],
+    modulePathIgnorePatterns: ['<rootDir>/dist']
 } as Partial<Config>;
 
 const config: Config = {

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -8,7 +8,8 @@ const sharedConfig = {
         }],
     },
     // any tests that operate on dist files shouldn't compile them again.
-    transformIgnorePatterns: ['<rootDir>/dist']
+    transformIgnorePatterns: ['<rootDir>/dist'],
+    modulePathIgnorePatterns : ['<rootDir>/dist'],
 } as Partial<Config>;
 
 const config: Config = {


### PR DESCRIPTION
This PR is to resolve a test warning introduced with https://github.com/maplibre/maplibre-gl-js/pull/3021.

To resolve this, the dist folder is added to jest config `modulePathIgnorePatterns` so that it's not visible to jest, preventing the duplicate module warning.