### PR TITLE
Add registry url to allow publishing npm package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
+          registry-url: 'https://registry.npmjs.org'
 
       - name: Get version
         id: package-version


### PR DESCRIPTION
Hopefully this would solve the issue.
If now, I can try and revert to the previous definition of the node version, it might help, IDK...

Based on this:
https://github.com/npm/cli/issues/6184#issuecomment-1544496444