### PR TITLE
fix sky2 calculateFogMatrix error and build error

### DIFF
--- a/src/render/render_to_texture.test.ts
+++ b/src/render/render_to_texture.test.ts
@@ -64,7 +64,7 @@ describe('render to texture', () => {
     const painter = {
         layersDrawn: 0,
         context: new Context(gl),
-        transform: {zoom: 10, calculatePosMatrix: () => {}},
+        transform: {zoom: 10, calculatePosMatrix: () => {}, calculateFogMatrix: () => {}},
         colorModeForRenderPass: () => ColorMode.alphaBlended,
         useProgram: () => { return {draw: () => { layersDrawn++; }}; },
         _renderTileClippingMasks: () => {},

--- a/test/build/min.test.ts
+++ b/test/build/min.test.ts
@@ -36,7 +36,7 @@ describe('test min build', () => {
         const decreaseQuota = 4096;
 
         // feel free to update this value after you've checked that it has changed on purpose :-)
-        const expectedBytes = 772222;
+        const expectedBytes = 777766;
 
         expect(actualBytes - expectedBytes).toBeLessThan(increaseQuota);
         expect(expectedBytes - actualBytes).toBeLessThan(decreaseQuota);


### PR DESCRIPTION
try to fix the sky2 branch 'Unit tests and Coverage' calculateFogMatrix error
```
Error: TypeError: painter.transform.calculateFogMatrix is not a function

    at drawTerrain (src/render/draw_terrain.ts:88:45)
    at RenderToTexture.renderLayer (src/render/render_to_texture.ts:[18](https://github.com/maplibre/maplibre-gl-js/actions/runs/7742575082/job/21112014472?pr=3645#step:6:19)7:24)
    at Object.<anonymous> (src/render/render_to_texture.test.ts:1[19](https://github.com/maplibre/maplibre-gl-js/actions/runs/7742575082/job/21112014472?pr=3645#step:6:20):[20](https://github.com/maplibre/maplibre-gl-js/actions/runs/7742575082/job/21112014472?pr=3645#step:6:21))

Error: TypeError: painter.transform.calculateFogMatrix is not a function

    at drawTerrain (src/render/draw_terrain.ts:88:45)
    at RenderToTexture.renderLayer (src/render/render_to_texture.ts:187:[24](https://github.com/maplibre/maplibre-gl-js/actions/runs/7742575082/job/21112014472?pr=3645#step:6:25))
    at Object.<anonymous> (src/render/render_to_texture.test.ts:132:20)

Error: TypeError: painter.transform.calculateFogMatrix is not a function

    at drawTerrain (src/render/draw_terrain.ts:88:45)
    at RenderToTexture.renderLayer (src/render/render_to_texture.ts:187:24)
    at Object.<anonymous> (src/render/render_to_texture.test.ts:144:20)
```


I used calculatePosMatrix as an example since it is referenced right above calculateFogMatrix in draw_terrain.ts . I searched how calculatePosMatrix  was used in render_to_texture.test.ts and coped it for calculateFogMatrix. it seems like it fixed the error since that ci is green now.