### PR TITLE
Use node version from .nvmrc file in CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,12 +17,10 @@ jobs:
           fetch-depth: 0
           ref: main
 
-      - name: Use Node.js 18 x64
-        uses: actions/setup-node@v3.6.0
+      - name: Use Node.js from nvmrc
+        uses: actions/setup-node@v3
         with:
-          node-version: 18
-          architecture: x64
-          registry-url: 'https://registry.npmjs.org'
+          node-version-file: '.nvmrc'
 
       - name: Get version
         id: package-version

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
         with:
-          node-version: lts/*
+          node-version-file: '.nvmrc'
       - run: npm ci
       - run: npm run lint
         if: success() || failure()
@@ -43,7 +43,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
         with:
-          node-version: lts/*
+          node-version-file: '.nvmrc'
       - name: Start display server
         if: runner.os == 'Linux'
         run: nohup Xvfb &
@@ -73,7 +73,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
         with:
-          node-version: lts/*
+          node-version-file: '.nvmrc'
       - run: npm ci
       - run: npm run build-dist
       - uses: actions/upload-artifact@v3
@@ -99,7 +99,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
         with:
-          node-version: lts/*
+          node-version-file: '.nvmrc'
       - name: install CJK fonts for local ideographs render tests
         run: sudo apt install fonts-noto-cjk
       - run: npm ci
@@ -134,7 +134,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
         with:
-          node-version: lts/*
+          node-version-file: '.nvmrc'
       - run: npm ci
       - name: Start display server
         if: runner.os == 'Linux'
@@ -162,7 +162,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
         with:
-          node-version: lts/*
+          node-version-file: '.nvmrc'
       - run: npm ci
       - run: npm run build-dist
       - run: npm run test-build

--- a/.github/workflows/upload-benchmarks.yml
+++ b/.github/workflows/upload-benchmarks.yml
@@ -11,11 +11,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Use Node.js 18 x64
-        uses: actions/setup-node@v3.6.0
+      - name: Use Node.js from nvmrc
+        uses: actions/setup-node@v3
         with:
-          node-version: 18
-          architecture: x64
+          node-version-file: '.nvmrc'
 
       - name: Install
         run: npm ci


### PR DESCRIPTION
Node LTS just changed from 18 to 20 making the CI fail.
While there's a need to fix this and update node, this will make a simple place to change the version for all the CI related flows and to developers using nvm (which they should).


