### PR TITLE
Add lock file version to `.npmrc`

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
-engine-strict=true
+engine-strict = true
+lockfileVersion = 3


### PR DESCRIPTION
maplibre-gj-js uses lock file version 3 (https://github.com/maplibre/maplibre-gl-js/blob/main/package-lock.json) so we should specify here in the `.npmrc` to help prevent changes. I added spaces between the = to make it easier to read.

Info: https://docs.npmjs.com/cli/v10/using-npm/config#lockfile-version 

As this is so minor, I haven't changed the CHANGELOG.md.