### PR TITLE
Fix the canvas-source example

### DIFF
--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -103,7 +103,7 @@ export type MapOptions = {
      */
     attributionControl?: boolean;
     /**
-     * Attribuition text to show in an {@link AttributionControl}. Only applicable if `options.attributionControl` is `true`.
+     * Attribution text to show in an {@link AttributionControl}. Only applicable if `options.attributionControl` is `true`.
      */
     customAttribution?: string | Array<string>;
     /**

--- a/test/examples/canvas-source.html
+++ b/test/examples/canvas-source.html
@@ -19,6 +19,7 @@
     //Animation from https://javascript.tutorials24x7.com/blog/how-to-draw-animated-circles-in-html5-canvas
     const canvas = document.getElementById('canvasID');
     const ctx = canvas.getContext('2d');
+    canvas.style.display = 'none';
     const circles = [];
     const radius = 20;
 


### PR DESCRIPTION
The following example looks broken, at least on Firefox. This PR fixes it.
https://maplibre.org/maplibre-gl-js/docs/examples/canvas-source/

Before
![image](https://github.com/maplibre/maplibre-gl-js/assets/242172/590520ba-d232-4829-8b00-51ba47dd3444)

After
![image](https://github.com/maplibre/maplibre-gl-js/assets/242172/d06f4a73-b2b9-4fca-a999-741e62cbb8dd)
