### PR TITLE
Remove maplibregl prefix from docs

### DIFF
--- a/build/generate-docs.ts
+++ b/build/generate-docs.ts
@@ -24,7 +24,7 @@ import {Map} from 'maplibre-gl';
 const map = new Map(...)
 \`\`\`
 
-\`Import\` statements are omitted from the examples for brevity.
+Import declarations are omitted from the examples for brevity.
 
 `;
     intro += lines.map(l => l.replace('../', './')).join('\n');

--- a/build/generate-docs.ts
+++ b/build/generate-docs.ts
@@ -17,6 +17,15 @@ We recommend looking at the [examples](../examples/index.md) as they will help y
 
 Most of the classes wirtten here have an "Options" object for initialization, it is recommended to check which options exist. 
 
+It is recommended to import what you need and the use it. Some examples for classes assume you did that.
+For example, import the \`Map\` class like this:
+\`\`\`ts
+import {Map} from 'maplibre-gl';
+const map = new Map(...)
+\`\`\`
+
+\`Import\` statements are omitted from the examples for brevity.
+
 `;
     intro += lines.map(l => l.replace('../', './')).join('\n');
     return intro;

--- a/package.json
+++ b/package.json
@@ -147,7 +147,7 @@
     "generate-typings": "dts-bundle-generator --export-referenced-types --umd-module-name=maplibregl -o ./dist/maplibre-gl.d.ts ./src/index.ts",
     "generate-docs": "typedoc && node --no-warnings --loader ts-node/esm build/generate-docs.ts",
     "generate-images": "node --no-warnings --loader ts-node/esm build/generate-doc-images.ts",
-    "build-dist": "run-p --print-label build-css generate-typings && run-p --print-label build-dev build-csp-dev && run-p --print-label build-prod build-csp",
+    "build-dist": "npm run build-css && npm run generate-typings && npm run build-dev && npm run build-csp-dev && npm run build-prod && npm run build-csp",
     "build-dev": "rollup --configPlugin @rollup/plugin-typescript -c --environment BUILD:dev",
     "watch-dev": "rollup --configPlugin @rollup/plugin-typescript -c --environment BUILD:dev --watch",
     "build-prod": "rollup --configPlugin @rollup/plugin-typescript -c --environment BUILD:production",

--- a/src/geo/lng_lat.ts
+++ b/src/geo/lng_lat.ts
@@ -15,7 +15,7 @@ export const earthRadius = 6371008.8;
  *
  * @example
  * ```ts
- * let v1 = new maplibregl.LngLat(-122.420679, 37.772537);
+ * let v1 = new LngLat(-122.420679, 37.772537);
  * let v2 = [-122.420679, 37.772537];
  * let v3 = {lon: -122.420679, lat: 37.772537};
  * ```
