### PR TITLE
Use a more popular push and commit GitHub action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,16 +31,11 @@ jobs:
         run: |
           npm version --commit-hooks false --git-tag-version false ${{ inputs.version }}
           ./build/bump-version-changelog.js
-      - name: Commit and push version bump
-        uses: actions-js/push@master
+      - name: Commit and push version bump with a tag
+        uses: stefanzweifel/git-auto-commit-action@v5
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          message: Bump version to ${{ inputs.version }}
-      - name: Tag commit and push
-        uses: mathieudutour/github-tag-action@v6.1
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          custom_tag: ${{ inputs.version }}
+          commit_message: Bump version to ${{ inputs.version }}
+          tagging_message:  ${{ inputs.version }}
 
       - name: Install
         run: npm ci


### PR DESCRIPTION
Uses a more popular GitHub action, also does the tag push in the same action, which makes more sense...
