### PR TITLE
Fix node-canvas source compile for node >= v21

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3942,7 +3942,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "@mapbox/node-pre-gyp": "^1.0.0",
-        "nan": "^2.17.0",
+        "nan": "^2.19.0",
         "simple-get": "^3.0.3"
       },
       "engines": {
@@ -9446,7 +9446,7 @@
       "license": "MIT"
     },
     "node_modules/nan": {
-      "version": "2.17.0",
+      "version": "2.19.0",
       "dev": true,
       "license": "MIT"
     },


### PR DESCRIPTION
The `maplibre-gl-js` install currently fails on arm64 macs when running Node >= 21.

The error is:

```
../../nan/nan.h:2546:8: error: no matching member function for call to 'SetAccessor'
tpl->SetAccessor(
```

The context is that `maplibre-gl-js` depends on `node-canvas@2.x` which has a dependency on the `nan` package and `nan` 2.17 had a bug that surfaced with node v21: https://github.com/nodejs/nan/pull/966.

Additionally `node-canvas` does not currently provide pre-compiled binaries for Arm64, so a source compile is needed.

So, the solution here is to upgrade the `nan` version to the latest release which fixes support with recent node.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [ ] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [ ] Briefly describe the changes in this PR.
 - [ ] Link to related issues.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [ ] Add an entry to `CHANGELOG.md` under the `## main` section.
