### PR TITLE
Improve tests reliability

### DIFF
--- a/test/integration/render/tests/text-variable-anchor/pitched-with-map/style.json
+++ b/test/integration/render/tests/text-variable-anchor/pitched-with-map/style.json
@@ -3,7 +3,7 @@
   "metadata": {
     "test": {
       "height": 256,
-      "operations": [["idle"]]
+      "operations": [["idle"], ["wait", 100]]
     }
   },
   "center": [

--- a/test/integration/render/tests/text-variable-anchor/pitched/style.json
+++ b/test/integration/render/tests/text-variable-anchor/pitched/style.json
@@ -3,7 +3,7 @@
   "metadata": {
     "test": {
       "height": 256,
-      "operations": [["idle"]]
+      "operations": [["idle"], ["wait", 100]]
     }
   },
   "center": [


### PR DESCRIPTION
This adds a few waits to flickering tests.
I believe that there's a race condition in these tests that prevents them from succeeding, but I don't have a good idea how to solve it, and this is the simplest solution.