### PR TITLE
Fix example button position

### DIFF
--- a/test/examples/animate-a-line.html
+++ b/test/examples/animate-a-line.html
@@ -16,6 +16,7 @@
 <style>
     button {
         position: absolute;
+        top: 0;
         margin: 20px;
     }
 

--- a/test/examples/change-building-color-based-on-zoom-level.html
+++ b/test/examples/change-building-color-based-on-zoom-level.html
@@ -16,8 +16,10 @@
 <style>
     #zoom {
         display: block;
-        position: relative;
-        margin: 20px auto;
+        position: absolute;
+        top: 20px;
+        left: 50%;
+        transform: translate(-50%);
         width: 50%;
         height: 40px;
         padding: 10px;

--- a/test/examples/fitbounds.html
+++ b/test/examples/fitbounds.html
@@ -16,8 +16,10 @@
 <style>
     #fit {
         display: block;
-        position: relative;
-        margin: 0px auto;
+        position: absolute;
+        top: 20px;
+        left: 50%;
+        transform: translate(-50%);
         width: 50%;
         height: 40px;
         padding: 10px;

--- a/test/examples/flyto-options.html
+++ b/test/examples/flyto-options.html
@@ -16,8 +16,10 @@
 <style>
     #fly {
         display: block;
-        position: relative;
-        margin: 0px auto;
+        position: absolute;
+        top: 20px;
+        left: 50%;
+        transform: translate(-50%);
         width: 50%;
         height: 40px;
         padding: 10px;

--- a/test/examples/flyto.html
+++ b/test/examples/flyto.html
@@ -16,8 +16,10 @@
 <style>
     #fly {
         display: block;
-        position: relative;
-        margin: 0px auto;
+        position: absolute;
+        top: 20px;
+        left: 50%;
+        transform: translate(-50%);
         width: 50%;
         height: 40px;
         padding: 10px;

--- a/test/examples/language-switch.html
+++ b/test/examples/language-switch.html
@@ -15,12 +15,14 @@
 <body>
 <style>
     #buttons {
+        display: flex;
+        justify-content: space-between;
+        position: absolute;
+        top: 20px;
         width: 90%;
-        margin: 0 auto;
     }
     .button {
         display: inline-block;
-        position: relative;
         cursor: pointer;
         width: 20%;
         padding: 8px;

--- a/test/examples/mouse-position.html
+++ b/test/examples/mouse-position.html
@@ -16,8 +16,10 @@
 <style type="text/css">
     #info {
         display: block;
-        position: relative;
-        margin: 0px auto;
+        position: absolute;
+        top: 20px;
+        left: 50%;
+        transform: translate(-50%);
         width: 50%;
         padding: 10px;
         border: none;

--- a/test/examples/render-world-copies.html
+++ b/test/examples/render-world-copies.html
@@ -16,6 +16,8 @@
 <style>
     #menu {
         position: absolute;
+        top: 0;
+        left: 0;
         background: #fff;
         padding: 10px;
         font-family: 'Open Sans', sans-serif;


### PR DESCRIPTION
## describe

some examples has overlay button, but they are render with wrong position.

so fixed the wrong positioning of the overlay buttons in the example.

## example:

### language-switch

#### before

<img width="1436" alt="image" src="https://github.com/maplibre/maplibre-gl-js/assets/48559454/39424eff-cd07-4f32-a20d-ea0f88ccb1d2">

https://maplibre.org/maplibre-gl-js/docs/examples/language-switch/

#### after

<img width="1436" alt="language-switch-alt" src="https://github.com/maplibre/maplibre-gl-js/assets/48559454/7045490e-57bb-43a8-b239-7c82d0ff8d20">


<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

<!--

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [ ] Link to related issues.
 - [x] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [ ] Add an entry to `CHANGELOG.md` under the `## main` section.

-->