### PR TITLE
fix: [issue-2238] stop camera animation on mac when reduced motion is on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Fix unit test warning about duplicate module names ([#3049](https://github.com/maplibre/maplibre-gl-js/pull/3049))
 - Correct marker position when switching between 2D and 3D view ([#2996](https://github.com/maplibre/maplibre-gl-js/pull/2996))
 - Fix error thrown when unsetting line-gradient [#2683]
+- Avoiding inertia animation on Mac when reduced motion is on ([#3068](https://github.com/maplibre/maplibre-gl-js/pull/3068))
 - _...Add new stuff here..._
 
 ## 3.3.1

--- a/src/ui/handler_manager.ts
+++ b/src/ui/handler_manager.ts
@@ -17,6 +17,7 @@ import {DragPanHandler} from './handler/shim/drag_pan';
 import {DragRotateHandler} from './handler/shim/drag_rotate';
 import {TwoFingersTouchZoomRotateHandler} from './handler/shim/two_fingers_touch';
 import {extend} from '../util/util';
+import {browser} from '../util/browser';
 import Point from '@mapbox/point-geometry';
 
 export type InputEvent = MouseEvent | TouchEvent | KeyboardEvent | WheelEvent;
@@ -583,7 +584,7 @@ export class HandlerManager {
 
             const shouldSnapToNorth = bearing => bearing !== 0 && -this._bearingSnap < bearing && bearing < this._bearingSnap;
 
-            if (inertialEase) {
+            if (inertialEase && (inertialEase.essential || !browser.prefersReducedMotion)) {
                 if (shouldSnapToNorth(inertialEase.bearing || this._map.getBearing())) {
                     inertialEase.bearing = 0;
                 }


### PR DESCRIPTION
To fix issue #2238, this PR modifies the camera animation behavior on Mac when the 'reduced motion' setting is on.

### Explanation:
 The **camera.easeTo** method is called after the map movement happens, in order to add if needed a kind of "inertia movement". The *easeTo* method is called with the **around** property option with the position that should be the end of the camera ease movement.
Currently, when the 'reduced motion' setting is on, the duration is changed by 0. This does not avoid the final result, it only avoids the animation, because the final result will be at the **around** position, so it looks like an unexpected jump.

Example of the current behaviour, another example can be found here #2238

https://github.com/maplibre/maplibre-gl-js/assets/10349981/df381d05-a92b-4561-a677-9cde719a1549

### Approaches to fix

- My first approach was to just `return this;` if the reduced motion was on, but that approach didn't work well because it broke the zoom when the method was called by a double click.

- Another approach can be to reassign the **around** property to the center, because as was said before the movement was already done, and the center is in the current position, so the following code in the method will try as usual to do a movement, but its start position will be equal to the end position, so no movement will occur at all.

- This PR approach avoids calling this method when reduced motion is on

Result with this approach

https://github.com/maplibre/maplibre-gl-js/assets/10349981/c8b8b3f0-c2d7-4789-8044-95e1a2fa49ce

## Launch Checklist

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [x] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [x] Add an entry to `CHANGELOG.md` under the `## main` section.
