### PR TITLE
Replace v8 with monocart for coverage

### DIFF
--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -106,7 +106,7 @@ jobs:
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3
         with:
-          files: ${{ github.workspace }}/coverage/coverage-render.json
+          files: ${{ github.workspace }}/coverage/render/coverage-final.json
           verbose: true
       - name: Upload render test failure
         if: failure()

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -74,7 +74,7 @@ jobs:
       - run: npm run test-integration
         if: success() || failure()
 
-  render-tests-ubuntu:
+  render-tests:
     name: Render tests
     env:
       SPLIT_COUNT: 3
@@ -106,7 +106,7 @@ jobs:
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3
         with:
-          files: ${{ github.workspace }}/coverage/render/coverage-final.json
+          files: ${{ github.workspace }}/coverage/render/codecov.json
           verbose: true
       - name: Upload render test failure
         if: failure()

--- a/package-lock.json
+++ b/package-lock.json
@@ -96,6 +96,7 @@
         "json-stringify-pretty-compact": "^4.0.0",
         "minimist": "^1.2.8",
         "mock-geolocation": "^1.0.11",
+        "monocart-coverage-reports": "^2.2.2",
         "nise": "^5.1.7",
         "npm-font-open-sans": "^1.1.0",
         "npm-run-all": "^4.1.5",
@@ -124,8 +125,7 @@
         "typedoc": "^0.25.7",
         "typedoc-plugin-markdown": "^3.17.1",
         "typedoc-plugin-missing-exports": "^2.2.0",
-        "typescript": "^5.3.3",
-        "v8-to-istanbul": "^9.2.0"
+        "typescript": "^5.3.3"
       },
       "engines": {
         "node": ">=16.14.0",
@@ -4325,6 +4325,12 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/console-grid": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/console-grid/-/console-grid-2.1.0.tgz",
+      "integrity": "sha512-anVyay6Cit66Tltl6/wO0pOX1LtWZl/wRC+q2tDWkzouUuZrjS8VPeDB+tx+qYrXzzR7u00SW5X5DVe1CaPu1w==",
+      "dev": true
+    },
     "node_modules/convert-source-map": {
       "version": "1.8.0",
       "dev": true,
@@ -5366,6 +5372,12 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true
+    },
+    "node_modules/eight-colors": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/eight-colors/-/eight-colors-1.2.1.tgz",
+      "integrity": "sha512-cWYq3U9uRlXGnPB5nUazQUIKLxthxfjzav2esBB0RqmgWhu6H5kNTiMzpt3UL1rCiTrJTRCiiib8iS881mzzlg==",
       "dev": true
     },
     "node_modules/ejs": {
@@ -7752,9 +7764,10 @@
       }
     },
     "node_modules/istanbul-lib-coverage": {
-      "version": "3.2.0",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
       "dev": true,
-      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=8"
       }
@@ -9176,6 +9189,12 @@
       "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
       "dev": true
     },
