### PR TITLE
fix: replace missing url of my plugin to newest

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -60,8 +60,8 @@ Adds a control to show a miniature overview of the current map.
 <br/><small>[View on GitHub](https://github.com/aesqe/mapboxgl-minimap)</small>
     
 #### maplibre-gl-temporal-control
-Temporal Controller plugin for MapLibre GL JS. [demo](https://kanahiro.github.io/maplibre-gl-temporal-control/raster.html).
-<br/><small>[View on GitHub](https://github.com/Kanahiro/maplibre-gl-temporal-control)</small>
+Temporal Controller plugin for MapLibre GL JS. [demo](https://mug-jp.github.io/maplibre-gl-temporal-control/raster.html).
+<br/><small>[View on GitHub](https://github.com/mug-jp/maplibre-gl-temporal-control)</small>
     
 #### mapbox-gl-valhalla
 Adds a control to provide isochrone features from valhalla server.


### PR DESCRIPTION
## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [x] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality.
 - [x] Document any changes to public APIs.
 - [x] Post benchmark scores.
 - [x] Add an entry to `CHANGELOG.md` under the `## main` section.


A url of `maplibre-gl-temporal-control` is missing because I've transfered it to organization [mug-jp](https://github.com/mug-jp), then replaced it.