### PR TITLE
use `with` for json modules instead of `assert`

### DIFF
--- a/build/banner.ts
+++ b/build/banner.ts
@@ -1,4 +1,4 @@
-import packageJSON from '../package.json' assert {type: 'json'};
+import packageJSON from '../package.json' with {type: 'json'};
 
 export default
 `/**

--- a/build/generate-doc-images.ts
+++ b/build/generate-doc-images.ts
@@ -1,7 +1,7 @@
 import path from 'path';
 import fs from 'fs';
 import puppeteer from 'puppeteer';
-import packageJson from '../package.json' assert { type: 'json' };
+import packageJson from '../package.json' with { type: 'json' };
 
 const exampleName = process.argv[2];
 const examplePath = path.resolve('test', 'examples');

--- a/build/generate-docs.ts
+++ b/build/generate-docs.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
-import typedocConfig from '../typedoc.json' assert {type: 'json'};
-import packageJson from '../package.json' assert {type: 'json'};
+import typedocConfig from '../typedoc.json' with {type: 'json'};
+import packageJson from '../package.json' with {type: 'json'};
 
 type HtmlDoc = {
     title: string;

--- a/src/data/bucket/symbol_bucket.test.ts
+++ b/src/data/bucket/symbol_bucket.test.ts
@@ -16,7 +16,7 @@ import {RGBAImage} from '../../util/image';
 import {ImagePosition} from '../../render/image_atlas';
 import {IndexedFeature, PopulateParameters} from '../bucket';
 import {StyleImage} from '../../style/style_image';
-import glyphs from '../../../test/unit/assets/fontstack-glyphs.json' assert {type: 'json'};
+import glyphs from '../../../test/unit/assets/fontstack-glyphs.json' with {type: 'json'};
 import {StyleGlyph} from '../../style/style_glyph';
 
 // Load a point feature from fixture tile.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import packageJSON from '../package.json' assert {type: 'json'};
+import packageJSON from '../package.json' with {type: 'json'};
 import {Map} from './ui/map';
 import {NavigationControl} from './ui/control/navigation_control';
 import {GeolocateControl} from './ui/control/geolocate_control';

--- a/src/source/vector_tile_source.test.ts
+++ b/src/source/vector_tile_source.test.ts
@@ -5,7 +5,7 @@ import {Tile} from './tile';
 import {OverscaledTileID} from './tile_id';
 import {Evented} from '../util/evented';
 import {RequestManager} from '../util/request_manager';
-import fixturesSource from '../../test/unit/assets/source.json' assert {type: 'json'};
+import fixturesSource from '../../test/unit/assets/source.json' with {type: 'json'};
 import {getMockDispatcher, getWrapDispatcher, sleep, waitForMetadataEvent} from '../util/test/util';
 import {Map} from '../ui/map';
 import {WorkerTileParameters} from './worker_source';

--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -1,7 +1,7 @@
 import {extend, warnOnce, uniqueId, isImageBitmap} from '../util/util';
 import {browser} from '../util/browser';
 import {DOM} from '../util/dom';
-import packageJSON from '../../package.json' assert {type: 'json'};
+import packageJSON from '../../package.json' with {type: 'json'};
 import {GetResourceResponse, getJSON} from '../util/ajax';
 import {ImageRequest} from '../util/image_request';
 import {RequestManager, ResourceType} from '../util/request_manager';

--- a/test/bench/benchmarks/filter_create.ts
+++ b/test/bench/benchmarks/filter_create.ts
@@ -1,7 +1,7 @@
 import Benchmark from '../lib/benchmark';
 
 import {featureFilter as createFilter} from '@maplibre/maplibre-gl-style-spec';
-import filters from '../data/filters.json' assert {type: 'json'};
+import filters from '../data/filters.json' with {type: 'json'};
 
 export default class FilterCreate extends Benchmark {
     bench() {

--- a/test/bench/benchmarks/filter_evaluate.ts
+++ b/test/bench/benchmarks/filter_evaluate.ts
@@ -3,7 +3,7 @@ import Benchmark from '../lib/benchmark';
 import {VectorTile} from '@mapbox/vector-tile';
 import Pbf from 'pbf';
 import {featureFilter as createFilter} from '@maplibre/maplibre-gl-style-spec';
-import filters from '../data/filters.json' assert {type: 'json'};
+import filters from '../data/filters.json' with {type: 'json'};
 
 export default class FilterEvaluate extends Benchmark {
     layers: any[];

--- a/test/bench/benchmarks/layers.ts
+++ b/test/bench/benchmarks/layers.ts
@@ -1,7 +1,7 @@
 
 import Benchmark from '../lib/benchmark';
 import createMap from '../lib/create_map';
-import style from '../data/empty.json' assert {type: 'json'};
+import style from '../data/empty.json' with {type: 'json'};
 
 const width = 1024;
 const height = 768;

--- a/test/bench/benchmarks/paint_states.ts
+++ b/test/bench/benchmarks/paint_states.ts
@@ -1,5 +1,5 @@
 
-import emptystyle from '../data/empty.json' assert {type: 'json'};
+import emptystyle from '../data/empty.json' with {type: 'json'};
 import Benchmark from '../lib/benchmark';
 import createMap from '../lib/create_map';
 

--- a/test/bench/benchmarks/remove_paint_state.ts
+++ b/test/bench/benchmarks/remove_paint_state.ts
@@ -1,5 +1,5 @@
 
-import emptystyle from '../data/empty.json' assert {type: 'json'};
+import emptystyle from '../data/empty.json' with {type: 'json'};
 import Benchmark from '../lib/benchmark';
 import createMap from '../lib/create_map';
 

--- a/test/bench/styles/index.ts
+++ b/test/bench/styles/index.ts
@@ -1,5 +1,5 @@
 import locationsWithTileID from '../lib/locations_with_tile_id';
-import styleBenchmarkLocations from '../data/style-benchmark-locations.json' assert {type: 'json'};
+import styleBenchmarkLocations from '../data/style-benchmark-locations.json' with {type: 'json'};
 import StyleLayerCreate from '../benchmarks/style_layer_create';
 import Validate from '../benchmarks/style_validate';
 import Layout from '../benchmarks/layout';

--- a/test/bench/versions/index.ts
+++ b/test/bench/versions/index.ts
@@ -1,5 +1,5 @@
 import locationsWithTileID from '../lib/locations_with_tile_id';
-import styleBenchmarkLocations from '../data/style-benchmark-locations.json' assert {type: 'json'};
+import styleBenchmarkLocations from '../data/style-benchmark-locations.json' with {type: 'json'};
 import Layout from '../benchmarks/layout';
 import Placement from '../benchmarks/placement';
 import SymbolLayout from '../benchmarks/symbol_layout';

--- a/test/build/min.test.ts
+++ b/test/build/min.test.ts
@@ -1,5 +1,5 @@
 import fs from 'fs';
-import packageJson from '../../package.json' assert {type: 'json'};
+import packageJson from '../../package.json' with {type: 'json'};
 
 const minBundle = fs.readFileSync('dist/maplibre-gl.js', 'utf8');
 

--- a/test/build/sourcemaps.test.ts
+++ b/test/build/sourcemaps.test.ts
@@ -1,4 +1,4 @@
-import packageJson from '../../package.json' assert {type: 'json'};
+import packageJson from '../../package.json' with {type: 'json'};
 import {globSync, glob} from 'glob';
 import path, {dirname} from 'path';
 import fs from 'node:fs/promises';

--- a/test/integration/symbol-shaping/shaping.test.ts
+++ b/test/integration/symbol-shaping/shaping.test.ts
@@ -2,7 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import {WritingMode, shapeIcon, shapeText, fitIconToText, PositionedIcon, Shaping} from '../../../src/symbol/shaping';
 import {ResolvedImage, Formatted, FormattedSection} from '@maplibre/maplibre-gl-style-spec';
-import expectedJson from './tests/text-shaping-linebreak.json' assert {type: 'json'};
+import expectedJson from './tests/text-shaping-linebreak.json' with {type: 'json'};
 import {ImagePosition} from '../../../src/render/image_atlas';
 import {StyleImage} from '../../../src/style/style_image';
 


### PR DESCRIPTION
The JSON modules / import attribute syntax has been changed from `assert` to `with`, which it appear to finally stabilize on.

https://github.com/tc39/proposal-json-modules
https://github.com/tc39/proposal-import-attributes/