### PR TITLE
fix meta descriptions of deckgl examples

### DIFF
--- a/test/examples/add-deckgl-layer-using-rest-api.html
+++ b/test/examples/add-deckgl-layer-using-rest-api.html
@@ -2,10 +2,7 @@
 <html lang="en">
   <head>
     <title>Create deck.gl layer using REST API</title>
-    <meta
-      property="og:description"
-      content="Create a deck.gl layer as an overlay from a REST API."
-    />
+    <meta property="og:description" content="Create a deck.gl layer as an overlay from a REST API." />
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="stylesheet" href="../../dist/maplibre-gl.css" />

--- a/test/examples/toggle-deckgl-layer.html
+++ b/test/examples/toggle-deckgl-layer.html
@@ -1,10 +1,8 @@
+<!DOCTYPE html>
 <html lang="en">
   <head>
     <title>Toggle deck.gl layer</title>
-    <meta
-      property="og:description"
-      content="Toggle deck.gl layer using maplibre."
-    />
+    <meta property="og:description" content="Toggle deck.gl layer using maplibre." />
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="stylesheet" href="../../dist/maplibre-gl.css" />
@@ -167,7 +165,7 @@
 
           map.addControl(overlay);
       }
-      
+
       let show = true; // Display the layer by default
 
       map.on('load', () => {


### PR DESCRIPTION

 - [x] Briefly describe the changes in this PR.
The meta descriptions of examples that extend beyond a single line demonstrate flawed sub headers, as in [here](https://maplibre.org/maplibre-gl-js/docs/examples/add-deckgl-layer-using-rest-api/). Instead of the content property `<meta property="og:description"` is displayed. 

This PR fixes that.