### PR TITLE
Add RasterTileSource setTiles method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ### ✨ Features and improvements
 
-- _...Add new stuff here..._
+- Add setTiles method to RasterTileSource to dynamically update existing tile
+  sources. ([3208](https://github.com/maplibre/maplibre-gl-js/pull/3208))
 
 ### 🐞 Bug fixes
 

--- a/src/source/raster_tile_source.test.ts
+++ b/src/source/raster_tile_source.test.ts
@@ -164,6 +164,17 @@ describe('RasterTileSource', () => {
         server.respond();
     });
 
+    test('supports updating tiles', () => {
+        const source = createSource({url: '/source.json'});
+        source.setTiles(['http://example.com/{z}/{x}/{y}.png?updated=true']);
+
+        source.on('data', (e) => {
+            if (e.sourceDataType === 'metadata') {
+                expect(source._options.tiles[0]).toBe('http://example.com/{z}/{x}/{y}.png?updated=true');
+            }
+        });
+    });
+
     test('cancels TileJSON request if removed', () => {
         const source = createSource({url: '/source.json'});
         source.onRemove();

--- a/src/source/raster_tile_source.test.ts
+++ b/src/source/raster_tile_source.test.ts
@@ -170,7 +170,7 @@ describe('RasterTileSource', () => {
 
         source.on('data', (e) => {
             if (e.sourceDataType === 'metadata') {
-                expect(source._options.tiles[0]).toBe('http://example.com/{z}/{x}/{y}.png?updated=true');
+                expect(source.tiles[0]).toBe('http://example.com/{z}/{x}/{y}.png?updated=true');
             }
         });
     });

--- a/src/source/raster_tile_source.ts
+++ b/src/source/raster_tile_source.ts
@@ -131,7 +131,7 @@ export class RasterTileSource extends Evented implements Source {
      * @returns `this`
      */
     setTiles(tiles: Array<string>): this {
-        this._options.tiles = tiles;
+        this.tiles = tiles;
         this.onRemove();
         this.load();
 

--- a/src/source/raster_tile_source.ts
+++ b/src/source/raster_tile_source.ts
@@ -124,6 +124,20 @@ export class RasterTileSource extends Evented implements Source {
         }
     }
 
+    /**
+     * Sets the source `tiles` property and re-renders the map.
+     *
+     * @param tiles - An array of one or more tile source URLs, as in the raster tiles spec (See the [Style Specification](https://maplibre.org/maplibre-style-spec/)
+     * @returns `this`
+     */
+    setTiles(tiles: Array<string>): this {
+        this._options.tiles = tiles;
+        this.onRemove();
+        this.load();
+
+        return this;
+    }
+
     serialize() {
         return extend({}, this._options);
     }

--- a/src/source/raster_tile_source.ts
+++ b/src/source/raster_tile_source.ts
@@ -124,6 +124,16 @@ export class RasterTileSource extends Evented implements Source {
         }
     }
 
+    setSourceProperty(callback: Function) {
+        if (this._tileJSONRequest) {
+            this._tileJSONRequest.cancel();
+        }
+
+        callback();
+
+        this.load();
+    }
+
     /**
      * Sets the source `tiles` property and re-renders the map.
      *
@@ -131,9 +141,9 @@ export class RasterTileSource extends Evented implements Source {
      * @returns `this`
      */
     setTiles(tiles: Array<string>): this {
-        this.tiles = tiles;
-        this.onRemove();
-        this.load();
+        this.setSourceProperty(() => {
+            this._options.tiles = tiles;
+        });
 
         return this;
     }


### PR DESCRIPTION
Resolves #3207. Adds a `setTiles` method to `RasterTileSource`. Changes made:

- Add `setTiles` to `RasterTileSource`
- Add unit test to confirm tiles update
- Changelog entry


[Screencast from 2023-10-11 13-43-31.webm](https://github.com/maplibre/maplibre-gl-js/assets/133472204/9ee52951-5289-4710-a77a-2418da89039a)

