### PR TITLE
Docs: Hint at how to add lists and streamline commands

### DIFF
--- a/build/generate-docs.ts
+++ b/build/generate-docs.ts
@@ -117,4 +117,4 @@ if (!fs.existsSync(typedocConfig.out)) {
 fs.rmSync(path.join(typedocConfig.out, 'README.md'));
 generateReadme();
 generateExamplesFolder();
-console.log('Docs generation completed, to see it in action run\n docker run --rm -it -p 8000:8000 -v ${PWD}:/docs squidfunk/mkdocs-material');
+console.log('Docs generation completed, to see it in action run\n npm run start-docs');

--- a/build/generate-docs.ts
+++ b/build/generate-docs.ts
@@ -15,7 +15,7 @@ function generateAPIIntroMarkdown(lines: string[]): string {
 This file is intended as a reference for the important and public classes of this API.
 We recommend looking at the [examples](../examples/index.md) as they will help you the most to start with MapLibre.
 
-Most of the classes wirtten here have an "Options" object for initialization, it is recommended to check which options exist. 
+Most of the classes wirtten here have an "Options" object for initialization, it is recommended to check which options exist.
 
 It is recommended to import what you need and the use it. Some examples for classes assume you did that.
 For example, import the \`Map\` class like this:

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,7 +25,7 @@ Finally, run:
 npm run start-docs
 ```
 
-Navigate to [http://0.0.0.0:8000/](http://0.0.0.0:8000/) to view the docs. After making changes, run `npm run generate-docs` again to apply them. Some tile service providers of the docs example pages such as MapTiler or Staida Maps might only send you tiles if the host is localhost. In that case, try http://localhost:8000. 
+Navigate to [http://0.0.0.0:8000/](http://0.0.0.0:8000/) to view the docs. After making changes, run `npm run generate-docs` again to apply them. Some tile service providers of the docs example pages such as MapTiler or Staida Maps might only send you tiles if the host is localhost. In that case, try http://localhost:8000.
 
 The examples section of the locally run documentation will use the GL JS version released that has the same version as the in the package.json.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -47,6 +47,7 @@ API documentation is written as [TSDoc comments](https://tsdoc.org/) and process
 * Functions that do not return a value (return `void`), should not have a `@returns` annotation.
 * Member descriptions should document what a member represents or gets and sets. They should also indicate whether the member is read-only.
 * Event descriptions should begin with "Fired when..." and so should describe when the event fires. Event entries should clearly document any data passed to the handler, with a link to MDN documentation of native Event objects when applicable.
+* Lists need an empty line above to be formatted as HTML list.
 
 ## Writing Examples
 


### PR DESCRIPTION
One commit adds a hin on how to add lists on the docs so they are formatted as html list (see https://github.com/maplibre/maplibre-gl-js/pull/3657).

Another commit streamlines the use of "npm run start-docs" which made it easier for me to understand the whole setup.