### PR TITLE
Add auth information + update license for Stamen Watercolor

### DIFF
--- a/test/examples/map-tiles.html
+++ b/test/examples/map-tiles.html
@@ -23,11 +23,13 @@
                 'raster-tiles': {
                     'type': 'raster',
                     'tiles': [
-                        'https://tiles.stadiamaps.com/tiles/stamen_watercolor/{z}/{x}/{y}.jpg'
+                      // NOTE: Layers from Stadia Maps do not require an API key for localhost development or most production
+                      // web deployments. See https://docs.stadiamaps.com/authentication/ for details.
+                      'https://tiles.stadiamaps.com/tiles/stamen_watercolor/{z}/{x}/{y}.jpg'
                     ],
                     'tileSize': 256,
                     'attribution':
-                        'Map tiles by <a target="_top" rel="noopener" href="http://stamen.com">Stamen Design</a>, under <a target="_top" rel="noopener" href="http://creativecommons.org/licenses/by/3.0">CC BY 3.0</a>. Data by <a target="_top" rel="noopener" href="http://openstreetmap.org">OpenStreetMap</a>, under <a target="_top" rel="noopener" href="http://creativecommons.org/licenses/by-sa/3.0">CC BY SA</a>'
+                        'Map tiles by <a target="_blank" href="http://stamen.com">Stamen Design</a>; Hosting by <a href="https://stadiamaps.com/" target="_blank">Stadia Maps</a>. Data &copy; <a href="https://www.openstreetmap.org/about" target="_blank">OpenStreetMap</a> contributors'
                 }
             },
             'layers': [

--- a/test/examples/map-tiles.html
+++ b/test/examples/map-tiles.html
@@ -23,9 +23,9 @@
                 'raster-tiles': {
                     'type': 'raster',
                     'tiles': [
-                      // NOTE: Layers from Stadia Maps do not require an API key for localhost development or most production
-                      // web deployments. See https://docs.stadiamaps.com/authentication/ for details.
-                      'https://tiles.stadiamaps.com/tiles/stamen_watercolor/{z}/{x}/{y}.jpg'
+                        // NOTE: Layers from Stadia Maps do not require an API key for localhost development or most production
+                        // web deployments. See https://docs.stadiamaps.com/authentication/ for details.
+                        'https://tiles.stadiamaps.com/tiles/stamen_watercolor/{z}/{x}/{y}.jpg'
                     ],
                     'tileSize': 256,
                     'attribution':


### PR DESCRIPTION
Building on #3105, this adds a comment about how to authenticate to the Stadia Maps tile servers.

It also updates the license information for the Watercolor tiles. TL;DR, adds attribution for Stadia hosting the tiles, standardizes the OSM attribution to match modern convention, and removes the CC BY 3.0 reference as it is confusing what it applies to (that's clarified below), and Stamen also bumped it to 4.0 to allow for easier use in academic contexts (IIRC; @RossThorn or @almccon can confirm details if desired).

The _tiles_ served by Stadia Maps are subject to our standard ToS, which prohibits things like mass downloads / caching forever. This is clarified on https://stadiamaps.com/attribution/, but is way too long to fit the distinction between design, code, and tile access in an attribution line, but we've spelled it out on our site for clarity.