### PR TITLE
Fix issue with pre-release check in CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,7 @@ jobs:
           else
             echo "changed=true" >> $GITHUB_OUTPUT
           fi
+          
     outputs:
       publish: ${{ steps.check.outputs.changed }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,8 +25,14 @@ jobs:
 
       - name: Check if version changed
         id: check
-        uses: EndBug/version-check@v2
-
+        run: |
+          latestNpmPackageVersion=$( npm view maplibre-gl version )
+          currentVersion=$( node -e "console.log(require('./package.json').version)" )
+          if [ "$latestNpmPackageVersion" == "$currentVersion" ]; then
+            echo "changed=false" >> $GITHUB_OUTPUT
+          else
+            echo "changed=true" >> $GITHUB_OUTPUT
+          fi
     outputs:
       publish: ${{ steps.check.outputs.changed }}
 


### PR DESCRIPTION
 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 
Last pre-release (4.0.0-pre.1) was not published to npm due to an issue with the action.
I have removed the action and written the code instead.

Relevant issue:
https://github.com/EndBug/version-check/issues/158