### PR TITLE
Replace "mapbox" source id with "maplibre" in render tests

### DIFF
--- a/test/integration/render/tests/collator/default/style.json
+++ b/test/integration/render/tests/collator/default/style.json
@@ -8,7 +8,7 @@
     }
   },
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "geojson",
       "data": {
         "type": "FeatureCollection",
@@ -182,7 +182,7 @@
     {
       "id": "literal",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "layout": {
         "text-field": ["let",
             "a", ["to-string", ["get", "a"]],

--- a/test/integration/render/tests/collator/resolved-locale/style.json
+++ b/test/integration/render/tests/collator/resolved-locale/style.json
@@ -8,7 +8,7 @@
     }
   },
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "geojson",
       "data": {
         "type": "FeatureCollection",
@@ -39,7 +39,7 @@
     {
       "id": "literal",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "layout": {
         "text-field": ["concat",
             "en == ",

--- a/test/integration/render/tests/debug/collision-overscaled/style.json
+++ b/test/integration/render/tests/debug/collision-overscaled/style.json
@@ -12,7 +12,7 @@
   ],
   "zoom": 17,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -33,7 +33,7 @@
     {
       "id": "line",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "road_label",
       "layout": {
         "icon-image": "triangle-stroked-12",

--- a/test/integration/render/tests/debug/collision/style.json
+++ b/test/integration/render/tests/debug/collision/style.json
@@ -15,7 +15,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -36,7 +36,7 @@
     {
       "id": "line",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "road_label",
       "layout": {
         "icon-image": "triangle-stroked-12",

--- a/test/integration/render/tests/debug/overdraw/style.json
+++ b/test/integration/render/tests/debug/overdraw/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -32,7 +32,7 @@
     {
       "id": "road",
       "type": "line",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "road"
     }
   ]

--- a/test/integration/render/tests/debug/tile-raster/style.json
+++ b/test/integration/render/tests/debug/tile-raster/style.json
@@ -23,7 +23,7 @@
       "maxzoom": 17,
       "tileSize": 256
     },
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -50,7 +50,7 @@
     {
       "id": "line-line",
       "type": "line",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "road",
       "paint": {
         "line-color": "orange"

--- a/test/integration/render/tests/debug/tile/style.json
+++ b/test/integration/render/tests/debug/tile/style.json
@@ -21,7 +21,7 @@
       "maxzoom": 1,
       "tileSize": 256
     },
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -50,7 +50,7 @@
     {
       "id": "line",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "road_label",
       "layout": {
         "text-field": "test",

--- a/test/integration/render/tests/extent/1024-circle/style.json
+++ b/test/integration/render/tests/extent/1024-circle/style.json
@@ -9,7 +9,7 @@
   ],
   "zoom": 0,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -26,9 +26,9 @@
       }
     },
     {
-      "id": "mapbox",
+      "id": "maplibre",
       "type": "circle",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "paint": {
         "circle-color": "black",

--- a/test/integration/render/tests/extent/1024-fill/style.json
+++ b/test/integration/render/tests/extent/1024-fill/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 0,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -28,9 +28,9 @@
       }
     },
     {
-      "id": "mapbox",
+      "id": "maplibre",
       "type": "fill",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "water",
       "paint": {
         "fill-color": "black",

--- a/test/integration/render/tests/extent/1024-line/style.json
+++ b/test/integration/render/tests/extent/1024-line/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 0,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -28,9 +28,9 @@
       }
     },
     {
-      "id": "mapbox",
+      "id": "maplibre",
       "type": "line",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "road",
       "paint": {
         "line-color": "black",

--- a/test/integration/render/tests/feature-state/vector-source/style.json
+++ b/test/integration/render/tests/feature-state/vector-source/style.json
@@ -7,7 +7,7 @@
         [
           "setFeatureState",
           {
-            "source": "mapbox",
+            "source": "maplibre",
             "sourceLayer": "poi_label",
             "id": "1000059876748"
           },
@@ -27,7 +27,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -46,7 +46,7 @@
     {
       "id": "poi_label",
       "type": "circle",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "paint": {
         "circle-radius": 5,

--- a/test/integration/render/tests/fill-pattern/precision/style.json
+++ b/test/integration/render/tests/fill-pattern/precision/style.json
@@ -10,7 +10,7 @@
     0
   ],
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 0,
       "tiles": [
@@ -30,7 +30,7 @@
     {
       "id": "land",
       "type": "fill",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "water",
       "paint": {
         "fill-pattern": "generic_icon"

--- a/test/integration/render/tests/fill-pattern/uneven-pattern/style.json
+++ b/test/integration/render/tests/fill-pattern/uneven-pattern/style.json
@@ -5,7 +5,7 @@
   },
   "zoom": 2,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -25,7 +25,7 @@
     {
       "id": "land",
       "type": "fill",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "water",
       "paint": {
         "fill-pattern": "interstate_1"

--- a/test/integration/render/tests/fill-pattern/wrapping-with-interpolation/style.json
+++ b/test/integration/render/tests/fill-pattern/wrapping-with-interpolation/style.json
@@ -9,7 +9,7 @@
     0
   ],
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -29,7 +29,7 @@
     {
       "id": "land",
       "type": "fill",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "water",
       "paint": {
         "fill-pattern": "black"

--- a/test/integration/render/tests/fill-visibility/none/style.json
+++ b/test/integration/render/tests/fill-visibility/none/style.json
@@ -12,7 +12,7 @@
   ],
   "zoom": 0,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -31,7 +31,7 @@
     {
       "id": "fill-visible",
       "type": "fill",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "water",
       "layout": {
         "visibility": "visible"
@@ -44,7 +44,7 @@
     {
       "id": "fill-none",
       "type": "fill",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "water",
       "layout": {
         "visibility": "none"

--- a/test/integration/render/tests/fill-visibility/visible/style.json
+++ b/test/integration/render/tests/fill-visibility/visible/style.json
@@ -12,7 +12,7 @@
   ],
   "zoom": 0,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -31,7 +31,7 @@
     {
       "id": "fill-visible",
       "type": "fill",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "water",
       "layout": {
         "visibility": "visible"
@@ -44,7 +44,7 @@
     {
       "id": "fill-none",
       "type": "fill",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "water",
       "layout": {
         "visibility": "none"

--- a/test/integration/render/tests/heatmap-color/default/style.json
+++ b/test/integration/render/tests/heatmap-color/default/style.json
@@ -13,7 +13,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -32,7 +32,7 @@
     {
       "id": "poi_label",
       "type": "heatmap",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "paint": {}
     }

--- a/test/integration/render/tests/heatmap-color/expression/style.json
+++ b/test/integration/render/tests/heatmap-color/expression/style.json
@@ -13,7 +13,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -32,7 +32,7 @@
     {
       "id": "poi_label",
       "type": "heatmap",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "paint": {
         "heatmap-color": [

--- a/test/integration/render/tests/heatmap-intensity/default/style.json
+++ b/test/integration/render/tests/heatmap-intensity/default/style.json
@@ -13,7 +13,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -32,7 +32,7 @@
     {
       "id": "poi_label",
       "type": "heatmap",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "paint": {}
     }

--- a/test/integration/render/tests/heatmap-intensity/function/style.json
+++ b/test/integration/render/tests/heatmap-intensity/function/style.json
@@ -13,7 +13,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -32,7 +32,7 @@
     {
       "id": "poi_label",
       "type": "heatmap",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "paint": {
         "heatmap-intensity": {

--- a/test/integration/render/tests/heatmap-intensity/literal/style.json
+++ b/test/integration/render/tests/heatmap-intensity/literal/style.json
@@ -13,7 +13,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -32,7 +32,7 @@
     {
       "id": "poi_label",
       "type": "heatmap",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "paint": {
         "heatmap-intensity": 0.5

--- a/test/integration/render/tests/heatmap-opacity/default/style.json
+++ b/test/integration/render/tests/heatmap-opacity/default/style.json
@@ -13,7 +13,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -32,7 +32,7 @@
     {
       "id": "poi_label",
       "type": "heatmap",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "paint": {}
     }

--- a/test/integration/render/tests/heatmap-opacity/function/style.json
+++ b/test/integration/render/tests/heatmap-opacity/function/style.json
@@ -13,7 +13,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -32,7 +32,7 @@
     {
       "id": "poi_label",
       "type": "heatmap",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "paint": {
         "heatmap-opacity": {

--- a/test/integration/render/tests/heatmap-opacity/literal/style.json
+++ b/test/integration/render/tests/heatmap-opacity/literal/style.json
@@ -13,7 +13,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -32,7 +32,7 @@
     {
       "id": "poi_label",
       "type": "heatmap",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "paint": {
         "heatmap-opacity": 0.5

--- a/test/integration/render/tests/heatmap-radius/default/style.json
+++ b/test/integration/render/tests/heatmap-radius/default/style.json
@@ -13,7 +13,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -32,7 +32,7 @@
     {
       "id": "poi_label",
       "type": "heatmap",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "paint": {}
     }

--- a/test/integration/render/tests/heatmap-radius/function/style.json
+++ b/test/integration/render/tests/heatmap-radius/function/style.json
@@ -13,7 +13,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -32,7 +32,7 @@
     {
       "id": "poi_label",
       "type": "heatmap",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "paint": {
         "heatmap-radius": {

--- a/test/integration/render/tests/heatmap-radius/literal/style.json
+++ b/test/integration/render/tests/heatmap-radius/literal/style.json
@@ -13,7 +13,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -32,7 +32,7 @@
     {
       "id": "poi_label",
       "type": "heatmap",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "paint": {
         "heatmap-radius": 20

--- a/test/integration/render/tests/heatmap-radius/pitch30/style.json
+++ b/test/integration/render/tests/heatmap-radius/pitch30/style.json
@@ -14,7 +14,7 @@
   "zoom": 14,
   "pitch": 30,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -33,7 +33,7 @@
     {
       "id": "poi_label",
       "type": "heatmap",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "paint": {
         "heatmap-radius": 20

--- a/test/integration/render/tests/heatmap-weight/default/style.json
+++ b/test/integration/render/tests/heatmap-weight/default/style.json
@@ -13,7 +13,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -32,7 +32,7 @@
     {
       "id": "poi_label",
       "type": "heatmap",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "paint": {}
     }

--- a/test/integration/render/tests/heatmap-weight/identity-property-function/style.json
+++ b/test/integration/render/tests/heatmap-weight/identity-property-function/style.json
@@ -13,7 +13,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -32,7 +32,7 @@
     {
       "id": "poi_label",
       "type": "heatmap",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "paint": {
         "heatmap-intensity": 0.05,

--- a/test/integration/render/tests/heatmap-weight/literal/style.json
+++ b/test/integration/render/tests/heatmap-weight/literal/style.json
@@ -13,7 +13,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -32,7 +32,7 @@
     {
       "id": "poi_label",
       "type": "heatmap",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "paint": {
         "heatmap-weight": 0.5

--- a/test/integration/render/tests/icon-offset/literal/style.json
+++ b/test/integration/render/tests/icon-offset/literal/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -31,7 +31,7 @@
     {
       "id": "literal",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "filter": [
         "==",

--- a/test/integration/render/tests/icon-offset/property-function/style.json
+++ b/test/integration/render/tests/icon-offset/property-function/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -31,7 +31,7 @@
     {
       "id": "literal",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "filter": [
         "==",

--- a/test/integration/render/tests/icon-offset/zoom-and-property-function/style.json
+++ b/test/integration/render/tests/icon-offset/zoom-and-property-function/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -31,7 +31,7 @@
     {
       "id": "literal",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "filter": [
         "==",

--- a/test/integration/render/tests/icon-opacity/default/style.json
+++ b/test/integration/render/tests/icon-opacity/default/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -32,7 +32,7 @@
     {
       "id": "icon",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "filter": [
         "==",

--- a/test/integration/render/tests/icon-opacity/function/style.json
+++ b/test/integration/render/tests/icon-opacity/function/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -32,7 +32,7 @@
     {
       "id": "icon",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "filter": [
         "==",

--- a/test/integration/render/tests/icon-opacity/icon-only/style.json
+++ b/test/integration/render/tests/icon-opacity/icon-only/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -32,7 +32,7 @@
     {
       "id": "icon-only",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "filter": [
         "==",

--- a/test/integration/render/tests/icon-opacity/literal/style.json
+++ b/test/integration/render/tests/icon-opacity/literal/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -32,7 +32,7 @@
     {
       "id": "icon",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "filter": [
         "==",

--- a/test/integration/render/tests/icon-opacity/text-and-icon/style.json
+++ b/test/integration/render/tests/icon-opacity/text-and-icon/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -32,7 +32,7 @@
     {
       "id": "text-and-icon",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "filter": [
         "==",

--- a/test/integration/render/tests/icon-opacity/text-only/style.json
+++ b/test/integration/render/tests/icon-opacity/text-only/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -32,7 +32,7 @@
     {
       "id": "text-only",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "filter": [
         "==",

--- a/test/integration/render/tests/icon-pitch-scaling/rotation-alignment-map/style.json
+++ b/test/integration/render/tests/icon-pitch-scaling/rotation-alignment-map/style.json
@@ -12,7 +12,7 @@
   "zoom": 14,
   "pitch": 30,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -33,7 +33,7 @@
     {
       "id": "icon",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "filter": [
         "==",

--- a/test/integration/render/tests/icon-pitch-scaling/rotation-alignment-viewport/style.json
+++ b/test/integration/render/tests/icon-pitch-scaling/rotation-alignment-viewport/style.json
@@ -12,7 +12,7 @@
   "zoom": 14,
   "pitch": 30,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -33,7 +33,7 @@
     {
       "id": "icon",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "filter": [
         "==",

--- a/test/integration/render/tests/icon-pixelratio-mismatch/default/style.json
+++ b/test/integration/render/tests/icon-pixelratio-mismatch/default/style.json
@@ -12,7 +12,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -32,7 +32,7 @@
     {
       "id": "icon-default",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "filter": [
         "==",

--- a/test/integration/render/tests/icon-text-fit/placement-line/style.json
+++ b/test/integration/render/tests/icon-text-fit/placement-line/style.json
@@ -12,7 +12,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -33,7 +33,7 @@
     {
       "id": "road",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "road_label",
       "layout": {
         "symbol-placement": "line",

--- a/test/integration/render/tests/icon-text-fit/text-variable-anchor-overlap/style.json
+++ b/test/integration/render/tests/icon-text-fit/text-variable-anchor-overlap/style.json
@@ -12,7 +12,7 @@
   ],
   "zoom": 16,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -33,7 +33,7 @@
     {
       "id": "road",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "road_label",
       "layout": {
         "text-variable-anchor": ["left", "right", "bottom", "top"],

--- a/test/integration/render/tests/icon-text-fit/text-variable-anchor/style.json
+++ b/test/integration/render/tests/icon-text-fit/text-variable-anchor/style.json
@@ -12,7 +12,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -33,7 +33,7 @@
     {
       "id": "road",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "road_label",
       "layout": {
         "text-variable-anchor": ["left", "right", "bottom", "top"],

--- a/test/integration/render/tests/icon-translate-anchor/map/style.json
+++ b/test/integration/render/tests/icon-translate-anchor/map/style.json
@@ -12,7 +12,7 @@
   "zoom": 14,
   "bearing": 90,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -32,7 +32,7 @@
     {
       "id": "text",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "filter": [
         "==",

--- a/test/integration/render/tests/icon-translate-anchor/viewport/style.json
+++ b/test/integration/render/tests/icon-translate-anchor/viewport/style.json
@@ -12,7 +12,7 @@
   "zoom": 14,
   "bearing": 90,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -32,7 +32,7 @@
     {
       "id": "text",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "filter": [
         "==",

--- a/test/integration/render/tests/icon-translate/default/style.json
+++ b/test/integration/render/tests/icon-translate/default/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -31,7 +31,7 @@
     {
       "id": "icon",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "filter": [
         "==",

--- a/test/integration/render/tests/icon-translate/function/style.json
+++ b/test/integration/render/tests/icon-translate/function/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -31,7 +31,7 @@
     {
       "id": "icon",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "filter": [
         "==",

--- a/test/integration/render/tests/icon-translate/literal/style.json
+++ b/test/integration/render/tests/icon-translate/literal/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -31,7 +31,7 @@
     {
       "id": "icon",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "filter": [
         "==",

--- a/test/integration/render/tests/icon-visibility/none/style.json
+++ b/test/integration/render/tests/icon-visibility/none/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -31,7 +31,7 @@
     {
       "id": "icon-none",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "filter": [
         "==",

--- a/test/integration/render/tests/icon-visibility/visible/style.json
+++ b/test/integration/render/tests/icon-visibility/visible/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -31,7 +31,7 @@
     {
       "id": "icon-visible",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "filter": [
         "==",

--- a/test/integration/render/tests/line-blur/default/style.json
+++ b/test/integration/render/tests/line-blur/default/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -30,7 +30,7 @@
     {
       "id": "road",
       "type": "line",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "road",
       "paint": {
         "line-width": 2,

--- a/test/integration/render/tests/line-blur/function/style.json
+++ b/test/integration/render/tests/line-blur/function/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -30,7 +30,7 @@
     {
       "id": "road",
       "type": "line",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "road",
       "paint": {
         "line-width": 2,

--- a/test/integration/render/tests/line-blur/literal/style.json
+++ b/test/integration/render/tests/line-blur/literal/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -30,7 +30,7 @@
     {
       "id": "road",
       "type": "line",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "road",
       "paint": {
         "line-width": 2,

--- a/test/integration/render/tests/line-blur/property-function/style.json
+++ b/test/integration/render/tests/line-blur/property-function/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -30,7 +30,7 @@
     {
       "id": "road",
       "type": "line",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "road",
       "paint": {
         "line-width": 10,

--- a/test/integration/render/tests/line-cap/butt/style.json
+++ b/test/integration/render/tests/line-cap/butt/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -30,7 +30,7 @@
     {
       "id": "butt",
       "type": "line",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "road",
       "layout": {
         "line-cap": "butt"

--- a/test/integration/render/tests/line-cap/round/style.json
+++ b/test/integration/render/tests/line-cap/round/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -30,7 +30,7 @@
     {
       "id": "round",
       "type": "line",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "road",
       "layout": {
         "line-cap": "round"

--- a/test/integration/render/tests/line-cap/square/style.json
+++ b/test/integration/render/tests/line-cap/square/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -30,7 +30,7 @@
     {
       "id": "square",
       "type": "line",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "road",
       "layout": {
         "line-cap": "square"

--- a/test/integration/render/tests/line-color/default/style.json
+++ b/test/integration/render/tests/line-color/default/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -30,7 +30,7 @@
     {
       "id": "road",
       "type": "line",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "road",
       "paint": {
         "line-width": 10

--- a/test/integration/render/tests/line-color/function/style.json
+++ b/test/integration/render/tests/line-color/function/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -30,7 +30,7 @@
     {
       "id": "road",
       "type": "line",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "road",
       "paint": {
         "line-width": 10,

--- a/test/integration/render/tests/line-color/literal/style.json
+++ b/test/integration/render/tests/line-color/literal/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -30,7 +30,7 @@
     {
       "id": "road",
       "type": "line",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "road",
       "paint": {
         "line-width": 10,

--- a/test/integration/render/tests/line-color/property-function/style.json
+++ b/test/integration/render/tests/line-color/property-function/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -30,7 +30,7 @@
     {
       "id": "road",
       "type": "line",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "road",
       "paint": {
         "line-width": 10,

--- a/test/integration/render/tests/line-dasharray/overscaled/style.json
+++ b/test/integration/render/tests/line-dasharray/overscaled/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 17,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -30,7 +30,7 @@
     {
       "id": "road",
       "type": "line",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "road",
       "paint": {
         "line-width": 2,

--- a/test/integration/render/tests/line-dasharray/slant/style.json
+++ b/test/integration/render/tests/line-dasharray/slant/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 18,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -30,7 +30,7 @@
     {
       "id": "road",
       "type": "line",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "building",
       "paint": {
         "line-width": 4,

--- a/test/integration/render/tests/line-gap-width/property-function/style.json
+++ b/test/integration/render/tests/line-gap-width/property-function/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -30,7 +30,7 @@
     {
       "id": "road",
       "type": "line",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "road",
       "paint": {
         "line-gap-width": {

--- a/test/integration/render/tests/line-offset/default/style.json
+++ b/test/integration/render/tests/line-offset/default/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -30,7 +30,7 @@
     {
       "id": "road",
       "type": "line",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "road",
       "paint": {
         "line-width": 2,

--- a/test/integration/render/tests/line-offset/function/style.json
+++ b/test/integration/render/tests/line-offset/function/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -30,7 +30,7 @@
     {
       "id": "road",
       "type": "line",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "road",
       "paint": {
         "line-width": 2,

--- a/test/integration/render/tests/line-offset/literal-negative/style.json
+++ b/test/integration/render/tests/line-offset/literal-negative/style.json
@@ -12,7 +12,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -31,7 +31,7 @@
     {
       "id": "road",
       "type": "line",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "road",
       "paint": {
         "line-width": 2,

--- a/test/integration/render/tests/line-offset/literal/style.json
+++ b/test/integration/render/tests/line-offset/literal/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -30,7 +30,7 @@
     {
       "id": "road",
       "type": "line",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "road",
       "paint": {
         "line-width": 2,

--- a/test/integration/render/tests/line-offset/property-function/style.json
+++ b/test/integration/render/tests/line-offset/property-function/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -30,7 +30,7 @@
     {
       "id": "road",
       "type": "line",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "road",
       "paint": {
         "line-offset": {

--- a/test/integration/render/tests/line-opacity/property-function/style.json
+++ b/test/integration/render/tests/line-opacity/property-function/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -30,7 +30,7 @@
     {
       "id": "road",
       "type": "line",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "road",
       "paint": {
         "line-width": 10,

--- a/test/integration/render/tests/line-pattern/pitch/style.json
+++ b/test/integration/render/tests/line-pattern/pitch/style.json
@@ -12,7 +12,7 @@
   "zoom": 17,
   "pitch": 60,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -32,7 +32,7 @@
     {
       "id": "road",
       "type": "line",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "road",
       "paint": {
         "line-width": 20,

--- a/test/integration/render/tests/line-pitch/default/style.json
+++ b/test/integration/render/tests/line-pitch/default/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -30,7 +30,7 @@
     {
       "id": "road",
       "type": "line",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "road",
       "paint": {
         "line-width": 10

--- a/test/integration/render/tests/line-pitch/pitch0/style.json
+++ b/test/integration/render/tests/line-pitch/pitch0/style.json
@@ -12,7 +12,7 @@
   "zoom": 14,
   "pitch": 0,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -31,7 +31,7 @@
     {
       "id": "road",
       "type": "line",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "road",
       "paint": {
         "line-width": 10

--- a/test/integration/render/tests/line-pitch/pitch15/style.json
+++ b/test/integration/render/tests/line-pitch/pitch15/style.json
@@ -12,7 +12,7 @@
   "zoom": 14,
   "pitch": 15,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -31,7 +31,7 @@
     {
       "id": "road",
       "type": "line",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "road",
       "paint": {
         "line-width": 10

--- a/test/integration/render/tests/line-pitch/pitch30/style.json
+++ b/test/integration/render/tests/line-pitch/pitch30/style.json
@@ -12,7 +12,7 @@
   "zoom": 14,
   "pitch": 30,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -31,7 +31,7 @@
     {
       "id": "road",
       "type": "line",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "road",
       "paint": {
         "line-width": 10

--- a/test/integration/render/tests/line-pitch/pitchAndBearing/style.json
+++ b/test/integration/render/tests/line-pitch/pitchAndBearing/style.json
@@ -13,7 +13,7 @@
   "bearing": 180,
   "pitch": 30,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -32,7 +32,7 @@
     {
       "id": "road",
       "type": "line",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "road",
       "paint": {
         "line-width": 10

--- a/test/integration/render/tests/line-translate-anchor/map/style.json
+++ b/test/integration/render/tests/line-translate-anchor/map/style.json
@@ -12,7 +12,7 @@
   "zoom": 14,
   "bearing": 90,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -31,7 +31,7 @@
     {
       "id": "road",
       "type": "line",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "road",
       "paint": {
         "line-width": 2,

--- a/test/integration/render/tests/line-translate-anchor/viewport/style.json
+++ b/test/integration/render/tests/line-translate-anchor/viewport/style.json
@@ -12,7 +12,7 @@
   "zoom": 14,
   "bearing": 90,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -31,7 +31,7 @@
     {
       "id": "road",
       "type": "line",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "road",
       "paint": {
         "line-width": 2,

--- a/test/integration/render/tests/line-translate/default/style.json
+++ b/test/integration/render/tests/line-translate/default/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -30,7 +30,7 @@
     {
       "id": "road",
       "type": "line",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "road",
       "paint": {
         "line-width": 2,

--- a/test/integration/render/tests/line-translate/function/style.json
+++ b/test/integration/render/tests/line-translate/function/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -30,7 +30,7 @@
     {
       "id": "road",
       "type": "line",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "road",
       "paint": {
         "line-width": 2,

--- a/test/integration/render/tests/line-translate/literal/style.json
+++ b/test/integration/render/tests/line-translate/literal/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -30,7 +30,7 @@
     {
       "id": "road",
       "type": "line",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "road",
       "paint": {
         "line-width": 2,

--- a/test/integration/render/tests/line-visibility/none/style.json
+++ b/test/integration/render/tests/line-visibility/none/style.json
@@ -12,7 +12,7 @@
   "zoom": 14,
   "bearing": 90,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -31,7 +31,7 @@
     {
       "id": "line-none",
       "type": "line",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "road",
       "layout": {
         "visibility": "none"

--- a/test/integration/render/tests/line-visibility/visible/style.json
+++ b/test/integration/render/tests/line-visibility/visible/style.json
@@ -12,7 +12,7 @@
   "zoom": 14,
   "bearing": 90,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -31,7 +31,7 @@
     {
       "id": "line-visible",
       "type": "line",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "road",
       "layout": {
         "visibility": "visible"

--- a/test/integration/render/tests/line-width/default/style.json
+++ b/test/integration/render/tests/line-width/default/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -30,7 +30,7 @@
     {
       "id": "road",
       "type": "line",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "road",
       "paint": {}
     }

--- a/test/integration/render/tests/line-width/function/style.json
+++ b/test/integration/render/tests/line-width/function/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -30,7 +30,7 @@
     {
       "id": "road",
       "type": "line",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "road",
       "paint": {
         "line-width": {

--- a/test/integration/render/tests/line-width/literal/style.json
+++ b/test/integration/render/tests/line-width/literal/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -30,7 +30,7 @@
     {
       "id": "road",
       "type": "line",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "road",
       "paint": {
         "line-width": 5

--- a/test/integration/render/tests/line-width/property-function/style.json
+++ b/test/integration/render/tests/line-width/property-function/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -30,7 +30,7 @@
     {
       "id": "road",
       "type": "line",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "road",
       "paint": {
         "line-width": {

--- a/test/integration/render/tests/line-width/very-overscaled/style.json
+++ b/test/integration/render/tests/line-width/very-overscaled/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 20,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -30,7 +30,7 @@
     {
       "id": "road",
       "type": "line",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "road",
       "paint": {
         "line-width": 5

--- a/test/integration/render/tests/linear-filter-opacity-edge/literal/style.json
+++ b/test/integration/render/tests/linear-filter-opacity-edge/literal/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -31,7 +31,7 @@
     {
       "id": "icon",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "filter": [
         "==",

--- a/test/integration/render/tests/regressions/mapbox-gl-js#2305/style.json
+++ b/test/integration/render/tests/regressions/mapbox-gl-js#2305/style.json
@@ -5,7 +5,7 @@
   },
   "zoom": 2,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -25,7 +25,7 @@
     {
       "id": "land",
       "type": "fill",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "water",
       "paint": {
         "fill-color": "blue"

--- a/test/integration/render/tests/regressions/mapbox-gl-js#2523/style.json
+++ b/test/integration/render/tests/regressions/mapbox-gl-js#2523/style.json
@@ -12,7 +12,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -33,7 +33,7 @@
     {
       "id": "literal",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "filter": [
         "==",

--- a/test/integration/render/tests/regressions/mapbox-gl-js#2533/style.json
+++ b/test/integration/render/tests/regressions/mapbox-gl-js#2533/style.json
@@ -9,7 +9,7 @@
     }
   },
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -32,7 +32,7 @@
     {
       "id": "land",
       "type": "fill",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "water",
       "paint": {
         "fill-color": "#3bb2d0",

--- a/test/integration/render/tests/regressions/mapbox-gl-js#2534/style.json
+++ b/test/integration/render/tests/regressions/mapbox-gl-js#2534/style.json
@@ -10,7 +10,7 @@
     }
   },
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -33,7 +33,7 @@
     {
       "id": "land",
       "type": "fill",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "water",
       "paint": {
         "fill-color": "#3bb2d0",

--- a/test/integration/render/tests/regressions/mapbox-gl-js#2787/style.json
+++ b/test/integration/render/tests/regressions/mapbox-gl-js#2787/style.json
@@ -3,8 +3,8 @@
   "metadata": {
     "test": {
       "operations": [
-        ["addLayer", {"id": "mapbox", "type": "background"}],
-        ["removeLayer", "mapbox"],
+        ["addLayer", {"id": "maplibre", "type": "background"}],
+        ["removeLayer", "maplibre"],
         ["wait"]
       ]
     }

--- a/test/integration/render/tests/regressions/mapbox-gl-js#3612/style.json
+++ b/test/integration/render/tests/regressions/mapbox-gl-js#3612/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 15,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -32,7 +32,7 @@
     {
       "id": "literal",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "filter": [
         "==",
@@ -56,7 +56,7 @@
     {
       "id": "translucent",
       "type": "fill",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "landuse",
       "filter": ["==", "class", "park"],
       "paint": {
@@ -67,7 +67,7 @@
     {
       "id": "opaque",
       "type": "fill",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "landuse",
       "filter": ["==", "class", "pitch"],
       "paint": {

--- a/test/integration/render/tests/regressions/mapbox-gl-js#4564/style.json
+++ b/test/integration/render/tests/regressions/mapbox-gl-js#4564/style.json
@@ -12,7 +12,7 @@
   ],
   "zoom": 16,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -32,7 +32,7 @@
     {
       "id": "road",
       "type": "line",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "road",
       "paint": {
         "line-width": 2,

--- a/test/integration/render/tests/regressions/mapbox-gl-js#5544/style.json
+++ b/test/integration/render/tests/regressions/mapbox-gl-js#5544/style.json
@@ -9,7 +9,7 @@
   "zoom": 2,
   "center": [-14.41400, 39.09187],
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "geojson",
       "data": {
         "type": "FeatureCollection",
@@ -182,7 +182,7 @@
     {
       "id": "lines-symbol",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "layout": {
         "text-field": "{name}",
         "symbol-placement": "line",
@@ -193,7 +193,7 @@
     }, {
       "id": "lines",
       "type": "line",
-      "source": "mapbox",
+      "source": "maplibre",
       "paint": {
           "line-opacity": 0.25
       }

--- a/test/integration/render/tests/regressions/mapbox-gl-js#5546/style.json
+++ b/test/integration/render/tests/regressions/mapbox-gl-js#5546/style.json
@@ -9,7 +9,7 @@
   "zoom": 2,
   "center": [-14.41400, 45],
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "geojson",
       "data": {
         "type": "FeatureCollection",
@@ -163,7 +163,7 @@
     {
       "id": "lines-symbol",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "layout": {
         "text-field": "{name}",
         "symbol-placement": "line",
@@ -174,7 +174,7 @@
     }, {
       "id": "lines",
       "type": "line",
-      "source": "mapbox",
+      "source": "maplibre",
       "paint": {
           "line-opacity": 0.25
       }

--- a/test/integration/render/tests/regressions/mapbox-gl-js#6806/style.json
+++ b/test/integration/render/tests/regressions/mapbox-gl-js#6806/style.json
@@ -13,7 +13,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -33,13 +33,13 @@
     {
       "id": "fill",
       "type": "fill",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "building"
     },
     {
       "id": "poi_heat",
       "type": "heatmap",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "paint": {}
     }

--- a/test/integration/render/tests/regressions/mapbox-gl-js#6919/style.json
+++ b/test/integration/render/tests/regressions/mapbox-gl-js#6919/style.json
@@ -14,7 +14,7 @@
   ],
   "zoom": 4.5,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -34,7 +34,7 @@
     {
       "id": "line-center",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "marine_label",
       "layout": {
         "text-field": "{name_en}",
@@ -51,7 +51,7 @@
     {
       "id": "line",
       "type": "line",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "marine_label",
       "paint": {
         "line-width": 1

--- a/test/integration/render/tests/regressions/mapbox-gl-js#7172/style.json
+++ b/test/integration/render/tests/regressions/mapbox-gl-js#7172/style.json
@@ -28,7 +28,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -48,7 +48,7 @@
     {
       "id": "icon",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "filter": [
         "==",

--- a/test/integration/render/tests/regressions/mapbox-gl-native#5648/style.json
+++ b/test/integration/render/tests/regressions/mapbox-gl-native#5648/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 0.99,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -31,7 +31,7 @@
     {
       "id": "land",
       "type": "fill",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "water",
       "paint": {
         "fill-color": "#3bb2d0"

--- a/test/integration/render/tests/regressions/mapbox-gl-native#9976/style.json
+++ b/test/integration/render/tests/regressions/mapbox-gl-native#9976/style.json
@@ -14,7 +14,7 @@
           {
             "id": "fill",
             "type": "fill",
-            "source": "mapbox",
+            "source": "maplibre",
             "paint": {
               "fill-pattern": "marker"
             }
@@ -36,7 +36,7 @@
           {
             "id": "road",
             "type": "line",
-            "source": "mapbox",
+            "source": "maplibre",
             "paint": {
               "line-width": 20,
               "line-pattern": "generic_icon"
@@ -52,7 +52,7 @@
   },
 "zoom": 11,
  "sources": {
-     "mapbox": {
+     "maplibre": {
        "type": "geojson",
        "maxzoom": 10,
        "data": {

--- a/test/integration/render/tests/remove-feature-state/vector-source/style.json
+++ b/test/integration/render/tests/remove-feature-state/vector-source/style.json
@@ -7,7 +7,7 @@
         [
           "setFeatureState",
           {
-            "source": "mapbox",
+            "source": "maplibre",
             "sourceLayer": "poi_label",
             "id": "1000059876748"
           },
@@ -21,7 +21,7 @@
         [
           "removeFeatureState",
           {
-            "source": "mapbox",
+            "source": "maplibre",
             "sourceLayer": "poi_label",
             "id": "1000059876748"
           },
@@ -39,7 +39,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -58,7 +58,7 @@
     {
       "id": "poi_label",
       "type": "circle",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "paint": {
         "circle-radius": 5,

--- a/test/integration/render/tests/runtime-styling/set-style-sprite/style.json
+++ b/test/integration/render/tests/runtime-styling/set-style-sprite/style.json
@@ -14,7 +14,7 @@
             ],
             "zoom": 14,
             "sources": {
-              "mapbox": {
+              "maplibre": {
                 "type": "vector",
                 "maxzoom": 14,
                 "tiles": [
@@ -34,7 +34,7 @@
               {
                 "id": "literal",
                 "type": "symbol",
-                "source": "mapbox",
+                "source": "maplibre",
                 "source-layer": "poi_label",
                 "filter": [
                   "==",
@@ -66,7 +66,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -86,7 +86,7 @@
     {
       "id": "literal",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "filter": [
         "==",

--- a/test/integration/render/tests/sparse-tileset/overdraw/style.json
+++ b/test/integration/render/tests/sparse-tileset/overdraw/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 1,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "tiles": [
         "local://tiles/sparse/{z}-{x}-{y}.mvt"
@@ -28,7 +28,7 @@
     },
     {
       "id": "water-layer",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "water",
       "type": "fill",
       "paint": {

--- a/test/integration/render/tests/sparse-tileset/overdraw204/style.json
+++ b/test/integration/render/tests/sparse-tileset/overdraw204/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 1,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "tiles": [
         "local://tiles/sparse204/{z}-{x}-{y}.mvt"
@@ -28,7 +28,7 @@
     },
     {
       "id": "water-layer",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "water",
       "type": "fill",
       "paint": {

--- a/test/integration/render/tests/sparse-tileset/rasterbase/style.json
+++ b/test/integration/render/tests/sparse-tileset/rasterbase/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 0,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "raster",
       "tiles": [
         "local://tiles/sparse/{z}-{x}-{y}.png"
@@ -29,7 +29,7 @@
     {
       "id": "raster-layer",
       "type": "raster",
-      "source": "mapbox",
+      "source": "maplibre",
       "paint": {
         "raster-fade-duration": 0
       }

--- a/test/integration/render/tests/sparse-tileset/rasterfallback/style.json
+++ b/test/integration/render/tests/sparse-tileset/rasterfallback/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 1,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "raster",
       "tiles": [
         "local://tiles/sparse/{z}-{x}-{y}.png"
@@ -29,7 +29,7 @@
     {
       "id": "raster-layer",
       "type": "raster",
-      "source": "mapbox",
+      "source": "maplibre",
       "paint": {
         "raster-fade-duration": 0
       }

--- a/test/integration/render/tests/sparse-tileset/rasterfallback204/style.json
+++ b/test/integration/render/tests/sparse-tileset/rasterfallback204/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 1,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "raster",
       "tiles": [
         "local://tiles/sparse204/{z}-{x}-{y}.png"
@@ -29,7 +29,7 @@
     {
       "id": "raster-layer",
       "type": "raster",
-      "source": "mapbox",
+      "source": "maplibre",
       "paint": {
         "raster-fade-duration": 0
       }

--- a/test/integration/render/tests/sparse-tileset/vectorbase/style.json
+++ b/test/integration/render/tests/sparse-tileset/vectorbase/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 0,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "tiles": [
         "local://tiles/sparse/{z}-{x}-{y}.mvt"
@@ -28,7 +28,7 @@
     },
     {
       "id": "water-layer",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "water",
       "type": "fill",
       "paint": {

--- a/test/integration/render/tests/symbol-cross-fade/chinese-fading-after-initial-load/style.json
+++ b/test/integration/render/tests/symbol-cross-fade/chinese-fading-after-initial-load/style.json
@@ -29,7 +29,7 @@
   "zoom": 2,
   "center": [-14.41400, 39.09187],
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "geojson",
       "data": {
         "type": "FeatureCollection",
@@ -202,7 +202,7 @@
     {
       "id": "lines-symbol",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "layout": {
         "text-field": "{name}",
         "symbol-placement": "line",
@@ -213,7 +213,7 @@
     }, {
       "id": "lines",
       "type": "line",
-      "source": "mapbox",
+      "source": "maplibre",
       "paint": {
           "line-opacity": 0.25
       }

--- a/test/integration/render/tests/symbol-cross-fade/chinese-no-fading-Initial-load/style.json
+++ b/test/integration/render/tests/symbol-cross-fade/chinese-no-fading-Initial-load/style.json
@@ -14,7 +14,7 @@
   "zoom": 3,
   "center": [-14.41400, 39.09187],
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "geojson",
       "data": {
         "type": "FeatureCollection",
@@ -187,7 +187,7 @@
     {
       "id": "lines-symbol",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "layout": {
         "text-field": "{name}",
         "symbol-placement": "line",
@@ -198,7 +198,7 @@
     }, {
       "id": "lines",
       "type": "line",
-      "source": "mapbox",
+      "source": "maplibre",
       "paint": {
           "line-opacity": 0.25
       }

--- a/test/integration/render/tests/symbol-placement/line-center-buffer/style.json
+++ b/test/integration/render/tests/symbol-placement/line-center-buffer/style.json
@@ -13,7 +13,7 @@
   ],
   "zoom": 4.5,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -33,7 +33,7 @@
     {
       "id": "line-center",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "marine_label",
       "layout": {
         "text-field": "{name_en}",
@@ -52,7 +52,7 @@
     {
       "id": "line",
       "type": "line",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "marine_label",
       "paint": {
         "line-width": 1

--- a/test/integration/render/tests/symbol-placement/line-center/style.json
+++ b/test/integration/render/tests/symbol-placement/line-center/style.json
@@ -12,7 +12,7 @@
   ],
   "zoom": 15,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -32,7 +32,7 @@
     {
       "id": "line-center",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "road_label",
       "layout": {
         "text-field": ".",
@@ -46,7 +46,7 @@
     {
       "id": "road",
       "type": "line",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "road_label",
       "paint": {
         "line-width": 1,

--- a/test/integration/render/tests/symbol-placement/line-overscaled-debug/style.json
+++ b/test/integration/render/tests/symbol-placement/line-overscaled-debug/style.json
@@ -12,7 +12,7 @@
   ],
   "zoom": 17,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -32,7 +32,7 @@
     {
       "id": "line",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "road_label",
       "layout": {
         "icon-image": "triangle-stroked-12",
@@ -46,7 +46,7 @@
     {
       "id": "point",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "filter": [
         "==",

--- a/test/integration/render/tests/symbol-placement/line-overscaled/style.json
+++ b/test/integration/render/tests/symbol-placement/line-overscaled/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 17,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -31,7 +31,7 @@
     {
       "id": "line",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "road_label",
       "layout": {
         "icon-image": "triangle-stroked-12",
@@ -45,7 +45,7 @@
     {
       "id": "point",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "filter": [
         "==",

--- a/test/integration/render/tests/symbol-placement/line/style.json
+++ b/test/integration/render/tests/symbol-placement/line/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -31,7 +31,7 @@
     {
       "id": "line",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "road_label",
       "layout": {
         "icon-image": "triangle-stroked-12",
@@ -45,7 +45,7 @@
     {
       "id": "point",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "filter": [
         "==",

--- a/test/integration/render/tests/symbol-placement/point-polygon/style.json
+++ b/test/integration/render/tests/symbol-placement/point-polygon/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 18,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -31,13 +31,13 @@
     {
       "id": "lines_pole_of_inaccessibility",
       "type": "line",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "building"
     },
     {
       "id": "pole_of_inaccessibility",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "building",
       "layout": {
         "symbol-placement": "point",

--- a/test/integration/render/tests/symbol-placement/point/style.json
+++ b/test/integration/render/tests/symbol-placement/point/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -31,7 +31,7 @@
     {
       "id": "line",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "road_label",
       "layout": {
         "icon-image": "triangle-stroked-12",
@@ -45,7 +45,7 @@
     {
       "id": "point",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "filter": [
         "==",

--- a/test/integration/render/tests/symbol-spacing/line-close/style.json
+++ b/test/integration/render/tests/symbol-spacing/line-close/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -31,7 +31,7 @@
     {
       "id": "point-close",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "filter": [
         "==",
@@ -52,7 +52,7 @@
     {
       "id": "point-far",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "filter": [
         "==",
@@ -73,7 +73,7 @@
     {
       "id": "line-close",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "road",
       "layout": {
         "icon-image": "triangle-stroked-12",
@@ -89,7 +89,7 @@
     {
       "id": "line-far",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "road",
       "layout": {
         "icon-image": "triangle-stroked-12",

--- a/test/integration/render/tests/symbol-spacing/line-far/style.json
+++ b/test/integration/render/tests/symbol-spacing/line-far/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -31,7 +31,7 @@
     {
       "id": "point-close",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "filter": [
         "==",
@@ -52,7 +52,7 @@
     {
       "id": "point-far",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "filter": [
         "==",
@@ -73,7 +73,7 @@
     {
       "id": "line-close",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "road",
       "layout": {
         "icon-image": "triangle-stroked-12",
@@ -89,7 +89,7 @@
     {
       "id": "line-far",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "road",
       "layout": {
         "icon-image": "triangle-stroked-12",

--- a/test/integration/render/tests/symbol-spacing/line-overscaled/style.json
+++ b/test/integration/render/tests/symbol-spacing/line-overscaled/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 17,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -31,7 +31,7 @@
     {
       "id": "point-close",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "filter": [
         "==",
@@ -52,7 +52,7 @@
     {
       "id": "point-far",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "filter": [
         "==",
@@ -73,7 +73,7 @@
     {
       "id": "line-close",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "road",
       "layout": {
         "icon-image": "triangle-stroked-12",
@@ -89,7 +89,7 @@
     {
       "id": "line-far",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "road",
       "layout": {
         "icon-image": "triangle-stroked-12",

--- a/test/integration/render/tests/symbol-spacing/point-close/style.json
+++ b/test/integration/render/tests/symbol-spacing/point-close/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -31,7 +31,7 @@
     {
       "id": "point-close",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "filter": [
         "==",
@@ -52,7 +52,7 @@
     {
       "id": "point-far",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "filter": [
         "==",
@@ -73,7 +73,7 @@
     {
       "id": "line-close",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "road",
       "layout": {
         "icon-image": "triangle-stroked-12",
@@ -89,7 +89,7 @@
     {
       "id": "line-far",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "road",
       "layout": {
         "icon-image": "triangle-stroked-12",

--- a/test/integration/render/tests/symbol-spacing/point-far/style.json
+++ b/test/integration/render/tests/symbol-spacing/point-far/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -31,7 +31,7 @@
     {
       "id": "point-close",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "filter": [
         "==",
@@ -52,7 +52,7 @@
     {
       "id": "point-far",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "filter": [
         "==",
@@ -73,7 +73,7 @@
     {
       "id": "line-close",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "road",
       "layout": {
         "icon-image": "triangle-stroked-12",
@@ -89,7 +89,7 @@
     {
       "id": "line-far",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "road",
       "layout": {
         "icon-image": "triangle-stroked-12",

--- a/test/integration/render/tests/symbol-visibility/none/style.json
+++ b/test/integration/render/tests/symbol-visibility/none/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -31,7 +31,7 @@
     {
       "id": "icon",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "filter": ["has", "maki"],
       "layout": {

--- a/test/integration/render/tests/symbol-visibility/visible/style.json
+++ b/test/integration/render/tests/symbol-visibility/visible/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -31,7 +31,7 @@
     {
       "id": "icon",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "filter": ["has", "maki"],
       "layout": {

--- a/test/integration/render/tests/text-anchor/bottom-left/style.json
+++ b/test/integration/render/tests/text-anchor/bottom-left/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -32,7 +32,7 @@
     {
       "id": "bottom-left",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "filter": [
         "==",

--- a/test/integration/render/tests/text-anchor/bottom-right/style.json
+++ b/test/integration/render/tests/text-anchor/bottom-right/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -32,7 +32,7 @@
     {
       "id": "bottom-right",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "filter": [
         "==",

--- a/test/integration/render/tests/text-anchor/bottom/style.json
+++ b/test/integration/render/tests/text-anchor/bottom/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -32,7 +32,7 @@
     {
       "id": "bottom",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "filter": [
         "==",

--- a/test/integration/render/tests/text-anchor/center/style.json
+++ b/test/integration/render/tests/text-anchor/center/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -32,7 +32,7 @@
     {
       "id": "center",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "filter": [
         "==",

--- a/test/integration/render/tests/text-anchor/left/style.json
+++ b/test/integration/render/tests/text-anchor/left/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -32,7 +32,7 @@
     {
       "id": "left",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "filter": [
         "==",

--- a/test/integration/render/tests/text-anchor/right/style.json
+++ b/test/integration/render/tests/text-anchor/right/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -32,7 +32,7 @@
     {
       "id": "right",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "filter": [
         "==",

--- a/test/integration/render/tests/text-anchor/top-left/style.json
+++ b/test/integration/render/tests/text-anchor/top-left/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -32,7 +32,7 @@
     {
       "id": "top-left",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "filter": [
         "==",

--- a/test/integration/render/tests/text-anchor/top-right/style.json
+++ b/test/integration/render/tests/text-anchor/top-right/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -32,7 +32,7 @@
     {
       "id": "top-right",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "filter": [
         "==",

--- a/test/integration/render/tests/text-anchor/top/style.json
+++ b/test/integration/render/tests/text-anchor/top/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -32,7 +32,7 @@
     {
       "id": "top",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "filter": [
         "==",

--- a/test/integration/render/tests/text-color/default/style.json
+++ b/test/integration/render/tests/text-color/default/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -31,7 +31,7 @@
     {
       "id": "text",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "filter": [
         "==",

--- a/test/integration/render/tests/text-color/function/style.json
+++ b/test/integration/render/tests/text-color/function/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -31,7 +31,7 @@
     {
       "id": "text",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "filter": [
         "==",

--- a/test/integration/render/tests/text-color/literal/style.json
+++ b/test/integration/render/tests/text-color/literal/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -31,7 +31,7 @@
     {
       "id": "text",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "filter": [
         "==",

--- a/test/integration/render/tests/text-color/translucent/style.json
+++ b/test/integration/render/tests/text-color/translucent/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -31,7 +31,7 @@
     {
       "id": "text",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "filter": [
         "==",

--- a/test/integration/render/tests/text-color/transparent/style.json
+++ b/test/integration/render/tests/text-color/transparent/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -31,7 +31,7 @@
     {
       "id": "text",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "filter": [
         "==",

--- a/test/integration/render/tests/text-field/formatted-line/style.json
+++ b/test/integration/render/tests/text-field/formatted-line/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -31,7 +31,7 @@
     {
       "id": "literal",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "road_label",
       "layout": {
         "symbol-placement": "line",

--- a/test/integration/render/tests/text-font/literal/style.json
+++ b/test/integration/render/tests/text-font/literal/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -31,7 +31,7 @@
     {
       "id": "literal",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "filter": [
         "==",

--- a/test/integration/render/tests/text-justify/left/style.json
+++ b/test/integration/render/tests/text-justify/left/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -31,7 +31,7 @@
     {
       "id": "left",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "filter": [
         "==",

--- a/test/integration/render/tests/text-justify/right/style.json
+++ b/test/integration/render/tests/text-justify/right/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -31,7 +31,7 @@
     {
       "id": "right",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "filter": [
         "==",

--- a/test/integration/render/tests/text-keep-upright/line-placement-false/style.json
+++ b/test/integration/render/tests/text-keep-upright/line-placement-false/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -31,7 +31,7 @@
     {
       "id": "line-placement-false",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "road",
       "layout": {
         "symbol-placement": "line",

--- a/test/integration/render/tests/text-keep-upright/line-placement-true-pitched/style.json
+++ b/test/integration/render/tests/text-keep-upright/line-placement-true-pitched/style.json
@@ -12,7 +12,7 @@
   "zoom": 14,
   "pitch": 35,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -32,7 +32,7 @@
     {
       "id": "line-placement-true",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "road",
       "layout": {
         "symbol-placement": "line",

--- a/test/integration/render/tests/text-keep-upright/line-placement-true-rotated/style.json
+++ b/test/integration/render/tests/text-keep-upright/line-placement-true-rotated/style.json
@@ -15,7 +15,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -35,7 +35,7 @@
     {
       "id": "line-placement-true",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "road",
       "layout": {
         "symbol-placement": "line",

--- a/test/integration/render/tests/text-keep-upright/line-placement-true/style.json
+++ b/test/integration/render/tests/text-keep-upright/line-placement-true/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -31,7 +31,7 @@
     {
       "id": "line-placement-true",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "road",
       "layout": {
         "symbol-placement": "line",

--- a/test/integration/render/tests/text-keep-upright/point-placement-align-map-false/style.json
+++ b/test/integration/render/tests/text-keep-upright/point-placement-align-map-false/style.json
@@ -12,7 +12,7 @@
   "zoom": 14,
   "bearing": 180,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -32,7 +32,7 @@
     {
       "id": "point-placement-align-map-false",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "layout": {
         "symbol-placement": "point",

--- a/test/integration/render/tests/text-keep-upright/point-placement-align-map-true/style.json
+++ b/test/integration/render/tests/text-keep-upright/point-placement-align-map-true/style.json
@@ -12,7 +12,7 @@
   "zoom": 14,
   "bearing": 180,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -32,7 +32,7 @@
     {
       "id": "point-placement-align-map-true",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "layout": {
         "symbol-placement": "point",

--- a/test/integration/render/tests/text-keep-upright/point-placement-align-viewport-false/style.json
+++ b/test/integration/render/tests/text-keep-upright/point-placement-align-viewport-false/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -31,7 +31,7 @@
     {
       "id": "point-placement-align-viewport-false",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "layout": {
         "symbol-placement": "point",

--- a/test/integration/render/tests/text-keep-upright/point-placement-align-viewport-true/style.json
+++ b/test/integration/render/tests/text-keep-upright/point-placement-align-viewport-true/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -31,7 +31,7 @@
     {
       "id": "point-placement-align-viewport-true",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "layout": {
         "symbol-placement": "point",

--- a/test/integration/render/tests/text-letter-spacing/function-close/style.json
+++ b/test/integration/render/tests/text-letter-spacing/function-close/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -31,7 +31,7 @@
     {
       "id": "functions",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "filter": [
         "==",

--- a/test/integration/render/tests/text-letter-spacing/function-far/style.json
+++ b/test/integration/render/tests/text-letter-spacing/function-far/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -31,7 +31,7 @@
     {
       "id": "functions",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "filter": [
         "==",

--- a/test/integration/render/tests/text-letter-spacing/literal/style.json
+++ b/test/integration/render/tests/text-letter-spacing/literal/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -31,7 +31,7 @@
     {
       "id": "literal",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "filter": [
         "==",

--- a/test/integration/render/tests/text-line-height/literal/style.json
+++ b/test/integration/render/tests/text-line-height/literal/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -31,7 +31,7 @@
     {
       "id": "literal",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "filter": [
         "==",

--- a/test/integration/render/tests/text-max-angle/line-center/style.json
+++ b/test/integration/render/tests/text-max-angle/line-center/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -31,7 +31,7 @@
     {
       "id": "literal",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "road",
       "layout": {
         "symbol-placement": "line-center",

--- a/test/integration/render/tests/text-max-angle/literal/style.json
+++ b/test/integration/render/tests/text-max-angle/literal/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -31,7 +31,7 @@
     {
       "id": "literal",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "road",
       "layout": {
         "symbol-placement": "line",

--- a/test/integration/render/tests/text-max-width/force-double-newline/style.json
+++ b/test/integration/render/tests/text-max-width/force-double-newline/style.json
@@ -6,7 +6,7 @@
     }
   },
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "geojson",
       "data": {
         "type": "FeatureCollection",
@@ -38,7 +38,7 @@
     {
       "id": "literal",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "layout": {
         "text-field": "abcde\n\nabcde",
         "text-font": [

--- a/test/integration/render/tests/text-max-width/force-newline-line-center/style.json
+++ b/test/integration/render/tests/text-max-width/force-newline-line-center/style.json
@@ -7,7 +7,7 @@
   },
   "zoom": 4,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "geojson",
       "data": {
         "type": "FeatureCollection",
@@ -45,7 +45,7 @@
     {
       "id": "literal",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "layout": {
         "symbol-placement": "line-center",
         "text-field": "abcde\nabcde",

--- a/test/integration/render/tests/text-max-width/force-newline-line/style.json
+++ b/test/integration/render/tests/text-max-width/force-newline-line/style.json
@@ -7,7 +7,7 @@
   },
   "zoom": 4,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "geojson",
       "data": {
         "type": "FeatureCollection",
@@ -45,7 +45,7 @@
     {
       "id": "literal",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "layout": {
         "symbol-placement": "line",
         "text-field": "abcde\nabcde",

--- a/test/integration/render/tests/text-max-width/force-newline/style.json
+++ b/test/integration/render/tests/text-max-width/force-newline/style.json
@@ -6,7 +6,7 @@
     }
   },
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "geojson",
       "data": {
         "type": "FeatureCollection",
@@ -38,7 +38,7 @@
     {
       "id": "literal",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "layout": {
         "text-field": "abcde\nabcde",
         "text-font": [

--- a/test/integration/render/tests/text-max-width/ideographic-breaking/style.json
+++ b/test/integration/render/tests/text-max-width/ideographic-breaking/style.json
@@ -6,7 +6,7 @@
     }
   },
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "geojson",
       "data": {
         "type": "FeatureCollection",
@@ -144,7 +144,7 @@
     {
       "id": "literal",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "layout": {
         "text-field": "{name}",
         "text-font": [

--- a/test/integration/render/tests/text-max-width/ideographic-punctuation-breaking/style.json
+++ b/test/integration/render/tests/text-max-width/ideographic-punctuation-breaking/style.json
@@ -6,7 +6,7 @@
     }
   },
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "geojson",
       "data": {
         "type": "FeatureCollection",
@@ -144,7 +144,7 @@
     {
       "id": "literal",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "layout": {
         "text-field": "{name}",
         "text-font": [

--- a/test/integration/render/tests/text-max-width/literal/style.json
+++ b/test/integration/render/tests/text-max-width/literal/style.json
@@ -6,7 +6,7 @@
     }
   },
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "geojson",
       "data": {
         "type": "FeatureCollection",
@@ -38,7 +38,7 @@
     {
       "id": "literal",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "layout": {
         "text-field": "For every fact there is an infinity of hypotheses.",
         "text-font": [

--- a/test/integration/render/tests/text-max-width/zero-width-line-center-placement/style.json
+++ b/test/integration/render/tests/text-max-width/zero-width-line-center-placement/style.json
@@ -12,7 +12,7 @@
   ],
   "zoom": 6,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "geojson",
       "data": {
         "type": "FeatureCollection",
@@ -50,7 +50,7 @@
     {
       "id": "literal",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "layout": {
         "symbol-placement": "line-center",
         "text-field": "Lorem ipsum dolor sit amet.",

--- a/test/integration/render/tests/text-max-width/zero-width-line-placement/style.json
+++ b/test/integration/render/tests/text-max-width/zero-width-line-placement/style.json
@@ -12,7 +12,7 @@
   ],
   "zoom": 4,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "geojson",
       "data": {
         "type": "FeatureCollection",
@@ -50,7 +50,7 @@
     {
       "id": "literal",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "layout": {
         "symbol-placement": "line",
         "text-field": "Lorem ipsum dolor sit amet.",

--- a/test/integration/render/tests/text-max-width/zero-width-point-placement/style.json
+++ b/test/integration/render/tests/text-max-width/zero-width-point-placement/style.json
@@ -8,7 +8,7 @@
   },
   "zoom": 1,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "geojson",
       "data": {
         "type": "FeatureCollection",
@@ -40,7 +40,7 @@
     {
       "id": "literal",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "layout": {
         "text-field": "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
         "text-font": [

--- a/test/integration/render/tests/text-offset/line-collision/style.json
+++ b/test/integration/render/tests/text-offset/line-collision/style.json
@@ -12,7 +12,7 @@
   "center": [-73, 15],
   "zoom": 4,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": ["local://tiles/mapbox.mapbox-streets-v7/{z}-{x}-{y}.mvt"]
@@ -30,7 +30,7 @@
     {
       "id": "line-concave",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "marine_label",
       "layout": {
         "text-field": "This used to be the Carribean",
@@ -45,7 +45,7 @@
     {
       "id": "line-convex",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "marine_label",
       "layout": {
         "text-field": "This used to be the Carribean",
@@ -60,7 +60,7 @@
     {
       "id": "line",
       "type": "line",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "marine_label",
       "paint": {
         "line-width": 1

--- a/test/integration/render/tests/text-offset/line-concave/style.json
+++ b/test/integration/render/tests/text-offset/line-concave/style.json
@@ -11,7 +11,7 @@
   "center": [-73, 15],
   "zoom": 4,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": ["local://tiles/mapbox.mapbox-streets-v7/{z}-{x}-{y}.mvt"]
@@ -29,7 +29,7 @@
     {
       "id": "line-center",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "marine_label",
       "layout": {
         "text-field": "This used to be the Carribean",
@@ -44,7 +44,7 @@
     {
       "id": "line",
       "type": "line",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "marine_label",
       "paint": {
         "line-width": 1

--- a/test/integration/render/tests/text-offset/line-convex/style.json
+++ b/test/integration/render/tests/text-offset/line-convex/style.json
@@ -11,7 +11,7 @@
   "center": [-73, 15],
   "zoom": 4,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": ["local://tiles/mapbox.mapbox-streets-v7/{z}-{x}-{y}.mvt"]
@@ -29,7 +29,7 @@
     {
       "id": "line-center",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "marine_label",
       "layout": {
         "text-field": "This used to be the Carribean",
@@ -44,7 +44,7 @@
     {
       "id": "line",
       "type": "line",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "marine_label",
       "paint": {
         "line-width": 1

--- a/test/integration/render/tests/text-offset/literal-multiline-anchorcenter-justifycenter-offsetnegative/style.json
+++ b/test/integration/render/tests/text-offset/literal-multiline-anchorcenter-justifycenter-offsetnegative/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -32,7 +32,7 @@
     {
       "id": "literal",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "filter": [
         "==",

--- a/test/integration/render/tests/text-offset/literal-multiline-anchorcenter-justifycenter-offsetpositive/style.json
+++ b/test/integration/render/tests/text-offset/literal-multiline-anchorcenter-justifycenter-offsetpositive/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -32,7 +32,7 @@
     {
       "id": "literal",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "filter": [
         "==",

--- a/test/integration/render/tests/text-offset/literal-multiline-anchorcenter-justifyleft-offsetnegative/style.json
+++ b/test/integration/render/tests/text-offset/literal-multiline-anchorcenter-justifyleft-offsetnegative/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -32,7 +32,7 @@
     {
       "id": "literal",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "filter": [
         "==",

--- a/test/integration/render/tests/text-offset/literal-multiline-anchorcenter-justifyleft-offsetpositive/style.json
+++ b/test/integration/render/tests/text-offset/literal-multiline-anchorcenter-justifyleft-offsetpositive/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -32,7 +32,7 @@
     {
       "id": "literal",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "filter": [
         "==",

--- a/test/integration/render/tests/text-offset/literal-multiline-anchorcenter-justifyright-offsetnegative/style.json
+++ b/test/integration/render/tests/text-offset/literal-multiline-anchorcenter-justifyright-offsetnegative/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -32,7 +32,7 @@
     {
       "id": "literal",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "filter": [
         "==",

--- a/test/integration/render/tests/text-offset/literal-multiline-anchorcenter-justifyright-offsetpositive/style.json
+++ b/test/integration/render/tests/text-offset/literal-multiline-anchorcenter-justifyright-offsetpositive/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -32,7 +32,7 @@
     {
       "id": "literal",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "filter": [
         "==",

--- a/test/integration/render/tests/text-offset/literal-multiline-anchorleft-justifycenter-offsetnegative/style.json
+++ b/test/integration/render/tests/text-offset/literal-multiline-anchorleft-justifycenter-offsetnegative/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -32,7 +32,7 @@
     {
       "id": "literal",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "filter": [
         "==",

--- a/test/integration/render/tests/text-offset/literal-multiline-anchorleft-justifycenter-offsetpositive/style.json
+++ b/test/integration/render/tests/text-offset/literal-multiline-anchorleft-justifycenter-offsetpositive/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -32,7 +32,7 @@
     {
       "id": "literal",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "filter": [
         "==",

--- a/test/integration/render/tests/text-offset/literal-multiline-anchorleft-justifyleft-offsetnegative/style.json
+++ b/test/integration/render/tests/text-offset/literal-multiline-anchorleft-justifyleft-offsetnegative/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -32,7 +32,7 @@
     {
       "id": "literal",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "filter": [
         "==",

--- a/test/integration/render/tests/text-offset/literal-multiline-anchorleft-justifyleft-offsetpositive/style.json
+++ b/test/integration/render/tests/text-offset/literal-multiline-anchorleft-justifyleft-offsetpositive/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -32,7 +32,7 @@
     {
       "id": "literal",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "filter": [
         "==",

--- a/test/integration/render/tests/text-offset/literal-multiline-anchorleft-justifyright-offsetnegative/style.json
+++ b/test/integration/render/tests/text-offset/literal-multiline-anchorleft-justifyright-offsetnegative/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -32,7 +32,7 @@
     {
       "id": "literal",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "filter": [
         "==",

--- a/test/integration/render/tests/text-offset/literal-multiline-anchorleft-justifyright-offsetpositive/style.json
+++ b/test/integration/render/tests/text-offset/literal-multiline-anchorleft-justifyright-offsetpositive/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -32,7 +32,7 @@
     {
       "id": "literal",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "filter": [
         "==",

--- a/test/integration/render/tests/text-offset/literal-multiline-anchorright-justifycenter-offsetnegative/style.json
+++ b/test/integration/render/tests/text-offset/literal-multiline-anchorright-justifycenter-offsetnegative/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -32,7 +32,7 @@
     {
       "id": "literal",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "filter": [
         "==",

--- a/test/integration/render/tests/text-offset/literal-multiline-anchorright-justifycenter-offsetpositive/style.json
+++ b/test/integration/render/tests/text-offset/literal-multiline-anchorright-justifycenter-offsetpositive/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -32,7 +32,7 @@
     {
       "id": "literal",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "filter": [
         "==",

--- a/test/integration/render/tests/text-offset/literal-multiline-anchorright-justifyleft-offsetnegative/style.json
+++ b/test/integration/render/tests/text-offset/literal-multiline-anchorright-justifyleft-offsetnegative/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -32,7 +32,7 @@
     {
       "id": "literal",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "filter": [
         "==",

--- a/test/integration/render/tests/text-offset/literal-multiline-anchorright-justifyleft-offsetpositive/style.json
+++ b/test/integration/render/tests/text-offset/literal-multiline-anchorright-justifyleft-offsetpositive/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -32,7 +32,7 @@
     {
       "id": "literal",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "filter": [
         "==",

--- a/test/integration/render/tests/text-offset/literal-multiline-anchorright-justifyright-offsetnegative/style.json
+++ b/test/integration/render/tests/text-offset/literal-multiline-anchorright-justifyright-offsetnegative/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -32,7 +32,7 @@
     {
       "id": "literal",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "filter": [
         "==",

--- a/test/integration/render/tests/text-offset/literal-multiline-anchorright-justifyright-offsetpositive/style.json
+++ b/test/integration/render/tests/text-offset/literal-multiline-anchorright-justifyright-offsetpositive/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -32,7 +32,7 @@
     {
       "id": "literal",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "filter": [
         "==",

--- a/test/integration/render/tests/text-offset/literal/style.json
+++ b/test/integration/render/tests/text-offset/literal/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -31,7 +31,7 @@
     {
       "id": "literal",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "filter": [
         "==",

--- a/test/integration/render/tests/text-opacity/default/style.json
+++ b/test/integration/render/tests/text-opacity/default/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -31,7 +31,7 @@
     {
       "id": "text",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "filter": [
         "==",

--- a/test/integration/render/tests/text-opacity/function/style.json
+++ b/test/integration/render/tests/text-opacity/function/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -31,7 +31,7 @@
     {
       "id": "text",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "filter": [
         "==",

--- a/test/integration/render/tests/text-opacity/literal/style.json
+++ b/test/integration/render/tests/text-opacity/literal/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -31,7 +31,7 @@
     {
       "id": "text",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "filter": [
         "==",

--- a/test/integration/render/tests/text-pitch-alignment/auto-text-rotation-alignment-map/style.json
+++ b/test/integration/render/tests/text-pitch-alignment/auto-text-rotation-alignment-map/style.json
@@ -12,7 +12,7 @@
   "zoom": 16,
   "pitch": 30,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -32,7 +32,7 @@
     {
       "id": "road",
       "type": "line",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "road",
       "paint": {
           "line-color": "#888",
@@ -42,7 +42,7 @@
     {
       "id": "text",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "road_label",
       "layout": {
         "symbol-placement": "line",

--- a/test/integration/render/tests/text-pitch-alignment/auto-text-rotation-alignment-viewport-glyph/style.json
+++ b/test/integration/render/tests/text-pitch-alignment/auto-text-rotation-alignment-viewport-glyph/style.json
@@ -12,7 +12,7 @@
   "zoom": 16,
   "pitch": 30,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -32,7 +32,7 @@
     {
       "id": "road",
       "type": "line",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "road",
       "paint": {
           "line-color": "#888",
@@ -42,7 +42,7 @@
     {
       "id": "text",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "road_label",
       "layout": {
         "symbol-placement": "line",

--- a/test/integration/render/tests/text-pitch-alignment/auto-text-rotation-alignment-viewport/style.json
+++ b/test/integration/render/tests/text-pitch-alignment/auto-text-rotation-alignment-viewport/style.json
@@ -12,7 +12,7 @@
   "zoom": 16,
   "pitch": 30,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -32,7 +32,7 @@
     {
       "id": "road",
       "type": "line",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "road",
       "paint": {
           "line-color": "#888",
@@ -42,7 +42,7 @@
     {
       "id": "text",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "road_label",
       "layout": {
         "symbol-placement": "line",

--- a/test/integration/render/tests/text-pitch-alignment/map-text-rotation-alignment-map/style.json
+++ b/test/integration/render/tests/text-pitch-alignment/map-text-rotation-alignment-map/style.json
@@ -12,7 +12,7 @@
   "zoom": 16,
   "pitch": 30,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -32,7 +32,7 @@
     {
       "id": "road",
       "type": "line",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "road",
       "paint": {
           "line-color": "#888",
@@ -42,7 +42,7 @@
     {
       "id": "text",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "road_label",
       "layout": {
         "symbol-placement": "line",

--- a/test/integration/render/tests/text-pitch-alignment/map-text-rotation-alignment-viewport-debug/style.json
+++ b/test/integration/render/tests/text-pitch-alignment/map-text-rotation-alignment-viewport-debug/style.json
@@ -13,7 +13,7 @@
   "zoom": 16,
   "pitch": 30,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -33,7 +33,7 @@
     {
       "id": "road",
       "type": "line",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "road",
       "paint": {
           "line-color": "#888",
@@ -43,7 +43,7 @@
     {
       "id": "text",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "road_label",
       "layout": {
         "symbol-placement": "line",

--- a/test/integration/render/tests/text-pitch-alignment/map-text-rotation-alignment-viewport/style.json
+++ b/test/integration/render/tests/text-pitch-alignment/map-text-rotation-alignment-viewport/style.json
@@ -12,7 +12,7 @@
   "zoom": 16,
   "pitch": 30,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -32,7 +32,7 @@
     {
       "id": "road",
       "type": "line",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "road",
       "paint": {
           "line-color": "#888",
@@ -42,7 +42,7 @@
     {
       "id": "text",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "road_label",
       "layout": {
         "symbol-placement": "line",

--- a/test/integration/render/tests/text-pitch-alignment/viewport-overzoomed-single-glyph/style.json
+++ b/test/integration/render/tests/text-pitch-alignment/viewport-overzoomed-single-glyph/style.json
@@ -8,7 +8,7 @@
   "pitch": 60,
   "bearing": 161.5,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 16,
       "tiles": [
@@ -28,7 +28,7 @@
     {
       "id": "road-label-large",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "road_label",
       "layout": {
         "text-size": { "base": 1, "stops": [ [ 9, 10 ], [ 20, 16 ] ] },

--- a/test/integration/render/tests/text-pitch-alignment/viewport-text-rotation-alignment-map/style.json
+++ b/test/integration/render/tests/text-pitch-alignment/viewport-text-rotation-alignment-map/style.json
@@ -12,7 +12,7 @@
   "zoom": 16,
   "pitch": 30,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -32,7 +32,7 @@
     {
       "id": "road",
       "type": "line",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "road",
       "paint": {
           "line-color": "#888",
@@ -42,7 +42,7 @@
     {
       "id": "text",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "road_label",
       "layout": {
         "symbol-placement": "line",

--- a/test/integration/render/tests/text-pitch-alignment/viewport-text-rotation-alignment-viewport/style.json
+++ b/test/integration/render/tests/text-pitch-alignment/viewport-text-rotation-alignment-viewport/style.json
@@ -12,7 +12,7 @@
   "zoom": 16,
   "pitch": 30,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -32,7 +32,7 @@
     {
       "id": "road",
       "type": "line",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "road",
       "paint": {
           "line-color": "#888",
@@ -42,7 +42,7 @@
     {
       "id": "text",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "road_label",
       "layout": {
         "symbol-placement": "line",

--- a/test/integration/render/tests/text-pitch-scaling/line-half/style.json
+++ b/test/integration/render/tests/text-pitch-scaling/line-half/style.json
@@ -12,7 +12,7 @@
   "zoom": 16,
   "pitch": 30,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -32,7 +32,7 @@
     {
       "id": "road",
       "type": "line",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "road",
       "paint": {
           "line-color": "#888",
@@ -42,7 +42,7 @@
     {
       "id": "text",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "road_label",
       "layout": {
         "symbol-placement": "line",

--- a/test/integration/render/tests/text-tile-edge-clipping/default/style.json
+++ b/test/integration/render/tests/text-tile-edge-clipping/default/style.json
@@ -12,7 +12,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -33,7 +33,7 @@
     {
       "id": "top",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "filter": [
         "==",

--- a/test/integration/render/tests/text-transform/lowercase/style.json
+++ b/test/integration/render/tests/text-transform/lowercase/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -31,7 +31,7 @@
     {
       "id": "lowercase",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "filter": [
         "==",

--- a/test/integration/render/tests/text-transform/uppercase/style.json
+++ b/test/integration/render/tests/text-transform/uppercase/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -31,7 +31,7 @@
     {
       "id": "uppercase",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "filter": [
         "==",

--- a/test/integration/render/tests/text-translate-anchor/map/style.json
+++ b/test/integration/render/tests/text-translate-anchor/map/style.json
@@ -12,7 +12,7 @@
   "zoom": 14,
   "bearing": 90,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -32,7 +32,7 @@
     {
       "id": "text",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "filter": [
         "==",

--- a/test/integration/render/tests/text-translate-anchor/viewport/style.json
+++ b/test/integration/render/tests/text-translate-anchor/viewport/style.json
@@ -12,7 +12,7 @@
   "zoom": 14,
   "bearing": 90,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -32,7 +32,7 @@
     {
       "id": "text",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "filter": [
         "==",

--- a/test/integration/render/tests/text-translate/default/style.json
+++ b/test/integration/render/tests/text-translate/default/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -31,7 +31,7 @@
     {
       "id": "text",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "filter": [
         "==",

--- a/test/integration/render/tests/text-translate/function/style.json
+++ b/test/integration/render/tests/text-translate/function/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -31,7 +31,7 @@
     {
       "id": "text",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "filter": [
         "==",

--- a/test/integration/render/tests/text-translate/literal/style.json
+++ b/test/integration/render/tests/text-translate/literal/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -31,7 +31,7 @@
     {
       "id": "text",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "filter": [
         "==",

--- a/test/integration/render/tests/text-variable-anchor-offset/all-anchors-icon-text-fit/style.json
+++ b/test/integration/render/tests/text-variable-anchor-offset/all-anchors-icon-text-fit/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -32,7 +32,7 @@
     {
       "id": "top",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "filter": [
         "==",

--- a/test/integration/render/tests/text-variable-anchor-offset/all-anchors-text-allow-overlap/style.json
+++ b/test/integration/render/tests/text-variable-anchor-offset/all-anchors-text-allow-overlap/style.json
@@ -12,7 +12,7 @@
   ],
   "zoom": 16,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -33,7 +33,7 @@
     {
       "id": "top",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "filter": [
         "==",

--- a/test/integration/render/tests/text-variable-anchor-offset/pitched-offset/style.json
+++ b/test/integration/render/tests/text-variable-anchor-offset/pitched-offset/style.json
@@ -16,7 +16,7 @@
   "zoom": 14,
   "pitch": 60,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -37,7 +37,7 @@
     {
       "id": "top",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "filter": [
         "==",

--- a/test/integration/render/tests/text-variable-anchor-offset/pitched-with-map/style.json
+++ b/test/integration/render/tests/text-variable-anchor-offset/pitched-with-map/style.json
@@ -16,7 +16,7 @@
   "zoom": 14,
   "pitch": 60,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -37,7 +37,7 @@
     {
       "id": "top",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "filter": [
         "==",

--- a/test/integration/render/tests/text-variable-anchor-offset/pitched/style.json
+++ b/test/integration/render/tests/text-variable-anchor-offset/pitched/style.json
@@ -13,7 +13,7 @@
   "zoom": 14,
   "pitch": 60,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -34,7 +34,7 @@
     {
       "id": "top",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "filter": [
         "==",

--- a/test/integration/render/tests/text-variable-anchor-offset/rotated-offset/style.json
+++ b/test/integration/render/tests/text-variable-anchor-offset/rotated-offset/style.json
@@ -12,7 +12,7 @@
   "zoom": 14,
   "bearing": 90,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -33,7 +33,7 @@
     {
       "id": "top",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "filter": [
         "==",

--- a/test/integration/render/tests/text-variable-anchor-offset/rotated-with-map/style.json
+++ b/test/integration/render/tests/text-variable-anchor-offset/rotated-with-map/style.json
@@ -13,7 +13,7 @@
   "zoom": 14,
   "bearing": 90,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -34,7 +34,7 @@
     {
       "id": "top",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "filter": [
         "==",

--- a/test/integration/render/tests/text-variable-anchor-offset/rotated/style.json
+++ b/test/integration/render/tests/text-variable-anchor-offset/rotated/style.json
@@ -12,7 +12,7 @@
   "zoom": 14,
   "bearing": 90,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -33,7 +33,7 @@
     {
       "id": "top",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "filter": [
         "==",

--- a/test/integration/render/tests/text-variable-anchor-offset/single-justification/style.json
+++ b/test/integration/render/tests/text-variable-anchor-offset/single-justification/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -32,7 +32,7 @@
     {
       "id": "top",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "filter": [
         "==",

--- a/test/integration/render/tests/text-variable-anchor-offset/single-line/style.json
+++ b/test/integration/render/tests/text-variable-anchor-offset/single-line/style.json
@@ -12,7 +12,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -33,7 +33,7 @@
     {
       "id": "top",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "filter": [
         "==",

--- a/test/integration/render/tests/text-variable-anchor-offset/top-bottom-left-right/style.json
+++ b/test/integration/render/tests/text-variable-anchor-offset/top-bottom-left-right/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 14.5,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -32,7 +32,7 @@
     {
       "id": "top",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "filter": ["all", [
           "==",
@@ -59,7 +59,7 @@
     {
       "id": "circles",
       "type": "circle",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "filter": [
         "==",

--- a/test/integration/render/tests/text-variable-anchor/all-anchors-icon-text-fit/style.json
+++ b/test/integration/render/tests/text-variable-anchor/all-anchors-icon-text-fit/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -32,7 +32,7 @@
     {
       "id": "top",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "filter": [
         "==",

--- a/test/integration/render/tests/text-variable-anchor/all-anchors-text-allow-overlap/style.json
+++ b/test/integration/render/tests/text-variable-anchor/all-anchors-text-allow-overlap/style.json
@@ -12,7 +12,7 @@
   ],
   "zoom": 16,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -33,7 +33,7 @@
     {
       "id": "top",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "filter": [
         "==",

--- a/test/integration/render/tests/text-variable-anchor/all-anchors/style.json
+++ b/test/integration/render/tests/text-variable-anchor/all-anchors/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -32,7 +32,7 @@
     {
       "id": "top",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "filter": [
         "==",

--- a/test/integration/render/tests/text-variable-anchor/pitched-offset/style.json
+++ b/test/integration/render/tests/text-variable-anchor/pitched-offset/style.json
@@ -13,7 +13,7 @@
   "zoom": 14,
   "pitch": 60,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -34,7 +34,7 @@
     {
       "id": "top",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "filter": [
         "==",

--- a/test/integration/render/tests/text-variable-anchor/pitched-rotated-debug/style.json
+++ b/test/integration/render/tests/text-variable-anchor/pitched-rotated-debug/style.json
@@ -17,7 +17,7 @@
   "pitch": 60,
   "bearing": 90,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -38,7 +38,7 @@
     {
       "id": "top",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "filter": [
         "==",

--- a/test/integration/render/tests/text-variable-anchor/pitched-with-map/style.json
+++ b/test/integration/render/tests/text-variable-anchor/pitched-with-map/style.json
@@ -13,7 +13,7 @@
   "zoom": 14,
   "pitch": 60,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -34,7 +34,7 @@
     {
       "id": "top",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "filter": [
         "==",

--- a/test/integration/render/tests/text-variable-anchor/pitched/style.json
+++ b/test/integration/render/tests/text-variable-anchor/pitched/style.json
@@ -13,7 +13,7 @@
   "zoom": 14,
   "pitch": 60,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -34,7 +34,7 @@
     {
       "id": "top",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "filter": [
         "==",

--- a/test/integration/render/tests/text-variable-anchor/rotated-offset/style.json
+++ b/test/integration/render/tests/text-variable-anchor/rotated-offset/style.json
@@ -12,7 +12,7 @@
   "zoom": 14,
   "bearing": 90,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -33,7 +33,7 @@
     {
       "id": "top",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "filter": [
         "==",

--- a/test/integration/render/tests/text-variable-anchor/rotated-with-map/style.json
+++ b/test/integration/render/tests/text-variable-anchor/rotated-with-map/style.json
@@ -13,7 +13,7 @@
   "zoom": 14,
   "bearing": 90,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -34,7 +34,7 @@
     {
       "id": "top",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "filter": [
         "==",

--- a/test/integration/render/tests/text-variable-anchor/rotated/style.json
+++ b/test/integration/render/tests/text-variable-anchor/rotated/style.json
@@ -12,7 +12,7 @@
   "zoom": 14,
   "bearing": 90,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -33,7 +33,7 @@
     {
       "id": "top",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "filter": [
         "==",

--- a/test/integration/render/tests/text-variable-anchor/single-justification/style.json
+++ b/test/integration/render/tests/text-variable-anchor/single-justification/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -32,7 +32,7 @@
     {
       "id": "top",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "filter": [
         "==",

--- a/test/integration/render/tests/text-variable-anchor/single-line/style.json
+++ b/test/integration/render/tests/text-variable-anchor/single-line/style.json
@@ -12,7 +12,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -33,7 +33,7 @@
     {
       "id": "top",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "filter": [
         "==",

--- a/test/integration/render/tests/text-variable-anchor/top-bottom-left-right/style.json
+++ b/test/integration/render/tests/text-variable-anchor/top-bottom-left-right/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 14.5,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -32,7 +32,7 @@
     {
       "id": "top",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "filter": ["all", [
           "==",
@@ -54,7 +54,7 @@
     {
       "id": "circles",
       "type": "circle",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "filter": [
         "==",

--- a/test/integration/render/tests/text-visibility/none/style.json
+++ b/test/integration/render/tests/text-visibility/none/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -31,7 +31,7 @@
     {
       "id": "icon",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "layout": {
         "text-field": "Test",

--- a/test/integration/render/tests/text-visibility/visible/style.json
+++ b/test/integration/render/tests/text-visibility/visible/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 14,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -31,7 +31,7 @@
     {
       "id": "icon",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "poi_label",
       "layout": {
         "text-field": "Test",

--- a/test/integration/render/tests/text-writing-mode/line_label/chinese-punctuation/style.json
+++ b/test/integration/render/tests/text-writing-mode/line_label/chinese-punctuation/style.json
@@ -9,7 +9,7 @@
   "zoom": 0,
   "center": [0, 0],
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "geojson",
       "data": {
           "type": "FeatureCollection",
@@ -182,7 +182,7 @@
     {
       "id": "lines-symbol",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "layout": {
         "text-field": "{name}",
         "symbol-placement": "line",
@@ -192,7 +192,7 @@
     }, {
       "id": "lines",
       "type": "line",
-      "source": "mapbox",
+      "source": "maplibre",
       "paint": {
           "line-opacity": 0.25
       }

--- a/test/integration/render/tests/text-writing-mode/line_label/chinese/style.json
+++ b/test/integration/render/tests/text-writing-mode/line_label/chinese/style.json
@@ -9,7 +9,7 @@
   "zoom": 2,
   "center": [-14.41400, 39.09187],
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "geojson",
       "data": {
         "type": "FeatureCollection",
@@ -182,7 +182,7 @@
     {
       "id": "lines-symbol",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "layout": {
         "text-field": "{name}",
         "symbol-placement": "line",
@@ -193,7 +193,7 @@
     }, {
       "id": "lines",
       "type": "line",
-      "source": "mapbox",
+      "source": "maplibre",
       "paint": {
           "line-opacity": 0.25
       }

--- a/test/integration/render/tests/text-writing-mode/line_label/latin/style.json
+++ b/test/integration/render/tests/text-writing-mode/line_label/latin/style.json
@@ -9,7 +9,7 @@
   "zoom": 2,
   "center": [-14.41400, 39.09187],
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "geojson",
       "data": {
         "type": "FeatureCollection",
@@ -182,7 +182,7 @@
     {
       "id": "lines-symbol",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "layout": {
         "text-field": "{name}",
         "symbol-placement": "line",
@@ -193,7 +193,7 @@
     }, {
       "id": "lines",
       "type": "line",
-      "source": "mapbox",
+      "source": "maplibre",
       "paint": {
           "line-opacity": 0.25
       }

--- a/test/integration/render/tests/text-writing-mode/line_label/mixed/style.json
+++ b/test/integration/render/tests/text-writing-mode/line_label/mixed/style.json
@@ -9,7 +9,7 @@
   "zoom": 2,
   "center": [-14.41400, 39.09187],
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "geojson",
       "data": {
         "type": "FeatureCollection",
@@ -182,7 +182,7 @@
     {
       "id": "lines-symbol",
       "type": "symbol",
-      "source": "mapbox",
+      "source": "maplibre",
       "layout": {
         "text-field": "{name}",
         "symbol-placement": "line",
@@ -193,7 +193,7 @@
     }, {
       "id": "lines",
       "type": "line",
-      "source": "mapbox",
+      "source": "maplibre",
       "paint": {
           "line-opacity": 0.25
       }

--- a/test/integration/render/tests/tilejson-bounds/default/style.json
+++ b/test/integration/render/tests/tilejson-bounds/default/style.json
@@ -11,7 +11,7 @@
     ],
     "zoom": 14,
     "sources": {
-      "mapbox": {
+      "maplibre": {
         "type": "vector",
         "maxzoom": 14,
         "tiles": [
@@ -31,7 +31,7 @@
       {
         "id": "road",
         "type": "line",
-        "source": "mapbox",
+        "source": "maplibre",
         "source-layer": "road",
         "paint": {
           "line-width": 2,

--- a/test/integration/render/tests/tilejson-bounds/overwrite-bounds/style.json
+++ b/test/integration/render/tests/tilejson-bounds/overwrite-bounds/style.json
@@ -11,7 +11,7 @@
     ],
     "zoom": 14,
     "sources": {
-      "mapbox": {
+      "maplibre": {
         "type": "vector",
         "maxzoom": 14,
         "url": "local://tilesets/vector.json",
@@ -29,7 +29,7 @@
       {
         "id": "road",
         "type": "line",
-        "source": "mapbox",
+        "source": "maplibre",
         "source-layer": "road",
         "paint": {
           "line-width": 2,

--- a/test/integration/render/tests/tms/tms/style.json
+++ b/test/integration/render/tests/tms/tms/style.json
@@ -5,7 +5,7 @@
   },
   "zoom": 2,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "scheme": "tms",
@@ -25,7 +25,7 @@
     {
       "id": "land",
       "type": "fill",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "water",
       "paint": {
         "fill-color": "blue"

--- a/test/integration/render/tests/zoomed-fill/default/style.json
+++ b/test/integration/render/tests/zoomed-fill/default/style.json
@@ -11,7 +11,7 @@
   ],
   "zoom": 16,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -30,7 +30,7 @@
     {
       "id": "fill",
       "type": "fill",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "building",
       "paint": {
         "fill-color": "black"

--- a/test/integration/render/tests/zoomed-fill/negative-zoom/style.json
+++ b/test/integration/render/tests/zoomed-fill/negative-zoom/style.json
@@ -12,7 +12,7 @@
   ],
   "zoom": -1,
   "sources": {
-    "mapbox": {
+    "maplibre": {
       "type": "vector",
       "maxzoom": 14,
       "tiles": [
@@ -31,7 +31,7 @@
     {
       "id": "fill",
       "type": "fill",
-      "source": "mapbox",
+      "source": "maplibre",
       "source-layer": "water",
       "paint": {
         "fill-color": "black"


### PR DESCRIPTION
Replaces `"mapbox"` source IDs with `"maplibre"`. New render tests should use `"maplibre"` as source IDs.

I couldn't get the render tests to run locally on ARM64 Linux (Puppeteer not available), but I expect that the render tests still pass.

## Launch Checklist

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.