### PR TITLE
Add maplibre-gl-dates to plugin directory

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -125,6 +125,9 @@ Render a geographic flow map visualization from a spreadsheet published on Googl
 Adds elevation contour lines to a map from raster-dem tiles.
 <br/><small>[View on GitHub](https://github.com/onthegomap/maplibre-contour)</small>
 
+#### maplibre-gl-dates
+Filters a time-enabled map by date. Optimized for OpenHistoricalMap vector tiles.
+<br/><small>[View on GitHub](https://github.com/OpenHistoricalMap/maplibre-gl-dates/)</small>
 
 ## Layer Types
 


### PR DESCRIPTION
Added a link to the [maplibre-gl-dates](https://github.com/OpenHistoricalMap/maplibre-gl-dates/) plugin to the Plugins page. This plugin is [recommended](https://wiki.openstreetmap.org/wiki/OpenHistoricalMap/Reuse#Rendering_a_map) for any MapLibre GL JS map based on OpenHistoricalMap vector tiles, though technically it also works with any OSM vector tiles that expose the same tags.