### PR TITLE
New map option to decide whether to cancel previous pending tiles while zooming in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 - Update Popup methods `addClass` & `removeClass` to return instance of Popup ([#3975](https://github.com/maplibre/maplibre-gl-js/pull/3975))
 
 ### ✨ Features and improvements
+- _...Add new stuff here..._
+- New map option to decide whether to cancel previous pending tiles while zooming in ([#4051](https://github.com/maplibre/maplibre-gl-js/pull/4051))
 - Sprites include optional textFitHeight and textFitWidth values ([#4019](https://github.com/maplibre/maplibre-gl-js/pull/4019))
 
 ### 🐞 Bug fixes

--- a/src/source/source_cache.ts
+++ b/src/source/source_cache.ts
@@ -287,8 +287,8 @@ export class SourceCache extends Evented {
     }
 
     /**
-    * For raster terrain source, backfill DEM to eliminate visible tile boundaries
-    */
+     * For raster terrain source, backfill DEM to eliminate visible tile boundaries
+     */
     _backfillDEM(tile: Tile) {
         const renderables = this.getRenderableIds();
         for (let i = 0; i < renderables.length; i++) {
@@ -734,7 +734,7 @@ export class SourceCache extends Evented {
                 }
                 if (tile) {
                     const hasData = tile.hasData();
-                    if (parentWasRequested || hasData) {
+                    if (hasData || !this.map?.cancelPendingTileRequestsWhileZooming || parentWasRequested) {
                         retain[parentId.key] = parentId;
                     }
                     // Save the current values, since they're the parent of the next iteration


### PR DESCRIPTION
This PR creates an opt-out behaviour for the changes which were introduced here since version 3.0:
https://github.com/maplibre/maplibre-gl-js/pull/2377

Now there is a new map option (which can also be changed during runtime) that determines whether pending (still loading) tiles from previous (farther) zoom levels are going to be canceled as we zoom in.
The change is backwards compatible, since the default behavior is just as before.
However if we disable the pending tile cancelation, we get the original (pre v3) behavior, which helps to progressively unveil map details when zooming into areas where tiles are not yet cached. For modern devices this could be the desired behavior.

Behavior with tile canceling (now the default, and active since v3):
https://github.com/maplibre/maplibre-gl-js/assets/73886099/d5ce23c4-ad5d-4548-96d0-8bb4f8ff49ae

Behavior without tile canceling (was default before v3):
https://github.com/maplibre/maplibre-gl-js/assets/73886099/7f42dc32-f526-4da5-bd86-03915d4e531d


## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [x] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality.
 - [x] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [x] Add an entry to `CHANGELOG.md` under the `## main` section.
