### PR TITLE
Fix zoom around 180 meridian (#3048)

### DIFF
--- a/src/geo/transform.ts
+++ b/src/geo/transform.ts
@@ -576,7 +576,7 @@ export class Transform {
     pointCoordinate(p: Point, terrain?: Terrain): MercatorCoordinate {
         // get point-coordinate from terrain coordinates framebuffer
         if (terrain) {
-            const coordinate = terrain.pointCoordinate(p, this.width, this._center.lng);
+            const coordinate = terrain.pointCoordinate(p);
             if (coordinate != null) {
                 return coordinate;
             }

--- a/src/geo/transform.ts
+++ b/src/geo/transform.ts
@@ -576,7 +576,7 @@ export class Transform {
     pointCoordinate(p: Point, terrain?: Terrain): MercatorCoordinate {
         // get point-coordinate from terrain coordinates framebuffer
         if (terrain) {
-            const coordinate = terrain.pointCoordinate(p);
+            const coordinate = terrain.pointCoordinate(p, this.width, this._center.lng);
             if (coordinate != null) {
                 return coordinate;
             }

--- a/src/render/terrain.test.ts
+++ b/src/render/terrain.test.ts
@@ -45,7 +45,7 @@ describe('Terrain', () => {
         terrain._fboCoordsTexture.texture = imageTexture.texture;
         terrain.coordsIndex.push('abcd');
 
-        const coordinate = terrain.pointCoordinate(new Point(0, 0), 1, 0);
+        const coordinate = terrain.pointCoordinate(new Point(0, 0));
 
         expect(coordinate).not.toBeNull();
     });

--- a/src/render/terrain.test.ts
+++ b/src/render/terrain.test.ts
@@ -45,7 +45,7 @@ describe('Terrain', () => {
         terrain._fboCoordsTexture.texture = imageTexture.texture;
         terrain.coordsIndex.push('abcd');
 
-        const coordinate = terrain.pointCoordinate(new Point(0, 0));
+        const coordinate = terrain.pointCoordinate(new Point(0, 0), 1, 0);
 
         expect(coordinate).not.toBeNull();
     });

--- a/src/render/terrain.ts
+++ b/src/render/terrain.ts
@@ -13,7 +13,7 @@ import {Painter} from './painter';
 import {Texture} from '../render/texture';
 import type {Framebuffer} from '../gl/framebuffer';
 import Point from '@mapbox/point-geometry';
-import {MercatorCoordinate} from '../geo/mercator_coordinate';
+import {MercatorCoordinate, lngFromMercatorX, mercatorXfromLng} from '../geo/mercator_coordinate';
 import {TerrainSourceCache} from '../source/terrain_source_cache';
 import {SourceCache} from '../source/source_cache';
 import {EXTENT} from '../data/extent';
@@ -324,9 +324,11 @@ export class Terrain {
     /**
      * Reads a pixel from the coords-framebuffer and translate this to mercator.
      * @param p - Screen-Coordinate
+     * @param width - width of the screen
+     * @param centerLng - longitude at the center of the screen
      * @returns mercator coordinate for a screen pixel
      */
-    pointCoordinate(p: Point): MercatorCoordinate {
+    pointCoordinate(p: Point, width: number, centerLng: number): MercatorCoordinate {
         const rgba = new Uint8Array(4);
         const context = this.painter.context, gl = context.gl;
         // grab coordinate pixel from coordinates framebuffer
@@ -341,8 +343,9 @@ export class Terrain {
         if (!tile) return null;
         const coordsSize = this._coordsTextureSize;
         const worldSize = (1 << tile.tileID.canonical.z) * coordsSize;
+        const mercatorX = (tile.tileID.canonical.x * coordsSize + x) / worldSize;
         return new MercatorCoordinate(
-            (tile.tileID.canonical.x * coordsSize + x) / worldSize,
+            this._allowMercatorOverflow(p, mercatorX, width, centerLng),
             (tile.tileID.canonical.y * coordsSize + y) / worldSize,
             this.getElevation(tile.tileID, x, y, coordsSize)
         );
@@ -440,5 +443,18 @@ export class Terrain {
             mercatorX,
             mercatorY
         };
+    }
+
+    _allowMercatorOverflow(p: Point, mercatorX: number, width: number, centerLng: number): number {
+        const inLeftHalf = p.x < (width / 2);
+        let lng = lngFromMercatorX(mercatorX);
+        if (
+            (inLeftHalf && Math.sign(lng) > 0 && Math.sign(centerLng) < 0) ||
+            (!inLeftHalf && Math.sign(lng) < 0 && Math.sign(centerLng) > 0)
+        ) {
+            lng = 360 * Math.sign(centerLng) + lng;
+            return mercatorXfromLng(lng);
+        }
+        return mercatorX;
     }
 }

--- a/src/render/terrain.ts
+++ b/src/render/terrain.ts
@@ -324,11 +324,9 @@ export class Terrain {
     /**
      * Reads a pixel from the coords-framebuffer and translate this to mercator.
      * @param p - Screen-Coordinate
-     * @param width - width of the screen
-     * @param centerLng - longitude at the center of the screen
      * @returns mercator coordinate for a screen pixel
      */
-    pointCoordinate(p: Point, width: number, centerLng: number): MercatorCoordinate {
+    pointCoordinate(p: Point): MercatorCoordinate {
         const rgba = new Uint8Array(4);
         const context = this.painter.context, gl = context.gl;
         // grab coordinate pixel from coordinates framebuffer
@@ -345,7 +343,7 @@ export class Terrain {
         const worldSize = (1 << tile.tileID.canonical.z) * coordsSize;
         const mercatorX = (tile.tileID.canonical.x * coordsSize + x) / worldSize;
         return new MercatorCoordinate(
-            this._allowMercatorOverflow(p, mercatorX, width, centerLng),
+            this._allowMercatorOverflow(p, mercatorX),
             (tile.tileID.canonical.y * coordsSize + y) / worldSize,
             this.getElevation(tile.tileID, x, y, coordsSize)
         );
@@ -445,9 +443,10 @@ export class Terrain {
         };
     }
 
-    _allowMercatorOverflow(p: Point, mercatorX: number, width: number, centerLng: number): number {
-        const inLeftHalf = p.x < (width / 2);
+    _allowMercatorOverflow(p: Point, mercatorX: number): number {
+        const inLeftHalf = p.x < (this.painter.width / 2);
         let lng = lngFromMercatorX(mercatorX);
+        const centerLng = this.painter.transform.center.lng;
         if (
             (inLeftHalf && Math.sign(lng) > 0 && Math.sign(centerLng) < 0) ||
             (!inLeftHalf && Math.sign(lng) < 0 && Math.sign(centerLng) > 0)

--- a/test/build/min.test.ts
+++ b/test/build/min.test.ts
@@ -36,7 +36,7 @@ describe('test min build', () => {
         const decreaseQuota = 4096;
 
         // feel free to update this value after you've checked that it has changed on purpose :-)
-        const expectedBytes = 761628;
+        const expectedBytes = 761698;
 
         expect(actualBytes - expectedBytes).toBeLessThan(increaseQuota);
         expect(expectedBytes - actualBytes).toBeLessThan(decreaseQuota);

--- a/test/build/min.test.ts
+++ b/test/build/min.test.ts
@@ -36,7 +36,7 @@ describe('test min build', () => {
         const decreaseQuota = 4096;
 
         // feel free to update this value after you've checked that it has changed on purpose :-)
-        const expectedBytes = 761698;
+        const expectedBytes = 761777;
 
         expect(actualBytes - expectedBytes).toBeLessThan(increaseQuota);
         expect(expectedBytes - actualBytes).toBeLessThan(decreaseQuota);


### PR DESCRIPTION
Fixes #3048.

Zoom was incorrect when mouse position and map center were on the opposite sides of 180 meridian. (With terrain 3d enabled).
To solve this, mercator coordinate has to be outside [0,1] range:
a) negative if mouse was on the left of 180
b) >1 if mouse was on the right of 180
(It's how it works in no-3d mode).

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [ ] Add an entry to `CHANGELOG.md` under the `## main` section.
