### PR TITLE
Removes manual steps in creating a version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,12 @@
 name: Release
 
 on:
-  workflow_dispatch
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Version to change to.
+        required: true
+        type: string
 
 jobs:
   release:
@@ -22,18 +27,20 @@ jobs:
         with:
           node-version-file: '.nvmrc'
 
-      - name: Get version
-        id: package-version
-        uses: martinbeentjes/npm-get-version-action@v1.3.1
-
-      # - name: Check tag does not exist yet
-      #   run: if git rev-list v${{ steps.package-version.outputs.current-version }}; then echo "Tag already exists. Aborting the release process."; exit 1; fi
-
+      - name: Bump version
+        run: |
+          npm version --commit-hooks false --git-tag-version false ${{ inputs.version }}
+          ./build/bump-version-changelog.js
+          git commit -m "Bump version to ${{ inputs.version }}"
+      - name: Push changes
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }} 
       - name: Tag commit and push
         uses: mathieudutour/github-tag-action@v6.1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          custom_tag: ${{ steps.package-version.outputs.current-version }}
+          custom_tag: ${{ inputs.version }}
 
       - name: Install
         run: npm ci
@@ -41,8 +48,8 @@ jobs:
       - name: Prepare release
         id: prepare_release
         run: |
-          echo "version_tag=v${{ steps.package-version.outputs.current-version }}" >> $GITHUB_OUTPUT
-          RELEASE_TYPE=$(node -e "console.log(require('semver').prerelease('${{ steps.package-version.outputs.current-version }}') ? 'prerelease' : 'regular')")
+          echo "version_tag=v${{ inputs.version }}" >> $GITHUB_OUTPUT
+          RELEASE_TYPE=$(node -e "console.log(require('semver').prerelease('${{ inputs.version }}') ? 'prerelease' : 'regular')")
           echo "release_type=$RELEASE_TYPE" >> $GITHUB_OUTPUT
 
       - name: Build

--- a/build/bump-version-changelog.js
+++ b/build/bump-version-changelog.js
@@ -1,0 +1,26 @@
+#!/usr/bin/env node
+
+/**
+ * This script updates the changelog.md file with the version given in the arguments
+ * It replaces ## main with ## <version>
+ * Removes _...Add new stuff here..._
+ * And adds on top a ## main with add stuff here.
+ */
+
+import * as fs from 'fs';
+
+const changelogPath = 'CHANGELOG.md';
+let changelog = fs.readFileSync(changelogPath, 'utf8');
+changelog = changelog.replace('## main', `## ${process.argv[2]}`);
+changelog = changelog.replaceAll('- _...Add new stuff here..._\n', '');
+changelog = `## main
+
+### ✨ Features and improvements
+- _...Add new stuff here..._
+
+### 🐞 Bug fixes
+- _...Add new stuff here..._
+
+` + changelog;
+
+fs.writeFileSync(changelogPath, changelog, 'utf8');

--- a/developer-guides/release-process.md
+++ b/developer-guides/release-process.md
@@ -2,11 +2,8 @@
 
 1. Review [`CHANGELOG.md`](../CHANGELOG.md)
    - Double-check that all changes included in the release are [appropriately documented](../CONTRIBUTING.md#changelog-conventions).
-   - To-be-released changes should be under a placeholder header. Update that header to the version number which is about to be released. This project uses [semantic versioning](https://docs.npmjs.com/about-semantic-versioning).
+   - To-be-released changes should be under the "main" header.
    - Commit any final changes to the changelog.
-2. Bump the version number with `npm version VERSIONTYPE --no-git-tag-version`
-  - e.g. if making a backwards-compatible release with new features, run `npm version minor --no-git-tag-version`
-  - [`npm version`](https://docs.npmjs.com/cli/commands/npm-version) will increment the version in `package.json` and `package-lock.json`.
-3. Run [`release.yml`](https://github.com/maplibre/maplibre-gl-js/actions/workflows/release.yml) by manual workflow dispatch. This builds the minified library, tags the commit based on the version in `package.json`, creates a GitHub release, uploads release assets, and publishes the build output to NPM.
+2. Run [`release.yml`](https://github.com/maplibre/maplibre-gl-js/actions/workflows/release.yml) by manual workflow dispatch and set the version number in the input. This builds the minified library, tags the commit based on the version in `package.json`, creates a GitHub release, uploads release assets, and publishes the build output to NPM.
 
 The workflow expects `${{ secrets.NPM_ORG_TOKEN }}` organization secret in order to push to NPM registry.


### PR DESCRIPTION
This does the following steps in the release workflow:
1. Add a required input of the version number
2. Updates the changelog and package.json (and lock) files.
3. Commits the changes to main branch
4. Continues with the regular flow of the release.

This removes the need to create a PR with a version bump which is very manual and redundant.

The changelog changes is done in a new script I added as part of this PR.
