### PR TITLE
Release 3.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 ## 3.5.1
 
 ### 🐞 Bug fixes
-- By compiling the bundle to ES2016, this fixed a regression related to await / async introduced in 3.5.0 ([#3228](https://github.com/maplibre/maplibre-gl-js/pull/3228))
+- Fix regression introduced in 3.5.0, related to async/await ([#3228](https://github.com/maplibre/maplibre-gl-js/pull/3228))
 
 
 ## 3.5.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@
 ### 🐞 Bug fixes
 
 - _...Add new stuff here..._
+## 3.5.1
+
+### 🐞 Bug fixes
+- Fixes issue with await / async, by compiling to ES2016 ([#3228](https://github.com/maplibre/maplibre-gl-js/pull/3228))
+
 
 ## 3.5.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 ## 3.5.1
 
 ### 🐞 Bug fixes
-- Fixes issue with await / async, by compiling to ES2016 ([#3228](https://github.com/maplibre/maplibre-gl-js/pull/3228))
+- By compiling the bundle to ES2016, this fixed a regression related to await / async introduced in 3.5.0 ([#3228](https://github.com/maplibre/maplibre-gl-js/pull/3228))
 
 
 ## 3.5.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "maplibre-gl",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "maplibre-gl",
-      "version": "3.5.0",
+      "version": "3.5.1",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@mapbox/geojson-rewind": "^0.5.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "maplibre-gl",
   "description": "BSD licensed community fork of mapbox-gl, a WebGL interactive maps library",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "main": "dist/maplibre-gl.js",
   "style": "dist/maplibre-gl.css",
   "license": "BSD-3-Clause",


### PR DESCRIPTION
### 🐞 Bug fixes
- Fix regression introduced in 3.5.0, related to async/await ([#3228](https://github.com/maplibre/maplibre-gl-js/pull/3228))