### PR TITLE
Prevent forks from attempting to publish the npm package (resulting in errors)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ jobs:
   release-check:
     name: Check if version changed
     runs-on: ubuntu-latest
+    if: github.repository == 'maplibre/maplibre-gl-js'
     defaults:
       run:
         shell: bash


### PR DESCRIPTION
This changes the GitHub Action to prevent forks from attempting to publish the npm package (resulting in errors) which could be frustrating for contributors.

e.g.
![image](https://github.com/maplibre/maplibre-gl-js/assets/1212885/cc49ad57-330f-4d69-9570-0f0933672ed4)



## Launch Checklist

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [ ] Link to related issues.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [ ] Add an entry to `CHANGELOG.md` under the `## main` section.
