### PR TITLE
Add terrain property to map style object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### 🐞 Bug fixes
 
+- Add terrain property to map style object ([#3234](https://github.com/maplibre/maplibre-gl-js/pull/3234))
 - _...Add new stuff here..._
 
 ## 3.5.0

--- a/src/style/style.test.ts
+++ b/src/style/style.test.ts
@@ -68,6 +68,7 @@ class StubMap extends Evented {
     }
 
     setTerrain() { }
+    getTerrain() { }
 }
 
 const getStubMap = () => new StubMap() as any;
@@ -2560,6 +2561,32 @@ describe('Style#hasTransitions', () => {
             style.setPaintProperty('background', 'background-color', 'blue');
             style.update({transition: {duration: 0, delay: 0}} as EvaluationParameters);
             expect(style.hasTransitions()).toBe(false);
+            done();
+        });
+    });
+});
+
+describe('Style#serialize', () => {
+    test('include terrain property when map has 3D terrain', done => {
+        const styleJson = createStyleJSON({terrain: {
+            source: 'terrainSource',
+            exaggeration: 1
+        }});
+        const style = new Style(getStubMap());
+        style.loadJSON(styleJson);
+
+        style.on('style.load', () => {
+            expect(style.serialize().terrain).toBe(styleJson.terrian);
+            done();
+        });
+    });
+
+    test('do not include terrain property when map does not have 3D terrain', done => {
+        const style = new Style(getStubMap());
+        style.loadJSON(createStyleJSON());
+
+        style.on('style.load', () => {
+            expect(style.serialize().terrain).toBeUndefined();
             done();
         });
     });

--- a/src/style/style.ts
+++ b/src/style/style.ts
@@ -1215,6 +1215,7 @@ export class Style extends Evented {
 
         const sources = mapObject(this.sourceCaches, (source) => source.serialize());
         const layers = this._serializeByIds(this._order);
+        const terrain = this.map.getTerrain() || undefined;
         const myStyleSheet = this.stylesheet;
 
         return filterObject({
@@ -1230,7 +1231,8 @@ export class Style extends Evented {
             glyphs: myStyleSheet.glyphs,
             transition: myStyleSheet.transition,
             sources,
-            layers
+            layers,
+            terrain
         },
         (value) => { return value !== undefined; });
     }


### PR DESCRIPTION
Fix issue https://github.com/maplibre/maplibre-gl-js/issues/3214, add `terrain` property to map `style` object.

**Before**
![before](https://github.com/maplibre/maplibre-gl-js/assets/28984604/894ce021-2838-46d1-960b-543de70d69c4)

**After**
![after](https://github.com/maplibre/maplibre-gl-js/assets/28984604/a5b86f19-3cf3-427b-a206-9767d77b7829)

---
## Launch Checklist
 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [x] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality.
 - [x] Add an entry to `CHANGELOG.md` under the `## main` section.
 
 -----
 closes #3214 
