### PR TITLE
Fix null feature properties in resolve_tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### 🐞 Bug fixes
 
+- Fix null feature properties in resolve_tokens ([#3272](https://github.com/maplibre/maplibre-gl-js/pull/3272))
 - _...Add new stuff here..._
 
 ## 3.5.2

--- a/src/util/resolve_tokens.test.ts
+++ b/src/util/resolve_tokens.test.ts
@@ -10,6 +10,10 @@ test('resolveToken', () => {
     expect(resolveTokens({name: 'Test'}, '{name}')).toBe('Test');
     expect(resolveTokens({name: 'Test'}, '{name}-suffix')).toBe('Test-suffix');
 
+    // No properties.
+    expect(resolveTokens(null, '{name}')).toBe('');
+    expect(resolveTokens(null, '{name}-suffix')).toBe('-suffix');
+
     // Undefined property.
     expect(resolveTokens({}, '{name}')).toBe('');
     expect(resolveTokens({}, '{name}-suffix')).toBe('-suffix');

--- a/src/util/resolve_tokens.ts
+++ b/src/util/resolve_tokens.ts
@@ -8,10 +8,10 @@
 export function resolveTokens(
     properties: {
         readonly [x: string]: unknown;
-    },
+    } | null,
     text: string
 ): string {
     return text.replace(/{([^{}]+)}/g, (match, key: string) => {
-        return key in properties ? String(properties[key]) : '';
+        return properties && key in properties ? String(properties[key]) : '';
     });
 }


### PR DESCRIPTION
There is a bug in `resolve_tokens`. When the feature properties are null, the code breaks with `TypeError: Cannot use 'in' operator to search for 'name' in null`. This can easily happen with GeoJSON source, that has some feature with `properties: null`, which is valid value according to GeoJSON specification.

