### PR TITLE
Fix actor not passing additional callback arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### 🐞 Bug fixes
 
 - _...Add new stuff here..._
-- Fix actor passing only the first 2 arguments to callbacks
+- Fixed actor passing only the first 2 arguments to callbacks ([#3130](https://github.com/maplibre/maplibre-gl-js/pull/3196))
 
 ## 3.5.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### 🐞 Bug fixes
 
 - _...Add new stuff here..._
+- Fix actor passing only the first 2 arguments to callbacks
 
 ## 3.5.2
 

--- a/src/util/actor.test.ts
+++ b/src/util/actor.test.ts
@@ -63,6 +63,32 @@ describe('Actor', () => {
         });
     });
 
+    test('calls the callback with the correct number of arguments', done => {
+        setTestWorker(class MockWorker {
+            self: any;
+            actor: Actor;
+            constructor(self) {
+                this.self = self;
+                this.actor = new Actor(self, this);
+            }
+            test(mapId, params, callback) {
+                setTimeout(callback, 0, null, '1st param', '2nd param', '3rd param');
+            }
+        });
+
+        const worker = workerFactory();
+
+        const m = new Actor(worker, {}, '1');
+
+        m.send('test', {value: 1729}, (err, param1, param2, param3) => {
+            expect(err).toBeFalsy();
+            expect(param1).toBe('1st param');
+            expect(param2).toBe('2nd param');
+            expect(param3).toBe('3rd param');
+            done();
+        });
+    });
+
     test('targets worker-initiated messages to correct map instance', done => {
         let workerActor;
 

--- a/src/util/actor.ts
+++ b/src/util/actor.ts
@@ -213,13 +213,13 @@ export class Actor {
                 if (task.error) {
                     callback(deserialize(task.error));
                 } else {
-                    callback(null, deserialize(task.data));
+                    callback(null, ...(deserialize(task.data) as any[]));
                 }
             }
         } else {
             let completed = false;
             const buffers: Array<Transferable> = [];
-            const done = task.hasCallback ? (err: Error, data?: any) => {
+            const done = task.hasCallback ? (err: Error, ...data: any[]) => {
                 completed = true;
                 delete this.cancelCallbacks[id];
                 const responseMessage: MessageData = {

--- a/test/integration/browser/browser.test.ts
+++ b/test/integration/browser/browser.test.ts
@@ -286,7 +286,7 @@ describe('Browser tests', () => {
                 };
             });
 
-            return new Promise<Record<string, number>>((resolve, reject) => {
+            return new Promise<Record<string, number>>((resolve) => {
                 map.addSource('cust', {
                     type: 'vector',
                     tiles: ['cust://{x}-{y}-{z}'],


### PR DESCRIPTION
Before this change, `Actor` was not forwarding additional callback arguments and assumed the callback is always in the form `(err, data) => {}`.

There are examples where the callback has more than 2 arguments. For example, in the `loadVectorTile` function implementation, the callback that is passed directly to the actor is defined as `(err?: Error | null, data?: ArrayBuffer | null, cacheControl?: string | null, expires?: string | null) => {}`. In this case, `Actor` only passes `data`, *forgetting* `cacheControl` and `expires`.

Linked issue: fixes https://github.com/maplibre/maplibre-gl-js/issues/3180

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [x] Write tests for all new functionality.
 - [x] Add an entry to `CHANGELOG.md` under the `## main` section.
