### PR TITLE
Add note on pseudo fullscreen mode on iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### ✨ Features and improvements
 
 - Add getLayersOrder() to Map and Style ([#3279](https://github.com/maplibre/maplibre-gl-js/pull/3279))
+- Updated description of `fullscreen` example ([#3311](https://github.com/maplibre/maplibre-gl-js/pull/3311))
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes

--- a/test/examples/fullscreen.html
+++ b/test/examples/fullscreen.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <title>View a fullscreen map</title>
-    <meta property="og:description" content="Toggle between current view and fullscreen mode." />
+    <meta property="og:description" content="Toggle between current view and fullscreen mode. Does not work on iPhones because a pseudo-fullscreen is used, and the code is embedded in an iframe, which prevents the map from scaling." />
     <meta charset='utf-8'>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel='stylesheet' href='../../dist/maplibre-gl.css' />


### PR DESCRIPTION
## Description
Fixes #3306 

In the issue https://github.com/maplibre/maplibre-gl-js/issues/3306 I discovered and described that the fullscreen mode example does not work on iOS because an iframe is used which prevents the map from scaling. I have therefore extended the description of this example accordingly.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [x] Add an entry to `CHANGELOG.md` under the `## main` section.
