### PR TITLE
#967 remove json-stringify-pretty-compact from devDependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## main
 
 ### ✨ Features and improvements
+- Remove `json-stringify-pretty-compact` from dev-dependencies ([#967](https://github.com/maplibre/maplibre-gl-js/issues/967))
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -96,7 +96,6 @@
         "jest-monocart-coverage": "^1.1.0",
         "jest-webgl-canvas-mock": "^2.5.3",
         "jsdom": "^24.0.0",
-        "json-stringify-pretty-compact": "^4.0.0",
         "junit-report-builder": "^3.2.1",
         "minimist": "^1.2.8",
         "mock-geolocation": "^1.0.11",

--- a/package.json
+++ b/package.json
@@ -104,7 +104,6 @@
     "jest-monocart-coverage": "^1.1.0",
     "jest-webgl-canvas-mock": "^2.5.3",
     "jsdom": "^24.0.0",
-    "json-stringify-pretty-compact": "^4.0.0",
     "junit-report-builder": "^3.2.1",
     "minimist": "^1.2.8",
     "mock-geolocation": "^1.0.11",


### PR DESCRIPTION
Fixes #967 - remove `json-stringify-pretty-compact` from devDependencies.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [x] Add an entry to `CHANGELOG.md` under the `## main` section.
