### PR TITLE
Fix SVG id's for maplibregl-ctrl-geolocate.svg

### DIFF
--- a/src/css/svg/maplibregl-ctrl-geolocate.svg
+++ b/src/css/svg/maplibregl-ctrl-geolocate.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="29" height="29" viewBox="0 0 20 20">
     <path d="M10 4C9 4 9 5 9 5v.1A5 5 0 0 0 5.1 9H5s-1 0-1 1 1 1 1 1h.1A5 5 0 0 0 9 14.9v.1s0 1 1 1 1-1 1-1v-.1a5 5 0 0 0 3.9-3.9h.1s1 0 1-1-1-1-1-1h-.1A5 5 0 0 0 11 5.1V5s0-1-1-1m0 2.5a3.5 3.5 0 1 1 0 7 3.5 3.5 0 1 1 0-7"/>
-    <circle cx="10" cy="10" r="2"/>
-    <path d="m14 5 1 1-9 9-1-1z"/>
+    <circle id="dot" cx="10" cy="10" r="2"/>
+    <path id="stroke" d="m14 5 1 1-9 9-1-1z"/>
 </svg>


### PR DESCRIPTION
I introduced a bug with #4181 by removing the ids for parts oft he compass which are actually used in the CSS to hide/change depending on the state. This PR adds those ids back.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [ ] Link to related issues.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [ ] Add an entry to `CHANGELOG.md` under the `## main` section.
