### PR TITLE
omit a warning if maxzoom <= clusterMaxZoom for geojson sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### ✨ Features and improvements
 - Support multiple layers in `map.on`, `map.once` and `map.off` methods ([#4279](https://github.com/maplibre/maplibre-gl-js/pull/4401))
+- Ensure GeoJSON cluster sources emit a console warning if `maxzoom` is less than or equal to `clusterMaxZoom` since in this case you may see unexpected results. ([#4604](https://github.com/maplibre/maplibre-gl-js/pull/4604))
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes

--- a/src/source/geojson_source.test.ts
+++ b/src/source/geojson_source.test.ts
@@ -68,11 +68,11 @@ describe('GeoJSONSource#constructor', () => {
         source.map = mapStub;
         source.load();
 
-        expect(warn).toHaveBeenCalledWith('The maxzoom value "4" is expected to be greater than the clusterMaxZoom value "4".')
+        expect(warn).toHaveBeenCalledWith('The maxzoom value "4" is expected to be greater than the clusterMaxZoom value "4".');
 
         warn.mockRestore();
     });
-})
+});
 
 describe('GeoJSONSource#setData', () => {
     function createSource(opts?) {

--- a/src/source/geojson_source.test.ts
+++ b/src/source/geojson_source.test.ts
@@ -55,6 +55,25 @@ const hawkHill = {
     }]
 } as GeoJSON.GeoJSON;
 
+describe('GeoJSONSource#constructor', () => {
+    const mapStub = {
+        _requestManager: {
+            transformRequest: (url) => { return {url}; }
+        }
+    } as any;
+    test('warn if maxzoom <= clusterMaxZoom', () => {
+        const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+        const source = new GeoJSONSource('id', {data: hawkHill, maxzoom: 4, clusterMaxZoom: 4} as GeoJSONSourceOptions, mockDispatcher, undefined);
+        source.map = mapStub;
+        source.load();
+
+        expect(warn).toHaveBeenCalledWith('The maxzoom value "4" is expected to be greater than the clusterMaxZoom value "4".')
+
+        warn.mockRestore();
+    });
+})
+
 describe('GeoJSONSource#setData', () => {
     function createSource(opts?) {
         opts = opts || {};

--- a/src/source/geojson_source.ts
+++ b/src/source/geojson_source.ts
@@ -4,6 +4,7 @@ import {extend} from '../util/util';
 import {EXTENT} from '../data/extent';
 import {ResourceType} from '../util/request_manager';
 import {browser} from '../util/browser';
+import {warnOnce} from '../util/util';
 
 import type {Source} from './source';
 import type {Map} from '../ui/map';
@@ -157,6 +158,10 @@ export class GeoJSONSource extends Evented implements Source {
         this.promoteId = options.promoteId;
 
         const scale = EXTENT / this.tileSize;
+
+        if (options.clusterMaxZoom !== undefined && this.maxzoom <= options.clusterMaxZoom) {
+            warnOnce(`The maxzoom value "${this.maxzoom}" is expected to be greater than the clusterMaxZoom value "${options.clusterMaxZoom}".`);
+        }
 
         // sent to the worker, along with `url: ...` or `data: literal geojson`,
         // so that it can load/parse/index the geojson data

--- a/src/source/geojson_source.ts
+++ b/src/source/geojson_source.ts
@@ -1,10 +1,9 @@
 import {Event, ErrorEvent, Evented} from '../util/evented';
 
-import {extend} from '../util/util';
+import {extend, warnOnce} from '../util/util';
 import {EXTENT} from '../data/extent';
 import {ResourceType} from '../util/request_manager';
 import {browser} from '../util/browser';
-import {warnOnce} from '../util/util';
 
 import type {Source} from './source';
 import type {Map} from '../ui/map';


### PR DESCRIPTION
closes #2691

> `clusterMaxZoom`: Max zoom on which to cluster points if clustering is enabled. Defaults to one zoom less than maxzoom (so that last zoom features are not clustered). Clusters are re-evaluated at integer zoom levels so setting clusterMaxZoom to 14 means the clusters will be displayed until z15.

If you set `clusterMaxZoom` to 18, clusters will continue to display >=18 <19 (up to 18.99...). To ensure you're still rending the source unclustered at z19 you need to have the source `maxzoom` set to at least 19.

If you the source `maxzoom` is less than or equal to the `clusterMaxZoom` then it won't stop clustering in the way you might expected based on your set `clusterMaxZoom` in this case we should emit a warning.

## Launch Checklist

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [ ] Add an entry to `CHANGELOG.md` under the `## main` section.
