### PR TITLE
filter 3d-buildings example by hide_3d property

### DIFF
--- a/test/examples/3d-buildings.html
+++ b/test/examples/3d-buildings.html
@@ -52,6 +52,7 @@
               'source-layer': 'building',
               'type': 'fill-extrusion',
               'minzoom': 15,
+              'filter': ['!=', ['get', 'hide_3d'], true],
               'paint': {
                   'fill-extrusion-color': [
                       'interpolate',


### PR DESCRIPTION
## Launch Checklist

This PR updates the 3D Buildings example to filter out buildings with the `hide_3d` property.

before:
![image](https://github.com/user-attachments/assets/b6f0070a-cac3-4064-a1b5-1053ee55f052)

after:
![image](https://github.com/user-attachments/assets/9014cb66-e36f-418e-a78e-f69c8f8c84da)


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [ ] Link to related issues.
 - [x] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [ ] Add an entry to `CHANGELOG.md` under the `## main` section.
