### PR TITLE
Add source types union

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### 🐞 Bug fixes
 - Fix popup appearing far from marker that was moved to a side globe ([3712](https://github.com/maplibre/maplibre-gl-js/pull/3712))
 - Set text color to ensure contrast in the attribution pill ([3737](https://github.com/maplibre/maplibre-gl-js/pull/3737))
+- Fix Source type to type available methods depending on source types ([3755](https://github.com/maplibre/maplibre-gl-js/pull/3755))
 - _...Add new stuff here..._
 
 ## 4.0.2

--- a/src/source/source.ts
+++ b/src/source/source.ts
@@ -13,6 +13,7 @@ import type {Map} from '../ui/map';
 import type {Tile} from './tile';
 import type {OverscaledTileID, CanonicalTileID} from './tile_id';
 import type {CanvasSourceSpecification} from '../source/canvas_source';
+import {SourceCacheSource} from './source_cache';
 
 const registeredSources = {} as {[key:string]: SourceClass};
 
@@ -122,7 +123,7 @@ export interface Source {
  * A general definition of a {@link Source} class for factory usage
  */
 export type SourceClass = {
-    new (id: string, specification: SourceSpecification | CanvasSourceSpecification, dispatcher: Dispatcher, eventedParent: Evented): Source;
+    new (id: string, specification: SourceSpecification | CanvasSourceSpecification, dispatcher: Dispatcher, eventedParent: Evented): SourceCacheSource;
 }
 
 /**
@@ -136,7 +137,7 @@ export type SourceClass = {
  * @param dispatcher - A {@link Dispatcher} instance, which can be used to send messages to the workers.
  * @returns a newly created source
  */
-export const create = (id: string, specification: SourceSpecification | CanvasSourceSpecification, dispatcher: Dispatcher, eventedParent: Evented): Source => {
+export const create = (id: string, specification: SourceSpecification | CanvasSourceSpecification, dispatcher: Dispatcher, eventedParent: Evented): SourceCacheSource => {
 
     const Class = getSourceType(specification.type);
     const source = new Class(id, specification, dispatcher, eventedParent);

--- a/src/ui/control/attribution_control.ts
+++ b/src/ui/control/attribution_control.ts
@@ -147,7 +147,7 @@ export class AttributionControl implements IControl {
             const sourceCache = sourceCaches[id];
             if (sourceCache.used || sourceCache.usedForTerrain) {
                 const source = sourceCache.getSource();
-                if (source.attribution && attributions.indexOf(source.attribution) < 0) {
+                if ('attribution' in source && attributions.indexOf(source.attribution) < 0) {
                     attributions.push(source.attribution);
                 }
             }

--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -2032,7 +2032,7 @@ export class Map extends Camera {
      * @see [Animate a point](https://maplibre.org/maplibre-gl-js/docs/examples/animate-point-along-line/)
      * @see [Add live realtime data](https://maplibre.org/maplibre-gl-js/docs/examples/live-geojson/)
      */
-    getSource(id: string): Source | undefined {
+    getSource(id: string) {
         return this.style.getSource(id);
     }
 


### PR DESCRIPTION
## Launch Checklist
Issue : https://github.com/maplibre/maplibre-gl-js/issues/3753

Here is a proposal to allow map source types to be handled by the lib user. Currently, the only type provided is a generic source type, preveting methods to be typed correctly.

## Before : 
![Screenshot 2024-02-26 at 17 43 35](https://github.com/maplibre/maplibre-gl-js/assets/5200291/da671b69-9614-4e6b-a9b3-6a6ef65e0807)

## After :
![Screenshot 2024-02-26 at 18 26 29](https://github.com/maplibre/maplibre-gl-js/assets/5200291/d633e214-22c3-4689-86c2-6bc33f2c99f1)

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [x] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Fix tests for all new functionality.
 - [-] Document any changes to public APIs.
 - [-] Post benchmark scores.
 - [-] Add an entry to `CHANGELOG.md` under the `## main` section.
