### PR TITLE
Docs: Improve list styles

### DIFF
--- a/src/geo/mercator_coordinate.ts
+++ b/src/geo/mercator_coordinate.ts
@@ -56,6 +56,7 @@ export function mercatorScale(lat: number) {
  * A `MercatorCoordinate` object represents a projected three dimensional position.
  *
  * `MercatorCoordinate` uses the web mercator projection ([EPSG:3857](https://epsg.io/3857)) with slightly different units:
+ *
  * - the size of 1 unit is the width of the projected world instead of the "mercator meter"
  * - the origin of the coordinate space is at the north-west corner instead of the middle
  *

--- a/src/source/tile.ts
+++ b/src/source/tile.ts
@@ -36,6 +36,7 @@ import {ExpiryData} from '../util/ajax';
 
 /**
  * The tile's state, can be:
+ *
  * - `loading` Tile data is in the process of loading.
  * - `loaded` Tile data has been loaded. Tile can be rendered.
  * - `reloading` Tile data has been loaded and is being updated. Tile can be rendered.

--- a/src/style/style_layer/custom_style_layer.ts
+++ b/src/style/style_layer/custom_style_layer.ts
@@ -27,6 +27,7 @@ type CustomRenderMethod = (gl: WebGLRenderingContext|WebGL2RenderingContext, mat
  * and they should appropriately handle {@link MapContextEvent} with `webglcontextlost` and `webglcontextrestored`.
  *
  * The `renderingMode` property controls whether the layer is treated as a `"2d"` or `"3d"` map layer. Use:
+ *
  * - `"renderingMode": "3d"` to use the depth buffer and share it with other layers
  * - `"renderingMode": "2d"` to add a layer with no depth. If you need to use the depth buffer for a `"2d"` layer you must use an offscreen
  *   framebuffer and {@link CustomLayerInterface#prerender}

--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -2694,9 +2694,9 @@ export class Map extends Camera {
      *
      * This method can only be used with sources that have a `feature.id` attribute. The `feature.id` attribute can be defined in three ways:
      *
-     * * For vector or GeoJSON sources, including an `id` attribute in the original data file.
-     * * For vector or GeoJSON sources, using the [`promoteId`](https://maplibre.org/maplibre-style-spec/sources/#vector-promoteId) option at the time the source is defined.
-     * * For GeoJSON sources, using the [`generateId`](https://maplibre.org/maplibre-style-spec/sources/#geojson-generateId) option to auto-assign an `id` based on the feature's index in the source data. If you change feature data using `map.getSource('some id').setData(..)`, you may need to re-apply state taking into account updated `id` values.
+     * - For vector or GeoJSON sources, including an `id` attribute in the original data file.
+     * - For vector or GeoJSON sources, using the [`promoteId`](https://maplibre.org/maplibre-style-spec/sources/#vector-promoteId) option at the time the source is defined.
+     * - For GeoJSON sources, using the [`generateId`](https://maplibre.org/maplibre-style-spec/sources/#geojson-generateId) option to auto-assign an `id` based on the feature's index in the source data. If you change feature data using `map.getSource('some id').setData(..)`, you may need to re-apply state taking into account updated `id` values.
      *
      * _Note: You can use the [`feature-state` expression](https://maplibre.org/maplibre-style-spec/expressions/#feature-state) to access the values in a feature's state object for the purposes of styling._
      *

--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -223,6 +223,7 @@ export type MapOptions = {
     pitch?: number;
     /**
      * If `true`, multiple copies of the world will be rendered side by side beyond -180 and 180 degrees longitude. If set to `false`:
+     *
      * - When the map is zoomed out far enough that a single representation of the world does not fill the map's entire
      * container, there will be blank space beyond 180 and -180 degrees longitude.
      * - Features that cross 180 and -180 degrees longitude will be cut in two (with one portion on the right edge of the
@@ -1094,6 +1095,7 @@ export class Map extends Camera {
 
     /**
      * Returns the state of `renderWorldCopies`. If `true`, multiple copies of the world will be rendered side by side beyond -180 and 180 degrees longitude. If set to `false`:
+     *
      * - When the map is zoomed out far enough that a single representation of the world does not fill the map's entire
      * container, there will be blank space beyond 180 and -180 degrees longitude.
      * - Features that cross 180 and -180 degrees longitude will be cut in two (with one portion on the right edge of the
@@ -1111,6 +1113,7 @@ export class Map extends Camera {
      * Sets the state of `renderWorldCopies`.
      *
      * @param renderWorldCopies - If `true`, multiple copies of the world will be rendered side by side beyond -180 and 180 degrees longitude. If set to `false`:
+     *
      * - When the map is zoomed out far enough that a single representation of the world does not fill the map's entire
      * container, there will be blank space beyond 180 and -180 degrees longitude.
      * - Features that cross 180 and -180 degrees longitude will be cut in two (with one portion on the right edge of the
@@ -3012,6 +3015,7 @@ export class Map extends Camera {
     /**
      * @internal
      * Call when a (re-)render of the map is required:
+     *
      * - The style has changed (`setPaintProperty()`, etc.)
      * - Source data has changed (e.g. tiles have finished loading)
      * - The map has is moving (or just finished moving)

--- a/src/ui/popup.ts
+++ b/src/ui/popup.ts
@@ -22,9 +22,11 @@ const defaultOptions = {
 
 /**
  * A pixel offset specified as:
+ *
  * - a single number specifying a distance from the location
  * - a {@link PointLike} specifying a constant offset
  * - an object of {@link Point}s specifying an offset for each anchor position
+ *
  * Negative offsets indicate left and up.
  */
 export type Offset = number | PointLike | {


### PR DESCRIPTION
This is a follow up to https://github.com/maplibre/maplibre-gl-js/pull/3655 but looks at all the other places where a list was used without an empty line above. The missing empty line is what breaks the markdown processing.

The list style that is used consistently in this PR is `-` which makes the list easier to read than the `*` I used in #3655.