### PR TITLE
Improve `extend` typings

### DIFF
--- a/src/source/geojson_source.ts
+++ b/src/source/geojson_source.ts
@@ -17,6 +17,7 @@ import type {GeoJSONWorkerOptions, LoadGeoJSONParameters} from './geojson_worker
 export type GeoJSONSourceOptions = GeoJSONSourceSpecification & {
     workerOptions?: GeoJSONWorkerOptions;
     collectResourceTiming?: boolean;
+    data: GeoJSON.GeoJSON | string;
 }
 
 export type GeoJsonSourceOptions = {
@@ -312,7 +313,7 @@ export class GeoJSONSource extends Evented implements Source {
      * @param diff - the diff object
      */
     async _updateWorkerData(diff?: GeoJSONSourceDiff) {
-        const options: LoadGeoJSONParameters = extend({}, this.workerOptions);
+        const options: LoadGeoJSONParameters = extend({type: this.type}, this.workerOptions);
         if (diff) {
             options.dataDiff = diff;
         } else if (typeof this._data === 'string') {
@@ -321,7 +322,6 @@ export class GeoJSONSource extends Evented implements Source {
         } else {
             options.data = JSON.stringify(this._data);
         }
-        options.type = this.type;
         this._pendingLoads++;
         this.fire(new Event('dataloading', {dataType: 'source'}));
         try {

--- a/src/style/light.ts
+++ b/src/style/light.ts
@@ -1,6 +1,6 @@
 import {interpolates, Color, latest as styleSpec} from '@maplibre/maplibre-gl-style-spec';
 
-import {extend, sphericalToCartesian} from '../util/util';
+import {sphericalToCartesian} from '../util/util';
 import {Evented} from '../util/evented';
 import {
     validateStyle,

--- a/src/style/light.ts
+++ b/src/style/light.ts
@@ -125,11 +125,11 @@ export class Light extends Evented {
             return false;
         }
 
-        return emitValidationErrors(this, validate.call(validateStyle, extend({
+        return emitValidationErrors(this, validate.call(validateStyle, {
             value,
             // Workaround for https://github.com/mapbox/mapbox-gl-js/issues/2407
             style: {glyphs: true, sprite: true},
             styleSpec
-        })));
+        }));
     }
 }

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -93,7 +93,11 @@ export function keysDifference<S, T>(
  * @param dest - destination object
  * @param sources - sources from which properties are pulled
  */
-export function extend(dest: any, ...sources: Array<any>): any {
+export function extend<T extends {}, U>(dest: T, source: U): T & U;
+export function extend<T extends {}, U, V>(dest: T, source1: U, source2: V): T & U & V;
+export function extend<T extends {}, U, V, W>(dest: T, source1: U, source2: V, source3: W): T & U & V & W;
+export function extend(dest: object, ...sources: Array<any>): any;
+export function extend(dest: object, ...sources: Array<any>): any {
     for (const src of sources) {
         for (const k in src) {
             dest[k] = src[k];


### PR DESCRIPTION
This adds proper typings to the `extend` method.
To be honest, I'm not sure if this method is the same as `Object.assign`, so I'm not sure it's actually needed.

But, just in case it's not, I improved the typings on it.