### PR TITLE
Apply new contrast feature syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - ⚠️ Allow breaking lines in labels before a left parenthesis ([#4138](https://github.com/maplibre/maplibre-gl-js/pull/4138))
 - ⚠️ Fix ignoring embedded line breaks when `symbol-placement` is `line` or `line-center` ([#4124](https://github.com/maplibre/maplibre-gl-js/pull/4124))
 - Ensure loseContext exists before calling it ([#4245](https://github.com/maplibre/maplibre-gl-js/pull/4245))
+- Update deprecated `-ms-high-contrast` vendor prefix to `(forced-colors: active)` and `(prefers-color-scheme: light)` as appropriate ([#4250](https://github.com/maplibre/maplibre-gl-js/pull/4250))
 - _...Add new stuff here..._
 
 ## 4.3.2

--- a/src/css/maplibre-gl.css
+++ b/src/css/maplibre-gl.css
@@ -93,7 +93,7 @@
     box-shadow: 0 0 0 2px rgb(0 0 0 / 10%);
 }
 
-@media (-ms-high-contrast: active) {
+@media (forced-colors: active) {
     .maplibregl-ctrl-group:not(:empty) {
         box-shadow: 0 0 0 2px ButtonText;
     }
@@ -123,7 +123,7 @@
     background-position: center center;
 }
 
-@media (-ms-high-contrast: active) {
+@media (forced-colors: active) {
     .maplibregl-ctrl-icon {
         background-color: transparent;
     }
@@ -184,7 +184,7 @@
     background-image: svg-load("svg/maplibregl-ctrl-zoom-in.svg", fill: #333);
 }
 
-@media (-ms-high-contrast: active) {
+@media (forced-colors: active) {
     .maplibregl-ctrl button.maplibregl-ctrl-zoom-out .maplibregl-ctrl-icon {
         background-image: svg-load("svg/maplibregl-ctrl-zoom-out.svg", fill: #fff);
     }
@@ -194,7 +194,7 @@
     }
 }
 
-@media (-ms-high-contrast: black-on-white) {
+@media (forced-colors: active) and (prefers-color-scheme: light) {
     .maplibregl-ctrl button.maplibregl-ctrl-zoom-out .maplibregl-ctrl-icon {
         background-image: svg-load("svg/maplibregl-ctrl-zoom-out.svg", fill: #000);
     }
@@ -212,7 +212,7 @@
     background-image: svg-load("svg/maplibregl-ctrl-shrink.svg");
 }
 
-@media (-ms-high-contrast: active) {
+@media (forced-colors: active) {
     .maplibregl-ctrl button.maplibregl-ctrl-fullscreen .maplibregl-ctrl-icon {
         background-image: svg-load("svg/maplibregl-ctrl-fullscreen.svg", fill: #fff);
     }
@@ -222,7 +222,7 @@
     }
 }
 
-@media (-ms-high-contrast: black-on-white) {
+@media (forced-colors: active) and (prefers-color-scheme: light) {
     .maplibregl-ctrl button.maplibregl-ctrl-fullscreen .maplibregl-ctrl-icon {
         background-image: svg-load("svg/maplibregl-ctrl-fullscreen.svg", fill: #000);
     }
@@ -236,7 +236,7 @@
     background-image: svg-load("svg/maplibregl-ctrl-compass.svg", fill: #333);
 }
 
-@media (-ms-high-contrast: active) {
+@media (forced-colors: active) {
     .maplibregl-ctrl button.maplibregl-ctrl-compass .maplibregl-ctrl-icon {
         @svg-load ctrl-compass-white url("svg/maplibregl-ctrl-compass.svg") {
             fill: #fff;
@@ -247,7 +247,7 @@
     }
 }
 
-@media (-ms-high-contrast: black-on-white) {
+@media (forced-colors: active) and (prefers-color-scheme: light) {
     .maplibregl-ctrl button.maplibregl-ctrl-compass .maplibregl-ctrl-icon {
         background-image: svg-load("svg/maplibregl-ctrl-compass.svg", fill: #000);
     }
@@ -351,7 +351,7 @@
     animation: maplibregl-spin 2s infinite linear;
 }
 
-@media (-ms-high-contrast: active) {
+@media (forced-colors: active) {
     .maplibregl-ctrl button.maplibregl-ctrl-geolocate .maplibregl-ctrl-icon {
         background-image: svg-inline(ctrl-geolocate-white);
     }
@@ -377,7 +377,7 @@
     }
 }
 
-@media (-ms-high-contrast: black-on-white) {
+@media (forced-colors: active) and (prefers-color-scheme: light) {
     .maplibregl-ctrl button.maplibregl-ctrl-geolocate .maplibregl-ctrl-icon {
         background-image: svg-inline(ctrl-geolocate-black);
     }
@@ -407,7 +407,7 @@ a.maplibregl-ctrl-logo.maplibregl-compact {
     width: 14px;
 }
 
-@media (-ms-high-contrast: active) {
+@media (forced-colors: active) {
     a.maplibregl-ctrl-logo {
         @svg-load ctrl-logo-white url("svg/maplibregl-ctrl-logo.svg") {
             #outline { opacity: 1; }
@@ -419,7 +419,7 @@ a.maplibregl-ctrl-logo.maplibregl-compact {
     }
 }
 
-@media (-ms-high-contrast: black-on-white) {
+@media (forced-colors: active) and (prefers-color-scheme: light) {
     a.maplibregl-ctrl-logo {
         @svg-load ctrl-logo-black url("svg/maplibregl-ctrl-logo.svg") {
             #outline { opacity: 1; fill: #fff; stroke: #fff; }
@@ -523,13 +523,13 @@ a.maplibregl-ctrl-logo.maplibregl-compact {
     }
 }
 
-@media screen and (-ms-high-contrast: active) {
+@media screen and (forced-colors: active) {
     .maplibregl-ctrl-attrib.maplibregl-compact::after {
         background-image: svg-load("svg/maplibregl-ctrl-attrib.svg", fill=#fff);
     }
 }
 
-@media screen and (-ms-high-contrast: black-on-white) {
+@media screen and (forced-colors: active) and (prefers-color-scheme: light) {
     .maplibregl-ctrl-attrib.maplibregl-compact::after {
         background-image: svg-load("svg/maplibregl-ctrl-attrib.svg");
     }


### PR DESCRIPTION
## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [x] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [x] Add an entry to `CHANGELOG.md` under the `## main` section.

Fixes #4193: -ms-high-contrast vendor prefix is being deprecated, as per: https://blogs.windows.com/msedgedev/2020/09/17/styling-for-windows-high-contrast-with-new-standards-for-forced-colors/

This PR merges to main, but note in the linked issue that it is suggested this may be a breaking change...? I don't believe it is a breaking change - the behaviour for MS Edge remains unchanged, and the PR fixes a previously unknown issue with Firefox (potentially other browsers).

## Before/after visuals

Used Windows in high contrast mode to test.

### Edge

#### Before
![Edge_current](https://github.com/maplibre/maplibre-gl-js/assets/19925993/e0639ecd-1056-4e74-9f95-110aa70cd157)

#### After
![Edge_post-fix](https://github.com/maplibre/maplibre-gl-js/assets/19925993/ba309a76-aa03-4920-87eb-2f957872eba2)

Console warning is no longer present.

### Firefox

#### Before
Note that Firefox did not appear to be working correctly beforehand (contrast of button elements too low):
![Firefox_current](https://github.com/maplibre/maplibre-gl-js/assets/19925993/0622ada5-9927-44a3-a955-818292ef9b05)

#### After
![Firefox_post-fix](https://github.com/maplibre/maplibre-gl-js/assets/19925993/52477063-7531-4923-8e19-616b3a12de03)

