### PR TITLE
Small correction to change log and an example's duplicate title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### ✨ Features and improvements
 
 - Convert plantuml diagrams to mermaid ([#3217](https://github.com/maplibre/maplibre-gl-js/pull/3217))
+- Improve buffer transfer in Safari after Safari fixed a memory leak bug ([#3225](https://github.com/maplibre/maplibre-gl-js/pull/3225))
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes

--- a/test/examples/variable-offset-label-placement.html
+++ b/test/examples/variable-offset-label-placement.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <title>Variable label placement</title>
+    <title>Variable label placement with offset</title>
     <meta property="og:description" content="Use text-variable-anchor-offset to allow high priority labels to shift position to stay on the map." />
     <meta charset='utf-8'>
     <meta name="viewport" content="width=device-width, initial-scale=1">


### PR DESCRIPTION
The title of the example is duplicated and caused a search confusion.
I forgot to add a change in the behavior in previous PR.
Both fixed in this small PR.