### PR TITLE
Fix MapOptions#style is optional in the Map constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - Fix image sources not being marked as loaded on error
 - Fix ScaleControl options should be optional. ([#4002](https://github.com/maplibre/maplibre-gl-js/pull/4002))
 - Fix race condition in SourceCache that makes unit tests unstable. Eliminate a redundant 'visibility' event fired from Style class. ([#3992](https://github.com/maplibre/maplibre-gl-js/issues/3992))
-
+- Fix MapOptions#style is optional in the Map constructor([#4003](https://github.com/maplibre/maplibre-gl-js/pull/4003))
 
 ## 4.1.2
 

--- a/src/style/style.ts
+++ b/src/style/style.ts
@@ -60,7 +60,6 @@ import {
     type GetImagesResponse
 } from '../util/actor_messages';
 
-const empty = emptyStyle() as StyleSpecification;
 /**
  * A feature identifier that is bound to a source
  */
@@ -311,7 +310,7 @@ export class Style extends Evented {
 
     loadEmpty() {
         this.fire(new Event('dataloading', {dataType: 'style'}));
-        this._load(empty, {validate: false});
+        this._load(emptyStyle(), {validate: false});
     }
 
     _load(json: StyleSpecification, options: StyleSwapOptions & StyleSetterOptions, previousStyle?: StyleSpecification) {

--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -298,7 +298,7 @@ export type MapOptions = {
      * the schema described in the [MapLibre Style Specification](https://maplibre.org/maplibre-style-spec/),
      * or a URL to such JSON.
      */
-    style: StyleSpecification | string;
+    style?: StyleSpecification | string;
     /**
      * If `false`, the map's pitch (tilt) control with "drag to rotate" interaction will be disabled.
      * @defaultValue true
@@ -387,7 +387,8 @@ const defaultOptions = {
     crossSourceCollisions: true,
     validateStyle: true,
     /**Because GL MAX_TEXTURE_SIZE is usually at least 4096px. */
-    maxCanvasSize: [4096, 4096]
+    maxCanvasSize: [4096, 4096],
+    style: '',
 } as CompleteMapOptions;
 
 /**


### PR DESCRIPTION
See `if (options.style) this.setStyle(...);` in the constructor

My use case is to use a base layer switcher so I do not want to set a style explicitly when instantiating the map.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [ ] Link to related issues.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [x] Add an entry to `CHANGELOG.md` under the `## main` section.
