### PR TITLE
Fix failing browser test by updating tiles only when adding new terrain

### DIFF
--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -1928,7 +1928,8 @@ export class Map extends Camera {
             // add terrain
             const sourceCache = this.style.sourceCaches[options.source];
             if (!sourceCache) throw new Error(`cannot load terrain, because there exists no source with ID: ${options.source}`);
-            sourceCache.reload();
+            // Update terrain tiles when adding new terrain
+            if (this.terrain === null) sourceCache.reload();
             // Warn once if user is using the same source for hillshade and terrain
             for (const index in this.style._layers) {
                 const thisLayer = this.style._layers[index];


### PR DESCRIPTION
As noted by @HarelM in https://github.com/maplibre/maplibre-gl-js/pull/3558#issuecomment-1883814307, the change in https://github.com/maplibre/maplibre-gl-js/pull/3545 (presumably when combined with the changes in https://github.com/maplibre/maplibre-gl-js/pull/3515) resulted in a failing browser test, where "idle" events aren't being correctly fired.

This is caused by terrain tiles getting stuck in the "updating" state.  This happens when `sourceCache.reload()` is called needlessly, i.e. when terrain is set on a map that already has terrain, as happens in the render test.

This fix ensures that the tile reloading only happens when terrain is added to a map that previously had no terrain.

## Launch Checklist

 - [X] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [X] Briefly describe the changes in this PR.
 - [X] Link to related issues.
