### PR TITLE
Add Allmaps as available plugin

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -27,7 +27,6 @@ Adds support for drawing and editing features on maps.
 <br/><small>[View on GitHub](https://github.com/mapbox/mapbox-gl-draw)</small>
 
 #### terra-draw
-
 Provides a MapLibre GL JS adapter to allow creation, selection and editing of geometries.
 <br/><small>[View on GitHub](https://github.com/JamesLMilner/terra-draw)</small>
 
@@ -152,6 +151,11 @@ A library for retrieving tiles from single-file, cloud-storage-optimized PMTiles
 #### maplibre-google-maps
 A library for integrating Google Maps as raster layers into MapLibre GL JS. It uses the new Google Map Tiles API.
 <br/><small>[View on GitHub](https://github.com/traccar/maplibre-google-maps)</small>
+
+#### allmaps-maplibre
+
+A package for displaying georeferenced [IIIF](https://iiif.io/) images by loading [Georeference Annotations](https://preview.iiif.io/api/georef/extension/georef/) and using WebGL to transform and overlay the images on their correct geographical position.
+<br/><small>[View on GitHub](https://github.com/allmaps/allmaps/tree/main/packages/maplibre)</small>
 
 ##  Framework Integrations
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -153,7 +153,6 @@ A library for integrating Google Maps as raster layers into MapLibre GL JS. It u
 <br/><small>[View on GitHub](https://github.com/traccar/maplibre-google-maps)</small>
 
 #### allmaps-maplibre
-
 A package for displaying georeferenced [IIIF](https://iiif.io/) images by loading [Georeference Annotations](https://preview.iiif.io/api/georef/extension/georef/) and using WebGL to transform and overlay the images on their correct geographical position.
 <br/><small>[View on GitHub](https://github.com/allmaps/allmaps/tree/main/packages/maplibre)</small>
 


### PR DESCRIPTION
## Launch Checklist

This PR add the [Allmaps Maplibre](https://github.com/allmaps/allmaps/tree/main/packages/maplibre) plugin to the plugin list.

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.

(also removes an extra 'enter' near the Terra Draw plugin)
(example might be coming in future PR)