### PR TITLE
Async actor remove cancelables

### DIFF
--- a/src/source/geojson_worker_source.test.ts
+++ b/src/source/geojson_worker_source.test.ts
@@ -25,12 +25,7 @@ describe('reloadTile', () => {
         ] as LayerSpecification[];
         const layerIndex = new StyleLayerIndex(layers);
         const source = new GeoJSONWorkerSource(actor, layerIndex, []);
-        const originalLoadVectorData = source.loadVectorTile;
-        let loadVectorCallCount = 0;
-        source.loadVectorTile = function(params, callback) {
-            loadVectorCallCount++;
-            return originalLoadVectorData.call(this, params, callback);
-        };
+        const spy = jest.spyOn(source, 'loadVectorTile');
         const geoJson = {
             'type': 'Feature',
             'geometry': {
@@ -49,7 +44,7 @@ describe('reloadTile', () => {
 
         // first call should load vector data from geojson
         const firstData = await source.reloadTile(tileParams as any as WorkerTileParameters);
-        expect(loadVectorCallCount).toBe(1);
+        expect(spy).toHaveBeenCalledTimes(1);
 
         // second call won't give us new rawTileData
         let data = await source.reloadTile(tileParams as any as WorkerTileParameters);
@@ -58,7 +53,7 @@ describe('reloadTile', () => {
         expect(data).toEqual(firstData);
 
         // also shouldn't call loadVectorData again
-        expect(loadVectorCallCount).toBe(1);
+        expect(spy).toHaveBeenCalledTimes(1);
 
         // replace geojson data
         await source.loadData({source: 'sourceId', data: JSON.stringify(geoJson)} as LoadGeoJSONParameters);
@@ -67,7 +62,7 @@ describe('reloadTile', () => {
         data = await source.reloadTile(tileParams as any as WorkerTileParameters);
         expect('rawTileData' in data).toBeTruthy();
         expect(data).toEqual(firstData);
-        expect(loadVectorCallCount).toBe(2);
+        expect(spy).toHaveBeenCalledTimes(2);
     });
 
 });

--- a/src/source/vector_tile_worker_source.ts
+++ b/src/source/vector_tile_worker_source.ts
@@ -15,7 +15,6 @@ import type {
 
 import type {IActor} from '../util/actor';
 import type {StyleLayerIndex} from '../style/style_layer_index';
-import type {Callback} from '../types/callback';
 import type {VectorTile} from '@mapbox/vector-tile';
 
 export type LoadVectorTileResult = {

--- a/src/source/vector_tile_worker_source.ts
+++ b/src/source/vector_tile_worker_source.ts
@@ -30,11 +30,6 @@ type FetchingState = {
     resourceTiming: any;
 }
 
-/**
- * The callback when finished loading vector data
- */
-export type LoadVectorDataCallback = Callback<LoadVectorTileResult>;
-
 export type AbortVectorData = () => void;
 export type LoadVectorData = (params: WorkerTileParameters, abortController: AbortController) => Promise<LoadVectorTileResult | null>;
 

--- a/src/source/video_source.ts
+++ b/src/source/video_source.ts
@@ -75,26 +75,27 @@ export class VideoSource extends ImageSource {
             this.urls.push(this.map._requestManager.transformRequest(url, ResourceType.Source).url);
         }
 
-        getVideo(this.urls, (err, video) => {
+        getVideo(this.urls).then((video) => {
             this._loaded = true;
-            if (err) {
-                this.fire(new ErrorEvent(err));
-            } else if (video) {
-                this.video = video;
-                this.video.loop = true;
-
-                // Start repainting when video starts playing. hasTransition() will then return
-                // true to trigger additional frames as long as the videos continues playing.
-                this.video.addEventListener('playing', () => {
-                    this.map.triggerRepaint();
-                });
-
-                if (this.map) {
-                    this.video.play();
-                }
-
-                this._finishLoading();
+            if (!video) {
+                return;
             }
+            this.video = video;
+            this.video.loop = true;
+
+            // Start repainting when video starts playing. hasTransition() will then return
+            // true to trigger additional frames as long as the videos continues playing.
+            this.video.addEventListener('playing', () => {
+                this.map.triggerRepaint();
+            });
+
+            if (this.map) {
+                this.video.play();
+            }
+
+            this._finishLoading();
+        }).catch((err) => {
+            this.fire(new ErrorEvent(err));
         });
     };
 

--- a/src/ui/map.test.ts
+++ b/src/ui/map.test.ts
@@ -554,39 +554,42 @@ describe('Map', () => {
 
     describe('#is_Loaded', () => {
 
-        test('Map#isSourceLoaded', done => {
+        test('Map#isSourceLoaded', async () => {
             const style = createStyle();
             const map = createMap({style});
 
-            map.on('load', () => {
+            await map.once('load');
+            const promise = new Promise<void>((resolve) => {
                 map.on('data', (e) => {
                     if (e.dataType === 'source' && e.sourceDataType === 'idle') {
                         expect(map.isSourceLoaded('geojson')).toBe(true);
-                        done();
+                        resolve();
                     }
                 });
-                map.addSource('geojson', createStyleSource());
-                expect(map.isSourceLoaded('geojson')).toBe(false);
             });
+            map.addSource('geojson', createStyleSource());
+            expect(map.isSourceLoaded('geojson')).toBe(false);
+            await promise;
         });
 
-        test('Map#isSourceLoaded (equivalent to event.isSourceLoaded)', done => {
+        test('Map#isSourceLoaded (equivalent to event.isSourceLoaded)', async () => {
             const style = createStyle();
             const map = createMap({style});
 
-            map.on('load', () => {
-                map.on('data', (e) => {
+            await map.once('load')
+            const promise = new Promise<void>((resolve) => {
+                map.on('data', (e: MapSourceDataEvent) => {
                     if (e.dataType === 'source' && 'source' in e) {
-                        const sourceDataEvent = e as MapSourceDataEvent;
-                        expect(map.isSourceLoaded('geojson')).toBe(sourceDataEvent.isSourceLoaded);
-                        if (sourceDataEvent.sourceDataType === 'idle') {
-                            done();
+                        expect(map.isSourceLoaded('geojson')).toBe(e.isSourceLoaded);
+                        if (e.sourceDataType === 'idle') {
+                            resolve();
                         }
                     }
                 });
-                map.addSource('geojson', createStyleSource());
-                expect(map.isSourceLoaded('geojson')).toBe(false);
             });
+            map.addSource('geojson', createStyleSource());
+            expect(map.isSourceLoaded('geojson')).toBe(false);
+            await promise;
         });
 
         test('Map#isStyleLoaded', done => {

--- a/src/ui/map.test.ts
+++ b/src/ui/map.test.ts
@@ -576,7 +576,7 @@ describe('Map', () => {
             const style = createStyle();
             const map = createMap({style});
 
-            await map.once('load')
+            await map.once('load');
             const promise = new Promise<void>((resolve) => {
                 map.on('data', (e: MapSourceDataEvent) => {
                     if (e.dataType === 'source' && 'source' in e) {

--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -3329,7 +3329,7 @@ export class Map extends Camera {
                 PerformanceUtils.frame(paintStartTimeStamp);
                 this._frameRequest = null;
                 this._render(paintStartTimeStamp);
-            }).catch(()=> {}); // ignore abort error
+            }).catch(() => {}); // ignore abort error
         }
     }
 

--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -49,7 +49,6 @@ import type {DoubleClickZoomHandler} from './handler/shim/dblclick_zoom';
 import type {TwoFingersTouchZoomRotateHandler} from './handler/shim/two_fingers_touch';
 import {defaultLocale} from './default_locale';
 import type {TaskID} from '../util/task_queue';
-import type {Cancelable} from '../types/cancelable';
 import type {
     FilterSpecification,
     StyleSpecification,
@@ -468,7 +467,7 @@ export class Map extends Camera {
     _canvas: HTMLCanvasElement;
     _maxTileCacheSize: number;
     _maxTileCacheZoomLevels: number;
-    _frame: Cancelable;
+    _frameRequest: AbortController;
     _styleDirty: boolean;
     _sourcesDirty: boolean;
     _placementDirty: boolean;
@@ -3040,9 +3039,9 @@ export class Map extends Camera {
 
     _contextLost = (event: any) => {
         event.preventDefault();
-        if (this._frame) {
-            this._frame.cancel();
-            this._frame = null;
+        if (this._frameRequest) {
+            this._frameRequest.abort();
+            this._frameRequest = null;
         }
         this.fire(new Event('webglcontextlost', {originalEvent: event}));
     };
@@ -3255,9 +3254,9 @@ export class Map extends Camera {
     redraw(): this {
         if (this.style) {
             // cancel the scheduled update
-            if (this._frame) {
-                this._frame.cancel();
-                this._frame = null;
+            if (this._frameRequest) {
+                this._frameRequest.abort();
+                this._frameRequest = null;
             }
             this._render(0);
         }
@@ -3279,9 +3278,9 @@ export class Map extends Camera {
         for (const control of this._controls) control.onRemove(this);
         this._controls = [];
 
-        if (this._frame) {
-            this._frame.cancel();
-            this._frame = null;
+        if (this._frameRequest) {
+            this._frameRequest.abort();
+            this._frameRequest = null;
         }
         this._renderTaskQueue.clear();
         this.painter.destroy();
@@ -3324,12 +3323,13 @@ export class Map extends Camera {
      * @see [Add an animated icon to the map](https://maplibre.org/maplibre-gl-js/docs/examples/add-image-animated/)
      */
     triggerRepaint() {
-        if (this.style && !this._frame) {
-            this._frame = browser.frame((paintStartTimeStamp: number) => {
+        if (this.style && !this._frameRequest) {
+            this._frameRequest = new AbortController();
+            browser.frameAsync(this._frameRequest).then((paintStartTimeStamp: number) => {
                 PerformanceUtils.frame(paintStartTimeStamp);
-                this._frame = null;
+                this._frameRequest = null;
                 this._render(paintStartTimeStamp);
-            });
+            }).catch(()=> {}); // ignore abort error
         }
     }
 

--- a/src/util/ajax.ts
+++ b/src/util/ajax.ts
@@ -2,7 +2,6 @@ import {extend, isWorker} from './util';
 import {config} from './config';
 import {createAbortError} from './abort_error';
 
-import type {Callback} from '../types/callback';
 import type {Cancelable} from '../types/cancelable';
 
 /**
@@ -44,7 +43,7 @@ export type RequestParameters = {
      */
     body?: string;
     /**
-     * Response body type to be returned `'string' | 'json' | 'arrayBuffer'`.
+     * Response body type to be returned.
      */
     type?: 'string' | 'json' | 'arrayBuffer' | 'image';
     /**
@@ -302,7 +301,7 @@ export const getVideo = (urls: Array<string>): Promise<HTMLVideoElement> => {
         video.onloadstart = () => {
             resolve(video);
         };
-        for (let url of urls) {
+        for (const url of urls) {
             const s: HTMLSourceElement = window.document.createElement('source');
             if (!sameOrigin(url)) {
                 video.crossOrigin = 'Anonymous';

--- a/src/util/ajax.ts
+++ b/src/util/ajax.ts
@@ -295,19 +295,20 @@ export function sameOrigin(inComingUrl: string) {
     return urlObj.protocol === locationObj.protocol && urlObj.host === locationObj.host;
 }
 
-export const getVideo = function(urls: Array<string>, callback: Callback<HTMLVideoElement>): Cancelable {
+export const getVideo = (urls: Array<string>): Promise<HTMLVideoElement> => {
     const video: HTMLVideoElement = window.document.createElement('video');
     video.muted = true;
-    video.onloadstart = function() {
-        callback(null, video);
-    };
-    for (let i = 0; i < urls.length; i++) {
-        const s: HTMLSourceElement = window.document.createElement('source');
-        if (!sameOrigin(urls[i])) {
-            video.crossOrigin = 'Anonymous';
+    return new Promise((resolve) => {
+        video.onloadstart = () => {
+            resolve(video);
+        };
+        for (let url of urls) {
+            const s: HTMLSourceElement = window.document.createElement('source');
+            if (!sameOrigin(url)) {
+                video.crossOrigin = 'Anonymous';
+            }
+            s.src = url;
+            video.appendChild(s);
         }
-        s.src = urls[i];
-        video.appendChild(s);
-    }
-    return {cancel: () => {}};
+    });
 };

--- a/test/bench/lib/create_map.ts
+++ b/test/bench/lib/create_map.ts
@@ -27,9 +27,9 @@ const createMap = (options: any): Promise<Map> => {
             .on(options.idle ? 'idle' : 'load', () => {
                 if (options.stubRender) {
                     // If there's a pending rerender, cancel it.
-                    if (map._frame) {
-                        map._frame.cancel();
-                        map._frame = null;
+                    if (map._frameRequest) {
+                        map._frameRequest.abort();
+                        map._frameRequest = null;
                     }
                 }
                 resolve(map);


### PR DESCRIPTION
Removes more places that use cancelable in favor of abort controller.
Changes getVideo to return a promise instead of callback/cancelable.
Improve usage in async in tests and added a spy.
