### PR TITLE
hardcode width to avoid busy loop after benchmark is run

### DIFF
--- a/test/bench/components/RegressionPlot.tsx
+++ b/test/bench/components/RegressionPlot.tsx
@@ -1,5 +1,5 @@
 import * as d3 from 'd3';
-import React, {useEffect, useMemo, useRef, useState} from 'react';
+import React from 'react';
 import {Axis} from './Axis';
 import {formatSample, Version, versionColor} from './util';
 
@@ -7,20 +7,9 @@ type RegressionPlotProps = {
     versions: Version[];
 }
 
-type RegressionPlotState = {
-    width: number;
-}
-
 export const RegressionPlot = (props: RegressionPlotProps) => {
-    const [state, setState] = useState<RegressionPlotState>({width: 100});
-    const svgElement = useRef(null);
-
-    useEffect(() => {
-        setState({width: svgElement.current.clientWidth});
-    }, [state]);
-
     const margin = {top: 10, right: 20, bottom: 30, left: 0};
-    const width = useMemo(() => { return state.width - margin.left - margin.right; }, [state]);
+    const width = 960 - margin.left - margin.right;
     const height = 200 - margin.top - margin.bottom;
     const versions = props.versions.filter(version => version.regression);
 
@@ -42,8 +31,7 @@ export const RegressionPlot = (props: RegressionPlotProps) => {
         <svg
             width="100%"
             height={height + margin.top + margin.bottom}
-            style={{overflow: 'visible'}}
-            ref={svgElement}>
+            style={{overflow: 'visible'}}>
             <g transform={`translate(${margin.left},${margin.top})`}>
                 <Axis orientation="bottom" scale={x} transform={`translate(0,${height})`}>
                     <text fill='#000' textAnchor="end" y={-6} x={width}>Iterations</text>

--- a/test/bench/components/StatisticsPlot.tsx
+++ b/test/bench/components/StatisticsPlot.tsx
@@ -1,5 +1,5 @@
 import * as d3 from 'd3';
-import React, {useEffect, useMemo, useRef, useState} from 'react';
+import React from 'react';
 import {kde} from '../lib/statistics';
 import {Axis} from './Axis';
 import {formatSample, Version, versionColor} from './util';
@@ -8,21 +8,10 @@ type StatisticsPlotProps = {
     versions: Version[];
 }
 
-type StatisticsPlotState = {
-    width: number;
-}
-
 export const StatisticsPlot = (props:StatisticsPlotProps) => {
 
-    const [state, setState] = useState<StatisticsPlotState>({width: 100});
-    const svgElement = useRef(null);
-
-    useEffect(() => {
-        setState({width: svgElement.current.clientWidth});
-    }, [state]);
-
     const margin = {top: 0, right: 20, bottom: 20, left: 0};
-    const width = useMemo(() => { return state.width - margin.left - margin.right; }, [state]);
+    const width = 960 - margin.left - margin.right;
     const height = 400 - margin.top - margin.bottom;
     const kdeWidth = 100;
 
@@ -65,9 +54,7 @@ export const StatisticsPlot = (props:StatisticsPlotProps) => {
         <svg
             width="100%"
             height={height + margin.top + margin.bottom}
-            style={{overflow: 'visible'}}
-            ref={svgElement}
-        >
+            style={{overflow: 'visible'}}>
             <defs>
                 <g id="up-arrow">
                     <path transform="translate(-6, -2)" style={{stroke: 'inherit', fill: 'inherit'}}


### PR DESCRIPTION
the code for adapting the benchmark graphs to parent width busy loops for me.
the width of the parent is hardcoded anyway so I just hardcoded it here also and removed the offending code.

I think for the benchmarks simpler code and less react knowledge is more important than the unused feature.

 - [+] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
