### PR TITLE
Set: `forceConsistentCasingInFileNames` rule to true (tsconfig)

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "forceConsistentCasingInFileNames": true,
     "allowJs": true,
     "allowSyntheticDefaultImports": true,
     "checkJs": true,


### PR DESCRIPTION
Set: `forceConsistentCasingInFileNames` rule to true (tsconfig)

This is recommended by Typescript:
https://typescriptlang.org/tsconfig/#forceConsistentCasingInFileNames

I've had this option set locally for and lint and test scripts complete without issues

I discovered this by using [WebHint VS Code extension](https://webhint.io/docs/user-guide/extensions/vscode-webhint/) which also recommend using it. 
https://webhint.io/docs/user-guide/hints/hint-typescript-config/consistent-casing

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [ ] Link to related issues.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [ ] Add an entry to `CHANGELOG.md` under the `## main` section.
