### PR TITLE
Allow release to run on every commit to main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,11 +1,39 @@
 name: Release
 
 on:
-  workflow_dispatch
+  push:
+    branches: [main]
+  workflow_dispatch:
 
 jobs:
+  release-check:
+    name: Check if version changed
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: main
+
+      - name: Use Node.js from nvmrc
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Check if version changed
+        id: check
+        uses: EndBug/version-check@v2
+
+    outputs:
+      publish: ${{ steps.check.outputs.changed }}
+
   release:
     name: Release
+    needs: release-check
+    if: ${{ needs.release-check.outputs.publish == 'true' }}
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -33,7 +61,6 @@ jobs:
       - name: Prepare release
         id: prepare_release
         run: |
-          echo "version_tag=v${{ steps.package-version.outputs.current-version }}" >> $GITHUB_OUTPUT
           RELEASE_TYPE=$(node -e "console.log(require('semver').prerelease('${{ steps.package-version.outputs.current-version }}') ? 'prerelease' : 'regular')")
           echo "release_type=$RELEASE_TYPE" >> $GITHUB_OUTPUT
 
@@ -61,6 +88,7 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_ORG_TOKEN }}
 
       - name: Tag commit and push
+        id: tag_version
         uses: mathieudutour/github-tag-action@v6.1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -85,8 +113,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag: ${{ steps.prepare_release.outputs.version_tag }}
-          name: ${{steps.prepare_release.outputs.version_tag }}
+          tag: ${{ steps.tag_version.outputs.new_tag }}
+          name: ${{ steps.tag_version.outputs.new_tag }}
           bodyFile: ${{ steps.release_notes.outputs.release_notes }}
           artifacts: "dist.zip"
           artifactContentType: "application/zip"
@@ -101,8 +129,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ steps.prepare_release.outputs.version_tag }}
-          release_name: ${{steps.prepare_release.outputs.version_tag }}
+          tag_name: ${{ steps.tag_version.outputs.new_tag }}
+          release_name: ${{ steps.tag_version.outputs.new_tag }}
           draft: false
           prerelease: true
 
@@ -128,8 +156,8 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: tmp
-          destination_dir: benchmarks/${{ steps.prepare_release.outputs.version_tag }}
-          commit_message: 'deploy: ${{ steps.prepare_release.outputs.version_tag }}'
+          destination_dir: benchmarks/${{ steps.tag_version.outputs.new_tag }}
+          commit_message: 'deploy: ${{ steps.tag_version.outputs.new_tag }}'
 
       - name: Build the Docs
         run: |
@@ -143,4 +171,4 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: site
           destination_dir: docs
-          commit_message: 'deploy docs: ${{ steps.prepare_release.outputs.version_tag }}'
+          commit_message: 'deploy docs: ${{ steps.tag_version.outputs.new_tag }}'

--- a/developer-guides/release-process.md
+++ b/developer-guides/release-process.md
@@ -5,6 +5,6 @@
    - To-be-released changes should be under the "main" header.
    - Commit any final changes to the changelog.
 2. Run [Create bump version PR](https://github.com/maplibre/maplibre-gl-js/actions/workflows/create-bump-version-pr.yml) by manual workflow dispatch and set the version number in the input. This will create a PR that changes the changelog and `package.json` file to review and merge.
-3. Once merged the you'll need to manually start the Release workflow, this action will creates a GitHub release, uploads release assets, and publishes the build output to NPM.
+3. Once merged, an automatic process will kick in and creates a GitHub release, uploads release assets, and publishes the build output to NPM.
 
 The workflow expects `${{ secrets.NPM_ORG_TOKEN }}` organization secret in order to push to NPM registry.


### PR DESCRIPTION
This allows the release to run on main every time there's a push.
It will check if the current version is the same, if not, it will publish a release to npm and all the other release stuff.
I've tested this to work on ngx-maplibre-gl, so I'm confidant that this is possible now.
