### PR TITLE
Fix bad curve on easeTo/flyTo in constrained space

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## main
 
 ### ✨ Features and improvements
+- Improve animation curve when easeTo and flyTo with constraints ([#3793](https://github.com/maplibre/maplibre-gl-js/pull/3793))
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes

--- a/src/geo/transform.test.ts
+++ b/src/geo/transform.test.ts
@@ -1,5 +1,5 @@
 import Point from '@mapbox/point-geometry';
-import {Transform} from './transform';
+import {MAX_VALID_LATITUDE, Transform} from './transform';
 import {LngLat} from './lng_lat';
 import {OverscaledTileID, CanonicalTileID} from '../source/tile_id';
 import {fixedLngLat, fixedCoord} from '../../test/unit/lib/fixed';
@@ -10,7 +10,6 @@ describe('transform', () => {
         const transform = new Transform(0, 22, 0, 60, true);
         transform.resize(500, 500);
         expect(transform.unmodified).toBe(true);
-        expect(transform.maxValidLatitude).toBe(85.051129);
         expect(transform.tileSize).toBe(512);
         expect(transform.worldSize).toBe(512);
         expect(transform.width).toBe(500);
@@ -353,8 +352,8 @@ describe('transform', () => {
     test('clamps latitude', () => {
         const transform = new Transform(0, 22, 0, 60, true);
 
-        expect(transform.project(new LngLat(0, -90))).toEqual(transform.project(new LngLat(0, -transform.maxValidLatitude)));
-        expect(transform.project(new LngLat(0, 90))).toEqual(transform.project(new LngLat(0, transform.maxValidLatitude)));
+        expect(transform.project(new LngLat(0, -90))).toEqual(transform.project(new LngLat(0, -MAX_VALID_LATITUDE)));
+        expect(transform.project(new LngLat(0, 90))).toEqual(transform.project(new LngLat(0, MAX_VALID_LATITUDE)));
     });
 
     test('clamps pitch', () => {

--- a/src/geo/transform.ts
+++ b/src/geo/transform.ts
@@ -729,10 +729,10 @@ export class Transform {
             lngRange = [-almost180, almost180];
         }
 
-        let minY = -90;
-        let maxY = 90;
-        let minX = -180;
-        let maxX = 180;
+        let minY = 0;
+        let maxY = this.worldSize;
+        let minX = 0;
+        let maxX = this.worldSize;
         let scaleY = 0;
         let scaleX = 0;
         const {x: screenWidth, y: screenHeight} = this.size;

--- a/src/geo/transform.ts
+++ b/src/geo/transform.ts
@@ -734,13 +734,13 @@ export class Transform {
         let minX = -180;
         let maxX = 180;
         let sy, sx, x2, y2;
-        const size = this.size;
+        const {x: screenWidth, y: screenHeight} = this.size;
 
         if (this.latRange) {
             const latRange = this.latRange;
             minY = mercatorYfromLat(latRange[1]) * this.worldSize;
             maxY = mercatorYfromLat(latRange[0]) * this.worldSize;
-            sy = maxY - minY < size.y ? size.y / (maxY - minY) : 0;
+            sy = maxY - minY < screenHeight ? screenHeight / (maxY - minY) : 0;
         }
 
         if (lngRange) {
@@ -757,7 +757,7 @@ export class Transform {
 
             if (maxX < minX) maxX += this.worldSize;
 
-            sx = maxX - minX < size.x ? size.x / (maxX - minX) : 0;
+            sx = maxX - minX < screenWidth ? screenWidth / (maxX - minX) : 0;
         }
 
         const point = this.project(lngLat);
@@ -775,7 +775,7 @@ export class Transform {
 
         if (this.latRange) {
             const y = point.y,
-                h2 = size.y / 2;
+                h2 = screenHeight / 2;
 
             if (y - h2 < minY) y2 = minY + h2;
             if (y + h2 > maxY) y2 = maxY - h2;
@@ -787,7 +787,7 @@ export class Transform {
             if (this._renderWorldCopies) {
                 x = wrap(point.x, centerX - this.worldSize / 2, centerX + this.worldSize / 2);
             }
-            const w2 = size.x / 2;
+            const w2 = screenWidth / 2;
 
             if (x - w2 < minX) x2 = minX + w2;
             if (x + w2 > maxX) x2 = maxX - w2;

--- a/src/geo/transform.ts
+++ b/src/geo/transform.ts
@@ -715,8 +715,8 @@ export class Transform {
     // 1) everything beyond the bounds is excluded
     // 2) a given lngLat is as near the center as possible
     // Bounds are those set by maxBounds or North & South "Poles" and, if only 1 globe is displayed, antimeridian.
-    // MinZoom and maxZoom don't affect the result here
     getConstrained(lngLat: LngLat, zoom: number): {center: LngLat; zoom: number} {
+        zoom = clamp(+zoom, this.minZoom, this.maxZoom);
         const result = {
             center: new LngLat(lngLat.lng, lngLat.lat),
             zoom
@@ -729,7 +729,7 @@ export class Transform {
             lngRange = [-almost180, almost180];
         }
 
-        const worldSize = this.tileSize * this.zoomScale(zoom); // A world size for the requested zoom level, not the current world size
+        const worldSize = this.tileSize * this.zoomScale(result.zoom); // A world size for the requested zoom level, not the current world size
         let minY = 0;
         let maxY = worldSize;
         let minX = 0;

--- a/src/geo/transform.ts
+++ b/src/geo/transform.ts
@@ -760,21 +760,21 @@ export class Transform {
             sx = maxX - minX < screenWidth ? screenWidth / (maxX - minX) : 0;
         }
 
-        const point = this.project(lngLat);
+        const {x: originalX, y: originalY} = this.project(lngLat);
 
         // how much the map should scale to fit the screen into given latitude/longitude ranges
         const s = Math.max(sx || 0, sy || 0);
 
         if (s) {
             result.center = this.unproject(new Point(
-                sx ? (maxX + minX) / 2 : point.x,
-                sy ? (maxY + minY) / 2 : point.y));
+                sx ? (maxX + minX) / 2 : originalX,
+                sy ? (maxY + minY) / 2 : originalY));
             result.zoom += this.scaleZoom(s);
             return result;
         }
 
         if (this.latRange) {
-            const y = point.y,
+            const y = originalY,
                 h2 = screenHeight / 2;
 
             if (y - h2 < minY) y2 = minY + h2;
@@ -783,9 +783,9 @@ export class Transform {
 
         if (lngRange) {
             const centerX = (minX + maxX) / 2;
-            let x = point.x;
+            let x = originalX;
             if (this._renderWorldCopies) {
-                x = wrap(point.x, centerX - this.worldSize / 2, centerX + this.worldSize / 2);
+                x = wrap(originalX, centerX - this.worldSize / 2, centerX + this.worldSize / 2);
             }
             const w2 = screenWidth / 2;
 
@@ -796,8 +796,8 @@ export class Transform {
         // pan the map if the screen goes off the range
         if (x2 !== undefined || y2 !== undefined) {
             result.center = this.unproject(new Point(
-                x2 !== undefined ? x2 : point.x,
-                y2 !== undefined ? y2 : point.y)).wrap();
+                x2 !== undefined ? x2 : originalX,
+                y2 !== undefined ? y2 : originalY)).wrap();
         }
 
         return result;

--- a/src/geo/transform.ts
+++ b/src/geo/transform.ts
@@ -733,7 +733,7 @@ export class Transform {
         let maxY = 90;
         let minX = -180;
         let maxX = 180;
-        let sy, sx, x2, y2;
+        let sy, sx;
         const {x: screenWidth, y: screenHeight} = this.size;
 
         if (this.latRange) {
@@ -761,6 +761,7 @@ export class Transform {
         }
 
         const {x: originalX, y: originalY} = this.project(lngLat);
+        let modifiedX, modifiedY;
 
         // how much the map should scale to fit the screen into given latitude/longitude ranges
         const s = Math.max(sx || 0, sy || 0);
@@ -777,8 +778,8 @@ export class Transform {
             const y = originalY,
                 h2 = screenHeight / 2;
 
-            if (y - h2 < minY) y2 = minY + h2;
-            if (y + h2 > maxY) y2 = maxY - h2;
+            if (y - h2 < minY) modifiedY = minY + h2;
+            if (y + h2 > maxY) modifiedY = maxY - h2;
         }
 
         if (lngRange) {
@@ -789,15 +790,15 @@ export class Transform {
             }
             const w2 = screenWidth / 2;
 
-            if (x - w2 < minX) x2 = minX + w2;
-            if (x + w2 > maxX) x2 = maxX - w2;
+            if (x - w2 < minX) modifiedX = minX + w2;
+            if (x + w2 > maxX) modifiedX = maxX - w2;
         }
 
         // pan the map if the screen goes off the range
-        if (x2 !== undefined || y2 !== undefined) {
+        if (modifiedX !== undefined || modifiedY !== undefined) {
             result.center = this.unproject(new Point(
-                x2 !== undefined ? x2 : originalX,
-                y2 !== undefined ? y2 : originalY)).wrap();
+                modifiedX !== undefined ? modifiedX : originalX,
+                modifiedY !== undefined ? modifiedY : originalY)).wrap();
         }
 
         return result;

--- a/src/geo/transform.ts
+++ b/src/geo/transform.ts
@@ -729,35 +729,36 @@ export class Transform {
             lngRange = [-almost180, almost180];
         }
 
+        const worldSize = this.tileSize * this.zoomScale(zoom); // A world size for the requested zoom level, not the current world size
         let minY = 0;
-        let maxY = this.worldSize;
+        let maxY = worldSize;
         let minX = 0;
-        let maxX = this.worldSize;
+        let maxX = worldSize;
         let scaleY = 0;
         let scaleX = 0;
         const {x: screenWidth, y: screenHeight} = this.size;
 
         if (this.latRange) {
             const latRange = this.latRange;
-            minY = mercatorYfromLat(latRange[1]) * this.worldSize;
-            maxY = mercatorYfromLat(latRange[0]) * this.worldSize;
+            minY = mercatorYfromLat(latRange[1]) * worldSize;
+            maxY = mercatorYfromLat(latRange[0]) * worldSize;
             const shouldZoomIn = maxY - minY < screenHeight;
             if (shouldZoomIn) scaleY = screenHeight / (maxY - minY);
         }
 
         if (lngRange) {
             minX = wrap(
-                mercatorXfromLng(lngRange[0]) * this.worldSize,
+                mercatorXfromLng(lngRange[0]) * worldSize,
                 0,
-                this.worldSize
+                worldSize
             );
             maxX = wrap(
-                mercatorXfromLng(lngRange[1]) * this.worldSize,
+                mercatorXfromLng(lngRange[1]) * worldSize,
                 0,
-                this.worldSize
+                worldSize
             );
 
-            if (maxX < minX) maxX += this.worldSize;
+            if (maxX < minX) maxX += worldSize;
 
             const shouldZoomIn = maxX - minX < screenWidth;
             if (shouldZoomIn) scaleX = screenWidth / (maxX - minX);
@@ -787,7 +788,7 @@ export class Transform {
             const centerX = (minX + maxX) / 2;
             let wrappedX = originalX;
             if (this._renderWorldCopies) {
-                wrappedX = wrap(originalX, centerX - this.worldSize / 2, centerX + this.worldSize / 2);
+                wrappedX = wrap(originalX, centerX - worldSize / 2, centerX + worldSize / 2);
             }
             const w2 = screenWidth / 2;
 

--- a/src/geo/transform.ts
+++ b/src/geo/transform.ts
@@ -733,14 +733,16 @@ export class Transform {
         let maxY = 90;
         let minX = -180;
         let maxX = 180;
-        let scaleY, scaleX;
+        let scaleY = 0;
+        let scaleX = 0;
         const {x: screenWidth, y: screenHeight} = this.size;
 
         if (this.latRange) {
             const latRange = this.latRange;
             minY = mercatorYfromLat(latRange[1]) * this.worldSize;
             maxY = mercatorYfromLat(latRange[0]) * this.worldSize;
-            scaleY = maxY - minY < screenHeight ? screenHeight / (maxY - minY) : 0;
+            const shouldZoomIn = maxY - minY < screenHeight;
+            if (shouldZoomIn) scaleY = screenHeight / (maxY - minY);
         }
 
         if (lngRange) {
@@ -757,16 +759,17 @@ export class Transform {
 
             if (maxX < minX) maxX += this.worldSize;
 
-            scaleX = maxX - minX < screenWidth ? screenWidth / (maxX - minX) : 0;
+            const shouldZoomIn = maxX - minX < screenWidth;
+            if (shouldZoomIn) scaleX = screenWidth / (maxX - minX);
         }
 
         const {x: originalX, y: originalY} = this.project(lngLat);
         let modifiedX, modifiedY;
 
-        // how much the map should scale to fit the screen into given latitude/longitude ranges
         const scale = Math.max(scaleX || 0, scaleY || 0);
 
         if (scale) {
+            // zoom in to exclude all beyond the given lng/lat ranges
             result.center = this.unproject(new Point(
                 scaleX ? (maxX + minX) / 2 : originalX,
                 scaleY ? (maxY + minY) / 2 : originalY));

--- a/src/geo/transform.ts
+++ b/src/geo/transform.ts
@@ -711,10 +711,12 @@ export class Transform {
         return this.mercatorMatrix.slice() as any;
     }
 
-    // Get center lngLat and zoom to ensure that
-    // 1) everything beyond the bounds is excluded
-    // 2) a given lngLat is as near the center as possible
-    // Bounds are those set by maxBounds or North & South "Poles" and, if only 1 globe is displayed, antimeridian.
+    /**
+     * Get center lngLat and zoom to ensure that
+     * 1) everything beyond the bounds is excluded
+     * 2) a given lngLat is as near the center as possible
+     * Bounds are those set by maxBounds or North & South "Poles" and, if only 1 globe is displayed, antimeridian.
+     */
     getConstrained(lngLat: LngLat, zoom: number): {center: LngLat; zoom: number} {
         zoom = clamp(+zoom, this.minZoom, this.maxZoom);
         const result = {

--- a/src/geo/transform.ts
+++ b/src/geo/transform.ts
@@ -797,9 +797,8 @@ export class Transform {
 
         // pan the map if the screen goes off the range
         if (modifiedX !== undefined || modifiedY !== undefined) {
-            result.center = this.unproject(new Point(
-                modifiedX !== undefined ? modifiedX : originalX,
-                modifiedY !== undefined ? modifiedY : originalY)).wrap();
+            const newPoint = new Point(modifiedX ?? originalX, modifiedY ?? originalY);
+            result.center = this.unproject(newPoint).wrap();
         }
 
         return result;

--- a/src/geo/transform.ts
+++ b/src/geo/transform.ts
@@ -775,23 +775,21 @@ export class Transform {
         }
 
         if (this.latRange) {
-            const y = originalY,
-                h2 = screenHeight / 2;
-
-            if (y - h2 < minY) modifiedY = minY + h2;
-            if (y + h2 > maxY) modifiedY = maxY - h2;
+            const h2 = screenHeight / 2;
+            if (originalY - h2 < minY) modifiedY = minY + h2;
+            if (originalY + h2 > maxY) modifiedY = maxY - h2;
         }
 
         if (lngRange) {
             const centerX = (minX + maxX) / 2;
-            let x = originalX;
+            let wrappedX = originalX;
             if (this._renderWorldCopies) {
-                x = wrap(originalX, centerX - this.worldSize / 2, centerX + this.worldSize / 2);
+                wrappedX = wrap(originalX, centerX - this.worldSize / 2, centerX + this.worldSize / 2);
             }
             const w2 = screenWidth / 2;
 
-            if (x - w2 < minX) modifiedX = minX + w2;
-            if (x + w2 > maxX) modifiedX = maxX - w2;
+            if (wrappedX - w2 < minX) modifiedX = minX + w2;
+            if (wrappedX + w2 > maxX) modifiedX = maxX - w2;
         }
 
         // pan the map if the screen goes off the range

--- a/src/geo/transform.ts
+++ b/src/geo/transform.ts
@@ -711,9 +711,14 @@ export class Transform {
         return this.mercatorMatrix.slice() as any;
     }
 
-    getConstrained(center: LngLat, zoom: number): {center: LngLat; zoom: number} {
+    // Get center lngLat and zoom to ensure that
+    // 1) everything beyond the bounds is excluded
+    // 2) a given lngLat is as near the center as possible
+    // Bounds are those set by maxBounds or North & South "Poles" and, if only 1 globe is displayed, antimeridian.
+    // MinZoom and maxZoom don't affect the result here
+    getConstrained(lngLat: LngLat, zoom: number): {center: LngLat; zoom: number} {
         const result = {
-            center: new LngLat(center.lng, center.lat),
+            center: new LngLat(lngLat.lng, lngLat.lat),
             zoom
         };
 
@@ -755,7 +760,7 @@ export class Transform {
             sx = maxX - minX < size.x ? size.x / (maxX - minX) : 0;
         }
 
-        const point = this.project(center);
+        const point = this.project(lngLat);
 
         // how much the map should scale to fit the screen into given latitude/longitude ranges
         const s = Math.max(sx || 0, sy || 0);

--- a/src/geo/transform.ts
+++ b/src/geo/transform.ts
@@ -733,14 +733,14 @@ export class Transform {
         let maxY = 90;
         let minX = -180;
         let maxX = 180;
-        let sy, sx;
+        let scaleY, scaleX;
         const {x: screenWidth, y: screenHeight} = this.size;
 
         if (this.latRange) {
             const latRange = this.latRange;
             minY = mercatorYfromLat(latRange[1]) * this.worldSize;
             maxY = mercatorYfromLat(latRange[0]) * this.worldSize;
-            sy = maxY - minY < screenHeight ? screenHeight / (maxY - minY) : 0;
+            scaleY = maxY - minY < screenHeight ? screenHeight / (maxY - minY) : 0;
         }
 
         if (lngRange) {
@@ -757,20 +757,20 @@ export class Transform {
 
             if (maxX < minX) maxX += this.worldSize;
 
-            sx = maxX - minX < screenWidth ? screenWidth / (maxX - minX) : 0;
+            scaleX = maxX - minX < screenWidth ? screenWidth / (maxX - minX) : 0;
         }
 
         const {x: originalX, y: originalY} = this.project(lngLat);
         let modifiedX, modifiedY;
 
         // how much the map should scale to fit the screen into given latitude/longitude ranges
-        const s = Math.max(sx || 0, sy || 0);
+        const scale = Math.max(scaleX || 0, scaleY || 0);
 
-        if (s) {
+        if (scale) {
             result.center = this.unproject(new Point(
-                sx ? (maxX + minX) / 2 : originalX,
-                sy ? (maxY + minY) / 2 : originalY));
-            result.zoom += this.scaleZoom(s);
+                scaleX ? (maxX + minX) / 2 : originalX,
+                scaleY ? (maxY + minY) / 2 : originalY));
+            result.zoom += this.scaleZoom(scale);
             return result;
         }
 

--- a/src/ui/camera.test.ts
+++ b/src/ui/camera.test.ts
@@ -905,6 +905,17 @@ describe('#easeTo', () => {
         }, 0);
     });
 
+    test('does not pan eastward across the antimeridian on a single-globe mercator map', done => {
+        const camera = createCamera({renderWorldCopies: false, zoom: 2});
+        camera.setCenter([170, 0]);
+        const initialLng = camera.getCenter().lng;
+        camera.on('moveend', () => {
+            expect(camera.getCenter().lng).toBeCloseTo(initialLng, 0);
+            done();
+        });
+        camera.easeTo({center: [210, 0], duration: 0});
+    });
+
     test('pans westward across the antimeridian', done => {
         const camera = createCamera();
         const stub = jest.spyOn(browser, 'now');
@@ -935,6 +946,17 @@ describe('#easeTo', () => {
                 camera.simulateFrame();
             }, 0);
         }, 0);
+    });
+
+    test('does not pan westward across the antimeridian on a single-globe mercator map', done => {
+        const camera = createCamera({renderWorldCopies: false, zoom: 2});
+        camera.setCenter([-170, 0]);
+        const initialLng = camera.getCenter().lng;
+        camera.on('moveend', () => {
+            expect(camera.getCenter().lng).toBeCloseTo(initialLng, 0);
+            done();
+        });
+        camera.easeTo({center: [-210, 0], duration: 0});
     });
 
     test('animation occurs when prefers-reduced-motion: reduce is set but overridden by essential: true', done => {

--- a/src/ui/camera.ts
+++ b/src/ui/camera.ts
@@ -1254,19 +1254,20 @@ export abstract class Camera extends Evented {
             startPitch = this.getPitch(),
             startPadding = this.getPadding();
 
-        const zoom = 'zoom' in options ? clamp(+options.zoom, tr.minZoom, tr.maxZoom) : startZoom;
         const bearing = 'bearing' in options ? this._normalizeBearing(options.bearing, startBearing) : startBearing;
         const pitch = 'pitch' in options ? +options.pitch : startPitch;
         const padding = 'padding' in options ? options.padding : tr.padding;
 
-        const scale = tr.zoomScale(zoom - startZoom);
         const offsetAsPoint = Point.convert(options.offset);
         let pointAtOffset = tr.centerPoint.add(offsetAsPoint);
         const locationAtOffset = tr.pointLocation(pointAtOffset);
         let center = LngLat.convert(options.center || locationAtOffset);
+        let zoom = 'zoom' in options ? clamp(+options.zoom, tr.minZoom, tr.maxZoom) : startZoom;
         this._normalizeCenter(center);
-
-        center = tr.getConstrained(center, zoom).center;
+        const constrained = tr.getConstrained(center, zoom);
+        center = constrained.center;
+        zoom = constrained.zoom;
+        const scale = tr.zoomScale(zoom - startZoom);
 
         const from = tr.project(locationAtOffset);
         const delta = tr.project(center).sub(from);

--- a/src/ui/camera.ts
+++ b/src/ui/camera.ts
@@ -987,8 +987,9 @@ export abstract class Camera extends Evented {
         const offsetAsPoint = Point.convert(options.offset);
         let pointAtOffset = tr.centerPoint.add(offsetAsPoint);
         const locationAtOffset = tr.pointLocation(pointAtOffset);
-        const center = LngLat.convert(options.center || locationAtOffset);
+        let center = LngLat.convert(options.center || locationAtOffset);
         this._normalizeCenter(center);
+        center = tr.getConstrained(center, zoom).center;
 
         const from = tr.project(locationAtOffset);
         const delta = tr.project(center).sub(from);
@@ -1260,8 +1261,10 @@ export abstract class Camera extends Evented {
         const offsetAsPoint = Point.convert(options.offset);
         let pointAtOffset = tr.centerPoint.add(offsetAsPoint);
         const locationAtOffset = tr.pointLocation(pointAtOffset);
-        const center = LngLat.convert(options.center || locationAtOffset);
+        let center = LngLat.convert(options.center || locationAtOffset);
         this._normalizeCenter(center);
+
+        center = tr.getConstrained(center, zoom).center;
 
         const from = tr.project(locationAtOffset);
         const delta = tr.project(center).sub(from);

--- a/src/ui/camera.ts
+++ b/src/ui/camera.ts
@@ -979,7 +979,6 @@ export abstract class Camera extends Evented {
             startPitch = this.getPitch(),
             startPadding = this.getPadding(),
 
-            zoom = 'zoom' in options ? +options.zoom : startZoom,
             bearing = 'bearing' in options ? this._normalizeBearing(options.bearing, startBearing) : startBearing,
             pitch = 'pitch' in options ? +options.pitch : startPitch,
             padding = 'padding' in options ? options.padding : tr.padding;
@@ -988,8 +987,11 @@ export abstract class Camera extends Evented {
         let pointAtOffset = tr.centerPoint.add(offsetAsPoint);
         const locationAtOffset = tr.pointLocation(pointAtOffset);
         let center = LngLat.convert(options.center || locationAtOffset);
+        let zoom = 'zoom' in options ? +options.zoom : startZoom;
         this._normalizeCenter(center);
-        center = tr.getConstrained(center, zoom).center;
+        const constrained = tr.getConstrained(center, zoom);
+        center = constrained.center;
+        zoom = constrained.zoom;
 
         const from = tr.project(locationAtOffset);
         const delta = tr.project(center).sub(from);

--- a/src/ui/camera.ts
+++ b/src/ui/camera.ts
@@ -986,12 +986,12 @@ export abstract class Camera extends Evented {
         const offsetAsPoint = Point.convert(options.offset);
         let pointAtOffset = tr.centerPoint.add(offsetAsPoint);
         const locationAtOffset = tr.pointLocation(pointAtOffset);
-        let center = LngLat.convert(options.center || locationAtOffset);
-        let zoom = 'zoom' in options ? +options.zoom : startZoom;
+
+        const {center, zoom} = tr.getConstrained(
+            LngLat.convert(options.center || locationAtOffset),
+            options.zoom ?? startZoom
+        );
         this._normalizeCenter(center);
-        const constrained = tr.getConstrained(center, zoom);
-        center = constrained.center;
-        zoom = constrained.zoom;
 
         const from = tr.project(locationAtOffset);
         const delta = tr.project(center).sub(from);
@@ -1261,12 +1261,12 @@ export abstract class Camera extends Evented {
         const offsetAsPoint = Point.convert(options.offset);
         let pointAtOffset = tr.centerPoint.add(offsetAsPoint);
         const locationAtOffset = tr.pointLocation(pointAtOffset);
-        let center = LngLat.convert(options.center || locationAtOffset);
-        let zoom = 'zoom' in options ? clamp(+options.zoom, tr.minZoom, tr.maxZoom) : startZoom;
+
+        const {center, zoom} = tr.getConstrained(
+            LngLat.convert(options.center || locationAtOffset),
+            options.zoom ?? startZoom
+        );
         this._normalizeCenter(center);
-        const constrained = tr.getConstrained(center, zoom);
-        center = constrained.center;
-        zoom = constrained.zoom;
         const scale = tr.zoomScale(zoom - startZoom);
 
         const from = tr.project(locationAtOffset);


### PR DESCRIPTION
 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [ ] Link to related issues.
 - [x] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality.
 - [x] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [x] Add an entry to `CHANGELOG.md` under the `## main` section.

I know there's a lot to review now so don't haste with this )

This PR involves several methods that animate the map's scale and center:
- `flyTo` (and therefore `fitBounds` and `fitScreenCoordinates`)
- `easeTo `(and therefore `panTo `and `panBy`)

These methods don't animate well when the destination point is near the bounds: those set by maxBounds, by vertical edges of the world, by antimeridian on single-globe map.

What is apparently incorrect in current easeTo and flyTo algorithms is that they don't apply these constraints when deciding on the destination. They just take the destination lngLat as it was provided by a user.
The result is that this "optimistic" animation hits the bounds somewhere in the process, and a smooth curve breaks into something more linear.

This PR fixes this problem. It runs the code from `transform._constrain` in advance, before the animation starts.
For that I had to extract most of `transform._constrain` code into a new `getConstrained` method that doesn't set anything on Transform instance but only calculates zoom and center for a given point. There are a lot of changes in this method but it's mostly just renaming the magic variables. 

The main meaningful change there is that I deal not with actual `transform.worldSize` but with a "theoretical" `worldSize `that corresponds to a requested zoom level.
Also, the requested zoom level is now clamped to [`minZoom`, `maxZoom`] _inside_ `getConstrained`. (Instead of doing that in `easeTo`/`flyTo`). I think it just makes sense because zoom bounds are closely related to coord bounds.

This change in itself is non-destructive and it surely changes the situation for the better.
The implications are:
* easeTo is always smooth near the bounds:
https://github.com/maplibre/maplibre-gl-js/assets/11789697/b5347134-a529-4575-993c-e7dd1883cf95


* flyTo is smooth near the bounds only in _some_ cases - when there is no significant zooming out (on low zoom levels or when a user sets `curve` option to something small).
In other cases flyTo trajectory gets only slightly better but is still broken.

The problem of flyTo is not only the final destination but intermidate frames too because of zooming out. Ideal solution to this will be to calculate the animation path with respect of constraints. But this will be a lot of engineering with little impact.

I see a couple of (supposedly) simple changes here. They may look a bit controversial but I think they will provide a better UX. They are _not included_ in this PR.

1) **Disable constraints** for the time of flyingTo.
This will result in:
- proper animation path
- "restricted" space (possibly white bg) will be visible for a little while. (I believe this is not essential).
- panning / zooming / whatever during the unfinished "flight" outside the bounds will cause an abrupt return into the bounds.
The last problem is of course not that small.	Though still we are in a better position: bad behaviour will happen only on interaction and in a situation where animation was ugly anyway.
In terms of code, I tried it and it looks easy.

2) It must be possible to **ignore user actions** when there is an unfinished flight and it's happening outside the bounds.
Result:
- animation always looks good.
- user can't pan/zoom/... during this "overflow". IDK if it's a big problem.
I can't say yet anything about code complexity of this step.

As for tests, I didn't add any. The only thing that changes here in terms of UX is the trajectory of animation. (Final point doesn't change).
Now it's more possible to test `getConstrained` in isolation but IDK if it's desirable.