### PR TITLE
geojson clusterArrayType option

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@mapbox/unitbezier": "^0.0.1",
     "@mapbox/vector-tile": "^1.3.1",
     "@mapbox/whoots-js": "^3.1.0",
-    "@maplibre/maplibre-gl-style-spec": "^20.3.1",
+    "@maplibre/maplibre-gl-style-spec": "andrewharvey/maplibre-gl-style-spec#cluster-array-type",
     "@types/geojson": "^7946.0.14",
     "@types/geojson-vt": "3.2.5",
     "@types/mapbox__point-geometry": "^0.1.4",
@@ -40,7 +40,7 @@
     "pbf": "^3.3.0",
     "potpack": "^2.0.0",
     "quickselect": "^3.0.0",
-    "supercluster": "^8.0.1",
+    "supercluster": "andrewharvey/supercluster#244",
     "tinyqueue": "^3.0.0",
     "vt-pbf": "^3.1.3"
   },

--- a/src/source/geojson_source.ts
+++ b/src/source/geojson_source.ts
@@ -30,6 +30,7 @@ export type GeoJSONSourceInternalOptions = {
     clusterMaxZoom?: number;
     clusterRadius?: number;
     clusterMinPoints?: number;
+    clusterArrayType?: "Float32Array" | "Float64Array";
     generateId?: boolean;
 }
 
@@ -179,7 +180,8 @@ export class GeoJSONSource extends Evented implements Source {
                 extent: EXTENT,
                 radius: (options.clusterRadius || 50) * scale,
                 log: false,
-                generateId: options.generateId || false
+                generateId: options.generateId || false,
+                arrayType: options.clusterArrayType || 'Float32Array'
             },
             clusterProperties: options.clusterProperties,
             filter: options.filter

--- a/src/source/geojson_worker_source.ts
+++ b/src/source/geojson_worker_source.ts
@@ -299,5 +299,11 @@ function getSuperclusterOptions({superclusterOptions, clusterProperties}: LoadGe
         }
     };
 
+    // convert String option value into a TypedArray constructor
+    const arrayTypes = {
+        Float32Array, Float64Array
+    };
+    superclusterOptions.arrayType = arrayTypes[superclusterOptions.arrayType];
+
     return superclusterOptions;
 }


### PR DESCRIPTION
At high clusterMaxZoom values and low clusterRadius values with data very close together, the default supercluster Float32Array type starts causing some features to cluster when they shouldn't based on your set clusterRadius.

To resolve this I've exposed an option on cluster sources to set the supercluster type to Float64Array.

I've posted this PR as a WIP for now as I don't think we should actually expose this option like this. I'm thinking we should try to determine based on the clusterMaxZoom and clusterRadius set that (we we just assume there will be very close data present) if Float32Array would suffice or if we need Float64Array and set it transparently.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [ ] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [ ] Briefly describe the changes in this PR.
 - [ ] Link to related issues.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [ ] Add an entry to `CHANGELOG.md` under the `## main` section.
