### PR TITLE
Fix image sources not being marked as loaded on error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### 🐞 Bug fixes
 - Fix different unwanted panning changes at the end of a panning motion, that happen on a large screen ([#3935](https://github.com/maplibre/maplibre-gl-js/issues/3935))
+- Fix image sources not being marked as loaded on error
 
 ## 4.1.2
 

--- a/src/source/image_source.ts
+++ b/src/source/image_source.ts
@@ -147,6 +147,7 @@ export class ImageSource extends Evented implements Source {
             }
         } catch (err) {
             this._request = null;
+            this._loaded = true;
             this.fire(new ErrorEvent(err));
         }
     }


### PR DESCRIPTION
## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->
This fixes image sources not being marked as loaded when loading of the image fails. 

This behavior changed as a result of https://github.com/maplibre/maplibre-gl-js/commit/859b1a7c1d88a111031f3938f1c329604120f1e0#diff-d4cf28d025bceded1ecd0f4b0b3095b831e34317b61f25611d3cf44e82d64c14 as the new try/catch approach doesn't change the `_loaded` variable on error. 

 - [X] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [X] Briefly describe the changes in this PR.
 - [ ] Link to related issues.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [X] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [X] Add an entry to `CHANGELOG.md` under the `## main` section.
