### PR TITLE
Revert "Bump codecov/codecov-action from 3 to 4"

### DIFF
--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -47,7 +47,7 @@ jobs:
       - run: npm ci
       - run: npm run test-unit-ci
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v3
         with:
           files: ${{ github.workspace }}/coverage/unit/codecov.json
           verbose: true
@@ -104,7 +104,7 @@ jobs:
           CURRENT_SPLIT_INDEX: ${{ matrix.split }}
         if: success() || failure()
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v3
         with:
           files: ${{ github.workspace }}/coverage/render/codecov.json
           verbose: true


### PR DESCRIPTION
Reverts #3661 as we don't get coverage report in version 4.
This is because version 4 requires codecov token, and there's still a discussion around how dependabot will use it:
https://github.com/codecov/feedback/issues/264
I generally would like to avoid adding a secret if possible.