### PR TITLE
Experimental "fix" for tile LOD when terrain is on

### DIFF
--- a/src/geo/transform.ts
+++ b/src/geo/transform.ts
@@ -401,7 +401,7 @@ export class Transform {
                 fullyVisible = intersectResult === 2;
             }
 
-            const refPoint = options.terrain ? cameraPoint : centerPoint;
+            const refPoint = /*options.terrain ? cameraPoint : centerPoint;*/ centerPoint;
             const distanceX = it.aabb.distanceX(refPoint);
             const distanceY = it.aabb.distanceY(refPoint);
             const longestDim = Math.max(Math.abs(distanceX), Math.abs(distanceY));


### PR DESCRIPTION
Experimenting with changing the behaviour of raster LOD when terrain is enabled - making it more similar to when terrain is disabled.
