### PR TITLE
fix flickering on map resize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ using `transformCameraUpdate` caused the `maxBounds` to stop working just for ea
 - Improve types a bit for `addSource` and `getSource` ([#4616](https://github.com/maplibre/maplibre-gl-js/pull/4616))
 - Fix the color near the horizon when terrain is enabled without any sky ([#4607](https://github.com/maplibre/maplibre-gl-js/pull/4607))
 - Fix bug where `fitBounds` and `cameraForBounds` would not display accross the 180th meridian (antimeridian)
+- Fix white flickering on map resize ([#4158](https://github.com/maplibre/maplibre-gl-js/pull/4158))
 - _...Add new stuff here..._
 
 ## 4.6.0

--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -638,7 +638,8 @@ export class Map extends Camera {
             let initialResizeEventCaptured = false;
             const throttledResizeCallback = throttle((entries: ResizeObserverEntry[]) => {
                 if (this._trackResize && !this._removed) {
-                    this.resize(entries)._update();
+                    this.resize(entries);
+                    this.redraw();
                 }
             }, 50);
             this._resizeObserver = new ResizeObserver((entries) => {


### PR DESCRIPTION
This PR fixes issue #4158.

When screen size changes, we immediately resize the canvas. Resizing canvas causes canvas to clear. Then, next render is scheduled using `_update` method. Because it is scheduled, and it happens asynchronously, in the time between the canvas is white.

There are two ways of solving the problem. Simple - in this PR, is to trigger render every time when canvas changes.
Other option would be to resize the canvas asynchronosly as well. I didn't try this approach, as it seems more complex, and I'm not sure if it is worth.

The downside of current approach is that the render might be called multiple time, which might impact performance. Although I'm not sure if this is an issue.

In this PR I replaced `_update` with `redraw` which happens immediately. Also `_update` also updates style and sources, which doesn't seem for me like something that should happen during resizing. Can you see any reason to do that?

In this PR https://github.com/maplibre/maplibre-gl-js/pull/4429 `_render` method was added, which is not ideal, because already frame was scheduled, and also triggering `_render` directly is not clearing scheduled frames, like `redraw`.


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [ ] Add an entry to `CHANGELOG.md` under the `## main` section.
