### PR TITLE
Fix MapOptions#style is optional in the Map constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### ✨ Features and improvements
 
 - Add events to `GeolocateControl` to allow a more granular interaction ([#3847](https://github.com/maplibre/maplibre-gl-js/pull/3847))
+- Make `MapOptions.style` optional to be consistent with `Map.setStyle(null)` ([#4151](https://github.com/maplibre/maplibre-gl-js/pull/4151))
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes

--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -299,8 +299,9 @@ export type MapOptions = {
      * The map's MapLibre style. This must be a JSON object conforming to
      * the schema described in the [MapLibre Style Specification](https://maplibre.org/maplibre-style-spec/),
      * or a URL to such JSON.
+     * When the style is not specified, calling {@link Map#setStyle} is required to render the map.
      */
-    style: StyleSpecification | string;
+    style?: StyleSpecification | string;
     /**
      * If `false`, the map's pitch (tilt) control with "drag to rotate" interaction will be disabled.
      * @defaultValue true


### PR DESCRIPTION
The use case is to delegate the style setting to a layer switcher control.

Note that is is already possible to set the style to null using `Map#setStyle(null)`. This PR updates the MapOptions interface to also allow that when a map instance is created.

Supersedes #4003

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [n/a] Link to related issues.
 - [n/a] Include before/after visuals or gifs if this PR includes visual changes.
 - [n/a] Write tests for all new functionality.
 - [n/a] Document any changes to public APIs - documentation is the type
 - [n/a] Post benchmark scores.
 - [n/a] Add an entry to `CHANGELOG.md` under the `## main` section.
