### PR TITLE
Handle loading of empty raster tiles (204 No Content)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### 🐞 Bug fixes
 - Fix zooming outside the central globe when terrain 3D is enabled ([#3425](https://github.com/maplibre/maplibre-gl-js/pull/3425))
+- Handle loading of empty raster tiles (204 No Content) ([#3428](https://github.com/maplibre/maplibre-gl-js/pull/3428))
 - _...Add new stuff here..._
 
 ## 4.0.0-pre.1

--- a/src/util/image_request.ts
+++ b/src/util/image_request.ts
@@ -133,7 +133,7 @@ export namespace ImageRequest {
 
     const arrayBufferToCanvasImageSource = (data: ArrayBuffer): Promise<HTMLImageElement | ImageBitmap | null> => {
         const imageBitmapSupported = typeof createImageBitmap === 'function';
-        if (imageBitmapSupported && data.byteLength) {
+        if (imageBitmapSupported) {
             return arrayBufferToImageBitmap(data);
         } else {
             return arrayBufferToImage(data);

--- a/src/util/image_request.ts
+++ b/src/util/image_request.ts
@@ -133,7 +133,7 @@ export namespace ImageRequest {
 
     const arrayBufferToCanvasImageSource = (data: ArrayBuffer): Promise<HTMLImageElement | ImageBitmap | null> => {
         const imageBitmapSupported = typeof createImageBitmap === 'function';
-        if (imageBitmapSupported) {
+        if (imageBitmapSupported && data.byteLength) {
             return arrayBufferToImageBitmap(data);
         } else {
             return arrayBufferToImage(data);

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -457,6 +457,9 @@ export function isImageBitmap(image: any): image is ImageBitmap {
  * @returns - A  promise resolved when the conversion is finished
  */
 export const arrayBufferToImageBitmap = async (data: ArrayBuffer): Promise<ImageBitmap> => {
+    if (data.byteLength === 0) {
+        return createImageBitmap(new ImageData(1, 1));
+    }
     const blob: Blob = new Blob([new Uint8Array(data)], {type: 'image/png'});
     try {
         return createImageBitmap(blob);


### PR DESCRIPTION
This PR tries to solve the issue of multiple errors in case of loading raster tiles from server responding 204s with no content.

Related to #160 and #1586, but a different approach.

There are currently two ways of loading the image data (ArrayBuffer):
- `arrayBufferToImage` ("legacy" way which uses `Image` under the hood) 
- the newer `arrayBufferToImageBitmap` (which requires [createImageBitmap](https://developer.mozilla.org/en-US/docs/Web/API/createImageBitmap)).

The legacy path has [always](https://github.com/maplibre/maplibre-gl-js/commit/f183b416b152868c2f787dbfa78f173fccfadb78#diff-bb4eb119021870bc4f2e7fcd6b535235bad4b6316c2d23ff218b5f5f2614fbabR67) been able to handle 204s correctly by load a transparent image instead: https://github.com/maplibre/maplibre-gl-js/blob/859b1a7c1d88a111031f3938f1c329604120f1e0/src/util/util.ts#L494

There is no such check for the `ImageBitmap` version and it just fails with an error (it's not as easy to mock the transparent image here).

This PR adds a simple check so that empty ArrayBuffers (= 204 no content responses) always use the legacy path.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [x] Add an entry to `CHANGELOG.md` under the `## main` section.
