### PR TITLE
fix missing icon ref in example

### DIFF
--- a/test/examples/change-case-of-labels.html
+++ b/test/examples/change-case-of-labels.html
@@ -35,7 +35,7 @@
             'type': 'symbol',
             'source': 'off-leash-areas',
             'layout': {
-                'icon-image': 'dog-park-11',
+                'icon-image': 'dog_park',
                 'text-field': [
                     'format',
                     ['upcase', ['get', 'FacilityName']],


### PR DESCRIPTION
## Launch Checklist

the "Change the case of labels" references `dog_park_11` which isn't a valid icon in the style, this updates it to `dog_park`.


before:
![image](https://github.com/user-attachments/assets/75e40435-0b9c-4f85-ad82-e46a61821b59)

after:
![image](https://github.com/user-attachments/assets/cd9b16c7-1a90-490b-8619-ce7d0dedef6e)


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [ ] Link to related issues.
 - [x] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [ ] Add an entry to `CHANGELOG.md` under the `## main` section.
