### PR TITLE
Bump maplibre-contour plugin in demo to fix safari DEM issue

### DIFF
--- a/test/examples/contour-lines.html
+++ b/test/examples/contour-lines.html
@@ -14,7 +14,7 @@
 </head>
 <body>
 <div id="map"></div>
-<script src="https://unpkg.com/maplibre-contour@0.0.2/dist/index.min.js"></script>
+<script src="https://unpkg.com/maplibre-contour@0.0.4/dist/index.min.js"></script>
 <script>
     const demSource = new mlcontour.DemSource({
         url: 'https://demotiles.maplibre.org/terrain-tiles/{z}/{x}/{y}.png',


### PR DESCRIPTION
Bump maplibre-contour plugin in demo to version 0.0.4 to pull in https://github.com/onthegomap/maplibre-contour/pull/85 so that the demo works properly on iOS 17 private browsing mode.