### PR TITLE
Set TS compile target to es2016

### DIFF
--- a/build/generate-dist-package.js
+++ b/build/generate-dist-package.js
@@ -11,16 +11,20 @@ async function ensureDist() {
   return dist
 }
 
-await writeFile(
-  new URL("package.json", await ensureDist()),
-  JSON.stringify({
-    name: "maplibre-gl",
-    type: "commonjs",
-    deprecated: "Please install maplibre-gl from parent directory instead",
-  })
-)
+async function main() {
+  await writeFile(
+    new URL("package.json", await ensureDist()),
+    JSON.stringify({
+      name: "maplibre-gl",
+      type: "commonjs",
+      deprecated: "Please install maplibre-gl from parent directory instead",
+    })
+  )
 
-await copyFile(
-  "./LICENSE.txt",
-  new URL("LICENSE.txt", await ensureDist())
-)
+  await copyFile(
+    "./LICENSE.txt",
+    new URL("LICENSE.txt", await ensureDist())
+  )
+}
+
+main().catch(console.error);

--- a/test/bench/gl-stats.ts
+++ b/test/bench/gl-stats.ts
@@ -20,29 +20,33 @@ function waitForConsole(page) {
     });
 }
 
-const browser = await puppeteer.launch({
-    headless: 'new'
-});
-try {
+async function main() {
+    const browser = await puppeteer.launch({
+        headless: 'new'
+    });
+    try {
 
-    const page = await browser.newPage();
-    await page.setViewport({width: 600, height: 600, deviceScaleFactor: 2});
+        const page = await browser.newPage();
+        await page.setViewport({width: 600, height: 600, deviceScaleFactor: 2});
 
-    console.log('collecting stats...');
-    await page.setContent(benchHTML);
+        console.log('collecting stats...');
+        await page.setContent(benchHTML);
 
-    // @ts-ignore
-    const stats = JSON.parse(await waitForConsole(page));
-    stats['bundle_size'] = maplibreGLJSSrc.length + maplibreGLCSSSrc.length;
-    stats['bundle_size_gz'] = zlib.gzipSync(maplibreGLJSSrc).length + zlib.gzipSync(maplibreGLCSSSrc).length;
-    stats.dt = execSync('git show --no-patch --no-notes --pretty=\'%cI\' HEAD').toString().substring(0, 19);
-    stats.commit = execSync('git rev-parse --short HEAD').toString().trim();
-    stats.message = execSync('git show -s --format=%s HEAD').toString().trim();
-    console.log(JSON.stringify(stats, null, 2));
+        // @ts-ignore
+        const stats = JSON.parse(await waitForConsole(page));
+        stats['bundle_size'] = maplibreGLJSSrc.length + maplibreGLCSSSrc.length;
+        stats['bundle_size_gz'] = zlib.gzipSync(maplibreGLJSSrc).length + zlib.gzipSync(maplibreGLCSSSrc).length;
+        stats.dt = execSync('git show --no-patch --no-notes --pretty=\'%cI\' HEAD').toString().substring(0, 19);
+        stats.commit = execSync('git rev-parse --short HEAD').toString().trim();
+        stats.message = execSync('git show -s --format=%s HEAD').toString().trim();
+        console.log(JSON.stringify(stats, null, 2));
 
-    fs.writeFileSync('data.json.gz', zlib.gzipSync(JSON.stringify(stats)));
+        fs.writeFileSync('data.json.gz', zlib.gzipSync(JSON.stringify(stats)));
 
-    await page.close();
-} finally {
-    await browser.close();
+        await page.close();
+    } finally {
+        await browser.close();
+    }
 }
+
+main().catch(console.error);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,7 @@
     "skipLibCheck": false,
     "sourceMap": true,
     "strict": false,
-    "target": "ES2019",
+    "target": "ES2016",
     "lib": [
       "ESNext",
       "DOM",


### PR DESCRIPTION
This should compile await/async down, maintaining a very high level of browser support.

Preparation for
- https://github.com/maplibre/maplibre-gl-js/pull/3185

Context 
- https://github.com/maplibre/maplibre-gl-js/pull/3185#discussion_r1349429451
- https://github.com/maplibre/maplibre-gl-js/pull/3185#discussion_r1349518420

Removed usage of top-level await from build scripts, because it won't allow us to have a compile target below es2017, thus forcing us to ship await/async to browsers and loosing Safari <10 support (0.19% browser usage).