### PR TITLE
Remove the "The layout Struct..." warning in code generation 

### DIFF
--- a/build/generate-struct-arrays.ts
+++ b/build/generate-struct-arrays.ts
@@ -111,7 +111,7 @@ function createStructArrayLayoutType({members, size, alignment}) {
 
     const key = `${members.map(m => `${m.components}${typeAbbreviations[m.type]}`).join('')}${size}`;
     const className = `StructArrayLayout${key}`;
-    
+
     if (!layoutCache[key]) {
         layoutCache[key] = {
             className,

--- a/build/generate-struct-arrays.ts
+++ b/build/generate-struct-arrays.ts
@@ -111,8 +111,7 @@ function createStructArrayLayoutType({members, size, alignment}) {
 
     const key = `${members.map(m => `${m.components}${typeAbbreviations[m.type]}`).join('')}${size}`;
     const className = `StructArrayLayout${key}`;
-    // Layout alignment to 4 bytes boundaries can be an issue on some set of graphics cards. Particularly AMD.
-    if (size % 4 !== 0) { console.warn(`Warning: The layout ${className} is not aligned to 4-bytes boundaries.`); }
+    
     if (!layoutCache[key]) {
         layoutCache[key] = {
             className,


### PR DESCRIPTION
## Launch Checklist

- #2053 

Fixes #2053 

As described in the issue, this warning is not helpful and no one seems to be looking at it, also it seems that maplibre-gl is working as expected, so I'm not sure this warning is still relevant.

Warnings:
```
Warning: The layout StructArrayLayout3i6 is not aligned to 4-bytes boundaries.
Warning: The layout StructArrayLayout3ui6 is not aligned to 4-bytes boundaries.
Warning: The layout StructArrayLayout3i6 is not aligned to 4-bytes boundaries.
Warning: The layout StructArrayLayout3ui6 is not aligned to 4-bytes boundaries.
Warning: The layout StructArrayLayout1ui2 is not aligned to 4-bytes boundaries.
```

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
