### PR TITLE
Fix docs markdown

### DIFF
--- a/src/render/terrain.ts
+++ b/src/render/terrain.ts
@@ -46,7 +46,7 @@ export type TerrainMesh = {
     segments: SegmentVector;
 }
 
- /**
+/**
  * @internal
  * This is the main class which handles most of the 3D Terrain logic. It has the following topics:
  *

--- a/src/render/terrain.ts
+++ b/src/render/terrain.ts
@@ -46,32 +46,38 @@ export type TerrainMesh = {
     segments: SegmentVector;
 }
 
-/**
+ /**
  * @internal
  * This is the main class which handles most of the 3D Terrain logic. It has the following topics:
- *    1) loads raster-dem tiles via the internal sourceCache this.sourceCache
- *    2) creates a depth-framebuffer, which is used to calculate the visibility of coordinates
- *    3) creates a coords-framebuffer, which is used the get to tile-coordinate for a screen-pixel
- *    4) stores all render-to-texture tiles in the this.sourceCache._tiles
- *    5) calculates the elevation for a specific tile-coordinate
- *    6) creates a terrain-mesh
  *
- *    A note about the GPU resource-usage:
- *    Framebuffers:
- *       - one for the depth & coords framebuffer with the size of the map-div.
- *       - one for rendering a tile to texture with the size of tileSize (= 512x512).
- *    Textures:
- *       - one texture for an empty raster-dem tile with size 1x1
- *       - one texture for an empty depth-buffer, when terrain is disabled with size 1x1
- *       - one texture for an each loaded raster-dem with size of the source.tileSize
- *       - one texture for the coords-framebuffer with the size of the map-div.
- *       - one texture for the depth-framebuffer with the size of the map-div.
- *       - one texture for the encoded tile-coords with the size 2*tileSize (=1024x1024)
- *       - finally for each render-to-texture tile (= this._tiles) a set of textures
- *         for each render stack (The stack-concept is documented in painter.ts).
- *         Normally there exists 1-3 Textures per tile, depending on the stylesheet.
- *         Each Textures has the size 2*tileSize (= 1024x1024). Also there exists a
- *         cache of the last 150 newest rendered tiles.
+ * 1. loads raster-dem tiles via the internal sourceCache this.sourceCache
+ * 2. creates a depth-framebuffer, which is used to calculate the visibility of coordinates
+ * 3. creates a coords-framebuffer, which is used the get to tile-coordinate for a screen-pixel
+ * 4. stores all render-to-texture tiles in the this.sourceCache._tiles
+ * 5. calculates the elevation for a specific tile-coordinate
+ * 6. creates a terrain-mesh
+ *
+ * A note about the GPU resource-usage:
+ *
+ * Framebuffers:
+ *
+ * - one for the depth & coords framebuffer with the size of the map-div.
+ * - one for rendering a tile to texture with the size of tileSize (= 512x512).
+ *
+ * Textures:
+ *
+ * - one texture for an empty raster-dem tile with size 1x1
+ * - one texture for an empty depth-buffer, when terrain is disabled with size 1x1
+ * - one texture for an each loaded raster-dem with size of the source.tileSize
+ * - one texture for the coords-framebuffer with the size of the map-div.
+ * - one texture for the depth-framebuffer with the size of the map-div.
+ * - one texture for the encoded tile-coords with the size 2*tileSize (=1024x1024)
+ * - finally for each render-to-texture tile (= this._tiles) a set of textures
+ * for each render stack (The stack-concept is documented in painter.ts).
+ *
+ * Normally there exists 1-3 Textures per tile, depending on the stylesheet.
+ * Each Textures has the size 2*tileSize (= 1024x1024). Also there exists a
+ * cache of the last 150 newest rendered tiles.
  *
  */
 export class Terrain {

--- a/src/source/terrain_source_cache.ts
+++ b/src/source/terrain_source_cache.ts
@@ -10,11 +10,12 @@ import {Terrain} from '../render/terrain';
 /**
  * @internal
  * This class is a helper for the Terrain-class, it:
- *   - loads raster-dem tiles
- *   - manages all renderToTexture tiles.
- *   - caches previous rendered tiles.
- *   - finds all necessary renderToTexture tiles for a OverscaledTileID area
- *   - finds the corresponding raster-dem tile for OverscaledTileID
+ *
+ * - loads raster-dem tiles
+ * - manages all renderToTexture tiles.
+ * - caches previous rendered tiles.
+ * - finds all necessary renderToTexture tiles for a OverscaledTileID area
+ * - finds the corresponding raster-dem tile for OverscaledTileID
  */
 export class TerrainSourceCache extends Evented {
     /**


### PR DESCRIPTION
fixes markdown syntax. These two classes are internal so it doesn't change anything public