### PR TITLE
Fix exception thrown from `isWebGL2` check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,14 @@
 ### 🐞 Bug fixes
 
 - Add terrain property to map style object ([#3234](https://github.com/maplibre/maplibre-gl-js/pull/3234))
+- Fix exception thrown from `isWebGL2` check ([#3238](https://github.com/maplibre/maplibre-gl-js/pull/3238))
 - _...Add new stuff here..._
+
 ## 3.5.1
 
 ### 🐞 Bug fixes
-- Fix regression introduced in 3.5.0, related to async/await ([#3228](https://github.com/maplibre/maplibre-gl-js/pull/3228))
 
+- Fix regression introduced in 3.5.0, related to async/await ([#3228](https://github.com/maplibre/maplibre-gl-js/pull/3228))
 
 ## 3.5.0
 

--- a/src/gl/webgl2.ts
+++ b/src/gl/webgl2.ts
@@ -5,7 +5,7 @@ export function isWebGL2(
     if (cache.has(gl)) {
         return cache.get(gl);
     } else {
-        const value = gl.getParameter(gl.VERSION).startsWith('WebGL 2.0');
+        const value = gl.getParameter(gl.VERSION)?.startsWith('WebGL 2.0');
         cache.set(gl, value);
         return value;
     }


### PR DESCRIPTION
`gl.getParameter(gl.VERSION)` returns null on some browsers, so `gl.getParameter(gl.VERSION).startsWith(...)` throws an exception. This change makes it so that `isWebGL2` returns false on browsers where `gl.getParameter(gl.VERSION)` returns null.