### PR TITLE
Markdown formatting fixes

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -9,6 +9,7 @@
 ### Parsing and layout
 
 Vector tiles are fetched and parsed on WebWorker threads.  "Parsing" a vector tile involves:
+
  - Deserializing source layers, feature properties, and feature geometries from the PBF.  This is handled by the [`vector-tile-js`](https://github.com/mapbox/vector-tile-js) library.
  - Transforming that data into _render-ready_ data that can be used by WebGL shaders to draw the map.  We refer to this process as "layout," and it carried out by `WorkerTile`, the `Bucket` classes, and `ProgramConfiguration`.
  - Indexing feature geometries into a `FeatureIndex`, used for spatial queries (e.g. `queryRenderedFeatures`).
@@ -56,10 +57,8 @@ Compiling and caching GL shader programs is managed by the `Painter` and `Progra
  - Expanding a `#pragma mapbox` statement in our shader source into either a _uniform_ or _attribute_, _varying_, and _local_ variable declaration, depending on whether or not the relevant style property is data-driven.
  - Creating and populating a _paint_ vertex array for data-driven properties, corresponding to the `attributes` declared in the shader. (This happens at layout time, on the worker side.)
 
-
 ## SourceCache
 
 ## Transform
 
 ## Controls
-

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,9 @@
+# Contributing to MapLibre GL JS
+
 Hi, and thanks in advance for contributing to MapLibre GL JS. Here's how we work. Please follow these conventions when submitting an issue or pull request.
 
 ## Do not violate Mapbox copyright!
+
 In December 2020 Mapbox decided to publish future versions of mapbox-gl-js under a proprietary license. **You are not allowed to backport code from Mapbox projects which has been contributed under this new license**. Unauthorized backports are the biggest threat to the MapLibre project. If you are unsure about this issue, [please ask](https://github.com/maplibre/maplibre-gl-js/discussions)!
 
 ## Best Practices for Contributions
@@ -215,6 +218,7 @@ Additionally, if you're using VSCode, the "Format Document" action or "Editor: F
 ### Version Control Conventions
 
 Here is a recommended way to get setup:
+
 1. Fork this project
 2. Clone your new fork, `git clone git@github.com:GithubUser/maplibre-gl-js.git`
 3. `cd maplibre-gl-js`

--- a/README.md
+++ b/README.md
@@ -51,7 +51,6 @@ Check out the features through [examples](https://maplibre.org/maplibre-gl-js/do
 
 <br />
 
-
 Want an example? Have a look at the official [MapLibre GL JS Documentation](https://maplibre.org/maplibre-gl-js/docs/examples/).
 
 Use MapLibre GL JS bindings for [React](https://visgl.github.io/react-map-gl/docs/get-started) and [Angular](https://github.com/maplibre/ngx-maplibre-gl). Find more at [awesome-maplibre](https://github.com/maplibre/awesome-maplibre).
@@ -68,7 +67,6 @@ Read the [CONTRIBUTING.md](CONTRIBUTING.md) guide in order to get familiar with 
 ### Avoid Fragmentation
 
 If you depend on a free software alternative to `mapbox-gl-js`, please consider joining our effort! Anyone with a stake in a healthy community-led fork is welcome to help us figure out our next steps. We welcome contributors and leaders! MapLibre GL JS already represents the combined efforts of a few early fork efforts, and we all benefit from "one project" rather than "our way". If you know of other forks, please reach out to them and direct them here.
- 
 
 > **MapLibre GL JS** is developed following [Semantic Versioning (2.0.0)](https://semver.org/spec/v2.0.0.html).
 

--- a/build/readme.md
+++ b/build/readme.md
@@ -21,9 +21,9 @@ These commands will use rollup to bundle the code. This is where the magic happe
 
 In the `rollup` folder there are some files that are used as linking files as they link to other files for rollup to pick when bundling.
 
-Rollup is generating 3 files throughout the process of bundling: 
+Rollup is generating 3 files throughout the process of bundling:
 
-`index.ts` a file containing all the code that will run in the main thread. 
+`index.ts` a file containing all the code that will run in the main thread.
 
 `shared.ts` a file containing all the code shared between the main and worker code.
 
@@ -34,14 +34,21 @@ These 3 files are then referenced and used by the `bundle_prelude.js` file. It a
 <hr>
 
 ### `npm run codegen`
+
 The `codegen` command runs the following three scripts, to update the corresponding code files based on the `v8.json` style source, and other data files. Contributors should run this command manually when the underlying style data is modified. The generated code files are then committed to the repo.
-#### generate-struct-arrays.ts		
+
+#### generate-struct-arrays.ts
+
 Generates `data/array_types.ts`, which consists of:
+
  - `StructArrayLayout_*` subclasses, one for each underlying memory layout
  - Named exports mapping each conceptual array type (e.g., `CircleLayoutArray`) to its corresponding `StructArrayLayout` class
  - Specific named `StructArray` subclasses, when type-specific struct accessors are needed (e.g., `CollisionBoxArray`)
-#### generate-style-code.ts			
+
+#### generate-style-code.ts
+
 Generates the various `style/style_layer/[layer type]_style_layer_properties.ts` code files based on the content of `v8.json`. These files provide the type signatures for the paint and layout properties for each type of style layer.
+
 <hr>
 
 ### Generate Release Nodes

--- a/developer-guides/release-process.md
+++ b/developer-guides/release-process.md
@@ -1,10 +1,10 @@
-## Publish to NPM
+# Publish to npm
 
 1. Review [`CHANGELOG.md`](../CHANGELOG.md)
    - Double-check that all changes included in the release are [appropriately documented](../CONTRIBUTING.md#changelog-conventions).
    - To-be-released changes should be under the "main" header.
    - Commit any final changes to the changelog.
 2. Run [Create bump version PR](https://github.com/maplibre/maplibre-gl-js/actions/workflows/create-bump-version-pr.yml) by manual workflow dispatch and set the version number in the input. This will create a PR that changes the changelog and `package.json` file to review and merge.
-3. Once merged, an automatic process will kick in and creates a GitHub release, uploads release assets, and publishes the build output to NPM.
+3. Once merged, an automatic process will kick in and creates a GitHub release, uploads release assets, and publishes the build output to npm.
 
-The workflow expects `${{ secrets.NPM_ORG_TOKEN }}` organization secret in order to push to NPM registry.
+The workflow expects `${{ secrets.NPM_ORG_TOKEN }}` organization secret in order to push to npm registry.

--- a/docs/guides/mapbox-migration-guide.md
+++ b/docs/guides/mapbox-migration-guide.md
@@ -31,7 +31,7 @@ MapLibre GL JS v1 is completely backward compatible with Mapbox GL JS v1. This c
 -      rel="stylesheet"
 -    />
 
-     
+
 +    <script src="https://unpkg.com/maplibre-gl@#.#.#/dist/maplibre-gl.js"></script>
 +    <link
 +      href="https://unpkg.com/maplibre-gl@#.#.#/dist/maplibre-gl.css"

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,6 @@
 
 MapLibre GL JS is a TypeScript library that uses WebGL to render interactive maps from vector tiles in a browser. The customization of the map comply with the [MapLibre Style Spec](https://maplibre.org/maplibre-style-spec). It is part of the [MapLibre ecosystem](https://github.com/maplibre), with a pendant for Mobile, Desktop, Servers called [MapLibre Native](https://maplibre.org/projects/maplibre-native/).
 
-
 ## Quickstart
 
 <iframe src="./examples/simple-map.html" width="100%" style="border:none"></iframe>
@@ -49,7 +48,6 @@ img-src data: blob: ;
 
 For strict CSP environments without `worker-src blob: ; child-src blob:` enabled, there's a separate MapLibre GL JS bundle (`maplibre-gl-csp.js` and `maplibre-gl-csp-worker.js`) which requires setting the path to the worker manually:
 
-
 ```html
 <script>
 maplibregl.setWorkerUrl("${urls.js().replace('.js', '-csp-worker.js')}");
@@ -70,7 +68,7 @@ Note too that if the CSS isn't available by the first render, as soon as the CSS
 The MapLibre GL JS (`.js` & `.css`) are distributed via [UNPKG.com](https://unpkg.com).
 You can view a listing of all the files in the MapLibre GL JS package by appending a `/` at the end of the MapLibre slug. This is useful to review other revisions or to review the files at UNPKG or the LICENSE. See examples in the following table:
 
-*Examples*
+### Examples
 
 | Use Case  | `.js` | `.css` |
 | :------- | :---: | :----: |


### PR DESCRIPTION
- Remove duplicate empty lines - these are ignored and rendered as 1 empty line anyway.
- Change NPM to npm (its always lower-case)
- Add a h1 title to CONTRIBUTING
- All headers should be followed by a line break

P.S. could consider adding a markdownlint config and/or using Prettier?

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [ ] Link to related issues.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [ ] Add an entry to `CHANGELOG.md` under the `## main` section.
