### PR TITLE
Fix rollup watch mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 - Add terrain property to map style object ([#3234](https://github.com/maplibre/maplibre-gl-js/pull/3234))
 - Fix exception thrown from `isWebGL2` check ([#3238](https://github.com/maplibre/maplibre-gl-js/pull/3238))
+- Fix rollup watch mode ([#3270](https://github.com/maplibre/maplibre-gl-js/pull/3270))
 - _...Add new stuff here..._
 
 ## 3.5.1

--- a/build/rollup_plugins.ts
+++ b/build/rollup_plugins.ts
@@ -47,3 +47,12 @@ export const plugins = (production: boolean): Plugin[] => [
         ignoreGlobal: true
     })
 ].filter(Boolean);
+
+export const watchStagingPlugin: Plugin = {
+    name: 'watch-external',
+    buildStart() {
+        this.addWatchFile('staging/maplibregl/index.js');
+        this.addWatchFile('staging/maplibregl/shared.js');
+        this.addWatchFile('staging/maplibregl/worker.js');
+    }
+};

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import sourcemaps from 'rollup-plugin-sourcemaps';
-import {plugins} from './build/rollup_plugins';
+import {plugins, watchStagingPlugin} from './build/rollup_plugins';
 import banner from './build/banner';
 import {RollupOptions} from 'rollup';
 
@@ -45,11 +45,19 @@ const config: RollupOptions[] = [{
         intro: fs.readFileSync('build/rollup/bundle_prelude.js', 'utf8'),
         banner
     },
+    watch: {
+        // give the staging chunks a chance to finish before rebuilding the dev build
+        buildDelay: 1000
+    },
     treeshake: false,
     plugins: [
         // Ingest the sourcemaps produced in the first step of the build.
         // This is the only reason we use Rollup for this second pass
-        sourcemaps()
+        sourcemaps(),
+        // When running in development watch mode, tell rollup explicitly to watch
+        // for changes to the staging chunks built by the previous step. Otherwise
+        // only they get built, but not the merged dev build js
+        ...production ? [] : [watchStagingPlugin]
     ],
 }];
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,6 @@
     "moduleResolution": "Node",
     "resolveJsonModule": true,
     "skipLibCheck": false,
-    "sourceMap": true,
     "strict": false,
     "target": "ES2016",
     "lib": [


### PR DESCRIPTION
When running in watch mode (`npm start`) I noticed that the dev js build wasn't getting rebuilt when files changed, just the staging chunks. It turns out that the first stage of the rollup build is aware of which input files get combined into which output files, but the second stage that merges the staging chunks into a dev.js build is not. I found [this stackoverflow post](https://stackoverflow.com/a/63548394) that explains how to resolve this issue by telling rollup explicitly to watch a set of file.  `npm start` rebuilds the dev.js file on each change now. 

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [ ] Link to related issues.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [x] Add an entry to `CHANGELOG.md` under the `## main` section.
