### PR TITLE
Adds RasterTileSource#setUrl method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
 ## main
 
 ### ✨ Features and improvements
-- _...Add new stuff here..._
+
+- Add `setUrl` method to RasterTileSource to dynamically update existing TileJSON resource. ([3700](https://github.com/maplibre/maplibre-gl-js/pull/3700))
 
 ### 🐞 Bug fixes
+
 - Fix Marker losing opacity after window resize ([#3656](https://github.com/maplibre/maplibre-gl-js/pull/3656))
 - Fix vector tiles not loading when html is opened via "file://" ([#3681](https://github.com/maplibre/maplibre-gl-js/pull/3681))
 
@@ -12,14 +14,16 @@
 ### ✨ Features and improvements
 
 - ⚠️ Remove all global getters and setters from `maplibregl`, this means the the following methods have changed:
+
   - `maplibregl.version` => `getVersion()`
   - `maplibregl.workerCount` => `getWorkerCount()`, `setWorkerCount(...)`
   - `maplibregl.maxParallelImageRequests` => `getMaxParallelImageRequests()`, `setMaxParallelImageRequests(...)`
   - `maplibregl.workerUrl` => `getWorkerUrl()`, `setWorkerUrl(...)`
 
   This is to avoid the need to use a global object and allow named exports/imports ([#3601](https://github.com/maplibre/maplibre-gl-js/issues/3601))
+
 - ⚠️ Change attribution to be on by default, change `MapOptions.attributionControl` to be the type that the control handles, removed `MapOptions.customAttribution` ([#3618](https://github.com/maplibre/maplibre-gl-js/issues/3618))
-Note: showing the logo of MapLibre is not required for using MapLibre.
+  Note: showing the logo of MapLibre is not required for using MapLibre.
 - ⚠️ Changed cooperative gesture config and removed the strings from it in favor of the locale variable ([#3621](https://github.com/maplibre/maplibre-gl-js/issues/3621))
 - ⚠️ Changed the terrain enable disable locale key to match the other keys' styles, updated the typings to allow using locale with more ease ([#3621](https://github.com/maplibre/maplibre-gl-js/issues/3621))
 - ⚠️ Add the ability to import a script in the worker thread and call `addProtocol` and `removeProtocol` there ([#3459](https://github.com/maplibre/maplibre-gl-js/pull/3459)) - this also changed how `addSourceType` works since now you'll need to load the script with `maplibregl.importScriptInWorkers`.
@@ -43,7 +47,7 @@ Note: showing the logo of MapLibre is not required for using MapLibre.
 ### 🐞 Bug fixes
 
 - Fix wheel zoom to be into the same direction above or under the horizon ([#3398](https://github.com/maplibre/maplibre-gl-js/issues/3398))
-- Fix _cameraForBoxAndBearing not fitting bounds properly when using asymettrical camera viewport and bearing.([#3591](https://github.com/maplibre/maplibre-gl-js/pull/3591))
+- Fix \_cameraForBoxAndBearing not fitting bounds properly when using asymettrical camera viewport and bearing.([#3591](https://github.com/maplibre/maplibre-gl-js/pull/3591))
 - Fix missing export `Map` type in the `d.ts` file ([#3564](https://github.com/maplibre/maplibre-gl-js/pull/3564))
 - Fix the shifted mouse events after a css transform scale on the map container ([#3437](https://github.com/maplibre/maplibre-gl-js/pull/3437))
 - Fix markers remaining transparent when disabling terrain ([#3431](https://github.com/maplibre/maplibre-gl-js/pull/3431))
@@ -59,7 +63,7 @@ Note: showing the logo of MapLibre is not required for using MapLibre.
 ### ✨ Features and improvements
 
 - ⚠️ Change attribution to be on by default, change `MapOptions.attributionControl` to be the type that the control handles, removed `MapOptions.customAttribution` ([#3618](https://github.com/maplibre/maplibre-gl-js/issues/3618))
-Note: showing the logo of MapLibre is not required for using MapLibre.
+  Note: showing the logo of MapLibre is not required for using MapLibre.
 - ⚠️ Changed cooperative gesture config and removed the strings from it in favor of the locale variable ([#3621](https://github.com/maplibre/maplibre-gl-js/issues/3621))
 - ⚠️ Changed the terrain enable disable locale key to match the other keys' styles, updated the typings to allow using locale with more ease ([#3621](https://github.com/maplibre/maplibre-gl-js/issues/3621))
 - Add "opacity" option and "setOpacity" method to Marker ([#3620](https://github.com/maplibre/maplibre-gl-js/pull/3620))
@@ -78,7 +82,7 @@ Note: showing the logo of MapLibre is not required for using MapLibre.
 ### 🐞 Bug fixes
 
 - Fix wheel zoom to be into the same direction above or under the horizon ([#3398](https://github.com/maplibre/maplibre-gl-js/issues/3398))
-- Fix _cameraForBoxAndBearing not fitting bounds properly when using asymettrical camera viewport and bearing ([#3591](https://github.com/maplibre/maplibre-gl-js/pull/3591))
+- Fix \_cameraForBoxAndBearing not fitting bounds properly when using asymettrical camera viewport and bearing ([#3591](https://github.com/maplibre/maplibre-gl-js/pull/3591))
 
 ## 4.0.0-pre.4
 

--- a/src/source/raster_tile_source.test.ts
+++ b/src/source/raster_tile_source.test.ts
@@ -179,6 +179,17 @@ describe('RasterTileSource', () => {
         expect((server.lastRequest as any).aborted).toBe(true);
     });
 
+    test('supports url property updates', () => {
+        const source = createSource({
+            url: 'http://localhost:2900/source.json'
+        });
+        source.setUrl('http://localhost:2900/source2.json');
+        expect(source.serialize()).toEqual({
+            type: 'raster',
+            url: 'http://localhost:2900/source2.json'
+        });
+    });
+
     it('serializes options', () => {
         const source = createSource({
             tiles: ['http://localhost:2900/raster/{z}/{x}/{y}.png'],

--- a/src/source/raster_tile_source.ts
+++ b/src/source/raster_tile_source.ts
@@ -156,14 +156,14 @@ export class RasterTileSource extends Evented implements Source {
      * @param url - A URL to a TileJSON resource. Supported protocols are `http:` and `https:`.
      * @returns `this`
      */
-        setUrl(url: string): this {
-            this.setSourceProperty(() => {
-                this.url = url;
-                this._options.url = url;
-            });
+    setUrl(url: string): this {
+        this.setSourceProperty(() => {
+            this.url = url;
+            this._options.url = url;
+        });
 
-            return this;
-        }
+        return this;
+    }
 
     serialize() {
         return extend({}, this._options);

--- a/src/source/raster_tile_source.ts
+++ b/src/source/raster_tile_source.ts
@@ -150,6 +150,21 @@ export class RasterTileSource extends Evented implements Source {
         return this;
     }
 
+    /**
+     * Sets the source `url` property and re-renders the map.
+     *
+     * @param url - A URL to a TileJSON resource. Supported protocols are `http:` and `https:`.
+     * @returns `this`
+     */
+        setUrl(url: string): this {
+            this.setSourceProperty(() => {
+                this.url = url;
+                this._options.url = url;
+            });
+
+            return this;
+        }
+
     serialize() {
         return extend({}, this._options);
     }


### PR DESCRIPTION
This PR adds the `setUrl` function to RasterTileSource:
- Add `setUrl` to RasterTileSource
- Add unit test to confirm tilejson url update
- Changelog entry