### PR TITLE
Tweak banner license comment to include @license.

### DIFF
--- a/build/banner.ts
+++ b/build/banner.ts
@@ -1,3 +1,7 @@
 import packageJSON from '../package.json' assert {type: 'json'};
 
-export default `/* MapLibre GL JS is licensed under the 3-Clause BSD License. Full text of license: https://github.com/maplibre/maplibre-gl-js/blob/v${packageJSON.version}/LICENSE.txt */`;
+export default
+`/**
+ * MapLibre GL JS
+ * @license 3-Clause BSD. Full text of license: https://github.com/maplibre/maplibre-gl-js/blob/v${packageJSON.version}/LICENSE.txt
+ */`;


### PR DESCRIPTION
UglifyJS is a popular js minifer. To preserve comments (without using regex) it expects (JSDoc-style) multiline comment with the keyword `@license, @preserve` etc.