### PR TITLE
Add Google Maps plugin link

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -149,6 +149,10 @@ A library for making it easier to use Esri services in MapLibre GL JS. Supports 
 A library for retrieving tiles from single-file, cloud-storage-optimized PMTiles archives, which don't require running a server or API.
 <br/><small>[View on GitHub](https://github.com/protomaps/PMTiles)</small>
 
+#### maplibre-google-maps
+A library for integrating Google Maps as raster layers into MapLibre GL JS. It uses the new Google Map Tiles API.
+<br/><small>[View on GitHub](https://github.com/traccar/maplibre-google-maps)</small>
+
 ##  Framework Integrations
 
 #### echartslayer


### PR DESCRIPTION
## Launch Checklist

A small plugin to use Google Maps with MapLibre. We had a lot of requests to integrate it in our own open source project and I think it will be useful for many others.