### PR TITLE
Disable search as was suggested

### DIFF
--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -52,6 +52,7 @@ jobs:
           files: ${{ github.workspace }}/coverage/unit/codecov.json
           verbose: true
           token: ${{ secrets.CODECOV_TOKEN }}
+          disable_search: true
 
   integration-tests:
     name: Integration tests
@@ -110,6 +111,7 @@ jobs:
           files: ${{ github.workspace }}/coverage/render/codecov.json
           verbose: true
           token: ${{ secrets.CODECOV_TOKEN }}
+          disable_search: true
       - name: Upload render test failure
         if: failure()
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Disable codecov search as was suggested here:
https://github.com/codecov/codecov-action/issues/1354

Looks like the report is returning the expected number of line in the code.