+    "node_modules/lz-utils": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/lz-utils/-/lz-utils-2.0.2.tgz",
+      "integrity": "sha512-i1PJN4hNEevkrvLMqNWCCac1BcB5SRaghywG7HVzWOyVkFOasLCG19ND1sY1F/ZEsM6SnGtoXyBWnmfqOM5r6g==",
+      "dev": true
+    },
     "node_modules/magic-string": {
       "version": "0.30.5",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.5.tgz",
@@ -9494,6 +9513,38 @@
       "version": "1.0.11",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/monocart-code-viewer": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/monocart-code-viewer/-/monocart-code-viewer-1.0.13.tgz",
+      "integrity": "sha512-lkA/KlskeghPFKz+rbv0KJwwC8MXOAGj4t50JCpa3ETfB8Gcye7iicCW8HKHH3zGVFcz34ROCntM3h6K2H3tNw==",
+      "dev": true
+    },
+    "node_modules/monocart-coverage-reports": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/monocart-coverage-reports/-/monocart-coverage-reports-2.2.2.tgz",
+      "integrity": "sha512-7DdDhmLRKR82VOnOl292jkHtHqbV28SMe+wZTOCxSIBSdNC0pcINos16GIIiNTtrXzABkSYQv7jOKDTevengMw==",
+      "dev": true,
+      "dependencies": {
+        "console-grid": "~2.1.0",
+        "eight-colors": "~1.2.1",
+        "istanbul-lib-coverage": "~3.2.2",
+        "istanbul-lib-report": "~3.0.1",
+        "istanbul-reports": "~3.1.6",
+        "lz-utils": "~2.0.2",
+        "monocart-code-viewer": "~1.0.13",
+        "monocart-formatter": "~2.3.0",
+        "turbogrid": "^3.0.13"
+      },
+      "bin": {
+        "mcr": "lib/cli.js"
+      }
+    },
+    "node_modules/monocart-formatter": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/monocart-formatter/-/monocart-formatter-2.3.0.tgz",
+      "integrity": "sha512-VV0BC8DD6w/TK8ufpwE+xA8NaOTLBYqh9pihWKoLppExNMYwkpGBscCebiQp51YpFccBgxc92M3nV2H6K5SUrw==",
+      "dev": true
     },
     "node_modules/moo-color": {
       "version": "1.0.2",
@@ -13354,6 +13405,12 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
+    },
+    "node_modules/turbogrid": {
+      "version": "3.0.13",
+      "resolved": "https://registry.npmjs.org/turbogrid/-/turbogrid-3.0.13.tgz",
+      "integrity": "sha512-8owt3hf29VDyW9excRMGccq/cmqspmvg8Zt6JgXw2uuq65drl50KXtGQpGevIbqQMnvltyfyLLJjzNnWK7tCVA==",
       "dev": true
     },
     "node_modules/type-check": {

--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
     "json-stringify-pretty-compact": "^4.0.0",
     "minimist": "^1.2.8",
     "mock-geolocation": "^1.0.11",
+    "monocart-coverage-reports": "^2.2.2",
     "nise": "^5.1.7",
     "npm-font-open-sans": "^1.1.0",
     "npm-run-all": "^4.1.5",
@@ -128,8 +129,7 @@
     "typedoc": "^0.25.7",
     "typedoc-plugin-markdown": "^3.17.1",
     "typedoc-plugin-missing-exports": "^2.2.0",
-    "typescript": "^5.3.3",
-    "v8-to-istanbul": "^9.2.0"
+    "typescript": "^5.3.3"
   },
   "overrides": {
     "postcss-inline-svg": {

--- a/test/integration/render/run_render_tests.ts
+++ b/test/integration/render/run_render_tests.ts
@@ -805,7 +805,7 @@ async function closePageAndFinish(page: Page, reportCoverage: boolean) {
     const coverageReport = new CoverageReport({
         name: 'MapLibre Coverage Report',
         outputDir: './coverage/render',
-        reports: [['json'], ['html']]
+        reports: [['v8'], ['codecov']]
     });
     coverageReport.cleanCache();
 

--- a/test/integration/render/run_render_tests.ts
+++ b/test/integration/render/run_render_tests.ts
@@ -8,7 +8,7 @@ import {fileURLToPath} from 'url';
 import {globSync} from 'glob';
 import http from 'http';
 import puppeteer, {Page, Browser} from 'puppeteer';
-import v8toIstanbul from 'v8-to-istanbul';
+import {CoverageReport} from 'monocart-coverage-reports';
 import {localizeURLs} from '../lib/localize-urls';
 import type {default as MapLibreGL, Map, CanvasSource, PointLike, StyleSpecification} from '../../../dist/maplibre-gl';
 
@@ -776,7 +776,7 @@ async function runTests(page: Page, testStyles: StyleWithTestData[], directory: 
 
 async function createPageAndStart(browser: Browser, testStyles: StyleWithTestData[], directory: string, options: RenderOptions) {
     const page = await browser.newPage();
-    page.coverage.startJSCoverage({includeRawScriptCoverage: true});
+    await page.coverage.startJSCoverage({includeRawScriptCoverage: true});
     applyDebugParameter(options, page);
     await page.addScriptTag({path: 'dist/maplibre-gl-dev.js'});
     await runTests(page, testStyles, directory);
@@ -789,13 +789,29 @@ async function closePageAndFinish(page: Page, reportCoverage: boolean) {
     if (!reportCoverage) {
         return;
     }
-    const converter = v8toIstanbul('./dist/maplibre-gl-dev.js');
-    await converter.load();
-    converter.applyCoverage(coverage.map(c => c.rawScriptCoverage!.functions).flat());
-    const coverageReport = converter.toIstanbul();
-    const report = JSON.stringify(coverageReport);
-    fs.mkdirSync('./coverage', {recursive: true});
-    fs.writeFileSync('./coverage/coverage-render.json', report);
+
+    const rawV8CoverageData = coverage.map((it) => {
+        // Convert to raw v8 coverage format
+        const entry: any =  {
+            source: it.text,
+            ...it.rawScriptCoverage
+        };
+        if (entry.url.endsWith('maplibre-gl-dev.js')) {
+            entry.sourceMap = JSON.parse(fs.readFileSync('dist/maplibre-gl-dev.js.map').toString('utf-8'));
+        }
+        return entry;
+    });
+
+    const coverageReport = new CoverageReport({
+        name: 'MapLibre Coverage Report',
+        outputDir: './coverage/render',
+        reports: [['json'], ['html']]
+    });
+    coverageReport.cleanCache();
+
+    await coverageReport.add(rawV8CoverageData);
+
+    await coverageReport.generate();
 }
 
 /**


### PR DESCRIPTION
## Launch Checklist

In order to solve the coverage issues introduced with v8 and the render test a different coverage tool is needed apparently.
See here:
https://github.com/cenfun/monocart-coverage-reports/issues/4
And here:
https://github.com/istanbuljs/v8-to-istanbul/issues/238


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
