### PR TITLE
Move changelog entry for Arabic Extended-B fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes
+- Fix right-to-left layout of labels that contain characters in the Arabic Extended-B code block. ([#4536](https://github.com/maplibre/maplibre-gl-js/pull/4536))
 - _...Add new stuff here..._
 
 ## 4.5.2
@@ -16,7 +17,6 @@
 ### 🐞 Bug fixes
 
 - Fix camera being able to move into 3D terrain ([#1542](https://github.com/maplibre/maplibre-gl-js/issues/1542))
-- Fix right-to-left layout of labels that contain characters in the Arabic Extended-B code block. ([#4536](https://github.com/maplibre/maplibre-gl-js/pull/4536))
 
 ## 4.5.1
 


### PR DESCRIPTION
Fixed a bad conflict resolution on my part in #4536 that put the changelog entry under the wrong heading.