### PR TITLE
Fix printing of errored render test count

### DIFF
--- a/test/integration/render/run_render_tests.ts
+++ b/test/integration/render/run_render_tests.ts
@@ -673,7 +673,7 @@ function printProgress(test: TestData, total: number, index: number) {
 /**
  * Prints the summary at the end of the run
  *
- * @param tests - all the tests with their resutls
+ * @param tests - all the tests with their results
  * @returns `true` if all the tests passed
  */
 function printStatistics(stats: TestStats): boolean {

--- a/test/integration/render/run_render_tests.ts
+++ b/test/integration/render/run_render_tests.ts
@@ -662,7 +662,7 @@ async function getImageFromStyle(styleForTest: StyleWithTestData, page: Page): P
  */
 function printProgress(test: TestData, total: number, index: number) {
     if (test.error) {
-        console.log('\x1b[31m', `${index}/${total}: errored ${test.id} ${test.error.message}`, '\x1b[0m');
+        console.log('\x1b[91m', `${index}/${total}: errored ${test.id} ${test.error.message}`, '\x1b[0m');
     } else if (!test.ok) {
         console.log('\x1b[31m', `${index}/${total}: failed ${test.id} ${test.difference}`, '\x1b[0m');
     } else {
@@ -877,7 +877,11 @@ async function executeRenderTests() {
     };
 
     if (process.env.UPDATE) {
-        console.log(`Updated ${testStyles.length} tests.`);
+        if (testStats.failed.length > 0) {
+            console.log(`Updated ${testStats.failed.length}/${testStats.total} tests, ${testStats.errored.length} errored.`);
+        } else {
+            console.log(`Updated ${testStats.total} tests.`);
+        }
         process.exit(0);
     }
 

--- a/test/integration/render/run_render_tests.ts
+++ b/test/integration/render/run_render_tests.ts
@@ -877,7 +877,7 @@ async function executeRenderTests() {
     };
 
     if (process.env.UPDATE) {
-        if (testStats.failed.length > 0) {
+        if (testStats.errored.length > 0) {
             console.log(`Updated ${testStats.failed.length}/${testStats.total} tests, ${testStats.errored.length} errored.`);
         } else {
             console.log(`Updated ${testStats.total} tests.`);


### PR DESCRIPTION
Fixes a bug in https://github.com/maplibre/maplibre-gl-js/pull/3980 where the number of errored tests was only printed when at least one test *failed* (was updated), instead of when at least one test *errored*.

Before:

![](https://github.com/maplibre/maplibre-gl-js/assets/57600346/75a3442a-ec75-4515-a71c-69014b50d24c)

![](https://github.com/maplibre/maplibre-gl-js/assets/57600346/753ec478-a3c3-4ea6-953f-9b8cd8f380d2)

After:

![](https://github.com/maplibre/maplibre-gl-js/assets/57600346/c0e61ed0-8efc-4e32-b10c-4609174e4257)

![](https://github.com/maplibre/maplibre-gl-js/assets/57600346/68212817-0333-4dd0-989e-06e102af20e1)

