### PR TITLE
Bump maplibre contour to 0.5.0

### DIFF
--- a/test/examples/contour-lines.html
+++ b/test/examples/contour-lines.html
@@ -14,7 +14,7 @@
 </head>
 <body>
 <div id="map"></div>
-<script src="https://unpkg.com/maplibre-contour@0.0.4/dist/index.min.js"></script>
+<script src="https://unpkg.com/maplibre-contour@0.0.5/dist/index.min.js"></script>
 <script>
     const demSource = new mlcontour.DemSource({
         url: 'https://demotiles.maplibre.org/terrain-tiles/{z}/{x}/{y}.png',


### PR DESCRIPTION
## Launch Checklist

Bump maplibre contour to 0.5.0 in the examples directory so that it will work with either maplibre v3 or v4 (https://github.com/onthegomap/maplibre-contour/pull/128)

See this example running against maplibre v4: https://onthegomap.github.io/maplibre-contour
vs. this example running against maplibre v3: https://onthegomap.github.io/maplibre-contour/maplibre-v3.html

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [ ] Link to related issues.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [ ] Add an entry to `CHANGELOG.md` under the `## main` section.
