### PR TITLE
Fix popup position around marker that was moved to side globe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes
+- Fix popup appearing far from marker that was moved to a side globe ([3712](https://github.com/maplibre/maplibre-gl-js/pull/3712))
 - _...Add new stuff here..._
 
 ## 4.0.2

--- a/src/ui/marker.test.ts
+++ b/src/ui/marker.test.ts
@@ -6,11 +6,15 @@ import Point from '@mapbox/point-geometry';
 import simulate from '../../test/unit/lib/simulate_interaction';
 import type {Terrain} from '../render/terrain';
 
-function createMap(options = {} as any) {
+type MapOptions = {
+    width?: number;
+}
+
+function createMap(options: MapOptions = {}) {
     const container = window.document.createElement('div');
     window.document.body.appendChild(container);
     Object.defineProperty(container, 'clientWidth', {value: options.width || 512});
-    Object.defineProperty(container, 'clientHeight', {value: options.height || 512});
+    Object.defineProperty(container, 'clientHeight', {value: 512});
     return globalCreateMap({container, ...options});
 }
 

--- a/src/ui/marker.test.ts
+++ b/src/ui/marker.test.ts
@@ -6,11 +6,11 @@ import Point from '@mapbox/point-geometry';
 import simulate from '../../test/unit/lib/simulate_interaction';
 import type {Terrain} from '../render/terrain';
 
-function createMap(options = {}) {
+function createMap(options = {} as any) {
     const container = window.document.createElement('div');
     window.document.body.appendChild(container);
-    Object.defineProperty(container, 'clientWidth', {value: 512});
-    Object.defineProperty(container, 'clientHeight', {value: 512});
+    Object.defineProperty(container, 'clientWidth', {value: options.width || 512});
+    Object.defineProperty(container, 'clientHeight', {value: options.height || 512});
     return globalCreateMap({container, ...options});
 }
 
@@ -284,6 +284,7 @@ describe('marker', () => {
         expect(marker.getPopup().options.offset['top-left']).toEqual([0, 0]);
         expect(marker.getPopup().options.offset['top-right']).toEqual([0, 0]);
 
+        map.remove();
     });
 
     test('Popup anchors around default Marker', () => {
@@ -352,6 +353,41 @@ describe('marker', () => {
             marker.getPopup()._container.classList.contains('maplibregl-popup-anchor-bottom-right')
         ).toBeTruthy();
 
+        map.remove();
+    });
+
+    test('Popup is opened at its marker position after marker is moved to another globe', () => {
+        const map = createMap({width: 3000});
+
+        const marker = new Marker()
+            .setLngLat([0, 0])
+            .setPopup(new Popup().setText('Test'))
+            .addTo(map);
+
+        marker._pos = new Point(2999, 242);
+        marker._lngLat = map.unproject(marker._pos);
+        marker.togglePopup();
+
+        expect(marker.getPopup()._pos.x).toBeCloseTo(marker._pos.x, 0);
+        map.remove();
+    });
+
+    test('Popup is re-opened at its marker position after marker is moved to another globe', () => {
+        const map = createMap({width: 3000});
+
+        const marker = new Marker()
+            .setLngLat([0, 0])
+            .setPopup(new Popup().setText('Test'))
+            .addTo(map)
+            .togglePopup()
+            .togglePopup();
+
+        marker._pos = new Point(2999, 242);
+        marker._lngLat = map.unproject(marker._pos);
+        marker.togglePopup();
+
+        expect(marker.getPopup()._pos.x).toBeCloseTo(marker._pos.x, 0);
+        map.remove();
     });
 
     test('Marker drag functionality can be added with drag option', () => {

--- a/src/ui/marker.ts
+++ b/src/ui/marker.ts
@@ -450,7 +450,6 @@ export class Marker extends Evented {
                 } as Offset : this._offset;
             }
             this._popup = popup;
-            if (this._lngLat) this._popup.setLngLat(this._lngLat);
 
             this._originalTabIndex = this._element.getAttribute('tabindex');
             if (!this._originalTabIndex) {
@@ -518,7 +517,9 @@ export class Marker extends Evented {
 
         if (!popup) return this;
         else if (popup.isOpen()) popup.remove();
-        else popup.addTo(this._map);
+        else {
+            popup.setLngLat(this._lngLat); popup.addTo(this._map);
+        }
         return this;
     }
 

--- a/src/ui/marker.ts
+++ b/src/ui/marker.ts
@@ -518,7 +518,8 @@ export class Marker extends Evented {
         if (!popup) return this;
         else if (popup.isOpen()) popup.remove();
         else {
-            popup.setLngLat(this._lngLat); popup.addTo(this._map);
+            popup.setLngLat(this._lngLat);
+            popup.addTo(this._map);
         }
         return this;
     }

--- a/src/ui/popup.ts
+++ b/src/ui/popup.ts
@@ -280,6 +280,7 @@ export class Popup extends Evented {
     setLngLat(lnglat: LngLatLike): this {
         this._lngLat = LngLat.convert(lnglat);
         this._pos = null;
+        this._flatPos = null;
 
         this._trackPointer = false;
 
@@ -312,6 +313,7 @@ export class Popup extends Evented {
     trackPointer(): this {
         this._trackPointer = true;
         this._pos = null;
+        this._flatPos = null;
         this._update();
         if (this._map) {
             this._map.off('move', this._update);


### PR DESCRIPTION
Fixes https://github.com/maplibre/maplibre-gl-js/issues/2775

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [ ] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [x] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [ ] Add an entry to `CHANGELOG.md` under the `## main` section.

Idea is to set lngLat every time the popup is opened (when Popup.addTo is called) and to reset the previous position.
This prevents smartWrap from doing its bad job.

https://github.com/maplibre/maplibre-gl-js/assets/11789697/fe6eadd0-1931-40f2-ae07-7e537513bca5

