### PR TITLE
Remove async/await from bundle

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -5,6 +5,7 @@ const sharedConfig = {
         // use typescript to convert from esm to cjs
         '[.](m|c)?(ts|js)(x)?$': ['ts-jest', {
             'isolatedModules': true,
+            'tsconfig':'tsconfig.jest.json'
         }],
     },
     // any tests that operate on dist files shouldn't compile them again.

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -5,7 +5,7 @@ const sharedConfig = {
         // use typescript to convert from esm to cjs
         '[.](m|c)?(ts|js)(x)?$': ['ts-jest', {
             'isolatedModules': true,
-            'tsconfig':'tsconfig.jest.json'
+            'tsconfig': 'tsconfig.jest.json'
         }],
     },
     // any tests that operate on dist files shouldn't compile them again.

--- a/tsconfig.jest.json
+++ b/tsconfig.jest.json
@@ -1,7 +1,6 @@
 {
-  "extends":"./tsconfig.json",
+  "extends": "./tsconfig.json",
   "compilerOptions": {
-    
-    "target": "ES2019",
+    "target": "ES2019"
   }
 }

--- a/tsconfig.jest.json
+++ b/tsconfig.jest.json
@@ -1,0 +1,7 @@
+{
+  "extends":"./tsconfig.json",
+  "compilerOptions": {
+    
+    "target": "ES2019",
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,7 @@
     "skipLibCheck": false,
     "sourceMap": true,
     "strict": false,
-    "target": "ES2019",
+    "target": "ES2016",
     "lib": [
       "ESNext",
       "DOM",
@@ -30,6 +30,7 @@
     "experimentalSpecifierResolution": "node",
     "esm": true,
     "compilerOptions": {
+      "target": "es2019",
       "types": [
         "node"
       ]
@@ -37,15 +38,10 @@
   },
   "include": [
     "rollup.config.*",
-    "src/**/*",
-    "test/bench/**/*",
-    "build/**/*"
+    "src/**/*"
   ],
   "exclude": [
     "node_modules",
-    "dist",
-    "build/rollup",
-    "test/bench/rollup",
-    "test/bench/**/*generated*"
+    "dist"
   ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -38,10 +38,16 @@
   },
   "include": [
     "rollup.config.*",
-    "src/**/*"
+    "src/**/*",
+    "test/bench/**/*"
   ],
   "exclude": [
     "node_modules",
-    "dist"
+    "dist",
+    "build/rollup",
+    "test/bench/rollup",
+    "test/bench/run-benchmarks.ts",
+    "test/bench/gl-stats.ts"  ,
+    "test/bench/**/*generated*"
   ]
 }


### PR DESCRIPTION
Async/await causes trouble in the bundle, so this PR compiles it down to es2016 promises.

Related to
- https://github.com/maplibre/maplibre-gl-js/discussions/3210#discussioncomment-7304396
- #3209