### PR TITLE
Remove popup when marker is behind terrain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## main
 
 ### ✨ Features and improvements
+- Hide Popup when its parent Marker is behind terrain ([#3865](https://github.com/maplibre/maplibre-gl-js/pull/3865))
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes

--- a/src/ui/marker.test.ts
+++ b/src/ui/marker.test.ts
@@ -1066,6 +1066,30 @@ describe('marker', () => {
         map.remove();
     });
 
+    test('Does not open a popup when behind 3d terrain', async () => {
+        const map = createMap();
+        const marker = new Marker()
+            .setLngLat([0, 0])
+            .addTo(map)
+            .setPopup(new Popup());
+
+        map.transform.lngLatToCameraDepth = () => .95;
+
+        map.terrain = {
+            getElevationForLngLatZoom: () => 0,
+            depthAtPoint: () => .92
+        } as any as Terrain;
+        map.fire('terrain');
+
+        await sleep(500);
+
+        marker.togglePopup();
+
+        expect(marker._popup.isOpen()).toBeFalsy();
+
+        map.remove();
+    });
+
     test('Marker\'s lng is wrapped when slightly crossing 180 with {renderWorldCopies: false}', () => {
         const map = createMap({width: 1024, renderWorldCopies: false});
         const marker = new Marker()

--- a/src/ui/marker.test.ts
+++ b/src/ui/marker.test.ts
@@ -1040,6 +1040,32 @@ describe('marker', () => {
         map.remove();
     });
 
+    test('Removes an open popup when going behind 3d terrain', async () => {
+        const map = createMap();
+        const marker = new Marker()
+            .setLngLat([0, 0])
+            .addTo(map)
+            .setPopup(new Popup());
+
+        await sleep(500);
+        marker.togglePopup();
+
+        expect(marker._popup.isOpen()).toBeTruthy();
+
+        map.transform.lngLatToCameraDepth = () => .95; // Mocking distance to marker
+
+        map.terrain = {
+            getElevationForLngLatZoom: () => 0,
+            depthAtPoint: () => .92
+        } as any as Terrain;
+        map.fire('terrain');
+
+        await sleep(500);
+
+        expect(marker._popup?.isOpen()).toBeFalsy();
+        map.remove();
+    });
+
     test('Marker\'s lng is wrapped when slightly crossing 180 with {renderWorldCopies: false}', () => {
         const map = createMap({width: 1024, renderWorldCopies: false});
         const marker = new Marker()

--- a/src/ui/marker.test.ts
+++ b/src/ui/marker.test.ts
@@ -157,13 +157,15 @@ describe('marker', () => {
         expect(!marker.getPopup()).toBeTruthy();
     });
 
-    test('Marker#togglePopup opens a popup that was closed', () => {
+    test('Marker#togglePopup opens a popup that was closed', async () => {
         const map = createMap();
         const marker = new Marker()
             .setLngLat([0, 0])
             .addTo(map)
-            .setPopup(new Popup())
-            .togglePopup();
+            .setPopup(new Popup());
+
+        await sleep(500);
+        marker.togglePopup();
 
         expect(marker.getPopup().isOpen()).toBeTruthy();
 
@@ -184,12 +186,14 @@ describe('marker', () => {
         map.remove();
     });
 
-    test('Enter key on Marker opens a popup that was closed', () => {
+    test('Enter key on Marker opens a popup that was closed', async () => {
         const map = createMap();
         const marker = new Marker()
             .setLngLat([0, 0])
             .addTo(map)
             .setPopup(new Popup());
+
+        await sleep(500);
 
         // popup not initially open
         expect(marker.getPopup().isOpen()).toBeFalsy();
@@ -202,12 +206,14 @@ describe('marker', () => {
         map.remove();
     });
 
-    test('Space key on Marker opens a popup that was closed', () => {
+    test('Space key on Marker opens a popup that was closed', async () => {
         const map = createMap();
         const marker = new Marker()
             .setLngLat([0, 0])
             .addTo(map)
             .setPopup(new Popup());
+
+        await sleep(500);
 
         // popup not initially open
         expect(marker.getPopup().isOpen()).toBeFalsy();
@@ -292,13 +298,15 @@ describe('marker', () => {
         map.remove();
     });
 
-    test('Popup anchors around default Marker', () => {
+    test('Popup anchors around default Marker', async () => {
         const map = createMap();
 
         const marker = new Marker()
             .setLngLat([0, 0])
             .setPopup(new Popup().setText('Test'))
             .addTo(map);
+
+        await sleep(500);
 
         // open the popup
         marker.togglePopup();
@@ -361,13 +369,15 @@ describe('marker', () => {
         map.remove();
     });
 
-    test('Popup is opened at its marker position after marker is moved to another globe', () => {
+    test('Popup is opened at its marker position after marker is moved to another globe', async () => {
         const map = createMap({width: 3000});
 
         const marker = new Marker()
             .setLngLat([0, 0])
             .setPopup(new Popup().setText('Test'))
             .addTo(map);
+
+        await sleep(500);
 
         marker._pos = new Point(2999, 242);
         marker._lngLat = map.unproject(marker._pos);
@@ -377,7 +387,7 @@ describe('marker', () => {
         map.remove();
     });
 
-    test('Popup is re-opened at its marker position after marker is moved to another globe', () => {
+    test('Popup is re-opened at its marker position after marker is moved to another globe', async () => {
         const map = createMap({width: 3000});
 
         const marker = new Marker()
@@ -387,6 +397,7 @@ describe('marker', () => {
             .togglePopup()
             .togglePopup();
 
+        await sleep(500);
         marker._pos = new Point(2999, 242);
         marker._lngLat = map.unproject(marker._pos);
         marker.togglePopup();

--- a/src/ui/marker.ts
+++ b/src/ui/marker.ts
@@ -140,7 +140,7 @@ export class Marker extends Evented {
     _pitchAlignment: Alignment;
     _rotationAlignment: Alignment;
     _originalTabIndex: string; // original tabindex of _element
-    _opacity: string;
+    _fullOpacity: string;
     _opacityWhenCovered: string;
     _opacityTimeout: ReturnType<typeof setTimeout>;
 
@@ -515,7 +515,7 @@ export class Marker extends Evented {
     togglePopup(): this {
         const popup = this._popup;
 
-        if (this._element.style.opacity !== this._opacity) return this;
+        if (this._element.style.opacity !== this._fullOpacity) return this;
 
         if (!popup) return this;
         else if (popup.isOpen()) popup.remove();
@@ -529,7 +529,7 @@ export class Marker extends Evented {
     _updateOpacity(force: boolean = false) {
         const terrain = this._map?.terrain;
         if (!terrain) {
-            if (this._element.style.opacity !== this._opacity) { this._element.style.opacity = this._opacity; }
+            if (this._element.style.opacity !== this._fullOpacity) { this._element.style.opacity = this._fullOpacity; }
             return;
         }
         if (force) {
@@ -551,7 +551,7 @@ export class Marker extends Evented {
 
         const forgiveness = .006;
         if (markerDistance - terrainDistance < forgiveness) {
-            this._element.style.opacity = this._opacity;
+            this._element.style.opacity = this._fullOpacity;
             return;
         }
         // If the base is obscured, use the offset to check if the marker's center is obscured.
@@ -563,7 +563,7 @@ export class Marker extends Evented {
         const centerIsInvisible = markerDistanceCenter - terrainDistanceCenter > forgiveness;
 
         if (this._popup && centerIsInvisible) this._popup.remove();
-        this._element.style.opacity = centerIsInvisible ? this._opacityWhenCovered : this._opacity;
+        this._element.style.opacity = centerIsInvisible ? this._opacityWhenCovered : this._fullOpacity;
     }
 
     _update = (e?: { type: 'move' | 'moveend' | 'terrain' | 'render' }) => {
@@ -839,11 +839,11 @@ export class Marker extends Evented {
      */
     setOpacity(opacity?: string, opacityWhenCovered?: string): this {
         if (opacity === undefined && opacityWhenCovered === undefined) {
-            this._opacity = '1';
+            this._fullOpacity = '1';
             this._opacityWhenCovered = '0.2';
         }
         if (opacity !== undefined) {
-            this._opacity = opacity;
+            this._fullOpacity = opacity;
         }
         if (opacityWhenCovered !== undefined) {
             this._opacityWhenCovered = opacityWhenCovered;

--- a/src/ui/marker.ts
+++ b/src/ui/marker.ts
@@ -140,7 +140,7 @@ export class Marker extends Evented {
     _pitchAlignment: Alignment;
     _rotationAlignment: Alignment;
     _originalTabIndex: string; // original tabindex of _element
-    _fullOpacity: string;
+    _opacity: string;
     _opacityWhenCovered: string;
     _opacityTimeout: ReturnType<typeof setTimeout>;
 
@@ -515,7 +515,7 @@ export class Marker extends Evented {
     togglePopup(): this {
         const popup = this._popup;
 
-        if (this._element.style.opacity !== this._fullOpacity) return this;
+        if (this._element.style.opacity !== this._opacity) return this;
 
         if (!popup) return this;
         else if (popup.isOpen()) popup.remove();
@@ -529,7 +529,7 @@ export class Marker extends Evented {
     _updateOpacity(force: boolean = false) {
         const terrain = this._map?.terrain;
         if (!terrain) {
-            if (this._element.style.opacity !== this._fullOpacity) { this._element.style.opacity = this._fullOpacity; }
+            if (this._element.style.opacity !== this._opacity) { this._element.style.opacity = this._opacity; }
             return;
         }
         if (force) {
@@ -551,7 +551,7 @@ export class Marker extends Evented {
 
         const forgiveness = .006;
         if (markerDistance - terrainDistance < forgiveness) {
-            this._element.style.opacity = this._fullOpacity;
+            this._element.style.opacity = this._opacity;
             return;
         }
         // If the base is obscured, use the offset to check if the marker's center is obscured.
@@ -563,7 +563,7 @@ export class Marker extends Evented {
         const centerIsInvisible = markerDistanceCenter - terrainDistanceCenter > forgiveness;
 
         if (this._popup?.isOpen() && centerIsInvisible) this._popup.remove();
-        this._element.style.opacity = centerIsInvisible ? this._opacityWhenCovered : this._fullOpacity;
+        this._element.style.opacity = centerIsInvisible ? this._opacityWhenCovered : this._opacity;
     }
 
     _update = (e?: { type: 'move' | 'moveend' | 'terrain' | 'render' }) => {
@@ -839,11 +839,11 @@ export class Marker extends Evented {
      */
     setOpacity(opacity?: string, opacityWhenCovered?: string): this {
         if (opacity === undefined && opacityWhenCovered === undefined) {
-            this._fullOpacity = '1';
+            this._opacity = '1';
             this._opacityWhenCovered = '0.2';
         }
         if (opacity !== undefined) {
-            this._fullOpacity = opacity;
+            this._opacity = opacity;
         }
         if (opacityWhenCovered !== undefined) {
             this._opacityWhenCovered = opacityWhenCovered;

--- a/src/ui/marker.ts
+++ b/src/ui/marker.ts
@@ -562,7 +562,7 @@ export class Marker extends Evented {
         // Display at full opacity if center is visible.
         const centerIsInvisible = markerDistanceCenter - terrainDistanceCenter > forgiveness;
 
-        if (this._popup && centerIsInvisible) this._popup.remove();
+        if (this._popup?.isOpen() && centerIsInvisible) this._popup.remove();
         this._element.style.opacity = centerIsInvisible ? this._opacityWhenCovered : this._fullOpacity;
     }
 

--- a/src/ui/marker.ts
+++ b/src/ui/marker.ts
@@ -515,7 +515,7 @@ export class Marker extends Evented {
     togglePopup(): this {
         const popup = this._popup;
 
-        if (this._element.style.opacity !== this._opacity) return this;
+        if (this._element.style.opacity === this._opacityWhenCovered) return this;
 
         if (!popup) return this;
         else if (popup.isOpen()) popup.remove();

--- a/src/ui/marker.ts
+++ b/src/ui/marker.ts
@@ -561,6 +561,8 @@ export class Marker extends Evented {
         const markerDistanceCenter = map.transform.lngLatToCameraDepth(this._lngLat, elevation + elevationToCenter);
         // Display at full opacity if center is visible.
         const centerIsInvisible = markerDistanceCenter - terrainDistanceCenter > forgiveness;
+
+        if (this._popup && centerIsInvisible) this._popup.remove();
         this._element.style.opacity = centerIsInvisible ? this._opacityWhenCovered : this._opacity;
     }
 

--- a/src/ui/marker.ts
+++ b/src/ui/marker.ts
@@ -515,6 +515,8 @@ export class Marker extends Evented {
     togglePopup(): this {
         const popup = this._popup;
 
+        if (this._element.style.opacity !== this._opacity) return this;
+
         if (!popup) return this;
         else if (popup.isOpen()) popup.remove();
         else {


### PR DESCRIPTION
Currently popups do not change opacity when hidden by terrain.
It looks especially bad when a popup is attached to a marker. Marker becomes semi-transparent, and popup doesn't.

By this PR I suggest to hide a "dependent" popup when its marker is behind terrain.
It's not the only possible solution but **1)** it's simple  and **2)** it actually seems more adequate than making a popup semi-transparent because such semi-transparent popup will create a lot of visual noise.

So here I make sure that
1) when marker gets hidden, it will close its popup
2) when marker is hidden, click will not open its popup

https://github.com/maplibre/maplibre-gl-js/assets/11789697/e48cc6f8-9abf-4551-be44-a8e977fc454c

This solution does not affect independent popups. They will still be fully opaque behind terrain.
It seems that visibility of dependent and independent popups are 2 different problems.
Visibility of a dependent popup should be determined by the marker.
Visibility of an independent popup should be determined by popup's own position relative to terrain.
It will require to somehow copy or reuse the bulky opacity-related code from marker.ts.

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [ ] Link to related issues.
 - [x] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [ ] Add an entry to `CHANGELOG.md` under the `## main` section.
