### PR TITLE
Investigate coverage reports

### DIFF
--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -74,7 +74,8 @@ jobs:
       - run: npm run test-integration
         if: success() || failure()
 
-  render-tests-ubuntu:
+  render-tests:
+    if: false
     name: Render tests
     env:
       SPLIT_COUNT: 3

--- a/test/integration/render/run_render_tests.ts
+++ b/test/integration/render/run_render_tests.ts
@@ -792,10 +792,10 @@ async function closePageAndFinish(page: Page, reportCoverage: boolean) {
     const converter = v8toIstanbul('./dist/maplibre-gl-dev.js');
     await converter.load();
     converter.applyCoverage(coverage.map(c => c.rawScriptCoverage!.functions).flat());
-    const coverageReport = converter.toIstanbul();
-    const report = JSON.stringify(coverageReport);
+    //const coverageReport = converter.toIstanbul();
+    //const report = JSON.stringify(coverageReport);
     fs.mkdirSync('./coverage', {recursive: true});
-    fs.writeFileSync('./coverage/coverage-render.json', report);
+    //fs.writeFileSync('./coverage/coverage-render.json', report);
 }
 
 /**


### PR DESCRIPTION
This is to allow the investigation of missing "empty" lines in the codecov report
