### PR TITLE
Upgrade CONTRIBUTING.md node.js version from ^18 to ^20.10

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,7 +54,7 @@ Install the Xcode Command Line Tools Package
 xcode-select --install
 ```
 
-Install [node.js](https://nodejs.org/) version ^20.10
+Install [node.js](https://nodejs.org/) version in [.nvmrc](.nvmrc)
 ```bash
 brew install node
 ```
@@ -138,7 +138,7 @@ Before you can [run the docs](./docs/README.md), you need to ensure Docker is in
 
 Consider using WSL and follow the above Linux guide or follow the next steps
 
-Install [git](https://git-scm.com/), [node.js](https://nodejs.org/) (version ^20.10), [npm and node-gyp](https://github.com/Microsoft/nodejs-guidelines/blob/master/windows-environment.md#compiling-native-addon-modules).
+Install [git](https://git-scm.com/), [node.js](https://nodejs.org/) (version in [.nvmrc](.nvmrc)), [npm and node-gyp](https://github.com/Microsoft/nodejs-guidelines/blob/master/windows-environment.md#compiling-native-addon-modules).
 
 Clone the repository
 ```bash


### PR DESCRIPTION
## Summary

Related with #3452, upgrade [CONTRIBUTING.md](https://github.com/maplibre/maplibre-gl-js/blob/v4.3.2/CONTRIBUTING.md) node.js version from `^18` to `^20.10`.

## Background

I encountered the following build error on my macOS 14.5 Apple Silicon + asdf Node.js 18.18.0 environment,
so I need to upgrade node.js to 20.10.0 which is defined in [.nvmrc](https://github.com/maplibre/maplibre-gl-js/blob/main/.nvmrc).

<details>
<summary>Lower Node.js version error details on macOS:</summary>

### Node.js v18.18.0
```bash
% npm install --build-from-source
npm ERR! code EBADENGINE
npm ERR! engine Unsupported engine
npm ERR! engine Not compatible with your version of node/npm: builtin-modules@4.0.0
npm ERR! notsup Not compatible with your version of node/npm: builtin-modules@4.0.0
npm ERR! notsup Required: {"node":">=18.20"}
npm ERR! notsup Actual:   {"npm":"9.8.1","node":"v18.18.0"}
```
### Node.js v20.0.0
```bash
% npm install --build-from-source
npm ERR! code EBADENGINE
npm ERR! engine Unsupported engine
npm ERR! engine Not compatible with your version of node/npm: cssnano@7.0.2
npm ERR! notsup Not compatible with your version of node/npm: cssnano@7.0.2
npm ERR! notsup Required: {"node":"^18.12.0 || ^20.9.0 || >=22.0"}
npm ERR! notsup Actual:   {"npm":"9.6.4","node":"v20.0.0"}
```

</details>

## Launch Checklist

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [ ] Link to related issues.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [ ] Add an entry to `CHANGELOG.md` under the `## main` section.
