### PR TITLE
Automate release

### DIFF
--- a/.github/workflows/create-bumb-version-pr.yml
+++ b/.github/workflows/create-bumb-version-pr.yml
@@ -1,0 +1,40 @@
+name: Create bump version PR
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Version to change to.
+        required: true
+        type: string
+
+jobs:
+  bump-version-pr:
+    name: Bump version PR
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    steps:
+
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: main
+
+      - name: Use Node.js from nvmrc
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Bump version
+        run: |
+          npm version --commit-hooks false --git-tag-version false ${{ inputs.version }}
+          ./build/bump-version-changelog.js
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v5
+        with:
+          commit-message: Bump version to ${{ inputs.version }}
+          branch: bump-version-to-${{ inputs.version }}
+          title: Bump version to ${{ inputs.version }}

--- a/.github/workflows/create-bumb-version-pr.yml
+++ b/.github/workflows/create-bumb-version-pr.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Bump version
         run: |
           npm version --commit-hooks false --git-tag-version false ${{ inputs.version }}
-          ./build/bump-version-changelog.js
+          ./build/bump-version-changelog.js ${{ inputs.version }}
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,10 +30,10 @@ jobs:
       - name: Set Continue Flag
         run: echo "run_release=${{ steps.check.outputs.changed }}" >> $GITHUB_OUTPUT
 
-release-publish:
-  needs: release-check
-  if: ${{ needs.release-check.outputs.run_release == 'true' }}
-  runs-on: ubuntu-latest
+  release-publish:
+    needs: release-check
+    if: ${{ needs.release-check.outputs.run_release == 'true' }}
+    runs-on: ubuntu-latest
     defaults:
       run:
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,8 +27,8 @@ jobs:
         id: check
         uses: EndBug/version-check@v2
 
-      - name: Set Continue Flag
-        run: echo "run_release=${{ steps.check.outputs.changed }}" >> $GITHUB_OUTPUT
+    outputs:
+      run_release: ${{ steps.check.outputs.changed }}
 
   release-publish:
     needs: release-check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,22 +1,18 @@
 name: Release
 
 on:
+  push:
+    branches: [main]
   workflow_dispatch:
-    inputs:
-      version:
-        description: Version to change to.
-        required: true
-        type: string
 
 jobs:
-  release:
+  release-check:
     name: Release
     runs-on: ubuntu-latest
     defaults:
       run:
         shell: bash
     steps:
-
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
@@ -27,15 +23,40 @@ jobs:
         with:
           node-version-file: '.nvmrc'
 
-      - name: Bump version
-        run: |
-          npm version --commit-hooks false --git-tag-version false ${{ inputs.version }}
-          ./build/bump-version-changelog.js
-      - name: Commit and push version bump with a tag
-        uses: stefanzweifel/git-auto-commit-action@v5
+      - name: Check if version changed
+        id: check
+        uses: EndBug/version-check@v2
+
+      - name: Set Continue Flag
+        run: echo "run_release=${{ steps.check.outputs.changed }}" >> $GITHUB_OUTPUT
+
+release-publish:
+  needs: release-check
+  if: ${{ needs.release-check.outputs.run_release == 'true' }}
+  runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v4
         with:
-          commit_message: Bump version to ${{ inputs.version }}
-          tagging_message:  ${{ inputs.version }}
+          fetch-depth: 0
+          ref: main
+
+      - name: Use Node.js from nvmrc
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Get version
+        id: package-version
+        uses: martinbeentjes/npm-get-version-action@v1.3.1
+
+      - name: Tag commit and push
+        uses: mathieudutour/github-tag-action@v6.1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          custom_tag: ${{ steps.package-version.outputs.current-version }}
 
       - name: Install
         run: npm ci
@@ -43,8 +64,8 @@ jobs:
       - name: Prepare release
         id: prepare_release
         run: |
-          echo "version_tag=v${{ inputs.version }}" >> $GITHUB_OUTPUT
-          RELEASE_TYPE=$(node -e "console.log(require('semver').prerelease('${{ inputs.version }}') ? 'prerelease' : 'regular')")
+          echo "version_tag=v${{ steps.package-version.outputs.current-version }}" >> $GITHUB_OUTPUT
+          RELEASE_TYPE=$(node -e "console.log(require('semver').prerelease('${{ steps.package-version.outputs.current-version }}') ? 'prerelease' : 'regular')")
           echo "release_type=$RELEASE_TYPE" >> $GITHUB_OUTPUT
 
       - name: Build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   release-check:
-    name: Release
+    name: Check if version changed
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -31,6 +31,7 @@ jobs:
       run_release: ${{ steps.check.outputs.changed }}
 
   release-publish:
+    name: Publish to NPM and GitHub
     needs: release-check
     if: ${{ needs.release-check.outputs.run_release == 'true' }}
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,12 +28,12 @@ jobs:
         uses: EndBug/version-check@v2
 
     outputs:
-      run_release: ${{ steps.check.outputs.changed }}
+      publish: ${{ steps.check.outputs.changed }}
 
   release-publish:
     name: Publish to NPM and GitHub
     needs: release-check
-    if: ${{ needs.release-check.outputs.run_release == 'true' }}
+    if: ${{ needs.release-check.outputs.publish == 'true' }}
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/developer-guides/release-process.md
+++ b/developer-guides/release-process.md
@@ -4,6 +4,7 @@
    - Double-check that all changes included in the release are [appropriately documented](../CONTRIBUTING.md#changelog-conventions).
    - To-be-released changes should be under the "main" header.
    - Commit any final changes to the changelog.
-2. Run [`release.yml`](https://github.com/maplibre/maplibre-gl-js/actions/workflows/release.yml) by manual workflow dispatch and set the version number in the input. This builds the minified library, tags the commit based on the version in `package.json`, creates a GitHub release, uploads release assets, and publishes the build output to NPM.
+2. Run [Create bump version PR](https://github.com/maplibre/maplibre-gl-js/actions/workflows/create-bump-version-pr.yml) by manual workflow dispatch and set the version number in the input. This will create a PR that changes the changelog and `package.json` file to review and merge.
+3. Once merged the release action will automatically see that the version was changed and creates a GitHub release, uploads release assets, and publishes the build output to NPM.
 
 The workflow expects `${{ secrets.NPM_ORG_TOKEN }}` organization secret in order to push to NPM registry.


### PR DESCRIPTION
This changes the release process to do the following steps:
1. Allow creating a bump version PR from the workflows manual run menu, allowing to set the version number.
2. Checks every commit to see if the `package.json` file had changed, if so, it will publish a version to npm and github automatically.

I tried to do it in one step but there are problems with permissions etc and I didn't want to create a PAT just for this.
While it's not ideal, we'll be able to push version more easily now. 
