### PR TITLE
Fix close events being fired for popups that aren't open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### 🐞 Bug fixes
 - Fix type definition on `localIdeographFontFamily` ([#3896](https://github.com/maplibre/maplibre-gl-js/pull/3896))
 - Fix unwanted panning changes at the end of a panning motion ([#3872](https://github.com/maplibre/maplibre-gl-js/issues/3872))
+- Fix `close` events being fired for popups that aren't open
 - _...Add new stuff here..._
 
 ## 4.1.1

--- a/src/ui/popup.test.ts
+++ b/src/ui/popup.test.ts
@@ -132,6 +132,18 @@ describe('popup', () => {
         expect(onClose).toHaveBeenCalled();
     });
 
+    test('Popup does not fire close event when removed if it is not on the map', () => {
+        const onClose = jest.fn();
+
+        new Popup()
+            .setText('Test')
+            .setLngLat([0, 0])
+            .on('close', onClose)
+            .remove();
+
+        expect(onClose).not.toHaveBeenCalled();
+    });
+
     test('Popup fires open event when added', () => {
         const map = createMap();
         const onOpen = jest.fn();

--- a/src/ui/popup.ts
+++ b/src/ui/popup.ts
@@ -258,9 +258,8 @@ export class Popup extends Evented {
             this._map.off('drag', this._onDrag);
             this._map._canvasContainer.classList.remove('maplibregl-track-pointer');
             delete this._map;
+            this.fire(new Event('close'));
         }
-
-        this.fire(new Event('close'));
 
         return this;
     };


### PR DESCRIPTION
This moves the line that fires close events to be inside the map section. This means that close events won't be fired for popups that weren't open when the popup was removed. The popup close events are currently fired for example when removing a marker that is linked to a popup from the map. 

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [X] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [X] Briefly describe the changes in this PR.
 - [ ] Link to related issues.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [X] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [X] Add an entry to `CHANGELOG.md` under the `## main` section.
