### PR TITLE
update stamen tile endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Fix unit test warning about duplicate module names ([#3049](https://github.com/maplibre/maplibre-gl-js/pull/3049))
 - Correct marker position when switching between 2D and 3D view ([#2996](https://github.com/maplibre/maplibre-gl-js/pull/2996))
 - Fix error thrown when unsetting line-gradient [#2683]
+- Update raster tile end points in documentation
 - _...Add new stuff here..._
 
 ## 3.3.1

--- a/src/source/raster_tile_source.ts
+++ b/src/source/raster_tile_source.ts
@@ -29,7 +29,7 @@ import type {
  * ```ts
  * map.addSource('raster-source', {
  *     'type': 'raster',
- *     'tiles': ['https://stamen-tiles.a.ssl.fastly.net/watercolor/{z}/{x}/{y}.jpg'],
+ *     'tiles': ['https://watercolormaps.collection.cooperhewitt.org/tile/watercolor/{z}/{x}/{y}.jpg'],
  *     'tileSize': 256,
  * });
  * ```

--- a/src/source/raster_tile_source.ts
+++ b/src/source/raster_tile_source.ts
@@ -29,7 +29,7 @@ import type {
  * ```ts
  * map.addSource('raster-source', {
  *     'type': 'raster',
- *     'tiles': ['https://watercolormaps.collection.cooperhewitt.org/tile/watercolor/{z}/{x}/{y}.jpg'],
+ *     'tiles': ['https://tiles.stadiamaps.com/tiles/stamen_watercolor/{z}/{x}/{y}.jpg'],
  *     'tileSize': 256,
  * });
  * ```

--- a/test/examples/map-tiles.html
+++ b/test/examples/map-tiles.html
@@ -23,7 +23,7 @@
                 'raster-tiles': {
                     'type': 'raster',
                     'tiles': [
-                        'https://stamen-tiles.a.ssl.fastly.net/watercolor/{z}/{x}/{y}.jpg'
+                        'https://watercolormaps.collection.cooperhewitt.org/tile/watercolor/{z}/{x}/{y}.jpg'
                     ],
                     'tileSize': 256,
                     'attribution':

--- a/test/examples/map-tiles.html
+++ b/test/examples/map-tiles.html
@@ -23,7 +23,7 @@
                 'raster-tiles': {
                     'type': 'raster',
                     'tiles': [
-                        'https://watercolormaps.collection.cooperhewitt.org/tile/watercolor/{z}/{x}/{y}.jpg'
+                        'https://tiles.stadiamaps.com/tiles/stamen_watercolor/{z}/{x}/{y}.jpg'
                     ],
                     'tileSize': 256,
                     'attribution':


### PR DESCRIPTION
## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Add an entry to `CHANGELOG.md` under the `## main` section.

## Description
Stamen is discontinuing our current method of serving our flagship map styles (read more about that [here](https://stamen.com/here-comes-the-future-of-stamen-maps/)) and the current link will be broken in a month.  This PR updates the any references to the old Watercolor map tile end point with a new link to the tiles hosted by the [Cooper Hewitt Design Museum](https://watercolormaps.collection.cooperhewitt.org/#12/40.7847/-73.9574).

## Visuals
running locally, the change works!
![image](https://github.com/maplibre/maplibre-gl-js/assets/24381390/000643b9-9cc8-44bd-93a6-25e438afc893)

the new `tiles` url in the locally running web page
![image](https://github.com/maplibre/maplibre-gl-js/assets/24381390/55dfce26-4479-4c94-99dc-028786b43732)
