### PR TITLE
Fix popup.trackPointer pointer cursor bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### 🐞 Bug fixes
 - Fix zooming outside the central globe when terrain 3D is enabled ([#3425](https://github.com/maplibre/maplibre-gl-js/pull/3425))
+- Fix cursor being shown indefinitely as a pointer when removing a popup with its `trackPointer` method active ([#3434](https://github.com/maplibre/maplibre-gl-js/pull/3434))
 - _...Add new stuff here..._
 
 ## 4.0.0-pre.1

--- a/src/ui/popup.test.ts
+++ b/src/ui/popup.test.ts
@@ -602,6 +602,22 @@ describe('popup', () => {
         expect(
             popup._container.classList.value
         ).not.toContain('maplibregl-popup-track-pointer');
+        expect(
+            map._canvasContainer.classList.value
+        ).not.toContain('maplibregl-track-pointer');
+    });
+
+    test('Pointer-tracked popup calling Popup#remove removes track-pointer class from map (#3434)', () => {
+        const map = createMap();
+        new Popup()
+            .setText('Test')
+            .trackPointer()
+            .addTo(map)
+            .remove();
+
+        expect(
+            map._canvasContainer.classList.value
+        ).not.toContain('maplibregl-track-pointer');
     });
 
     test('Positioned popup lacks pointer-tracking class', () => {

--- a/src/ui/popup.ts
+++ b/src/ui/popup.ts
@@ -246,6 +246,7 @@ export class Popup extends Evented {
             this._map.off('mousemove', this._onMouseMove);
             this._map.off('mouseup', this._onMouseUp);
             this._map.off('drag', this._onDrag);
+            this._map._canvasContainer.classList.remove('maplibregl-track-pointer');
             delete this._map;
         }
 


### PR DESCRIPTION
Fixes #3405

### Bug description
The ".maplibregl-track-pointer" CSS class get's added to the map when a popup uses its `trackPointer` method. This makes sure the map displays a pointer cursor. The issue is that when you disable the popup using its `remove` method it doesn't remove this CSS class from the map causing the cursor to be shown as a pointer indefinitely.

### Changes
When using a popup's `remove` method it will make sure to remove the ".maplibregl-track-pointer" CSS class from the map.

Before:
<img src="https://github.com/maplibre/maplibre-gl-js/assets/9056487/b89e6f72-4338-4043-92a2-1d9a1c55ee17" width="300">

After:
<img src="https://github.com/maplibre/maplibre-gl-js/assets/9056487/cd6cc12b-7fb5-4cb4-a3b4-8f6c3e7c3fa0" width="300">

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [x] Include before/after visuals or gifs if this PR includes visual changes.
 - [x]  Write tests for all new functionality.
 - [x] Add an entry to `CHANGELOG.md` under the `## main` section.
