### PR TITLE
Fixes prepare script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,16 +23,9 @@ jobs:
         with:
           node-version-file: '.nvmrc'
 
-      - name: Check if version changed
+      - name: Check if version has been updated
         id: check
-        run: |
-          latestNpmPackageVersion=$( npm view maplibre-gl versions --json | jq '.[-1]' -r )
-          currentVersion=$( node -e "console.log(require('./package.json').version)" )
-          if [ "$latestNpmPackageVersion" == "$currentVersion" ]; then
-            echo "changed=false" >> $GITHUB_OUTPUT
-          else
-            echo "changed=true" >> $GITHUB_OUTPUT
-          fi
+        uses: EndBug/version-check@v2
           
     outputs:
       publish: ${{ steps.check.outputs.changed }}

--- a/package.json
+++ b/package.json
@@ -171,7 +171,7 @@
     "test-render": "node --no-warnings --loader ts-node/esm test/integration/render/run_render_tests.ts",
     "test-unit": "jest --selectProjects=unit",
     "test-watch-roots": "jest --watch",
-    "codegen": "run-p generate-dist-package generate-style-code generate-struct-arrays generate-shaders generate-typings",
+    "codegen": "run-p generate-dist-package generate-style-code generate-struct-arrays generate-shaders && generate-typings",
     "benchmark": "node --no-warnings --loader ts-node/esm test/bench/run-benchmarks.ts",
     "gl-stats": "node --no-warnings --loader ts-node/esm test/bench/gl-stats.ts",
     "prepare": "npm run codegen",

--- a/package.json
+++ b/package.json
@@ -171,7 +171,7 @@
     "test-render": "node --no-warnings --loader ts-node/esm test/integration/render/run_render_tests.ts",
     "test-unit": "jest --selectProjects=unit",
     "test-watch-roots": "jest --watch",
-    "codegen": "run-p generate-dist-package generate-style-code generate-struct-arrays generate-shaders && generate-typings",
+    "codegen": "run-p --print-label generate-dist-package generate-style-code generate-struct-arrays generate-shaders && npm run generate-typings",
     "benchmark": "node --no-warnings --loader ts-node/esm test/bench/run-benchmarks.ts",
     "gl-stats": "node --no-warnings --loader ts-node/esm test/bench/gl-stats.ts",
     "prepare": "npm run codegen",

--- a/package.json
+++ b/package.json
@@ -171,7 +171,7 @@
     "test-render": "node --no-warnings --loader ts-node/esm test/integration/render/run_render_tests.ts",
     "test-unit": "jest --selectProjects=unit",
     "test-watch-roots": "jest --watch",
-    "codegen": "run-p generate-dist-package generate-style-code generate-struct-arrays generate-shaders",
+    "codegen": "run-p generate-dist-package generate-style-code generate-struct-arrays generate-shaders generate-typings",
     "benchmark": "node --no-warnings --loader ts-node/esm test/bench/run-benchmarks.ts",
     "gl-stats": "node --no-warnings --loader ts-node/esm test/bench/gl-stats.ts",
     "prepare": "npm run codegen",


### PR DESCRIPTION
This fixes the prepare script to be more robust due to recent changes that require the types to be present while transpiling the rest of the project.
