### PR TITLE
Fix scale control default parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### 🐞 Bug fixes
 - Fix different unwanted panning changes at the end of a panning motion, that happen on a large screen ([#3935](https://github.com/maplibre/maplibre-gl-js/issues/3935))
 - Fix image sources not being marked as loaded on error
+- Fix ScaleControl options should be optional. ([#4002](https://github.com/maplibre/maplibre-gl-js/pull/4002))
 
 ## 4.1.2
 

--- a/src/ui/control/scale_control.ts
+++ b/src/ui/control/scale_control.ts
@@ -1,5 +1,4 @@
 import {DOM} from '../../util/dom';
-import {extend} from '../../util/util';
 
 import type {Map} from '../map';
 import type {ControlPosition, IControl} from './control';
@@ -51,8 +50,8 @@ export class ScaleControl implements IControl {
     _container: HTMLElement;
     options: ScaleControlOptions;
 
-    constructor(options: ScaleControlOptions) {
-        this.options = extend({}, defaultOptions, options);
+    constructor(options?: ScaleControlOptions) {
+        this.options = {...defaultOptions, ...options};
     }
 
     getDefaultPosition(): ControlPosition {


### PR DESCRIPTION
Before this CL, the following would generate an error:

```ts
const scaleCtrl = new ScaleControl():
```

because options is not marked as optional.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [ ] Link to related issues.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [x] Add an entry to `CHANGELOG.md` under the `## main` section.
