### PR TITLE
Ensure `loseContext` exists before calling it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 - ⚠️ Allow breaking lines in labels before a left parenthesis ([#4138](https://github.com/maplibre/maplibre-gl-js/pull/4138))
 - ⚠️ Fix ignoring embedded line breaks when `symbol-placement` is `line` or `line-center` ([#4124](https://github.com/maplibre/maplibre-gl-js/pull/4124))
+- ⚠️ Ensure loseContext exists before calling it ([#4245](https://github.com/maplibre/maplibre-gl-js/pull/4245))
 - _...Add new stuff here..._
 
 ## 4.3.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 
 - ⚠️ Allow breaking lines in labels before a left parenthesis ([#4138](https://github.com/maplibre/maplibre-gl-js/pull/4138))
 - ⚠️ Fix ignoring embedded line breaks when `symbol-placement` is `line` or `line-center` ([#4124](https://github.com/maplibre/maplibre-gl-js/pull/4124))
-- ⚠️ Ensure loseContext exists before calling it ([#4245](https://github.com/maplibre/maplibre-gl-js/pull/4245))
+- Ensure loseContext exists before calling it ([#4245](https://github.com/maplibre/maplibre-gl-js/pull/4245))
 - _...Add new stuff here..._
 
 ## 4.3.2

--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -3154,7 +3154,7 @@ export class Map extends Camera {
 
         this._resizeObserver?.disconnect();
         const extension = this.painter.context.gl.getExtension('WEBGL_lose_context');
-        if (extension) extension.loseContext();
+        if (extension && extension.loseContext) extension.loseContext();
         this._canvas.removeEventListener('webglcontextrestored', this._contextRestored, false);
         this._canvas.removeEventListener('webglcontextlost', this._contextLost, false);
         DOM.remove(this._canvasContainer);

--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -3154,7 +3154,7 @@ export class Map extends Camera {
 
         this._resizeObserver?.disconnect();
         const extension = this.painter.context.gl.getExtension('WEBGL_lose_context');
-        if (extension && extension.loseContext) extension.loseContext();
+        if (extension?.loseContext) extension.loseContext();
         this._canvas.removeEventListener('webglcontextrestored', this._contextRestored, false);
         this._canvas.removeEventListener('webglcontextlost', this._contextLost, false);
         DOM.remove(this._canvasContainer);


### PR DESCRIPTION
@birkskyum Similar fix was necessary to get `plotly.js` working with `virtual-webgl` (v1).
See https://github.com/plotly/mapbox-gl-js/commit/71e2cfcc875e7a06d81154ba7d419ff3ecee92e4

This is for your brilliant pull request https://github.com/plotly/plotly.js/pull/7015
if you could possibly test a build with `make-baselines-virtual-webgl` to see if it passes on CircleCI 
or alternatively add the following script to the top of plotly.js `devtools/test_dashboard/index.js` and then `npm start` to test interactively.
```html
<script src="https://unpkg.com/browse/virtual-webgl@1.0.6/src/virtual-webgl.js"></script>
```

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [ ] Link to related issues.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [x] Add an entry to `CHANGELOG.md` under the `## main` section.
