### PR TITLE
Docs: Format list for `setFeatureState`

### DIFF
--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -2693,9 +2693,10 @@ export class Map extends Camera {
      * Features are identified by their `feature.id` attribute, which can be any number or string.
      *
      * This method can only be used with sources that have a `feature.id` attribute. The `feature.id` attribute can be defined in three ways:
-     * - For vector or GeoJSON sources, including an `id` attribute in the original data file.
-     * - For vector or GeoJSON sources, using the [`promoteId`](https://maplibre.org/maplibre-style-spec/sources/#vector-promoteId) option at the time the source is defined.
-     * - For GeoJSON sources, using the [`generateId`](https://maplibre.org/maplibre-style-spec/sources/#geojson-generateId) option to auto-assign an `id` based on the feature's index in the source data. If you change feature data using `map.getSource('some id').setData(..)`, you may need to re-apply state taking into account updated `id` values.
+     *
+     * * For vector or GeoJSON sources, including an `id` attribute in the original data file.
+     * * For vector or GeoJSON sources, using the [`promoteId`](https://maplibre.org/maplibre-style-spec/sources/#vector-promoteId) option at the time the source is defined.
+     * * For GeoJSON sources, using the [`generateId`](https://maplibre.org/maplibre-style-spec/sources/#geojson-generateId) option to auto-assign an `id` based on the feature's index in the source data. If you change feature data using `map.getSource('some id').setData(..)`, you may need to re-apply state taking into account updated `id` values.
      *
      * _Note: You can use the [`feature-state` expression](https://maplibre.org/maplibre-style-spec/expressions/#feature-state) to access the values in a feature's state object for the purposes of styling._
      *


### PR DESCRIPTION
The docs for [`setFeatureState`](https://maplibre.org/maplibre-gl-js/docs/API/classes/Map/#setfeaturestate) include a list but that list is not formatted as such. That makes it hard to read.

> <img width="708" alt="image" src="https://github.com/maplibre/maplibre-gl-js/assets/111561/35d87e9b-9cc7-4513-977c-06593038700d">

I am not sure how the Markdown formatting of the doc comments work exactly but I am assuming that a new line before the list starts and `*` for the list might solve the issue. 