### PR TITLE
Docs: Fix a type warning on `generateMarkdownForExample`

### DIFF
--- a/build/generate-docs.ts
+++ b/build/generate-docs.ts
@@ -93,13 +93,13 @@ function generateExamplesFolder() {
         htmlContent = htmlContent.replace(/\.\.\/\.\.\//g, maplibreUnpgk);
         htmlContent = htmlContent.replace(/-dev.js/g, '.js');
         const htmlContentLines = htmlContent.split('\n');
-        const title = htmlContentLines.find(l => l.includes('<title'))?.replace('<title>', '').replace('</title>', '').trim();
-        const description = htmlContentLines.find(l => l.includes('og:description'))?.replace(/.*content=\"(.*)\".*/, '$1');
+        const title = htmlContentLines.find(l => l.includes('<title'))?.replace('<title>', '').replace('</title>', '').trim()!;
+        const description = htmlContentLines.find(l => l.includes('og:description'))?.replace(/.*content=\"(.*)\".*/, '$1')!;
         fs.writeFileSync(path.join(examplesDocsFolder, file), htmlContent);
         const mdFileName = file.replace('.html', '.md');
         indexArray.push({
-            title: title!,
-            description: description!,
+            title,
+            description,
             mdFileName
         });
         const exampleMarkdown = generateMarkdownForExample(title, description, file, htmlContent);


### PR DESCRIPTION
The `!` moves on level up so this error goes away:

<img width="1035" alt="Bildschirmfoto 2024-02-04 um 18 06 36" src="https://github.com/maplibre/maplibre-gl-js/assets/111561/3e680885-577f-4a81-a468-808359e4b9b1">
