### PR TITLE
examples: disable kbd rotation (#4330)

### DIFF
--- a/test/examples/disable-rotation.html
+++ b/test/examples/disable-rotation.html
@@ -26,6 +26,9 @@
     // disable map rotation using right click + drag
     map.dragRotate.disable();
 
+    // disable map rotation using keyboard
+    map.keyboard.disable();
+
     // disable map rotation using touch rotation gesture
     map.touchZoomRotate.disableRotation();
 </script>


### PR DESCRIPTION
The `disable-rotation` example currently disables camera rotation via right click + drag and touch gestures. However, keyboard-based rotation remains enabled.

Let's ensure that rotation via keyboard input is also disabled such that we provide a comprehensive example of how to fully disable map rotation.

This fixes: https://github.com/maplibre/maplibre-gl-js/issues/4330.

![Screenshot 2024-06-26 154455](https://github.com/maplibre/maplibre-gl-js/assets/50264607/c55b20a6-eb78-4d51-8516-0e2c1f9348fb)

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [x] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [ ] Add an entry to `CHANGELOG.md` under the `## main` section.
