### PR TITLE
WIP - Allow importing .ts files instead of sloppy imports

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "forceConsistentCasingInFileNames": true,
     "allowJs": true,
+    "allowImportingTsExtensions": true,
     "allowSyntheticDefaultImports": true,
     "checkJs": true,
     "isolatedModules": false,


### PR DESCRIPTION
This TS 5.0 [feature](https://www.typescriptlang.org/tsconfig/#allowImportingTsExtensions) allow us to incrementally move beyond sloppy imports and use .ts extensions like

`import { namedImport } from "./file.ts"`

I've update the ./src/util/ folder in a separate commit here to validate it's effect

 - [X] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
