### PR TITLE
Remove postcss-inline-svg overrides because of upsteam fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -138,14 +138,6 @@
     "typedoc-plugin-missing-exports": "^3.0.0",
     "typescript": "^5.5.4"
   },
-  "overrides": {
-    "postcss-inline-svg": {
-      "css-select": "^5.1.0",
-      "dom-serializer": "^2.0.0",
-      "htmlparser2": "^8.0.1",
-      "postcss-value-parser": "^4.2.0"
-    }
-  },
   "scripts": {
     "generate-dist-package": "node --no-warnings --loader ts-node/esm build/generate-dist-package.js",
     "generate-shaders": "node --no-warnings --loader ts-node/esm build/generate-shaders.ts",


### PR DESCRIPTION
In Jan 2023, I noticed we had a security bug, in a dependency `postcss-inline-svg`, because of a dependency it had.

There was already a ticket in the repo to update said deps:
- https://github.com/TrySound/postcss-inline-svg/pull/103

But until it got merged/released, we could fix it locally by using overrides.

This has now been fixed upstream since v6 of postcss-inline-svg, which we already use. This version use the exact same versions of nested deps as we set in the overrides (can be verified in the [package.json](https://github.com/TrySound/postcss-inline-svg/blob/master/package.json), and by the fact our lockfile doesn't change after this), so it's now ready to be cleaned up.


 - [X] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!