### PR TITLE
Add layers slots

### DIFF
--- a/src/style/style.ts
+++ b/src/style/style.ts
@@ -962,7 +962,7 @@ export class Style extends Evented {
         }
     }
 
-    fillSlot(slotId: string, layers: AddLayerObject[]) {
+    populateSlot(slotId: string, layers: AddLayerObject[]) {
         if (!Array.isArray(layers) || !this._slots[slotId]) return;
         for (const oldLayerId of this._slots[slotId].layerIds) {
             this.removeLayer(oldLayerId);

--- a/src/style/style.ts
+++ b/src/style/style.ts
@@ -185,6 +185,7 @@ export class Style extends Evented {
     _layers: {[_: string]: StyleLayer};
     _serializedLayers: {[_: string]: LayerSpecification};
     _order: Array<string>;
+    _orderWithSlots: Array<string>;
     sourceCaches: {[_: string]: SourceCache};
     zoomHistory: ZoomHistory;
     _loaded: boolean;
@@ -339,7 +340,9 @@ export class Style extends Evented {
     }
 
     private _createLayers() {
-        const dereferencedLayers = deref(this.stylesheet.layers);
+        this._orderWithSlots = this.stylesheet.layers.map((layer) => layer.id);
+        const layersWithoutSlots = this.stylesheet.layers.filter(l => l.type !== 'slot');
+        const dereferencedLayers = deref(layersWithoutSlots);
 
         // Broadcast layers to workers first, so that expensive style processing (createStyleLayer)
         // can happen in parallel on both main and worker threads.

--- a/src/style/style_layer.ts
+++ b/src/style/style_layer.ts
@@ -14,7 +14,8 @@ import type {Bucket} from '../data/bucket';
 import type Point from '@mapbox/point-geometry';
 import type {FeatureFilter, FeatureState,
     LayerSpecification,
-    FilterSpecification} from '@maplibre/maplibre-gl-style-spec';
+    FilterSpecification,
+    SlotLayerSpecification} from '@maplibre/maplibre-gl-style-spec';
 import type {TransitionParameters, PropertyValue} from './properties';
 import {EvaluationParameters} from './evaluation_parameters';
 import type {CrossfadeParameters} from './evaluation_parameters';
@@ -77,9 +78,9 @@ export abstract class StyleLayer extends Evented {
         this.type = layer.type;
         this._featureFilter = {filter: () => true, needGeometry: false};
 
-        if (layer.type === 'custom') return;
+        if (layer.type === 'custom' || layer.type === 'slot') return;
 
-        layer = (layer as any as LayerSpecification);
+        layer = (layer as any as Exclude<LayerSpecification, SlotLayerSpecification>);
 
         this.metadata = layer.metadata;
         this.minzoom = layer.minzoom;

--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -2363,7 +2363,7 @@ export class Map extends Camera {
 
     fillSlotWithLayers(slotId: string, layers: AddLayerObject[]) {
         if (!this.style) return;
-        this.style.fillSlot(slotId, layers);
+        this.style.fillSlot(slotId, [...layers]);
         return this._update(true);
     }
 

--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -2361,6 +2361,12 @@ export class Map extends Camera {
         return this._update(true);
     }
 
+    fillSlotWithLayers(slotId: string, layers: AddLayerObject[]) {
+        if (!this.style) return;
+        this.style.fillSlot(slotId, layers);
+        return this._update(true);
+    }
+
     /**
      * Moves a layer to a different z-position.
      *

--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -2361,9 +2361,9 @@ export class Map extends Camera {
         return this._update(true);
     }
 
-    fillSlotWithLayers(slotId: string, layers: AddLayerObject[]) {
+    populateSlot(slotId: string, layers: AddLayerObject[]) {
         if (!this.style) return;
-        this.style.fillSlot(slotId, [...layers]);
+        this.style.populateSlot(slotId, [...layers]);
         return this._update(true);
     }
 

--- a/src/ui/slots.test.ts
+++ b/src/ui/slots.test.ts
@@ -2,25 +2,25 @@
 describe('Slots', () => {
     test('Empty slot does not affect rendering of free layers', () => {
     });
-    test('fillSlotWithLayers adds 2 layers before a layer that comes after a slot', () => {
+    test('populateSlot adds 2 layers before a layer that comes after a slot', () => {
     });
-    test('fillSlotWithLayers appends 2 layers when there is no more layers after a slot', () => {
+    test('populateSlot appends 2 layers when there is no more layers after a slot', () => {
     });
-    test('Layers are inserted into Style._layers in the same order as provided to fillSlotWithLayers', () => {
+    test('Layers are inserted into Style._layers in the same order as provided to populateSlot', () => {
     });
-    test('fillSlotWithLayers empties the slot if empty array is passed to fillSlot', () => {
+    test('populateSlot empties the slot if empty array is passed to it', () => {
     });
-    test('fillSlotWithLayers empties the slot before inserting new layers', () => {
+    test('populateSlot empties the slot before inserting new layers', () => {
     });
-    test('fillSlotWithLayers does not throw when called with wrong slotId', () => {
+    test('populateSlot does not throw when called with wrong slotId', () => {
     });
-    test('fillSlotWithLayers keeps layers in slot untouched when called with invalid layers argument', () => {
+    test('populateSlot keeps layers in slot untouched when called with invalid layers argument', () => {
     });
-    test('fillSlotWithLayers adds layers when Style._layers was empty', () => {
+    test('populateSlot adds layers when Style._layers was empty', () => {
     });
-    test('fillSlotWithLayers adds layers in correct position when the next layer was an empty slot and there were no layers after that', () => {
+    test('populateSlot adds layers in correct position when the next layer was an empty slot and there were no layers after that', () => {
     });
-    test('fillSlotWithLayers adds layers in correct position when the next layer was a filled slot', () => {
+    test('populateSlot adds layers in correct position when the next layer was a filled slot', () => {
     });
     test('map.addLayer adds a layer before a slot when called with beforeId === slotId', () => {
     });
@@ -33,9 +33,9 @@ describe('Slots', () => {
     test('After setStyle with {diff: true} slots are emptied and can be filled again', () => {
         // This can be an inconvenience to a user but I think it'll be difficult to do it otherwise
         // Also, with slots there will less reason to call setStyle
-        // - because in many cases fillSlotWithLayers will be a good alternative
+        // - because in many cases populateSlot will be a good alternative
     });
-    test('fillSlotWithLayers does not insert layers when called called with an id of free layer', () => {
+    test('populateSlot does not insert layers when called called with an id of free layer', () => {
     });
     test('New slot cannot be added via map.addLayer', () => {
     });

--- a/src/ui/slots.test.ts
+++ b/src/ui/slots.test.ts
@@ -1,0 +1,66 @@
+
+describe('Slots', () => {
+    test('Empty slot does not affect rendering of free layers', () => {
+    });
+    test('fillSlotWithLayers adds 2 layers before a layer that comes after a slot', () => {
+    });
+    test('fillSlotWithLayers appends 2 layers when there is no more layers after a slot', () => {
+    });
+    test('Layers are inserted into Style._layers in the same order as provided to fillSlotWithLayers', () => {
+    });
+    test('fillSlotWithLayers empties the slot if empty array is passed to fillSlot', () => {
+    });
+    test('fillSlotWithLayers empties the slot before inserting new layers', () => {
+    });
+    test('fillSlotWithLayers does not throw when called with wrong slotId', () => {
+    });
+    test('fillSlotWithLayers keeps layers in slot untouched when called with invalid layers argument', () => {
+    });
+    test('fillSlotWithLayers adds layers when Style._layers was empty', () => {
+    });
+    test('fillSlotWithLayers adds layers in correct position when the next layer was an empty slot and there were no layers after that', () => {
+    });
+    test('fillSlotWithLayers adds layers in correct position when the next layer was a filled slot', () => {
+    });
+    test('map.addLayer adds a layer before a slot when called with beforeId === slotId', () => {
+    });
+    test('map.addLayer adds a layer to a slot when called with beforeId === idOfSlottedLayer', () => {
+        // It's against my design
+        // but it will be cruel to fail a user in this situation
+    });
+    test('After setStyle with {diff: false} slots are emptied and can be filled again', () => {
+    });
+    test('After setStyle with {diff: true} slots are emptied and can be filled again', () => {
+        // This can be an inconvenience to a user but I think it'll be difficult to do it otherwise
+        // Also, with slots there will less reason to call setStyle
+        // - because in many cases fillSlotWithLayers will be a good alternative
+    });
+    test('fillSlotWithLayers does not insert layers when called called with an id of free layer', () => {
+    });
+    test('New slot cannot be added via map.addLayer', () => {
+    });
+    test('Calling map.removeLayer with slotted layer id removes this layer from a slot', () => {
+    });
+    test('calling map.removeLayer with slot id does not remove a slot', () => {
+        // Because it makes no sense to remove slots
+    });
+    test('QUESTIONNABLE: map.getStyle returns only regular layers, both free and slotted ones, but without slots themselves', () => {
+        // This is how it will work by default (it returns layers from Style._layers, and it doesn't contain slots).
+        // Returning slots and slotted layers together is problematic in current implementation
+    });
+    test('map.getLayersOrder returns only regular layers, both free and slotted ones, but without slots themselves', () => {
+    });
+    test('map.getLayer(slotId) returns [what?]', () => {
+        // Perhaps it will be nice to tell what layers are now in this slot
+    });
+    test('map.moveLayer(slotId) does not move slot', () => {
+        // Makes little sense and hard to implement
+    });
+    test('map.moveLayer(slottedLayerId) removes layer from its slot, if new position is outside the slot', () => {
+    });
+    test('map.moveLayer(layerId) adds a previously unslotted layer to a slot, if new position is within this slot', () => {
+    });
+    test('map.setLayerZoomRange(slotId) does [what?]', () => {
+        // It can set a zoom range on every slotted layer
+    });
+});

--- a/test/examples/slots.html
+++ b/test/examples/slots.html
@@ -1,0 +1,142 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>Display a map</title>
+    <meta property="og:description" content="Initialize a map in an HTML element with MapLibre GL JS." />
+    <meta charset='utf-8'>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel='stylesheet' href='../../dist/maplibre-gl.css' />
+    <script src='../../dist/maplibre-gl-dev.js'></script>
+    <style>
+        body { margin: 0; padding: 0; }
+        html, body, #map { height: 100%; }
+    </style>
+</head>
+<body>
+<div id="map"></div>
+<script>
+    const motorway = {
+        'id': 'road_motorway',
+        'type': 'line',
+        'source': 'openmaptiles',
+        'source-layer': 'transportation',
+        'minzoom': 5,
+        'layout': {
+            'line-cap': 'round',
+            'line-join': 'round',
+            'visibility': 'visible'
+        },
+        'paint': {
+            'line-color': 'hsl(26, 87%, 62%)',
+            'line-width': 4
+        }
+    };
+
+    const background = {
+        'id': 'background',
+        'type': 'background',
+        'layout': {
+            'visibility': 'visible'
+        },
+        'paint': {
+            'background-color': 'rgba(246, 241, 100, 1)'
+        }
+    };
+
+    const water = {
+        'id': 'water',
+        'type': 'fill',
+        'source': 'openmaptiles',
+        'source-layer': 'water',
+        'layout': {
+            'visibility': 'visible'
+        },
+        'paint': {
+            'fill-color': 'rgba(134, 204, 250, 1)'
+        },
+        'metadata': {}
+    };
+
+    const highwayShield = {
+        'id': 'highway-shield',
+        'type': 'symbol',
+        'source': 'openmaptiles',
+        'source-layer': 'transportation_name',
+        'minzoom': 8,
+        'layout': {
+            'icon-size': 2,
+            'text-font': [
+                'Noto Sans Regular'
+            ],
+            'text-size': 20,
+            'icon-image': 'road_{ref_length}',
+            'text-field': '{ref}',
+            'symbol-spacing': 80,
+            'symbol-placement': {
+                'base': 1,
+                'stops': [
+                    [
+                        10,
+                        'point'
+                    ],
+                    [
+                        11,
+                        'line'
+                    ]
+                ]
+            },
+            'symbol-avoid-edges': true,
+            'icon-rotation-alignment': 'viewport',
+            'text-rotation-alignment': 'viewport'
+        },
+        'paint': {
+            'text-color': 'rgba(37, 36, 36, 1)'
+        }
+    };
+
+    const style = {
+        'version': 8,
+        'id': 'streets',
+        'name': 'Streets',
+        'sources': {
+            'openmaptiles': {
+                'url': 'https://api.maptiler.com/tiles/v3/tiles.json?key=get_your_own_OpIi9ZULNHzrESv6T2vL',
+                'type': 'vector'
+            },
+            'maptiler_attribution': {
+                'attribution': '<a href="https://www.maptiler.com/copyright/" target="_blank">&copy; MapTiler</a> <a href="https://www.openstreetmap.org/copyright" target="_blank">&copy; OpenStreetMap contributors</a>',
+                'type': 'vector'
+            }
+        },
+        'layers': [
+            background,
+            water,
+            {type: 'slot', id: 'motorway-slot'},
+            highwayShield
+        ],
+        'metadata': {
+            'maptiler:copyright': 'This style was generated on MapTiler Cloud. Usage outside of MapTiler Cloud requires valid MapTiler Data Package: https://www.maptiler.com/data/package/ -- please contact us.'
+        },
+        'glyphs': 'https://api.maptiler.com/fonts/{fontstack}/{range}.pbf?key=get_your_own_OpIi9ZULNHzrESv6T2vL',
+        'sprite': 'https://api.maptiler.com/maps/streets/sprite',
+        'bearing': 0,
+        'pitch': 0,
+        'center': [
+            12.0488,
+            55.83567
+        ],
+        'zoom': 12.62,
+
+};
+
+    const map = new maplibregl.Map({
+        container: 'map',
+        style,
+        hash: true,
+    });
+
+    // map.fillSlot('motorway-slot', motorway);
+
+</script>
+</body>
+</html>

--- a/test/examples/slots.html
+++ b/test/examples/slots.html
@@ -8,39 +8,34 @@
     <link rel='stylesheet' href='../../dist/maplibre-gl.css' />
     <script src='../../dist/maplibre-gl-dev.js'></script>
     <style>
-        body { margin: 0; padding: 0; }
-        html, body, #map { height: 100%; }
+        body { margin: 0; padding: 0; display: flex; flex-direction: column; }
+        html, body { height: 100%; }
+        #map { flex: 1; }
+        .inputs { user-select: none; font-size: 16px; }
+        label { display: inline-block; padding: 8px 10px; cursor: pointer; }
     </style>
 </head>
 <body>
+<div class="inputs">
+    <label>
+        <input type="checkbox" id="roads">
+        Roads
+    </label>
+    <label>
+        <input type="checkbox" id="contours">
+        Contours
+    </label>
+    <label>
+        <input type="checkbox" id="buildings">
+        Buildings
+    </label>
+</div>
 <div id="map"></div>
 <script>
-    const motorway = {
-        'id': 'road_motorway',
-        'type': 'line',
-        'source': 'openmaptiles',
-        'source-layer': 'transportation',
-        'minzoom': 5,
-        'layout': {
-            'line-cap': 'round',
-            'line-join': 'round',
-            'visibility': 'visible'
-        },
-        'paint': {
-            'line-color': 'hsl(26, 87%, 62%)',
-            'line-width': 4
-        }
-    };
-
     const background = {
         'id': 'background',
         'type': 'background',
-        'layout': {
-            'visibility': 'visible'
-        },
-        'paint': {
-            'background-color': 'rgba(246, 241, 100, 1)'
-        }
+        'paint': {'background-color': 'rgb(216, 210, 206)'}
     };
 
     const water = {
@@ -48,50 +43,70 @@
         'type': 'fill',
         'source': 'openmaptiles',
         'source-layer': 'water',
-        'layout': {
-            'visibility': 'visible'
-        },
-        'paint': {
-            'fill-color': 'rgba(134, 204, 250, 1)'
-        },
-        'metadata': {}
+        'paint': {'fill-color': 'rgba(134, 204, 250, 1)'},
     };
 
-    const highwayShield = {
-        'id': 'highway-shield',
-        'type': 'symbol',
-        'source': 'openmaptiles',
-        'source-layer': 'transportation_name',
-        'minzoom': 8,
-        'layout': {
-            'icon-size': 2,
-            'text-font': [
-                'Noto Sans Regular'
-            ],
-            'text-size': 20,
-            'icon-image': 'road_{ref_length}',
-            'text-field': '{ref}',
-            'symbol-spacing': 80,
-            'symbol-placement': {
-                'base': 1,
-                'stops': [
-                    [
-                        10,
-                        'point'
-                    ],
-                    [
-                        11,
-                        'line'
-                    ]
-                ]
-            },
-            'symbol-avoid-edges': true,
-            'icon-rotation-alignment': 'viewport',
-            'text-rotation-alignment': 'viewport'
+    const roadsLayers = [
+        {
+            'id': 'road_motorway',
+            'type': 'line',
+            'source': 'openmaptiles',
+            'source-layer': 'transportation',
+            'paint': {
+                'line-color': 'hsl(16, 47%, 62%)',
+                'line-width': 2
+            }
         },
-        'paint': {
-            'text-color': 'rgba(37, 36, 36, 1)'
+        {
+            'id': 'shield',
+            'type': 'symbol',
+            'source': 'openmaptiles',
+            'source-layer': 'transportation_name',
+            'minzoom': 8,
+            'layout': {
+                'icon-size': 1.5,
+                'text-size': 16,
+                'icon-image': 'road_{ref_length}',
+                'text-field': '{ref}',
+                'symbol-spacing': 120,
+                'symbol-placement': 'line',
+                'icon-rotation-alignment': 'viewport',
+                'text-rotation-alignment': 'viewport'
+            },
+            'paint': {'text-color': 'rgba(37, 36, 36, 1)'},
+            'filter': ['in', 'class', 'primary']
         }
+    ];
+
+    const contoursLayers = [
+        {
+            'id': 'Contour',
+            'source': 'contours',
+            'source-layer': 'contour',
+            'type': 'line',
+            'paint': {'line-color': 'hsla(0, 0%, 62%, 50%)'},
+        },
+        {
+            'id': 'Contour labels',
+            'source': 'contours',
+            'source-layer': 'contour',
+            'type': 'symbol',
+            'layout': {
+                'text-size': 12,
+                'text-field': '{height}',
+                'text-padding': 35,
+                'symbol-placement': 'line',
+            },
+            'paint': {'text-color': 'hsl(9, 16%, 32%)'}
+        },
+    ];
+
+    const buildings = {
+        'id': 'Building',
+        'type': 'fill',
+        'source': 'openmaptiles',
+        'source-layer': 'building',
+        'paint': {'fill-color': 'RGB(175, 185, 200)'}
     };
 
     const style = {
@@ -103,40 +118,48 @@
                 'url': 'https://api.maptiler.com/tiles/v3/tiles.json?key=get_your_own_OpIi9ZULNHzrESv6T2vL',
                 'type': 'vector'
             },
-            'maptiler_attribution': {
-                'attribution': '<a href="https://www.maptiler.com/copyright/" target="_blank">&copy; MapTiler</a> <a href="https://www.openstreetmap.org/copyright" target="_blank">&copy; OpenStreetMap contributors</a>',
+            'contours': {
+                'url': 'https://api.maptiler.com/tiles/contours/tiles.json?key=get_your_own_OpIi9ZULNHzrESv6T2vL',
                 'type': 'vector'
-            }
-        },
-        'layers': [
-            background,
-            water,
-            {type: 'slot', id: 'motorway-slot'},
-            highwayShield
-        ],
-        'metadata': {
-            'maptiler:copyright': 'This style was generated on MapTiler Cloud. Usage outside of MapTiler Cloud requires valid MapTiler Data Package: https://www.maptiler.com/data/package/ -- please contact us.'
+            },
         },
         'glyphs': 'https://api.maptiler.com/fonts/{fontstack}/{range}.pbf?key=get_your_own_OpIi9ZULNHzrESv6T2vL',
         'sprite': 'https://api.maptiler.com/maps/streets/sprite',
-        'bearing': 0,
-        'pitch': 0,
-        'center': [
-            12.0488,
-            55.83567
+        'layers': [
+            background,
+            {type: 'slot', id: 'buildings'},
+            {type: 'slot', id: 'contours'},
+            water,
+            {type: 'slot', id: 'roads'}
         ],
-        'zoom': 12.62,
-
-};
+        'center': [
+            10.20328,
+            46.77293
+        ],
+        'zoom': 14.8
+    };
 
     const map = new maplibregl.Map({
         container: 'map',
         style,
-        hash: true,
     });
 
-    // map.fillSlot('motorway-slot', motorway);
+    map.setMaxBounds([[10.150882249176192, 46.74657373570173], [10.255677750822713, 46.79927337210148]]);
 
+    map.on('style.load', () => {
+        map.fillSlotWithLayers('roads', roadsLayers);
+        document.querySelector('input#roads').checked = true;
+    });
+
+    document.querySelector('input#roads').addEventListener('change', e => {
+        map.fillSlotWithLayers('roads', e.target.checked ? roadsLayers : []);
+    });
+    document.querySelector('input#contours').addEventListener('change', e => {
+        map.fillSlotWithLayers('contours', e.target.checked ? contoursLayers : []);
+    });
+    document.querySelector('input#buildings').addEventListener('change', e => {
+        map.fillSlotWithLayers('buildings', e.target.checked ? [buildings] : []);
+    });
 </script>
 </body>
 </html>

--- a/test/examples/slots.html
+++ b/test/examples/slots.html
@@ -147,18 +147,18 @@
     map.setMaxBounds([[10.150882249176192, 46.74657373570173], [10.255677750822713, 46.79927337210148]]);
 
     map.on('style.load', () => {
-        map.fillSlotWithLayers('roads', roadsLayers);
+        map.populateSlot('roads', roadsLayers);
         document.querySelector('input#roads').checked = true;
     });
 
     document.querySelector('input#roads').addEventListener('change', e => {
-        map.fillSlotWithLayers('roads', e.target.checked ? roadsLayers : []);
+        map.populateSlot('roads', e.target.checked ? roadsLayers : []);
     });
     document.querySelector('input#contours').addEventListener('change', e => {
-        map.fillSlotWithLayers('contours', e.target.checked ? contoursLayers : []);
+        map.populateSlot('contours', e.target.checked ? contoursLayers : []);
     });
     document.querySelector('input#buildings').addEventListener('change', e => {
-        map.fillSlotWithLayers('buildings', e.target.checked ? [buildings] : []);
+        map.populateSlot('buildings', e.target.checked ? [buildings] : []);
     });
 </script>
 </body>


### PR DESCRIPTION
This PR facilitates toggling of layers, especially groups of layers.
Changes to API:
- user can specify a layer of `{type: 'slot')` (Therefore it requires a corresponding change in style-spec)
- user can fill a slot with an array of layers (and remove all layers from a slot) via `map.populateSlot` method

----
 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [x] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [ ] Add an entry to `CHANGELOG.md` under the `## main` section.


## Rationale.
This is motivated by a recent [discussion](https://github.com/maplibre/maplibre-gl-js/discussions/3787) and my own hard experience with toggling.
User currently has no straightforward solutions for toggling. It's overall possible but in a rather awkward way.
It gets especially difficult when you need to toggle _groups_ of layers, and especially groups of layers that come _after each other_ (because `beforeId` in such case becomes unreliable).
Current API compels a user to add layers to the style object from the start and later toggle their visibility. This is 1) really inconvenient and 2) it seems like wasting computational time for stuff that might be never shown.

Benefits of this change are that:
- it gives a more expressive way to toggle, without the need to know beforeIds
- makes it easier to add/remove layers in batches.

## Comparison to mapbox slots
The concept and implementation are quite different.
Both my slots and mapbox slots are "named places where you can insert extra layers".
But in mapbox:
- slots are not made for toggling. They allow to put layers into certain named positions but they do not allow to remove/replace all layers from a slot.
- positions of slots are not user-defined but hardcoded into mapbox basemap.
- layers are added to a slot one by one. It's done by providing a "slot" property on a layer object.
- there are no special methods to populate a slot

My implementation allows a user to define his own points and to populate them in batches.
I assume that a user has a logically coherent group of layers, such as "all about roads" or "all about contours" and wants to be able to switch on/off the entire group.
This case is demonstrated in the example page that is included in this PR.

## Style-spec
Style spec has to permit layers of type `slot` that have no other properties except `id`.

## Some possible problems with this code
Implementation is quite simple but it creates a lot of cases where things can go wrong.
I tried to summarize the possible quirks in a test file that's included.
Other possible improvements:
- Currently I insert a batch of layers just by calling style.addLayer in a loop - not sure if it's ok from performance pov, perhaps there is better way to do it.
- There is no way to define a _filled_ slot as part of style object; slot can be filled only later via populateSlot.
- In order to populate a layer from the start, you have to wait for style.load

## Video of example page

https://github.com/maplibre/maplibre-gl-js/assets/11789697/b3a692e5-bdd7-4769-89ea-a927658eba96

