### PR TITLE
Fix null color in packColor function when using setFeatureState

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🐞 Bug fixes
 
-- _...Add new stuff here..._
+- packColor function can now handle null values. Eliminates feature rendering from crashing when using setFeatureState function.
 
 ## 4.5.0
 

--- a/src/data/program_configuration.ts
+++ b/src/data/program_configuration.ts
@@ -35,12 +35,7 @@ export type BinderUniform = {
     binding: Uniform<any>;
 };
 
-export function packColor(color: Color): [number, number] {
-    if (!color) {
-        console.warn("Color is null, switching to default color");
-        color = Color.black;
-    }
-
+function packColor(color: Color): [number, number] {
     return [
         packUint8ToFloat(255 * color.r, 255 * color.g),
         packUint8ToFloat(255 * color.b, 255 * color.a)

--- a/src/data/program_configuration.ts
+++ b/src/data/program_configuration.ts
@@ -35,7 +35,12 @@ export type BinderUniform = {
     binding: Uniform<any>;
 };
 
-function packColor(color: Color): [number, number] {
+export function packColor(color: Color): [number, number] {
+    if (!color) {
+        console.warn("Color is null, switching to default color");
+        color = Color.black;
+    }
+
     return [
         packUint8ToFloat(255 * color.r, 255 * color.g),
         packUint8ToFloat(255 * color.b, 255 * color.a)

--- a/src/style/color.test.ts
+++ b/src/style/color.test.ts
@@ -1,0 +1,16 @@
+// test/unit/util/color.test.ts
+
+import { packColor } from '../data/program_configuration';
+import { packUint8ToFloat } from '../shaders/encode_attribute'; // Ensure this function is imported or defined if needed
+
+describe('packColor', () => {
+    it('should handle null colors', () => {
+        const defaultPackedColor = packColor(null);
+        const expectedPackedColor = [
+            packUint8ToFloat(0, 0),
+            packUint8ToFloat(0, 255)
+        ];
+
+        expect(defaultPackedColor).toEqual(expectedPackedColor);
+    });
+});


### PR DESCRIPTION
This should show the failing test for color.test.ts under a draft PR request as directed by the CONTRIBUTION.md

Current version should fail the color.tests.ts because packColor function cannot handle null values.