### PR TITLE
Fix marker opacity after resize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes
-- _...Add new stuff here..._
+- Fix Marker losing opacity after window resize ([#3656](https://github.com/maplibre/maplibre-gl-js/pull/3656))
 
 ## 4.0.0
 

--- a/src/ui/marker.test.ts
+++ b/src/ui/marker.test.ts
@@ -1,4 +1,4 @@
-import {createMap as globalCreateMap, beforeMapTest} from '../util/test/util';
+import {createMap as globalCreateMap, beforeMapTest, sleep} from '../util/test/util';
 import {Marker} from './marker';
 import {Popup} from './popup';
 import {LngLat} from '../geo/lng_lat';
@@ -14,14 +14,8 @@ function createMap(options = {}) {
     return globalCreateMap({container, ...options});
 }
 
-let spiedRAF;
 beforeEach(() => {
     beforeMapTest();
-    spiedRAF = jest.spyOn(window, 'requestAnimationFrame');
-    spiedRAF.mockImplementation((callback: FrameRequestCallback): number => { callback(0); return 0; });
-});
-afterEach(() => {
-    spiedRAF.mockRestore();
 });
 
 describe('marker', () => {
@@ -798,7 +792,7 @@ describe('marker', () => {
         map.remove();
     });
 
-    test('Marker removed after update when terrain is on should clear timeout', () => {
+    test('Marker removed after update when terrain is on should clear timeout', async () => {
         jest.spyOn(global, 'setTimeout');
         jest.spyOn(global, 'clearTimeout');
         const map = createMap();
@@ -812,6 +806,7 @@ describe('marker', () => {
         map.transform.lngLatToCameraDepth = () => .95;
 
         marker.setOffset([10, 10]);
+        await sleep(100);
 
         expect(setTimeout).toHaveBeenCalled();
         marker.remove();
@@ -845,20 +840,22 @@ describe('marker', () => {
         map.remove();
     });
 
-    test('Sets default opacity if it\'s not provided as option', () => {
+    test('Sets default opacity if it\'s not provided as option', async () => {
         const map = createMap();
         const marker = new Marker()
             .setLngLat([0, 0])
             .addTo(map);
+        await sleep(100);
         expect(marker.getElement().style.opacity).toMatch('1');
         map.remove();
     });
 
-    test('Sets opacity according to options.opacity', () => {
+    test('Sets opacity according to options.opacity', async () => {
         const map = createMap();
         const marker = new Marker({opacity: '0.7'})
             .setLngLat([0, 0])
             .addTo(map);
+        await sleep(100);
         expect(marker.getElement().style.opacity).toMatch('.7');
         map.remove();
     });
@@ -883,7 +880,7 @@ describe('marker', () => {
         map.remove();
     });
 
-    test('Marker changes opacity behind terrain and when terrain is removed', () => {
+    test('Marker changes opacity behind terrain and when terrain is removed', async () => {
         const map = createMap();
         map.transform.lngLatToCameraDepth = () => .95; // Mocking distance to marker
         const marker = new Marker()
@@ -897,25 +894,28 @@ describe('marker', () => {
             getElevationForLngLatZoom: () => 0,
             depthAtPoint: () => .95 // Mocking distance to terrain
         } as any as Terrain;
+        await sleep(100);
         map.fire('terrain');
 
         expect(marker.getElement().style.opacity).toMatch('1');
 
         // Terrain blocks marker
         map.terrain.depthAtPoint = () => .92; // Mocking terrain blocking marker
+        await sleep(100);
         map.fire('moveend');
 
         expect(marker.getElement().style.opacity).toMatch('.2');
 
         // Remove terrain
         map.terrain = null;
+        await sleep(100);
         map.fire('terrain');
         expect(marker.getElement().style.opacity).toMatch('1');
 
         map.remove();
     });
 
-    test('Applies options.opacity when 3d terrain is enabled and marker is in clear view', () => {
+    test('Applies options.opacity when 3d terrain is enabled and marker is in clear view', async () => {
         const map = createMap();
         map.transform.lngLatToCameraDepth = () => .95; // Mocking distance to marker
         const marker = new Marker({opacity: '0.7'})
@@ -926,13 +926,14 @@ describe('marker', () => {
             getElevationForLngLatZoom: () => 0,
             depthAtPoint: () => .95
         } as any as Terrain;
+        await sleep(100);
         map.fire('terrain');
 
         expect(marker.getElement().style.opacity).toMatch('.7');
         map.remove();
     });
 
-    test('Applies options.opacity when marker\'s base is hidden by 3d terrain but its center is visible', () => {
+    test('Applies options.opacity when marker\'s base is hidden by 3d terrain but its center is visible', async () => {
         const map = createMap();
         map.transform.lngLatToCameraDepth = () => .95; // Mocking distance to marker
         const marker = new Marker({opacity: '0.7'})
@@ -943,13 +944,14 @@ describe('marker', () => {
             getElevationForLngLatZoom: () => 0,
             depthAtPoint: (p) => p.y === 256 ? .95 : .92 // return "far" given the marker's center coord; return "near" otherwise
         } as any as Terrain;
+        await sleep(100);
         map.fire('terrain');
 
         expect(marker.getElement().style.opacity).toMatch('.7');
         map.remove();
     });
 
-    test('Applies options.opacityWhenCovered when marker is hidden by 3d terrain', () => {
+    test('Applies options.opacityWhenCovered when marker is hidden by 3d terrain', async () => {
         const map = createMap();
         map.transform.lngLatToCameraDepth = () => .95; // Mocking distance to marker
         const marker = new Marker({opacity: '0.7', opacityWhenCovered: '0.3'})
@@ -960,6 +962,7 @@ describe('marker', () => {
             getElevationForLngLatZoom: () => 0,
             depthAtPoint: () => .92
         } as any as Terrain;
+        await sleep(100);
         map.fire('terrain');
 
         expect(marker.getElement().style.opacity).toMatch('0.3');

--- a/src/ui/marker.test.ts
+++ b/src/ui/marker.test.ts
@@ -14,8 +14,14 @@ function createMap(options = {}) {
     return globalCreateMap({container, ...options});
 }
 
+let spiedRAF;
 beforeEach(() => {
     beforeMapTest();
+    spiedRAF = jest.spyOn(window, 'requestAnimationFrame');
+    spiedRAF.mockImplementation((callback: FrameRequestCallback): number => { callback(0); return 0; });
+});
+afterEach(() => {
+    spiedRAF.mockRestore();
 });
 
 describe('marker', () => {
@@ -960,7 +966,7 @@ describe('marker', () => {
         map.remove();
     });
 
-    test('Applies new "opacityWhenCovered" provided by setOpacity when marker is hidden by 3d terrain', async () => {
+    test('Applies new "opacityWhenCovered" provided by setOpacity when marker is hidden by 3d terrain', () => {
         const map = createMap();
         map.transform.lngLatToCameraDepth = () => .95; // Mocking distance to marker
         const marker = new Marker({opacityWhenCovered: '0.15'})

--- a/src/ui/marker.ts
+++ b/src/ui/marker.ts
@@ -142,7 +142,6 @@ export class Marker extends Evented {
     _opacity: string;
     _opacityWhenCovered: string;
     _opacityTimeout: ReturnType<typeof setTimeout>;
-    _frameRequest: AbortController;
 
     /**
      * @param options - the options
@@ -597,9 +596,7 @@ export class Marker extends Evented {
 
         DOM.setTransform(this._element, `${anchorTranslate[this._anchor]} translate(${this._pos.x}px, ${this._pos.y}px) ${pitch} ${rotation}`);
 
-        this._frameRequest = new AbortController();
-        browser.frameAsync(this._frameRequest).then(() => { // Run _updateOpacity only after painter.render and drawDepth
-            this._frameRequest = null;
+        browser.frameAsync(new AbortController()).then(() => { // Run _updateOpacity only after painter.render and drawDepth
             this._updateOpacity(e && e.type === 'moveend');
         }).catch(() => {});
     };

--- a/src/ui/marker.ts
+++ b/src/ui/marker.ts
@@ -521,7 +521,7 @@ export class Marker extends Evented {
     }
 
     _updateOpacity = (force: boolean = false) => {
-        const terrain = this._map.terrain;
+        const terrain = this._map?.terrain;
         if (!terrain) {
             if (this._element.style.opacity !== this._opacity) { this._element.style.opacity = this._opacity; }
             return;

--- a/src/ui/marker.ts
+++ b/src/ui/marker.ts
@@ -520,7 +520,7 @@ export class Marker extends Evented {
         return this;
     }
 
-    _updateOpacity(force: boolean = false) {
+    _updateOpacity = (force: boolean = false) => {
         const terrain = this._map.terrain;
         if (!terrain) {
             if (this._element.style.opacity !== this._opacity) { this._element.style.opacity = this._opacity; }
@@ -556,7 +556,7 @@ export class Marker extends Evented {
         // Display at full opacity if center is visible.
         const centerIsInvisible = markerDistanceCenter - terrainDistanceCenter > forgiveness;
         this._element.style.opacity = centerIsInvisible ? this._opacityWhenCovered : this._opacity;
-    }
+    };
 
     _update = (e?: { type: 'move' | 'moveend' | 'terrain' | 'render' }) => {
         if (!this._map) return;

--- a/src/ui/marker.ts
+++ b/src/ui/marker.ts
@@ -594,7 +594,9 @@ export class Marker extends Evented {
         }
 
         DOM.setTransform(this._element, `${anchorTranslate[this._anchor]} translate(${this._pos.x}px, ${this._pos.y}px) ${pitch} ${rotation}`);
-        this._updateOpacity(e && e.type === 'moveend');
+
+        // Run it after painter.render and drawDepth
+        requestAnimationFrame((_) => this._updateOpacity(e && e.type === 'moveend'));
     };
 
     /**


### PR DESCRIPTION
Fixes https://github.com/maplibre/maplibre-gl-js/issues/3646

https://github.com/maplibre/maplibre-gl-js/assets/11789697/4a68acdd-a41e-4c36-9088-138eb6cd6604

### Explanation
On resize Marker was updated **before** map._render.
When marker is updated, it reads the depthTexture to figure out the terrainDistance.
At this moment depthTexture was **empty** because it was just re-initialized due to resize. It was populated only later as part of map._render.
So the order of events on each resize was: _resize -> destroy depthTexture -> read it -> populate it_.

My idea is to delay opacity-related code using requestAnimationFrame (because map render is delayed so). It ensures that marker's opacity is updated **after** map render and after drawDepth.

From my understanding, this fix is untestable because ResizeObserver in jest doesn't really work.


