### PR TITLE
Reset scroll handler state properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### 🐞 Bug fixes
 
+- Fixed Interrupting a scroll zoom causes the next scroll zoom to return to the prior zoom level by reseting scroll handler state properly ([#2709](https://github.com/maplibre/maplibre-gl-js/issues/2709), [#3051](https://github.com/maplibre/maplibre-gl-js/pull/305))
 - _...Add new stuff here..._
 
 ## 3.3.1

--- a/src/ui/handler/scroll_zoom.ts
+++ b/src/ui/handler/scroll_zoom.ts
@@ -256,7 +256,6 @@ export class ScrollZoomHandler implements Handler {
 
         // if we've had scroll events since the last render frame, consume the
         // accumulated delta, and update the target zoom level accordingly
-        console.log(`fr, ${this._delta} ${this._targetZoom}`);
         if (this._delta !== 0) {
             // For trackpad events and single mouse wheel ticks, use the default zoom rate
             const zoomRate = (this._type === 'wheel' && Math.abs(this._delta) > wheelZoomDelta) ? this._wheelZoomRate : this._defaultZoomRate;

--- a/src/ui/handler/scroll_zoom.ts
+++ b/src/ui/handler/scroll_zoom.ts
@@ -256,6 +256,7 @@ export class ScrollZoomHandler implements Handler {
 
         // if we've had scroll events since the last render frame, consume the
         // accumulated delta, and update the target zoom level accordingly
+        console.log(`fr, ${this._delta} ${this._targetZoom}`);
         if (this._delta !== 0) {
             // For trackpad events and single mouse wheel ticks, use the default zoom rate
             const zoomRate = (this._type === 'wheel' && Math.abs(this._delta) > wheelZoomDelta) ? this._wheelZoomRate : this._defaultZoomRate;
@@ -351,5 +352,11 @@ export class ScrollZoomHandler implements Handler {
 
     reset() {
         this._active = false;
+        this._zooming = false;
+        delete this._targetZoom;
+        if (this._finishTimeout) {
+            clearTimeout(this._finishTimeout);
+            delete this._finishTimeout;
+        }
     }
 }

--- a/test/integration/browser/browser.test.ts
+++ b/test/integration/browser/browser.test.ts
@@ -67,7 +67,7 @@ describe('Browser tests', () => {
 
     test('Should continue zooming from last mouse position after scroll and flyto, see #2709', async () => {
         const finalZoom = await page.evaluate(() => {
-            return new Promise<void>((resolve, _reject) => {
+            return new Promise<number>((resolve, _reject) => {
                 map.once('zoom', () => {
                     map.flyTo({
                         zoom: 9

--- a/test/integration/browser/browser.test.ts
+++ b/test/integration/browser/browser.test.ts
@@ -65,6 +65,26 @@ describe('Browser tests', () => {
         expect(firstFiredEvent).toBe('load');
     }, 20000);
 
+    test('Should continue zooming from last mouse position after scroll and flyto, see #2709', async () => {
+        const finalZoom = await page.evaluate(() => {
+            return new Promise<void>((resolve, _reject) => {
+                map.once('zoom', () => {
+                    map.flyTo({
+                        zoom: 9
+                    });
+                    setTimeout(() => {
+                        map.getCanvas().dispatchEvent(new WheelEvent('wheel', {deltaY: 120, bubbles: true}));
+                        map.once('idle', () => {
+                            resolve(map.getZoom());
+                        });
+                    }, 1000);
+                });
+                map.getCanvas().dispatchEvent(new WheelEvent('wheel', {deltaY: 120, bubbles: true}));
+            });
+        });
+        expect(finalZoom).toBeGreaterThan(2);
+    }, 20000);
+
     test('Drag to the left', async () => {
 
         const canvas = await page.$('.maplibregl-canvas');


### PR DESCRIPTION
Fixes #2709

This basically resets the scroll handler state better which solves the above bug.
I couldn't find a way to test this using the existing unit test, as they are more of integration tests.
The browser test was a last resort, but it reproduces the bug perfectly.
