### PR TITLE
Add getLayersOrder() to Map and Style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## main
 
+### ✨ Features and improvements
+
+- Add getLayersOrder() to Map and Style ([#3279]https://github.com/maplibre/maplibre-gl-js/pull/3279)
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### ✨ Features and improvements
 
-- Add getLayersOrder() to Map and Style ([#3279]https://github.com/maplibre/maplibre-gl-js/pull/3279)
+- Add getLayersOrder() to Map and Style ([#3279](https://github.com/maplibre/maplibre-gl-js/pull/3279))
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes

--- a/src/style/style.test.ts
+++ b/src/style/style.test.ts
@@ -2155,6 +2155,36 @@ describe('Style#setLayerZoomRange', () => {
     });
 });
 
+describe('Style#getLayersOrder', () => {
+    test('returns ids of layers in the correct order', done => {
+        const style = new Style(getStubMap());
+        style.loadJSON({
+            'version': 8,
+            'sources': {
+                'raster': {
+                    type: 'raster',
+                    tiles: ['http://tiles.server']
+                }
+            },
+            'layers': [{
+                'id': 'raster',
+                'type': 'raster',
+                'source': 'raster'
+            }]
+        });
+
+        style.on('style.load', () => {
+            style.addLayer({
+                id: 'custom',
+                type: 'custom',
+                render() {}
+            }, 'raster');
+            expect(style.getLayersOrder()).toEqual(['custom', 'raster']);
+            done();
+        });
+    });
+});
+
 describe('Style#queryRenderedFeatures', () => {
 
     let style;

--- a/src/style/style.ts
+++ b/src/style/style.ts
@@ -1008,7 +1008,16 @@ export class Style extends Evented {
     }
 
     /**
-     * checks if a specific layer is present within the style.
+     * Return the ids of all layers currently in the style, including custom layers, in order.
+     *
+     * @returns ids of layers, in order
+     */
+    getLayersOrder(): string[] {
+        return [...this._order];
+    }
+
+    /**
+     * Checks if a specific layer is present within the style.
      *
      * @param id - the id of the desired layer
      * @returns a boolean specifying if the given layer is present

--- a/src/ui/map.test.ts
+++ b/src/ui/map.test.ts
@@ -811,6 +811,36 @@ describe('Map', () => {
         expect(mapLayer.source).toBe(layer.source);
     });
 
+    describe('#getLayersOrder', () => {
+        test('returns ids of layers in the correct order', done => {
+            const map = createMap({
+                style: extend(createStyle(), {
+                    'sources': {
+                        'raster': {
+                            type: 'raster',
+                            tiles: ['http://tiles.server']
+                        }
+                    },
+                    'layers': [{
+                        'id': 'raster',
+                        'type': 'raster',
+                        'source': 'raster'
+                    }]
+                })
+            });
+
+            map.on('style.load', () => {
+                map.addLayer({
+                    id: 'custom',
+                    type: 'custom',
+                    render() {}
+                }, 'raster');
+                expect(map.getLayersOrder()).toEqual(['custom', 'raster']);
+                done();
+            });
+        });
+    });
+
     describe('#resize', () => {
         test('sets width and height from container clients', () => {
             const map = createMap(),

--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -2487,7 +2487,7 @@ export class Map extends Camera {
      *
      * @example
      * ```ts
-     * const order = map.getLayersOrder();
+     * const orderedLayerIds = map.getLayersOrder();
      * ```
      */
     getLayersOrder(): string[] {

--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -2484,6 +2484,11 @@ export class Map extends Camera {
      * Return the ids of all layers currently in the style, including custom layers, in order.
      *
      * @returns ids of layers, in order
+     *
+     * @example
+     * ```ts
+     * const order = map.getLayersOrder();
+     * ```
      */
     getLayersOrder(): string[] {
         return this.style.getLayersOrder();

--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -2481,6 +2481,15 @@ export class Map extends Camera {
     }
 
     /**
+     * Return the ids of all layers currently in the style, including custom layers, in order.
+     *
+     * @returns ids of layers, in order
+     */
+    getLayersOrder(): string[] {
+        return this.style.getLayersOrder();
+    }
+
+    /**
      * Sets the zoom extent for the specified style layer. The zoom extent includes the
      * [minimum zoom level](https://maplibre.org/maplibre-style-spec/layers/#minzoom)
      * and [maximum zoom level](https://maplibre.org/maplibre-style-spec/layers/#maxzoom))


### PR DESCRIPTION
## Launch Checklist

Closes https://github.com/maplibre/maplibre-gl-js/issues/3277. Adds a getter for Style's _order "private" property to Style and Map.

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality.
 - [x] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [x] Add an entry to `CHANGELOG.md` under the `## main` section.
