### PR TITLE
Revert release.yml to original version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,44 +1,17 @@
 name: Release
 
 on:
-  push:
-    branches: [main]
-  workflow_dispatch:
+  workflow_dispatch
 
 jobs:
-  release-check:
-    name: Check if version changed
+  release:
+    name: Release
     runs-on: ubuntu-latest
     defaults:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          ref: main
 
-      - name: Use Node.js from nvmrc
-        uses: actions/setup-node@v4
-        with:
-          node-version-file: '.nvmrc'
-
-      - name: Check if version changed
-        id: check
-        uses: EndBug/version-check@v2
-
-    outputs:
-      publish: ${{ steps.check.outputs.changed }}
-
-  release-publish:
-    name: Publish to NPM and GitHub
-    needs: release-check
-    if: ${{ needs.release-check.outputs.publish == 'true' }}
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        shell: bash
-    steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0

--- a/developer-guides/release-process.md
+++ b/developer-guides/release-process.md
@@ -5,6 +5,6 @@
    - To-be-released changes should be under the "main" header.
    - Commit any final changes to the changelog.
 2. Run [Create bump version PR](https://github.com/maplibre/maplibre-gl-js/actions/workflows/create-bump-version-pr.yml) by manual workflow dispatch and set the version number in the input. This will create a PR that changes the changelog and `package.json` file to review and merge.
-3. Once merged the release action will automatically see that the version was changed and creates a GitHub release, uploads release assets, and publishes the build output to NPM.
+3. Once merged the you'll need to manually start the Release workflow, this action will creates a GitHub release, uploads release assets, and publishes the build output to NPM.
 
 The workflow expects `${{ secrets.NPM_ORG_TOKEN }}` organization secret in order to push to NPM registry.


### PR DESCRIPTION
Seems like GitHub Actions workflow runner doesn't have the right permissions to use org level secrets, so this needs to be manual again to have the right permissions, unfortunately...
I've updated the workflow and the relevant readme.