### PR TITLE
Add Marker's "opacity" option and "setOpacity" method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### ✨ Features and improvements
 
+- Add "opacity" option and "setOpacity" method to Marker ([#3620](https://github.com/maplibre/maplibre-gl-js/pull/3620))
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes

--- a/src/ui/marker.test.ts
+++ b/src/ui/marker.test.ts
@@ -867,6 +867,16 @@ describe('marker', () => {
         map.remove();
     });
 
+    test('Resets opacity to default when setOpacity is called without arguments', () => {
+        const map = createMap();
+        const marker = new Marker({opacity: 0.7})
+            .setLngLat([0, 0])
+            .addTo(map);
+        marker.setOpacity();
+        expect(marker.getElement().style.opacity).toBe('1');
+        map.remove();
+    });
+
     test('Marker changes opacity behind terrain and when terrain is removed', () => {
         const map = createMap();
         map.transform.lngLatToCameraDepth = () => .95; // Mocking distance to marker

--- a/src/ui/marker.test.ts
+++ b/src/ui/marker.test.ts
@@ -850,7 +850,7 @@ describe('marker', () => {
 
     test('Sets opacity according to options.opacity', () => {
         const map = createMap();
-        const marker = new Marker({opacity: ['0.7', '']})
+        const marker = new Marker({opacity: 0.7})
             .setLngLat([0, 0])
             .addTo(map);
         expect(marker.getElement().style.opacity).toMatch('.7');
@@ -859,10 +859,10 @@ describe('marker', () => {
 
     test('Changes opacity to a new value provided by setOpacity', () => {
         const map = createMap();
-        const marker = new Marker({opacity: ['0.7', '']})
+        const marker = new Marker({opacity: 0.7})
             .setLngLat([0, 0])
             .addTo(map);
-        marker.setOpacity(['0.6', '']);
+        marker.setOpacity(0.6);
         expect(marker.getElement().style.opacity).toMatch('.6');
         map.remove();
     });
@@ -899,10 +899,10 @@ describe('marker', () => {
         map.remove();
     });
 
-    test('Applies options.opacity[0] when 3d terrain is enabled and marker is in clear view', () => {
+    test('Applies options.opacity when 3d terrain is enabled and marker is in clear view', () => {
         const map = createMap();
         map.transform.lngLatToCameraDepth = () => .95; // Mocking distance to marker
-        const marker = new Marker({opacity: ['0.7', '0.3']})
+        const marker = new Marker({opacity: 0.7})
             .setLngLat([0, 0])
             .addTo(map);
 
@@ -916,10 +916,10 @@ describe('marker', () => {
         map.remove();
     });
 
-    test('Applies options.opacity[1] when marker is hidden by 3d terrain', () => {
+    test('Applies options.opacityWhenCovered when marker is hidden by 3d terrain', () => {
         const map = createMap();
         map.transform.lngLatToCameraDepth = () => .95; // Mocking distance to marker
-        const marker = new Marker({opacity: ['0.7', '0.3']})
+        const marker = new Marker({opacity: 0.7, opacityWhenCovered: 0.3})
             .setLngLat([0, 0])
             .addTo(map);
 
@@ -930,6 +930,25 @@ describe('marker', () => {
         map.fire('terrain');
 
         expect(marker.getElement().style.opacity).toMatch('0.3');
+        map.remove();
+    });
+
+    test('Applies new "opacityWhenCovered" provided by setOpacity when marker is hidden by 3d terrain', async () => {
+        const map = createMap();
+        map.transform.lngLatToCameraDepth = () => .95; // Mocking distance to marker
+        const marker = new Marker({opacityWhenCovered: 0.15})
+            .setLngLat([0, 0])
+            .addTo(map);
+
+        map.terrain = {
+            getElevationForLngLatZoom: () => 0,
+            depthAtPoint: () => .92
+        } as any as Terrain;
+        map.fire('terrain');
+
+        marker.setOpacity(undefined, 0.35);
+
+        expect(marker.getElement().style.opacity).toMatch('0.35');
         map.remove();
     });
 });

--- a/src/ui/marker.test.ts
+++ b/src/ui/marker.test.ts
@@ -850,7 +850,7 @@ describe('marker', () => {
 
     test('Sets opacity according to options.opacity', () => {
         const map = createMap();
-        const marker = new Marker({opacity: 0.7})
+        const marker = new Marker({opacity: '0.7'})
             .setLngLat([0, 0])
             .addTo(map);
         expect(marker.getElement().style.opacity).toMatch('.7');
@@ -859,17 +859,17 @@ describe('marker', () => {
 
     test('Changes opacity to a new value provided by setOpacity', () => {
         const map = createMap();
-        const marker = new Marker({opacity: 0.7})
+        const marker = new Marker({opacity: '0.7'})
             .setLngLat([0, 0])
             .addTo(map);
-        marker.setOpacity(0.6);
+        marker.setOpacity('0.6');
         expect(marker.getElement().style.opacity).toMatch('.6');
         map.remove();
     });
 
     test('Resets opacity to default when setOpacity is called without arguments', () => {
         const map = createMap();
-        const marker = new Marker({opacity: 0.7})
+        const marker = new Marker({opacity: '0.7'})
             .setLngLat([0, 0])
             .addTo(map);
         marker.setOpacity();
@@ -912,7 +912,7 @@ describe('marker', () => {
     test('Applies options.opacity when 3d terrain is enabled and marker is in clear view', () => {
         const map = createMap();
         map.transform.lngLatToCameraDepth = () => .95; // Mocking distance to marker
-        const marker = new Marker({opacity: 0.7})
+        const marker = new Marker({opacity: '0.7'})
             .setLngLat([0, 0])
             .addTo(map);
 
@@ -929,7 +929,7 @@ describe('marker', () => {
     test('Applies options.opacityWhenCovered when marker is hidden by 3d terrain', () => {
         const map = createMap();
         map.transform.lngLatToCameraDepth = () => .95; // Mocking distance to marker
-        const marker = new Marker({opacity: 0.7, opacityWhenCovered: 0.3})
+        const marker = new Marker({opacity: '0.7', opacityWhenCovered: '0.3'})
             .setLngLat([0, 0])
             .addTo(map);
 
@@ -946,7 +946,7 @@ describe('marker', () => {
     test('Applies new "opacityWhenCovered" provided by setOpacity when marker is hidden by 3d terrain', async () => {
         const map = createMap();
         map.transform.lngLatToCameraDepth = () => .95; // Mocking distance to marker
-        const marker = new Marker({opacityWhenCovered: 0.15})
+        const marker = new Marker({opacityWhenCovered: '0.15'})
             .setLngLat([0, 0])
             .addTo(map);
 
@@ -956,7 +956,7 @@ describe('marker', () => {
         } as any as Terrain;
         map.fire('terrain');
 
-        marker.setOpacity(undefined, 0.35);
+        marker.setOpacity(undefined, '0.35');
 
         expect(marker.getElement().style.opacity).toMatch('0.35');
         map.remove();

--- a/src/ui/marker.test.ts
+++ b/src/ui/marker.test.ts
@@ -839,6 +839,34 @@ describe('marker', () => {
         map.remove();
     });
 
+    test('Sets default opacity if it\'s not provided as option', () => {
+        const map = createMap();
+        const marker = new Marker()
+            .setLngLat([0, 0])
+            .addTo(map);
+        expect(marker.getElement().style.opacity).toMatch('1');
+        map.remove();
+    });
+
+    test('Sets opacity according to options.opacity', () => {
+        const map = createMap();
+        const marker = new Marker({opacity: ['0.7', '']})
+            .setLngLat([0, 0])
+            .addTo(map);
+        expect(marker.getElement().style.opacity).toMatch('.7');
+        map.remove();
+    });
+
+    test('Changes opacity to a new value provided by setOpacity', () => {
+        const map = createMap();
+        const marker = new Marker({opacity: ['0.7', '']})
+            .setLngLat([0, 0])
+            .addTo(map);
+        marker.setOpacity(['0.6', '']);
+        expect(marker.getElement().style.opacity).toMatch('.6');
+        map.remove();
+    });
+
     test('Marker changes opacity behind terrain and when terrain is removed', () => {
         const map = createMap();
         map.transform.lngLatToCameraDepth = () => .95; // Mocking distance to marker
@@ -868,6 +896,40 @@ describe('marker', () => {
         map.fire('terrain');
         expect(marker.getElement().style.opacity).toMatch('1');
 
+        map.remove();
+    });
+
+    test('Applies options.opacity[0] when 3d terrain is enabled and marker is in clear view', () => {
+        const map = createMap();
+        map.transform.lngLatToCameraDepth = () => .95; // Mocking distance to marker
+        const marker = new Marker({opacity: ['0.7', '0.3']})
+            .setLngLat([0, 0])
+            .addTo(map);
+
+        map.terrain = {
+            getElevationForLngLatZoom: () => 0,
+            depthAtPoint: () => .95
+        } as any as Terrain;
+        map.fire('terrain');
+
+        expect(marker.getElement().style.opacity).toMatch('.7');
+        map.remove();
+    });
+
+    test('Applies options.opacity[1] when marker is hidden by 3d terrain', () => {
+        const map = createMap();
+        map.transform.lngLatToCameraDepth = () => .95; // Mocking distance to marker
+        const marker = new Marker({opacity: ['0.7', '0.3']})
+            .setLngLat([0, 0])
+            .addTo(map);
+
+        map.terrain = {
+            getElevationForLngLatZoom: () => 0,
+            depthAtPoint: () => .92
+        } as any as Terrain;
+        map.fire('terrain');
+
+        expect(marker.getElement().style.opacity).toMatch('0.3');
         map.remove();
     });
 });

--- a/src/ui/marker.ts
+++ b/src/ui/marker.ts
@@ -159,9 +159,7 @@ export class Marker extends Evented {
         this._rotationAlignment = options && options.rotationAlignment || 'auto';
         this._pitchAlignment = options && options.pitchAlignment && options.pitchAlignment !== 'auto' ?  options.pitchAlignment : this._rotationAlignment;
         this.setOpacity(); // set default opacity
-        if (options) {
-            this.setOpacity(options.opacity, options.opacityWhenCovered);
-        }
+        this.setOpacity(options?.opacity, options?.opacityWhenCovered);
 
         if (!options || !options.element) {
             this._defaultMarker = true;

--- a/src/ui/marker.ts
+++ b/src/ui/marker.ts
@@ -158,8 +158,10 @@ export class Marker extends Evented {
         this._rotation = options && options.rotation || 0;
         this._rotationAlignment = options && options.rotationAlignment || 'auto';
         this._pitchAlignment = options && options.pitchAlignment && options.pitchAlignment !== 'auto' ?  options.pitchAlignment : this._rotationAlignment;
-        this._opacity = options && options.opacity !== undefined ? options.opacity : 1;
-        this._opacityWhenCovered = options && options.opacityWhenCovered !== undefined ? options.opacityWhenCovered : 0.2;
+        this.setOpacity(); // set default opacity
+        if (options) {
+            this.setOpacity(options.opacity, options.opacityWhenCovered);
+        }
 
         if (!options || !options.element) {
             this._defaultMarker = true;
@@ -830,7 +832,9 @@ export class Marker extends Evented {
         if (opacityWhenCovered !== undefined) {
             this._opacityWhenCovered = opacityWhenCovered;
         }
-        this._updateOpacity(true);
+        if (this._map) {
+            this._updateOpacity(true);
+        }
         return this;
     }
 }

--- a/src/ui/marker.ts
+++ b/src/ui/marker.ts
@@ -77,12 +77,12 @@ type MarkerOptions = {
      * Marker's opacity when it's in clear view (not behind 3d terrain)
      * @defaultValue 1
      */
-    opacity?: number;
+    opacity?: string;
     /**
      * Marker's opacity when it's behind 3d terrain
      * @defaultValue 0.2
      */
-    opacityWhenCovered?: number;
+    opacityWhenCovered?: string;
 };
 
 /**
@@ -138,8 +138,8 @@ export class Marker extends Evented {
     _pitchAlignment: Alignment;
     _rotationAlignment: Alignment;
     _originalTabIndex: string; // original tabindex of _element
-    _opacity: number;
-    _opacityWhenCovered: number;
+    _opacity: string;
+    _opacityWhenCovered: string;
     _opacityTimeout: ReturnType<typeof setTimeout>;
 
     /**
@@ -523,7 +523,7 @@ export class Marker extends Evented {
     _updateOpacity(force: boolean = false) {
         const terrain = this._map.terrain;
         if (!terrain) {
-            if (this._element.style.opacity !== String(this._opacity)) { this._element.style.opacity = String(this._opacity); }
+            if (this._element.style.opacity !== this._opacity) { this._element.style.opacity = this._opacity; }
             return;
         }
         if (force) {
@@ -545,7 +545,7 @@ export class Marker extends Evented {
 
         const forgiveness = .006;
         if (markerDistance - terrainDistance < forgiveness) {
-            this._element.style.opacity = String(this._opacity);
+            this._element.style.opacity = this._opacity;
             return;
         }
         // If the base is obscured, use the offset to check if the marker's center is obscured.
@@ -555,7 +555,7 @@ export class Marker extends Evented {
         const markerDistanceCenter = map.transform.lngLatToCameraDepth(this._lngLat, elevation + elevationToCenter);
         // Display at full opacity if center is visible.
         const centerIsInvisible = markerDistanceCenter - terrainDistanceCenter > forgiveness;
-        this._element.style.opacity = centerIsInvisible ? String(this._opacityWhenCovered) : String(this._opacity);
+        this._element.style.opacity = centerIsInvisible ? this._opacityWhenCovered : this._opacity;
     }
 
     _update = (e?: { type: 'move' | 'moveend' | 'terrain' | 'render' }) => {
@@ -819,10 +819,10 @@ export class Marker extends Evented {
      * @param opacityWhenCovered - Sets the `opacityWhenCovered` property of the marker.
      * @returns `this`
      */
-    setOpacity(opacity?: number, opacityWhenCovered?: number): this {
+    setOpacity(opacity?: string, opacityWhenCovered?: string): this {
         if (opacity === undefined && opacityWhenCovered === undefined) {
-            this._opacity = 1;
-            this._opacityWhenCovered = 0.2;
+            this._opacity = '1';
+            this._opacityWhenCovered = '0.2';
         }
         if (opacity !== undefined) {
             this._opacity = opacity;

--- a/src/ui/marker.ts
+++ b/src/ui/marker.ts
@@ -814,11 +814,16 @@ export class Marker extends Evented {
     }
 
     /**
-     * Sets the `opacity` property of the marker.
+     * Sets the `opacity` and `opacityWhenCovered` properties of the marker.
      * @param opacity - Sets the `opacity` property of the marker.
+     * @param opacityWhenCovered - Sets the `opacityWhenCovered` property of the marker.
      * @returns `this`
      */
     setOpacity(opacity?: number, opacityWhenCovered?: number): this {
+        if (opacity === undefined && opacityWhenCovered === undefined) {
+            this._opacity = 1;
+            this._opacityWhenCovered = 0.2;
+        }
         if (opacity !== undefined) {
             this._opacity = opacity;
         }

--- a/src/ui/marker.ts
+++ b/src/ui/marker.ts
@@ -815,6 +815,7 @@ export class Marker extends Evented {
 
     /**
      * Sets the `opacity` and `opacityWhenCovered` properties of the marker.
+     * When called without arguments, resets opacity and opacityWhenCovered to defaults
      * @param opacity - Sets the `opacity` property of the marker.
      * @param opacityWhenCovered - Sets the `opacityWhenCovered` property of the marker.
      * @returns `this`

--- a/src/ui/marker.ts
+++ b/src/ui/marker.ts
@@ -138,8 +138,8 @@ export class Marker extends Evented {
     _pitchAlignment: Alignment;
     _rotationAlignment: Alignment;
     _originalTabIndex: string; // original tabindex of _element
-    _opacity: string;
-    _opacityWhenCovered: string;
+    _opacity: number;
+    _opacityWhenCovered: number;
     _opacityTimeout: ReturnType<typeof setTimeout>;
 
     /**
@@ -158,8 +158,8 @@ export class Marker extends Evented {
         this._rotation = options && options.rotation || 0;
         this._rotationAlignment = options && options.rotationAlignment || 'auto';
         this._pitchAlignment = options && options.pitchAlignment && options.pitchAlignment !== 'auto' ?  options.pitchAlignment : this._rotationAlignment;
-        this._opacity = options && options.opacity !== undefined ? String(options.opacity) : '1';
-        this._opacityWhenCovered = options && options.opacityWhenCovered !== undefined ? String(options.opacityWhenCovered) : '0.2';
+        this._opacity = options && options.opacity !== undefined ? options.opacity : 1;
+        this._opacityWhenCovered = options && options.opacityWhenCovered !== undefined ? options.opacityWhenCovered : 0.2;
 
         if (!options || !options.element) {
             this._defaultMarker = true;
@@ -523,7 +523,7 @@ export class Marker extends Evented {
     _updateOpacity(force: boolean = false) {
         const terrain = this._map.terrain;
         if (!terrain) {
-            if (this._element.style.opacity !== this._opacity) { this._element.style.opacity = this._opacity; }
+            if (this._element.style.opacity !== String(this._opacity)) { this._element.style.opacity = String(this._opacity); }
             return;
         }
         if (force) {
@@ -545,7 +545,7 @@ export class Marker extends Evented {
 
         const forgiveness = .006;
         if (markerDistance - terrainDistance < forgiveness) {
-            this._element.style.opacity = this._opacity;
+            this._element.style.opacity = String(this._opacity);
             return;
         }
         // If the base is obscured, use the offset to check if the marker's center is obscured.
@@ -555,7 +555,7 @@ export class Marker extends Evented {
         const markerDistanceCenter = map.transform.lngLatToCameraDepth(this._lngLat, elevation + elevationToCenter);
         // Display at full opacity if center is visible.
         const centerIsInvisible = markerDistanceCenter - terrainDistanceCenter > forgiveness;
-        this._element.style.opacity = centerIsInvisible ? this._opacityWhenCovered : this._opacity;
+        this._element.style.opacity = centerIsInvisible ? String(this._opacityWhenCovered) : String(this._opacity);
     }
 
     _update = (e?: { type: 'move' | 'moveend' | 'terrain' | 'render' }) => {
@@ -820,10 +820,10 @@ export class Marker extends Evented {
      */
     setOpacity(opacity?: number, opacityWhenCovered?: number): this {
         if (opacity !== undefined) {
-            this._opacity = String(opacity);
+            this._opacity = opacity;
         }
         if (opacityWhenCovered !== undefined) {
-            this._opacityWhenCovered = String(opacityWhenCovered);
+            this._opacityWhenCovered = opacityWhenCovered;
         }
         this._updateOpacity(true);
         return this;

--- a/test/build/min.test.ts
+++ b/test/build/min.test.ts
@@ -36,7 +36,7 @@ describe('test min build', () => {
         const decreaseQuota = 4096;
 
         // feel free to update this value after you've checked that it has changed on purpose :-)
-        const expectedBytes = 772222;
+        const expectedBytes = 772550;
 
         expect(actualBytes - expectedBytes).toBeLessThan(increaseQuota);
         expect(expectedBytes - actualBytes).toBeLessThan(decreaseQuota);


### PR DESCRIPTION
Implements https://github.com/maplibre/maplibre-gl-js/issues/3458

A small caveat here.
This solution means that all users have to provide an array of 2 strings. (2nd string is the reduced opacity when marker is behind the terrain).
But in most cases (without 3d terrain) this second string will be useless and just an incovenience.
Perhaps it makes sense to split this single option and method to:
'opacity/setOpacity' and 'reducedOpacity/setReducedOpacity'