### PR TITLE
set text color in the attribution pill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### 🐞 Bug fixes
 - Fix popup appearing far from marker that was moved to a side globe ([3712](https://github.com/maplibre/maplibre-gl-js/pull/3712))
+- Set text color in the attribution pill ([3737](https://github.com/maplibre/maplibre-gl-js/pull/3737))
 - _...Add new stuff here..._
 
 ## 4.0.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🐞 Bug fixes
 - Fix popup appearing far from marker that was moved to a side globe ([3712](https://github.com/maplibre/maplibre-gl-js/pull/3712))
-- Set text color in the attribution pill ([3737](https://github.com/maplibre/maplibre-gl-js/pull/3737))
+- Set text color to ensure contrast in the attribution pill ([3737](https://github.com/maplibre/maplibre-gl-js/pull/3737))
 - _...Add new stuff here..._
 
 ## 4.0.2

--- a/src/css/maplibre-gl.css
+++ b/src/css/maplibre-gl.css
@@ -446,6 +446,7 @@ a.maplibregl-ctrl-logo.maplibregl-compact {
         margin: 10px;
         position: relative;
         background-color: #fff;
+        color: #000;
         border-radius: 12px;
         box-sizing: content-box;
     }


### PR DESCRIPTION
Set the text color to ensure readability/contrast of the attribution pill.

| before | after |
| --- | --- |
| ![before](https://github.com/maplibre/maplibre-gl-js/assets/7001/a3209868-e3cd-4882-993c-ecf643b2a358) | ![after](https://github.com/maplibre/maplibre-gl-js/assets/7001/9dc38358-beaf-4126-8ca6-84937a7489bb) |

(In the example above, the page's **text** has a light color, to contrast with the dark background. This percolates to the attribution text, which is set on a light background.)

Only the text color needs to be specified. The background is specified in 
https://github.com/maplibre/maplibre-gl-js/blob/0aeb2c0f926fcb4f922791642f0e3ee8119043a2/src/css/maplibre-gl.css#L448

and the link color is specified in 
https://github.com/maplibre/maplibre-gl-js/blob/0aeb2c0f926fcb4f922791642f0e3ee8119043a2/src/css/maplibre-gl.css#L540


closes #3732

## Launch Checklist

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [x] Include before/after visuals or gifs if this PR includes visual changes.
 - [-] Write tests for all new functionality.
 - [-] Document any changes to public APIs.
 - [-] Post benchmark scores.
 - [x] Add an entry to `CHANGELOG.md` under the `## main` section.
