### PR TITLE
Don't reuse old requestedCameraState.

### DIFF
--- a/src/ui/camera.ts
+++ b/src/ui/camera.ts
@@ -308,10 +308,6 @@ export abstract class Camera extends Evented {
         this._zooming = false;
         this.transform = transform;
         this._bearingSnap = options.bearingSnap;
-
-        this.on('moveend', () => {
-            delete this._requestedCameraState;
-        });
     }
 
     /**
@@ -1125,6 +1121,7 @@ export abstract class Camera extends Evented {
         if (bearing !== undefined) nextTransform.bearing = bearing;
         if (elevation !== undefined) nextTransform.elevation = elevation;
         this.transform.apply(nextTransform);
+        delete this._requestedCameraState;
     }
 
     _fireMoveEvents(eventData?: any) {

--- a/src/ui/camera.ts
+++ b/src/ui/camera.ts
@@ -1098,10 +1098,7 @@ export abstract class Camera extends Evented {
      */
     _getTransformForUpdate(): Transform {
         if (!this.transformCameraUpdate) return this.transform;
-
-        if (!this._requestedCameraState) {
-            this._requestedCameraState = this.transform.clone();
-        }
+        this._requestedCameraState = this.transform.clone();
         return this._requestedCameraState;
     }
 


### PR DESCRIPTION
Fixes unexpected camera jumps when transformCameraUpdate is specified and user is panning on maps with terrain (Fixes #4233).

Camera._getTransformForUpdate clones the transform on first call. After that, it is reused on later calls. I am not sure why, maybe only performance reasons? If the transform is cloned on every call (as changed by the PR), the jumps are gone. Could not find any problems yet and the tests run fine. Maybe I overlooked something. 

## Launch Checklist

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [ ] Add an entry to `CHANGELOG.md` under the `## main` section.
