### PR TITLE
Fix zoom on side globes with terrain 3D

### DIFF
--- a/src/render/terrain.ts
+++ b/src/render/terrain.ts
@@ -13,7 +13,7 @@ import {Painter} from './painter';
 import {Texture} from '../render/texture';
 import type {Framebuffer} from '../gl/framebuffer';
 import Point from '@mapbox/point-geometry';
-import {MercatorCoordinate, lngFromMercatorX, mercatorXfromLng} from '../geo/mercator_coordinate';
+import {MercatorCoordinate} from '../geo/mercator_coordinate';
 import {TerrainSourceCache} from '../source/terrain_source_cache';
 import {SourceCache} from '../source/source_cache';
 import {EXTENT} from '../data/extent';
@@ -341,9 +341,8 @@ export class Terrain {
         if (!tile) return null;
         const coordsSize = this._coordsTextureSize;
         const worldSize = (1 << tile.tileID.canonical.z) * coordsSize;
-        const mercatorX = (tile.tileID.canonical.x * coordsSize + x) / worldSize;
         return new MercatorCoordinate(
-            this._allowMercatorOverflow(p, mercatorX),
+            (tile.tileID.canonical.x * coordsSize + x) / worldSize + tile.tileID.wrap,
             (tile.tileID.canonical.y * coordsSize + y) / worldSize,
             this.getElevation(tile.tileID, x, y, coordsSize)
         );
@@ -441,19 +440,5 @@ export class Terrain {
             mercatorX,
             mercatorY
         };
-    }
-
-    _allowMercatorOverflow(p: Point, mercatorX: number): number {
-        const inLeftHalf = p.x < (this.painter.width / 2);
-        let lng = lngFromMercatorX(mercatorX);
-        const centerLng = this.painter.transform.center.lng;
-        if (
-            (inLeftHalf && Math.sign(lng) > 0 && Math.sign(centerLng) < 0) ||
-            (!inLeftHalf && Math.sign(lng) < 0 && Math.sign(centerLng) > 0)
-        ) {
-            lng = 360 * Math.sign(centerLng) + lng;
-            return mercatorXfromLng(lng);
-        }
-        return mercatorX;
     }
 }


### PR DESCRIPTION
Fixes #3048 (again).

Unfortunately my first solution (https://github.com/maplibre/maplibre-gl-js/commit/f99ad8c5f818291a1cfa067a5ded8b010dc983f0) wasn't great because:
1) it was too complex (I've found a simpler one)
2) it didn't solve the problem completely. The issue was still reproducible when more than one full globe was visible horizontally.

In the end the entire solution is in one line src/render/terrain.ts:345

## Launch Checklist

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [ ] Add an entry to `CHANGELOG.md` under the `## main` section.
