### PR TITLE
Render tests: better visibility of errors when updating expected images

### DIFF
--- a/test/integration/render/run_render_tests.ts
+++ b/test/integration/render/run_render_tests.ts
@@ -673,7 +673,7 @@ function printProgress(test: TestData, total: number, index: number) {
 /**
  * Prints the summary at the end of the run
  *
- * @param tests - all the tests with their resutls
+ * @param tests - all the tests with their results
  * @returns `true` if all the tests passed
  */
 function printStatistics(stats: TestStats): boolean {

--- a/test/integration/render/run_render_tests.ts
+++ b/test/integration/render/run_render_tests.ts
@@ -662,7 +662,7 @@ async function getImageFromStyle(styleForTest: StyleWithTestData, page: Page): P
  */
 function printProgress(test: TestData, total: number, index: number) {
     if (test.error) {
-        console.log('\x1b[31m', `${index}/${total}: errored ${test.id} ${test.error.message}`, '\x1b[0m');
+        console.log('\x1b[91m', `${index}/${total}: errored ${test.id} ${test.error.message}`, '\x1b[0m');
     } else if (!test.ok) {
         console.log('\x1b[31m', `${index}/${total}: failed ${test.id} ${test.difference}`, '\x1b[0m');
     } else {
@@ -877,7 +877,11 @@ async function executeRenderTests() {
     };
 
     if (process.env.UPDATE) {
-        console.log(`Updated ${testStyles.length} tests.`);
+        if (testStats.failed.length > 0) {
+            console.log(`Updated ${testStats.failed.length}/${testStats.total} tests, ${testStats.errored.length} errored.`);
+        } else {
+            console.log(`Updated ${testStats.total} tests.`);
+        }
         process.exit(0);
     }
 


### PR DESCRIPTION
This PR makes two changes to render tests that improve the developer's experience when creating/updating render tests:

- Messages for errored tests are printed with a different shade of red, making them more visible at a glance (they now look different than failed tests).
- When updating render tests, it print a slightly different message with the count of errored tests after all tests are finished running.

Rationale: when creating a new render test and iterating it, it is very easy to overlook that your test image is not getting updated, because the test is instead timing out, for example because there is an error in the style.json. These changes make such errored (unupdated) tests much more visible.

Before:

![](https://github.com/maplibre/maplibre-gl-js/assets/57600346/22b49909-80ec-4dba-a1a8-1e343df5a28d)

After:

![](https://github.com/maplibre/maplibre-gl-js/assets/57600346/74c066a7-b4f9-490b-bb0e-7cfcb3b03d8a)

Assumption: tests that result in error are not actually updated. But it seems that right now all successfully updated tests are reported as failed.

## Launch Checklist

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [ ] Link to related issues.
 - [x] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [ ] Add an entry to `CHANGELOG.md` under the `## main` section.