### PR TITLE
Improve link to react wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Check out the features through [examples](https://maplibre.org/maplibre-gl-js/do
 
 Want an example? Have a look at the official [MapLibre GL JS Documentation](https://maplibre.org/maplibre-gl-js/docs/examples/).
 
-Use MapLibre GL JS bindings for React (https://visgl.github.io/react-map-gl/docs/get-started#using-with-a-compatible-fork) and Angular (https://github.com/maplibre/ngx-maplibre-gl). Find more at [awesome-maplibre](https://github.com/maplibre/awesome-maplibre).
+Use MapLibre GL JS bindings for React (https://visgl.github.io/react-map-gl/docs/get-started) and Angular (https://github.com/maplibre/ngx-maplibre-gl). Find more at [awesome-maplibre](https://github.com/maplibre/awesome-maplibre).
 
 <br />
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Check out the features through [examples](https://maplibre.org/maplibre-gl-js/do
 
 Want an example? Have a look at the official [MapLibre GL JS Documentation](https://maplibre.org/maplibre-gl-js/docs/examples/).
 
-Use MapLibre GL JS bindings for React (https://visgl.github.io/react-map-gl/docs/get-started) and Angular (https://github.com/maplibre/ngx-maplibre-gl). Find more at [awesome-maplibre](https://github.com/maplibre/awesome-maplibre).
+Use MapLibre GL JS bindings for [React](https://visgl.github.io/react-map-gl/docs/get-started) and [Angular](https://github.com/maplibre/ngx-maplibre-gl). Find more at [awesome-maplibre](https://github.com/maplibre/awesome-maplibre).
 
 <br />
 


### PR DESCRIPTION
We can link directly to https://visgl.github.io/react-map-gl/docs/get-started now that there is a react-map-gl/maplibre export.



also changed this:
<img width="661" alt="Screenshot 2024-05-02 at 13 06 25" src="https://github.com/maplibre/maplibre-gl-js/assets/74932975/7269e78a-196d-4970-b371-b7f3ebae086b">


to this:
<img width="457" alt="Screenshot 2024-05-02 at 13 05 08" src="https://github.com/maplibre/maplibre-gl-js/assets/74932975/8b0c6888-d762-4bcb-9a72-9a64efbebca4">
