### PR TITLE
Upload test results in case of failure

### DIFF
--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -51,6 +51,11 @@ jobs:
           echo "DISPLAY=:0" >> $GITHUB_ENV
       - run: npm ci
       - run: npm run test-unit-ci
+      - name: Upload test results to Codecov
+        if: '!cancelled()'
+        uses: codecov/test-results-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v4
         with:
@@ -58,10 +63,7 @@ jobs:
           verbose: true
           token: ${{ secrets.CODECOV_TOKEN }}
           disable_search: true
-      - name: Upload test results to Codecov
-        uses: codecov/test-results-action@v1
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+      
 
 
   integration-tests:


### PR DESCRIPTION
Uploads the test results even in case of failure.
This will hopefully allow in the future to take note of flickering tests.