@@ -43,7 +43,7 @@ export type LngLatLike = LngLat | {
  *
  * @example
  * ```ts
- * let ll = new maplibregl.LngLat(-123.9749, 40.7736);
+ * let ll = new LngLat(-123.9749, 40.7736);
  * ll.lng; // = -123.9749
  * ```
  * @see [Get coordinates of the mouse pointer](https://maplibre.org/maplibre-gl-js/docs/examples/mouse-position/)
@@ -75,7 +75,7 @@ export class LngLat {
      * @returns The wrapped `LngLat` object.
      * @example
      * ```ts
-     * let ll = new maplibregl.LngLat(286.0251, 40.7736);
+     * let ll = new LngLat(286.0251, 40.7736);
      * let wrapped = ll.wrap();
      * wrapped.lng; // = -73.9749
      * ```
@@ -90,7 +90,7 @@ export class LngLat {
      * @returns The coordinates represented as an array of longitude and latitude.
      * @example
      * ```ts
-     * let ll = new maplibregl.LngLat(-73.9749, 40.7736);
+     * let ll = new LngLat(-73.9749, 40.7736);
      * ll.toArray(); // = [-73.9749, 40.7736]
      * ```
      */
@@ -104,7 +104,7 @@ export class LngLat {
      * @returns The coordinates represented as a string of the format `'LngLat(lng, lat)'`.
      * @example
      * ```ts
-     * let ll = new maplibregl.LngLat(-73.9749, 40.7736);
+     * let ll = new LngLat(-73.9749, 40.7736);
      * ll.toString(); // = "LngLat(-73.9749, 40.7736)"
      * ```
      */
@@ -120,8 +120,8 @@ export class LngLat {
      * @returns Distance in meters between the two coordinates.
      * @example
      * ```ts
-     * let new_york = new maplibregl.LngLat(-74.0060, 40.7128);
-     * let los_angeles = new maplibregl.LngLat(-118.2437, 34.0522);
+     * let new_york = new LngLat(-74.0060, 40.7128);
+     * let los_angeles = new LngLat(-118.2437, 34.0522);
      * new_york.distanceTo(los_angeles); // = 3935751.690893987, "true distance" using a non-spherical approximation is ~3966km
      * ```
      */
@@ -146,7 +146,7 @@ export class LngLat {
      * @example
      * ```ts
      * let arr = [-73.9749, 40.7736];
-     * let ll = maplibregl.LngLat.convert(arr);
+     * let ll = LngLat.convert(arr);
      * ll;   // = LngLat {lng: -73.9749, lat: 40.7736}
      * ```
      */

--- a/src/geo/lng_lat_bounds.ts
+++ b/src/geo/lng_lat_bounds.ts
@@ -9,11 +9,11 @@ import type {LngLatLike} from './lng_lat';
  *
  * @example
  * ```ts
- * let v1 = new maplibregl.LngLatBounds(
- *   new maplibregl.LngLat(-73.9876, 40.7661),
- *   new maplibregl.LngLat(-73.9397, 40.8002)
+ * let v1 = new LngLatBounds(
+ *   new LngLat(-73.9876, 40.7661),
+ *   new LngLat(-73.9397, 40.8002)
  * );
- * let v2 = new maplibregl.LngLatBounds([-73.9876, 40.7661], [-73.9397, 40.8002])
+ * let v2 = new LngLatBounds([-73.9876, 40.7661], [-73.9397, 40.8002])
  * let v3 = [[-73.9876, 40.7661], [-73.9397, 40.8002]];
  * ```
  */
@@ -33,9 +33,9 @@ export type LngLatBoundsLike = LngLatBounds | [LngLatLike, LngLatLike] | [number
  *
  * @example
  * ```ts
- * let sw = new maplibregl.LngLat(-73.9876, 40.7661);
- * let ne = new maplibregl.LngLat(-73.9397, 40.8002);
- * let llb = new maplibregl.LngLatBounds(sw, ne);
+ * let sw = new LngLat(-73.9876, 40.7661);
+ * let ne = new LngLat(-73.9397, 40.8002);
+ * let llb = new LngLatBounds(sw, ne);
  * ```
  */
 export class LngLatBounds {
@@ -49,17 +49,17 @@ export class LngLatBounds {
      * @param ne - The northeast corner of the bounding box.
      * @example
      * ```ts
-     * let sw = new maplibregl.LngLat(-73.9876, 40.7661);
-     * let ne = new maplibregl.LngLat(-73.9397, 40.8002);
-     * let llb = new maplibregl.LngLatBounds(sw, ne);
+     * let sw = new LngLat(-73.9876, 40.7661);
+     * let ne = new LngLat(-73.9397, 40.8002);
+     * let llb = new LngLatBounds(sw, ne);
      * ```
      * OR
      * ```ts
-     * let llb = new maplibregl.LngLatBounds([-73.9876, 40.7661, -73.9397, 40.8002]);
+     * let llb = new LngLatBounds([-73.9876, 40.7661, -73.9397, 40.8002]);
      * ```
      * OR
      * ```ts
-     * let llb = new maplibregl.LngLatBounds([sw, ne]);
+     * let llb = new LngLatBounds([sw, ne]);
      * ```
      */
     constructor(sw?: LngLatLike | [number, number, number, number] | [LngLatLike, LngLatLike], ne?: LngLatLike) {
@@ -157,7 +157,7 @@ export class LngLatBounds {
      * @returns The bounding box's center.
      * @example
      * ```ts
-     * let llb = new maplibregl.LngLatBounds([-73.9876, 40.7661], [-73.9397, 40.8002]);
+     * let llb = new LngLatBounds([-73.9876, 40.7661], [-73.9397, 40.8002]);
      * llb.getCenter(); // = LngLat {lng: -73.96365, lat: 40.78315}
      * ```
      */
@@ -228,7 +228,7 @@ export class LngLatBounds {
      * southwest and northeast coordinates of the bounding represented as arrays of numbers.
      * @example
      * ```ts
-     * let llb = new maplibregl.LngLatBounds([-73.9876, 40.7661], [-73.9397, 40.8002]);
+     * let llb = new LngLatBounds([-73.9876, 40.7661], [-73.9397, 40.8002]);
      * llb.toArray(); // = [[-73.9876, 40.7661], [-73.9397, 40.8002]]
      * ```
      */
@@ -243,7 +243,7 @@ export class LngLatBounds {
      * `'LngLatBounds(LngLat(lng, lat), LngLat(lng, lat))'`.
      * @example
      * ```ts
-     * let llb = new maplibregl.LngLatBounds([-73.9876, 40.7661], [-73.9397, 40.8002]);
+     * let llb = new LngLatBounds([-73.9876, 40.7661], [-73.9397, 40.8002]);
      * llb.toString(); // = "LngLatBounds(LngLat(-73.9876, 40.7661), LngLat(-73.9397, 40.8002))"
      * ```
      */
@@ -267,12 +267,12 @@ export class LngLatBounds {
      * @returns `true` if the point is within the bounding box.
      * @example
      * ```ts
-     * let llb = new maplibregl.LngLatBounds(
-     *   new maplibregl.LngLat(-73.9876, 40.7661),
-     *   new maplibregl.LngLat(-73.9397, 40.8002)
+     * let llb = new LngLatBounds(
+     *   new LngLat(-73.9876, 40.7661),
+     *   new LngLat(-73.9397, 40.8002)
      * );
      *
-     * let ll = new maplibregl.LngLat(-73.9567, 40.7789);
+     * let ll = new LngLat(-73.9567, 40.7789);
      *
      * console.log(llb.contains(ll)); // = true
      * ```
@@ -301,7 +301,7 @@ export class LngLatBounds {
      * @example
      * ```ts
      * let arr = [[-73.9876, 40.7661], [-73.9397, 40.8002]];
-     * let llb = maplibregl.LngLatBounds.convert(arr); // = LngLatBounds {_sw: LngLat {lng: -73.9876, lat: 40.7661}, _ne: LngLat {lng: -73.9397, lat: 40.8002}}
+     * let llb = LngLatBounds.convert(arr); // = LngLatBounds {_sw: LngLat {lng: -73.9876, lat: 40.7661}, _ne: LngLat {lng: -73.9397, lat: 40.8002}}
      * ```
      */
     static convert(input: LngLatBoundsLike | null): LngLatBounds {
@@ -318,8 +318,8 @@ export class LngLatBounds {
      * @returns A new `LngLatBounds` object representing the coordinates extended by the `radius`.
      * @example
      * ```ts
-     * let center = new maplibregl.LngLat(-73.9749, 40.7736);
-     * maplibregl.LngLatBounds.fromLngLat(100).toArray(); // = [[-73.97501862141328, 40.77351016847229], [-73.97478137858673, 40.77368983152771]]
+     * let center = new LngLat(-73.9749, 40.7736);
+     * LngLatBounds.fromLngLat(100).toArray(); // = [[-73.97501862141328, 40.77351016847229], [-73.97478137858673, 40.77368983152771]]
      * ```
      */
     static fromLngLat(center: LngLat, radius:number = 0): LngLatBounds {

--- a/src/geo/mercator_coordinate.ts
+++ b/src/geo/mercator_coordinate.ts
@@ -70,7 +70,7 @@ export function mercatorScale(lat: number) {
  *
  * @example
  * ```ts
- * let nullIsland = new maplibregl.MercatorCoordinate(0.5, 0.5, 0);
+ * let nullIsland = new MercatorCoordinate(0.5, 0.5, 0);
  * ```
  * @see [Add a custom style layer](https://maplibre.org/maplibre-gl-js/docs/examples/custom-style-layer/)
  */
@@ -98,7 +98,7 @@ export class MercatorCoordinate implements IMercatorCoordinate {
      * @returns The projected mercator coordinate.
      * @example
      * ```ts
-     * let coord = maplibregl.MercatorCoordinate.fromLngLat({ lng: 0, lat: 0}, 0);
+     * let coord = MercatorCoordinate.fromLngLat({ lng: 0, lat: 0}, 0);
      * coord; // MercatorCoordinate(0.5, 0.5, 0)
      * ```
      */
@@ -117,7 +117,7 @@ export class MercatorCoordinate implements IMercatorCoordinate {
      * @returns The `LngLat` object.
      * @example
      * ```ts
-     * let coord = new maplibregl.MercatorCoordinate(0.5, 0.5, 0);
+     * let coord = new MercatorCoordinate(0.5, 0.5, 0);
      * let lngLat = coord.toLngLat(); // LngLat(0, 0)
      * ```
      */
@@ -133,7 +133,7 @@ export class MercatorCoordinate implements IMercatorCoordinate {
      * @returns The altitude in meters.
      * @example
      * ```ts
-     * let coord = new maplibregl.MercatorCoordinate(0, 0, 0.02);
+     * let coord = new MercatorCoordinate(0, 0, 0.02);
      * coord.toAltitude(); // 6914.281956295339
      * ```
      */

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,7 +58,7 @@ export type * from '@maplibre/maplibre-gl-style-spec';
  * rtl text will then be rendered only after the plugin finishes loading.
  * @example
  * ```ts
- * maplibregl.setRTLTextPlugin('https://unpkg.com/@mapbox/mapbox-gl-rtl-text@0.2.3/mapbox-gl-rtl-text.js', false);
+ * setRTLTextPlugin('https://unpkg.com/@mapbox/mapbox-gl-rtl-text@0.2.3/mapbox-gl-rtl-text.js', false);
  * ```
  * @see [Add support for right-to-left scripts](https://maplibre.org/maplibre-gl-js/docs/examples/mapbox-gl-rtl-text/)
  */
@@ -70,7 +70,7 @@ function setRTLTextPlugin(pluginURL: string, lazy: boolean) { return rtlMainThre
  *
  * @example
  * ```ts
- * const pluginStatus = maplibregl.getRTLTextPluginStatus();
+ * const pluginStatus = getRTLTextPluginStatus();
  * ```
  */
 function getRTLTextPluginStatus() { return rtlMainThreadPluginFactory().getRTLTextPluginStatus(); }
@@ -87,7 +87,7 @@ function getVersion() { return version; }
  * @returns Number of workers currently configured.
  * @example
  * ```ts
- * const workerCount = maplibregl.getWorkerCount()
+ * const workerCount = getWorkerCount()
  * ```
  */
 function getWorkerCount() { return WorkerPool.workerCount; }
@@ -98,7 +98,7 @@ function getWorkerCount() { return WorkerPool.workerCount; }
  *
  * @example
  * ```ts
- * maplibregl.setWorkerCount(2);
+ * setWorkerCount(2);
  * ```
  */
 function setWorkerCount(count: number) { WorkerPool.workerCount = count; }
@@ -109,7 +109,7 @@ function setWorkerCount(count: number) { WorkerPool.workerCount = count; }
  * @returns Number of parallel requests currently configured.
  * @example
  * ```ts
- * maplibregl.getMaxParallelImageRequests();
+ * getMaxParallelImageRequests();
  * ```
  */
 function getMaxParallelImageRequests() { return config.MAX_PARALLEL_IMAGE_REQUESTS; }
@@ -119,7 +119,7 @@ function getMaxParallelImageRequests() { return config.MAX_PARALLEL_IMAGE_REQUES
  *
  * @example
  * ```ts
- * maplibregl.setMaxParallelImageRequests(10);
+ * setMaxParallelImageRequests(10);
  * ```
  */
 function setMaxParallelImageRequests(numRequests: number) { config.MAX_PARALLEL_IMAGE_REQUESTS = numRequests; }
@@ -160,7 +160,7 @@ function setWorkerUrl(value: string) { config.WORKER_URL = value; }
  * self.addPRotocol('custom', loadFn);
  *
  * // main.js
- * maplibregl.importScriptInWorkers('add-protocol-worker.js');
+ * importScriptInWorkers('add-protocol-worker.js');
  * ```
  */
 function importScriptInWorkers(workerUrl: string) { return getGlobalDispatcher().broadcast('importScript', workerUrl); }

--- a/src/source/protocol_crud.ts
+++ b/src/source/protocol_crud.ts
@@ -15,7 +15,7 @@ export function getProtocol(url: string) {
  * @example
  * ```ts
  * // This will fetch a file using the fetch API (this is obviously a non interesting example...)
- * maplibregl.addProtocol('custom', async (params, abortController) => {
+ * addProtocol('custom', async (params, abortController) => {
  *      const t = await fetch(`https://${params.url.split("://")[1]}`);
  *      if (t.status == 200) {
  *          const buffer = await t.arrayBuffer();
@@ -25,7 +25,7 @@ export function getProtocol(url: string) {
  *      }
  *  });
  * // the following is an example of a way to return an error when trying to load a tile
- * maplibregl.addProtocol('custom2', async (params, abortController) => {
+ * addProtocol('custom2', async (params, abortController) => {
  *      throw new Error('someErrorMessage'));
  * });
  * ```
@@ -40,7 +40,7 @@ export function addProtocol(customProtocol: string, loadFn: AddProtocolAction) {
  * @param customProtocol - the custom protocol to remove registration for
  * @example
  * ```ts
- * maplibregl.removeProtocol('custom');
+ * removeProtocol('custom');
  * ```
  */
 export function removeProtocol(customProtocol: string) {

--- a/src/ui/camera.ts
+++ b/src/ui/camera.ts
@@ -39,7 +39,7 @@ export type RequireAtLeastOne<T> = { [K in keyof T]-?: Required<Pick<T, K>> & Pa
  * @example
  * Set the map's initial perspective with CameraOptions
  * ```ts
- * let map = new maplibregl.Map({
+ * let map = new Map({
  *   container: 'map',
  *   style: 'https://demotiles.maplibre.org/style.json',
  *   center: [-73.5804, 45.53483],

--- a/src/ui/control/attribution_control.ts
+++ b/src/ui/control/attribution_control.ts
@@ -25,8 +25,8 @@ type AttributionControlOptions = {
  * @group Markers and Controls
  * @example
  * ```ts
- * let map = new maplibregl.Map({attributionControl: false})
- *     .addControl(new maplibregl.AttributionControl({
+ * let map = new Map({attributionControl: false})
+ *     .addControl(new AttributionControl({
  *         compact: true
  *     }));
  * ```

--- a/src/ui/control/fullscreen_control.ts
+++ b/src/ui/control/fullscreen_control.ts
@@ -27,7 +27,7 @@ type FullscreenControlOptions = {
  *
  * @example
  * ```ts
- * map.addControl(new maplibregl.FullscreenControl({container: document.querySelector('body')}));
+ * map.addControl(new FullscreenControl({container: document.querySelector('body')}));
  * ```
  * @see [View a fullscreen map](https://maplibre.org/maplibre-gl-js/docs/examples/fullscreen/)
  *

--- a/src/ui/control/geolocate_control.ts
+++ b/src/ui/control/geolocate_control.ts
@@ -79,7 +79,7 @@ let noTimeout = false;
  *
  * @example
  * ```ts
- * map.addControl(new maplibregl.GeolocateControl({
+ * map.addControl(new GeolocateControl({
  *     positionOptions: {
  *         enableHighAccuracy: true
  *     },
@@ -106,7 +106,7 @@ let noTimeout = false;
  * @example
  * ```ts
  * // Initialize the geolocate control.
- * let geolocate = new maplibregl.GeolocateControl({
+ * let geolocate = new GeolocateControl({
  *   positionOptions: {
  *       enableHighAccuracy: true
  *   },
@@ -124,7 +124,7 @@ let noTimeout = false;
  * @example
  * ```ts
  * // Initialize the geolocate control.
- * let geolocate = new maplibregl.GeolocateControl({
+ * let geolocate = new GeolocateControl({
  *   positionOptions: {
  *       enableHighAccuracy: true
  *   },
@@ -142,7 +142,7 @@ let noTimeout = false;
  * @example
  * ```ts
  * // Initialize the geolocate control.
- * let geolocate = new maplibregl.GeolocateControl({
+ * let geolocate = new GeolocateControl({
  *   positionOptions: {
  *       enableHighAccuracy: true
  *   },
@@ -160,7 +160,7 @@ let noTimeout = false;
  * @example
  * ```ts
  * // Initialize the geolocate control.
- * let geolocate = new maplibregl.GeolocateControl({
+ * let geolocate = new GeolocateControl({
  *   positionOptions: {
  *       enableHighAccuracy: true
  *   },
@@ -178,7 +178,7 @@ let noTimeout = false;
  * @example
  * ```ts
  * // Initialize the geolocate control.
- * let geolocate = new maplibregl.GeolocateControl({
+ * let geolocate = new GeolocateControl({
  *   positionOptions: {
  *       enableHighAccuracy: true
  *   },
@@ -546,7 +546,7 @@ export class GeolocateControl extends Evented implements IControl {
      * @example
      * ```ts
      * // Initialize the geolocate control.
-     * let geolocate = new maplibregl.GeolocateControl({
+     * let geolocate = new GeolocateControl({
      *  positionOptions: {
      *    enableHighAccuracy: true
      *  },

--- a/src/ui/control/logo_control.ts
+++ b/src/ui/control/logo_control.ts
@@ -21,7 +21,7 @@ type LogoControlOptions = {
  *
  * @example
  * ```ts
- * map.addControl(new maplibregl.LogoControl({compact: false}));
+ * map.addControl(new LogoControl({compact: false}));
  * ```
  **/
 export class LogoControl implements IControl {

--- a/src/ui/control/navigation_control.ts
+++ b/src/ui/control/navigation_control.ts
@@ -39,7 +39,7 @@ const defaultOptions: NavigationControlOptions = {
  *
  * @example
  * ```ts
- * let nav = new maplibregl.NavigationControl();
+ * let nav = new NavigationControl();
  * map.addControl(nav, 'top-left');
  * ```
  * @see [Display map navigation controls](https://maplibre.org/maplibre-gl-js/docs/examples/navigation/)

--- a/src/ui/control/scale_control.ts
+++ b/src/ui/control/scale_control.ts
@@ -37,7 +37,7 @@ const defaultOptions: ScaleControlOptions = {
  *
  * @example
  * ```ts
- * let scale = new maplibregl.ScaleControl({
+ * let scale = new ScaleControl({
  *     maxWidth: 80,
  *     unit: 'imperial'
  * });

--- a/src/ui/control/terrain_control.ts
+++ b/src/ui/control/terrain_control.ts
@@ -11,8 +11,8 @@ import type {TerrainSpecification} from '@maplibre/maplibre-gl-style-spec';
  *
  * @example
  * ```ts
- * let map = new maplibregl.Map({TerrainControl: false})
- *     .addControl(new maplibregl.TerrainControl({
+ * let map = new Map({TerrainControl: false})
+ *     .addControl(new TerrainControl({
  *         source: "terrain"
  *     }));
  * ```

--- a/src/ui/events.ts
+++ b/src/ui/events.ts
@@ -39,7 +39,7 @@ export type MapSourceDataType = 'content' | 'metadata' | 'visibility' | 'idle';
  * @example
  * ```ts
  * // Initialize the map
- * let map = new maplibregl.Map({ // map options });
+ * let map = new Map({ // map options });
  * // Set an event listener for a specific layer
  * map.on('the-event-name', 'poi-label', function(e) {
  *   console.log('An event has occurred on a visible portion of the poi-label layer');
@@ -138,7 +138,7 @@ export type MapLayerEventType = {
  * @example
  * ```ts
  * // Initialize the map
- * let map = new maplibregl.Map({ // map options });
+ * let map = new Map({ // map options });
  * // Set an event listener
  * map.on('the-event-name', () => {
  *   console.log('An event has occurred!');

--- a/src/ui/handler/cooperative_gestures.ts
+++ b/src/ui/handler/cooperative_gestures.ts
@@ -28,7 +28,7 @@ export type GestureOptions = {
  *
  * @example
  * ```ts
- * const map = new maplibregl.Map({
+ * const map = new Map({
  *   cooperativeGestures: {
  *      windowsHelpText: "Use Ctrl + scroll to zoom the map",
  *      macHelpText: "Use ⌘ + scroll to zoom the map",

--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -403,7 +403,7 @@ const defaultOptions = {
  *
  * @example
  * ```ts
- * let map = new maplibregl.Map({
+ * let map = new Map({
  *   container: 'map',
  *   center: [-122.420679, 37.772537],
  *   zoom: 13,
@@ -702,7 +702,7 @@ export class Map extends Camera {
      * @example
      * Add zoom and rotation controls to the map.
      * ```ts
-     * map.addControl(new maplibregl.NavigationControl());
+     * map.addControl(new NavigationControl());
      * ```
      * @see [Display map navigation controls](https://maplibre.org/maplibre-gl-js/docs/examples/navigation/)
      */
@@ -740,7 +740,7 @@ export class Map extends Camera {
      * @example
      * ```ts
      * // Define a new navigation control.
-     * let navigation = new maplibregl.NavigationControl();
+     * let navigation = new NavigationControl();
      * // Add zoom and rotation controls to the map.
      * map.addControl(navigation);
      * // Remove zoom and rotation controls from the map.
@@ -766,7 +766,7 @@ export class Map extends Camera {
      * @example
      * ```ts
      * // Define a new navigation control.
-     * let navigation = new maplibregl.NavigationControl();
+     * let navigation = new NavigationControl();
      * // Add zoom and rotation controls to the map.
      * map.addControl(navigation);
      * // Check that the navigation control exists on the map.
@@ -1348,7 +1348,7 @@ export class Map extends Camera {
      * // Set an event listener that will fire
      * // when a feature on the countries layer of the map is clicked
      * map.on('click', 'countries', (e) => {
-     *   new maplibregl.Popup()
+     *   new Popup()
      *     .setLngLat(e.lngLat)
      *     .setHTML(`Country name: ${e.features[0].properties.name}`)
      *     .addTo(map);

--- a/src/ui/marker.ts
+++ b/src/ui/marker.ts
@@ -82,7 +82,7 @@ type MarkerOptions = {
  *
  * @example
  * ```ts
- * let marker = new maplibregl.Marker()
+ * let marker = new Marker()
  *   .setLngLat([30.5, 50.5])
  *   .addTo(map);
  * ```
@@ -90,7 +90,7 @@ type MarkerOptions = {
  * @example
  * Set options
  * ```ts
- * let marker = new maplibregl.Marker({
+ * let marker = new Marker({
  *     color: "#FFFFFF",
  *     draggable: true
  *   }).setLngLat([30.5, 50.5])
@@ -286,7 +286,7 @@ export class Marker extends Evented {
      * @returns `this`
      * @example
      * ```ts
-     * let marker = new maplibregl.Marker()
+     * let marker = new Marker()
      *   .setLngLat([30.5, 50.5])
      *   .addTo(map); // add the marker to the map
      * ```
@@ -314,7 +314,7 @@ export class Marker extends Evented {
      * Removes the marker from a map
      * @example
      * ```ts
-     * let marker = new maplibregl.Marker().addTo(map);
+     * let marker = new Marker().addTo(map);
      * marker.remove();
      * ```
      * @returns `this`
@@ -369,7 +369,7 @@ export class Marker extends Evented {
      * @example
      * Create a new marker, set the longitude and latitude, and add it to the map
      * ```ts
-     * new maplibregl.Marker()
+     * new Marker()
      *   .setLngLat([-65.017, -16.457])
      *   .addTo(map);
      * ```
@@ -399,9 +399,9 @@ export class Marker extends Evented {
      * @returns `this`
      * @example
      * ```ts
-     * let marker = new maplibregl.Marker()
+     * let marker = new Marker()
      *  .setLngLat([0, 0])
-     *  .setPopup(new maplibregl.Popup().setHTML("<h1>Hello World!</h1>")) // add popup
+     *  .setPopup(new Popup().setHTML("<h1>Hello World!</h1>")) // add popup
      *  .addTo(map);
      * ```
      * @see [Attach a popup to a marker instance](https://maplibre.org/maplibre-gl-js/docs/examples/set-popup/)
@@ -472,9 +472,9 @@ export class Marker extends Evented {
      * @returns popup
      * @example
      * ```ts
-     * let marker = new maplibregl.Marker()
+     * let marker = new Marker()
      *  .setLngLat([0, 0])
-     *  .setPopup(new maplibregl.Popup().setHTML("<h1>Hello World!</h1>"))
+     *  .setPopup(new Popup().setHTML("<h1>Hello World!</h1>"))
      *  .addTo(map);
      *
      * console.log(marker.getPopup()); // return the popup instance
@@ -489,9 +489,9 @@ export class Marker extends Evented {
      * @returns `this`
      * @example
      * ```ts
-     * let marker = new maplibregl.Marker()
+     * let marker = new Marker()
      *  .setLngLat([0, 0])
-     *  .setPopup(new maplibregl.Popup().setHTML("<h1>Hello World!</h1>"))
+     *  .setPopup(new Popup().setHTML("<h1>Hello World!</h1>"))
      *  .addTo(map);
      *
      * marker.togglePopup(); // toggle popup open or closed
@@ -608,7 +608,7 @@ export class Marker extends Evented {
      *
      * @example
      * ```
-     * let marker = new maplibregl.Marker()
+     * let marker = new Marker()
      * marker.addClassName('some-class')
      * ```
      */
@@ -623,7 +623,7 @@ export class Marker extends Evented {
      *
      * @example
      * ```ts
-     * let marker = new maplibregl.Marker()
+     * let marker = new Marker()
      * marker.removeClassName('some-class')
      * ```
      */
@@ -640,7 +640,7 @@ export class Marker extends Evented {
      *
      * @example
      * ```ts
-     * let marker = new maplibregl.Marker()
+     * let marker = new Marker()
      * marker.toggleClassName('toggleClass')
      * ```
      */

--- a/src/ui/popup.ts
+++ b/src/ui/popup.ts
@@ -97,7 +97,7 @@ const focusQuerySelector = [
  * @example
  * Create a popup
  * ```ts
- * let popup = new maplibregl.Popup();
+ * let popup = new Popup();
  * // Set an event listener that will fire
  * // any time the popup is opened
  * popup.on('open', function(){
@@ -108,7 +108,7 @@ const focusQuerySelector = [
  * @example
  * Create a popup
  * ```ts
- * let popup = new maplibregl.Popup();
+ * let popup = new Popup();
  * // Set an event listener that will fire
  * // any time the popup is closed
  * popup.on('close', function(){
@@ -129,7 +129,7 @@ const focusQuerySelector = [
  *  'left': [markerRadius, (markerHeight - markerRadius) * -1],
  *  'right': [-markerRadius, (markerHeight - markerRadius) * -1]
  *  };
- * let popup = new maplibregl.Popup({offset: popupOffsets, className: 'my-class'})
+ * let popup = new Popup({offset: popupOffsets, className: 'my-class'})
  *   .setLngLat(e.lngLat)
  *   .setHTML("<h1>Hello World!</h1>")
  *   .setMaxWidth("300px")
@@ -169,7 +169,7 @@ export class Popup extends Evented {
      * @returns `this`
      * @example
      * ```ts
-     * new maplibregl.Popup()
+     * new Popup()
      *   .setLngLat([0, 0])
      *   .setHTML("<h1>Null Island</h1>")
      *   .addTo(map);
@@ -223,7 +223,7 @@ export class Popup extends Evented {
      *
      * @example
      * ```ts
-     * let popup = new maplibregl.Popup().addTo(map);
+     * let popup = new Popup().addTo(map);
      * popup.remove();
      * ```
      * @returns `this`
@@ -299,7 +299,7 @@ export class Popup extends Evented {
      * For most use cases, set `closeOnClick` and `closeButton` to `false`.
      * @example
      * ```ts
-     * let popup = new maplibregl.Popup({ closeOnClick: false, closeButton: false })
+     * let popup = new Popup({ closeOnClick: false, closeButton: false })
      *   .setHTML("<h1>Hello World!</h1>")
      *   .trackPointer()
      *   .addTo(map);
@@ -329,7 +329,7 @@ export class Popup extends Evented {
      * @example
      * Change the `Popup` element's font size
      * ```ts
-     * let popup = new maplibregl.Popup()
+     * let popup = new Popup()
      *   .setLngLat([-96, 37.8])
      *   .setHTML("<p>Hello World!</p>")
      *   .addTo(map);
@@ -353,7 +353,7 @@ export class Popup extends Evented {
      * @returns `this`
      * @example
      * ```ts
-     * let popup = new maplibregl.Popup()
+     * let popup = new Popup()
      *   .setLngLat(e.lngLat)
      *   .setText('Hello, world!')
      *   .addTo(map);
@@ -374,7 +374,7 @@ export class Popup extends Evented {
      * @returns `this`
      * @example
      * ```ts
-     * let popup = new maplibregl.Popup()
+     * let popup = new Popup()
      *   .setLngLat(e.lngLat)
      *   .setHTML("<h1>Hello World!</h1>")
      *   .addTo(map);
@@ -430,7 +430,7 @@ export class Popup extends Evented {
      * ```ts
      * let div = document.createElement('div');
      * div.innerHTML = 'Hello, world!';
-     * let popup = new maplibregl.Popup()
+     * let popup = new Popup()
      *   .setLngLat(e.lngLat)
      *   .setDOMContent(div)
      *   .addTo(map);
@@ -463,7 +463,7 @@ export class Popup extends Evented {
      *
      * @example
      * ```ts
-     * let popup = new maplibregl.Popup()
+     * let popup = new Popup()
      * popup.addClassName('some-class')
      * ```
      */
@@ -480,7 +480,7 @@ export class Popup extends Evented {
      *
      * @example
      * ```ts
-     * let popup = new maplibregl.Popup()
+     * let popup = new Popup()
      * popup.removeClassName('some-class')
      * ```
      */
@@ -511,7 +511,7 @@ export class Popup extends Evented {
      *
      * @example
      * ```ts
-     * let popup = new maplibregl.Popup()
+     * let popup = new Popup()
      * popup.toggleClassName('toggleClass')
      * ```
      */

--- a/src/util/global_worker_pool.ts
+++ b/src/util/global_worker_pool.ts
@@ -15,7 +15,7 @@ export function getGlobalWorkerPool() {
 
 /**
  * Initializes resources like WebWorkers that can be shared across maps to lower load
- * times in some situations. `maplibregl.workerUrl` and `maplibregl.workerCount`, if being
+ * times in some situations. `setWorkerUrl()` and `setWorkerCount()`, if being
  * used, must be set before `prewarm()` is called to have an effect.
  *
  * By default, the lifecycle of these resources is managed automatically, and they are
@@ -23,7 +23,7 @@ export function getGlobalWorkerPool() {
  * resources will be created ahead of time, and will not be cleared when the last Map
  * is removed from the page. This allows them to be re-used by new Map instances that
  * are created later. They can be manually cleared by calling
- * `maplibregl.clearPrewarmedResources()`. This is only necessary if your web page remains
+ * `clearPrewarmedResources()`. This is only necessary if your web page remains
  * active but stops using maps altogether.
  *
  * This is primarily useful when using GL-JS maps in a single page app, wherein a user
@@ -32,7 +32,7 @@ export function getGlobalWorkerPool() {
  *
  * @example
  * ```ts
- * maplibregl.prewarm()
+ * prewarm()
  * ```
  */
 export function prewarm() {
@@ -41,14 +41,14 @@ export function prewarm() {
 }
 
 /**
- * Clears up resources that have previously been created by `maplibregl.prewarm()`.
+ * Clears up resources that have previously been created by `prewarm()`.
  * Note that this is typically not necessary. You should only call this function
  * if you expect the user of your app to not return to a Map view at any point
  * in your application.
  *
  * @example
  * ```ts
- * maplibregl.clearPrewarmedResources()
+ * clearPrewarmedResources()
  * ```
  */
 export function clearPrewarmedResources() {

--- a/src/util/worker_pool.ts
+++ b/src/util/worker_pool.ts
@@ -22,7 +22,7 @@ export class WorkerPool {
 
     acquire(mapId: number | string): Array<ActorTarget> {
         if (!this.workers) {
-            // Lazily look up the value of maplibregl.workerCount so that
+            // Lazily look up the value of getWorkerCount so that
             // client code has had a chance to set it.
             this.workers = [];
             while (this.workers.length < WorkerPool.workerCount) {

--- a/test/integration/render/tests/text-offset/line-collision/style.json
+++ b/test/integration/render/tests/text-offset/line-collision/style.json
@@ -6,7 +6,7 @@
       "height": 256,
       "width": 1024,
       "collisionDebug": true,
-      "operations": [["idle"], ["wait", 100]]
+    "operations": [["idle"], ["wait", 500]]
     }
   },
   "center": [-73, 15],

--- a/typedoc.json
+++ b/typedoc.json
@@ -12,11 +12,11 @@
     "out": "./docs/API",
     "excludeExternals": true,
     "excludeInternal": true,
+    "placeInternalsInOwningModule": true,
     "excludeNotDocumented": true,
     "treatWarningsAsErrors": true,
     "entryPoints": ["./src/index.ts"],
     "intentionallyNotExported": ["CollisionBoxArray"],
-    "internalModule": "maplibregl",
     "navigation": {
         "includeCategories": false,
         "includeGroups": true


### PR DESCRIPTION
## Launch Checklist

This is in continue to:
- https://github.com/Gerrit0/typedoc-plugin-missing-exports/issues/23

This removes the maplibregl module from the docs and remove this prefix.
It is available in the examples, but when using this with a bundler (which is the most used case nowadays) you should not use this prefix and just import what you need.


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
