### PR TITLE
Allow pinch trackpad gesture while cooperative gestures is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## main
 
+- Allow trackpad pinch gestures to break through the `cooperativeGestures` setting, bringing it in line with other embedded map behaviours, such as Google Maps and Mapbox. ([#4465](https://github.com/maplibre/maplibre-gl-js/pull/4465))
+
 ### ✨ Features and improvements
 
 - Expose projection matrix parameters ([#3136](https://github.com/maplibre/maplibre-gl-js/pull/3136))

--- a/src/ui/handler/cooperative_gestures.test.ts
+++ b/src/ui/handler/cooperative_gestures.test.ts
@@ -1,8 +1,8 @@
-import { browser } from '../../util/browser';
+import {browser} from '../../util/browser';
 import {Map} from '../map';
-import { DOM } from '../../util/dom';
+import {DOM} from '../../util/dom';
 import simulate from '../../../test/unit/lib/simulate_interaction';
-import { beforeMapTest, sleep } from '../../util/test/util';
+import {beforeMapTest, sleep} from '../../util/test/util';
 
 function createMap(cooperativeGestures) {
     return new Map({

--- a/src/ui/handler/cooperative_gestures.test.ts
+++ b/src/ui/handler/cooperative_gestures.test.ts
@@ -1,8 +1,8 @@
-import {browser} from '../../util/browser';
+import { browser } from '../../util/browser';
 import {Map} from '../map';
-import {DOM} from '../../util/dom';
+import { DOM } from '../../util/dom';
 import simulate from '../../../test/unit/lib/simulate_interaction';
-import {beforeMapTest, sleep} from '../../util/test/util';
+import { beforeMapTest, sleep } from '../../util/test/util';
 
 function createMap(cooperativeGestures) {
     return new Map({
@@ -85,6 +85,39 @@ describe('CoopGesturesHandler', () => {
         const startZoom = map.getZoom();
         // simulate a single 'wheel' event
         simulate.wheel(map.getCanvas(), {type: 'wheel', deltaY: -simulate.magicWheelZoomDelta, ctrlKey: true});
+        map._renderTaskQueue.run();
+
+        now += 400;
+        browserNow.mockReturnValue(now);
+        map._renderTaskQueue.run();
+
+        const endZoom = map.getZoom();
+        expect(endZoom - startZoom).toBeCloseTo(0.0285, 3);
+
+        map.remove();
+    });
+
+    test('Zooms on trackpad pinch when metaKey is the bypass key', () => {
+        // NOTE: This should pass regardless of whether cooperativeGestures is enabled or not
+        const browserNow = jest.spyOn(browser, 'now');
+        let now = 1555555555555;
+        browserNow.mockReturnValue(now);
+
+        const map = createMap(true);
+
+        // pretend we're on a Mac, where the ctrlKey isn't the bypassKey
+        map.cooperativeGestures._bypassKey = 'metaKey';
+        map._renderTaskQueue.run();
+
+        const startZoom = map.getZoom();
+        // simulate a single 'wheel' trackpad pinch event
+        simulate.wheel(map.getCanvas(), {
+            type: 'wheel',
+            deltaY: -simulate.magicWheelZoomDelta,
+
+            // this is how a browser identifies a trackpad pinch
+            ctrlKey: true
+        });
         map._renderTaskQueue.run();
 
         now += 400;

--- a/src/ui/handler/cooperative_gestures.ts
+++ b/src/ui/handler/cooperative_gestures.ts
@@ -1,7 +1,7 @@
-import {DOM} from '../../util/dom';
-import {Handler} from '../handler_manager';
+import { DOM } from '../../util/dom';
+import { Handler } from '../handler_manager';
 
-import type {Map} from '../map';
+import type { Map } from '../map';
 
 /**
  * The {@link CooperativeGesturesHandler} options object for the gesture settings
@@ -97,7 +97,20 @@ export class CooperativeGesturesHandler implements Handler {
         if (!this._map.scrollZoom.isEnabled()) {
             return;
         }
-        this._onCooperativeGesture(!e[this._bypassKey]);
+        
+        const isPrevented = this.shouldPreventWheelEvent(e);
+        this._onCooperativeGesture(isPrevented);
+    }
+
+    shouldPreventWheelEvent(e: WheelEvent) {
+        if (!this.isEnabled()) {
+            return false;
+        }
+
+        const isTrackpadPinch = e.ctrlKey;
+        const isBypassed = e[this._bypassKey] || isTrackpadPinch;
+
+        return !isBypassed;
     }
 
     _onCooperativeGesture(showNotification: boolean) {

--- a/src/ui/handler/cooperative_gestures.ts
+++ b/src/ui/handler/cooperative_gestures.ts
@@ -1,7 +1,7 @@
-import { DOM } from '../../util/dom';
-import { Handler } from '../handler_manager';
+import {DOM} from '../../util/dom';
+import {Handler} from '../handler_manager';
 
-import type { Map } from '../map';
+import type {Map} from '../map';
 
 /**
  * The {@link CooperativeGesturesHandler} options object for the gesture settings
@@ -97,7 +97,7 @@ export class CooperativeGesturesHandler implements Handler {
         if (!this._map.scrollZoom.isEnabled()) {
             return;
         }
-        
+
         const isPrevented = this.shouldPreventWheelEvent(e);
         this._onCooperativeGesture(isPrevented);
     }

--- a/src/ui/handler/scroll_zoom.ts
+++ b/src/ui/handler/scroll_zoom.ts
@@ -1,15 +1,15 @@
-import { DOM } from '../../util/dom';
+import {DOM} from '../../util/dom';
 
 import {defaultEasing, bezier} from '../../util/util';
 import {browser} from '../../util/browser';
-import { interpolates } from '@maplibre/maplibre-gl-style-spec';
-import { LngLat } from '../../geo/lng_lat';
-import { TransformProvider } from './transform-provider';
+import {interpolates} from '@maplibre/maplibre-gl-style-spec';
+import {LngLat} from '../../geo/lng_lat';
+import {TransformProvider} from './transform-provider';
 
 import type {Map} from '../map';
 import type Point from '@mapbox/point-geometry';
 import type {AroundCenterOptions} from './two_fingers_touch';
-import { Handler } from '../handler_manager';
+import {Handler} from '../handler_manager';
 
 // deltaY value for mouse scroll wheel identification
 const wheelZoomDelta = 4.000244140625;

--- a/src/ui/handler/scroll_zoom.ts
+++ b/src/ui/handler/scroll_zoom.ts
@@ -1,15 +1,15 @@
-import {DOM} from '../../util/dom';
+import { DOM } from '../../util/dom';
 
 import {defaultEasing, bezier} from '../../util/util';
 import {browser} from '../../util/browser';
-import {interpolates} from '@maplibre/maplibre-gl-style-spec';
-import {LngLat} from '../../geo/lng_lat';
-import {TransformProvider} from './transform-provider';
+import { interpolates } from '@maplibre/maplibre-gl-style-spec';
+import { LngLat } from '../../geo/lng_lat';
+import { TransformProvider } from './transform-provider';
 
 import type {Map} from '../map';
 import type Point from '@mapbox/point-geometry';
 import type {AroundCenterOptions} from './two_fingers_touch';
-import {Handler} from '../handler_manager';
+import { Handler } from '../handler_manager';
 
 // deltaY value for mouse scroll wheel identification
 const wheelZoomDelta = 4.000244140625;
@@ -151,7 +151,7 @@ export class ScrollZoomHandler implements Handler {
 
     wheel(e: WheelEvent) {
         if (!this.isEnabled()) return;
-        if (this._map.cooperativeGestures.isEnabled() && !e[this._map.cooperativeGestures._bypassKey]) {
+        if (this._map.cooperativeGestures.shouldPreventWheelEvent(e)) {
             return;
         }
         let value = e.deltaMode === WheelEvent.DOM_DELTA_LINE ? e.deltaY * 40 : e.deltaY;

--- a/test/build/min.test.ts
+++ b/test/build/min.test.ts
@@ -1,5 +1,5 @@
 import fs from 'fs';
-import packageJson from '../../package.json' with {type: 'json'};
+import packageJson from '../../package.json' with { type: 'json' };
 
 const minBundle = fs.readFileSync('dist/maplibre-gl.js', 'utf8');
 
@@ -36,7 +36,7 @@ describe('test min build', () => {
         const decreaseQuota = 4096;
 
         // feel free to update this value after you've checked that it has changed on purpose :-)
-        const expectedBytes = 799999;
+        const expectedBytes = 800300;
 
         expect(actualBytes - expectedBytes).toBeLessThan(increaseQuota);
         expect(expectedBytes - actualBytes).toBeLessThan(decreaseQuota);


### PR DESCRIPTION
## What this does

Enables pinching on a trackpad to zoom the map while `cooperativeGestures` is enabled.

Fixes #4463

## Implementation

A pinch on a trackpad is actually a `wheel` event but with `ctrlKey: true`. This change adds a new method to the `CooperativeGesturesHandler` called `shouldPreventWheelEvent` which is used internally for deciding whether to show the cooperative gestures message, and from the `ScrollZoomHandler::wheel` method, to determine whether or not to handle the gesture in the map.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [X] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [X] Briefly describe the changes in this PR.
 - [X] Link to related issues.
 - [X] Write tests for all new functionality.
 - [X] Add an entry to `CHANGELOG.md` under the `## main` section.
