### PR TITLE
#3103 added showButton option to GeoLocate control.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## main
 
 ### ✨ Features and improvements
+- Add `showButton` option to `GeoLocateControl`. ([#3103](https://github.com/maplibre/maplibre-gl-js/issues/3103))
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes

--- a/src/css/maplibre-gl.css
+++ b/src/css/maplibre-gl.css
@@ -354,6 +354,10 @@
     animation: maplibregl-spin 2s infinite linear;
 }
 
+.maplibregl-ctrl button.maplibregl-ctrl-geolocate.maplibregl-ctrl-geolocate-hidden {
+    display: none;
+}
+
 @media (-ms-high-contrast: active) {
     .maplibregl-ctrl button.maplibregl-ctrl-geolocate .maplibregl-ctrl-icon {
         background-image: svg-inline(ctrl-geolocate-white);

--- a/src/ui/control/geolocate_control.test.ts
+++ b/src/ui/control/geolocate_control.test.ts
@@ -499,4 +499,13 @@ describe('GeolocateControl with no options', () => {
         await zoomendPromise;
         expect(geolocate._circleElement.style.width).toBeTruthy();
     });
+
+    test('don\'t show button if showButton = false', async () => {
+        const geolocate = new GeolocateControl({
+            showButton: false
+        });
+        map.addControl(geolocate);
+        await sleep(0);
+        expect(geolocate._geolocateButton.style.display).toBe('none');
+    });
 });

--- a/src/ui/control/geolocate_control.test.ts
+++ b/src/ui/control/geolocate_control.test.ts
@@ -590,6 +590,6 @@ describe('GeolocateControl with no options', () => {
         });
         map.addControl(geolocate);
         await sleep(0);
-        expect(geolocate._geolocateButton.style.display).toBe('none');
+        expect(geolocate._geolocateButton.classList.contains('maplibregl-ctrl-geolocate-hidden')).toBeTruthy();
     });
 });

--- a/src/ui/control/geolocate_control.ts
+++ b/src/ui/control/geolocate_control.ts
@@ -540,7 +540,7 @@ export class GeolocateControl extends Evented implements IControl {
 
         // if showButton is false, don't add the button to the map
         if (!this.options.showButton) {
-            this._geolocateButton.style.display = 'none';
+            this._geolocateButton.classList.add('maplibregl-ctrl-geolocate-hidden');
         }
 
         if (supported === false) {

--- a/src/ui/control/geolocate_control.ts
+++ b/src/ui/control/geolocate_control.ts
@@ -38,6 +38,11 @@ type GeolocateControlOptions = {
      * @defaultValue true
      */
     showUserLocation?: boolean;
+    /**
+     * If `false` the Geolocate button will not be shown on the map.
+     * @defaultValue true
+     */
+    showButton?: boolean;
 };
 
 const defaultOptions: GeolocateControlOptions = {
@@ -51,7 +56,8 @@ const defaultOptions: GeolocateControlOptions = {
     },
     trackUserLocation: false,
     showAccuracyCircle: true,
-    showUserLocation: true
+    showUserLocation: true,
+    showButton: true
 };
 
 let numberOfWatches = 0;
@@ -487,6 +493,11 @@ export class GeolocateControl extends Evented implements IControl {
         this._geolocateButton = DOM.create('button', 'maplibregl-ctrl-geolocate', this._container);
         DOM.create('span', 'maplibregl-ctrl-icon', this._geolocateButton).setAttribute('aria-hidden', 'true');
         this._geolocateButton.type = 'button';
+
+        // if showButton is false, don't add the button to the map
+        if (!this.options.showButton) {
+            this._geolocateButton.style.display = 'none';
+        }
 
         if (supported === false) {
             warnOnce('Geolocation support is not available so the GeolocateControl will be disabled.');


### PR DESCRIPTION
#3103 added `showButton` option to GeoLocate control.

![1ec6596717587fab65ea5ab2467e557b](https://github.com/maplibre/maplibre-gl-js/assets/135112/b42d22c6-5df2-4229-a56f-d2a04f3d6a06)

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [x] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality.
 - [x] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [x] Add an entry to `CHANGELOG.md` under the `## main` section.
