### PR TITLE
doc plugins add link to maplibre-react-components and maplibregl-theme

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -214,6 +214,11 @@ Provides a [Webtoolkit](https://www.webtoolkit.eu/wt) integration.
 Provides a [React](https://facebook.github.io/react/) integration.
 <br/><small>[View on GitHub](https://github.com/alex3165/react-mapbox-gl)</small>
 
+#### maplibre-react-components
+
+Lightweight MapLibre only binding for React.
+<br/><small>[Documentation](https://maplibre-react-components.pentatrion.com/) - [View on GitHub](https://github.com/lhapaipai/maplibre-react-components)</small>
+
 #### angular-mapboxgl-directive
 
 Provides an [AngularJS](https://angularjs.org/) directive.
@@ -299,6 +304,11 @@ Manage layers, sources, and properties with syntactic sugar and convenience func
 
 This library provides a request transforming function enabling the consumption of MapboxGL Styles in MapLibreGL.
 <br/><small>[View on GitHub](https://github.com/rowanwins/maplibregl-mapbox-request-transformer)</small>
+
+#### maplibregl-theme
+
+Custom themes for your MapLibre GL Web app.
+<br/><small>[Theme customizer](https://maplibre-theme.pentatrion.com/) - [View on GitHub](https://github.com/lhapaipai/maplibre-theme)</small>
 
 ## Development Tools
 


### PR DESCRIPTION
I would like to add these 2 links that are already present on awesome MapLibre in the documentation.

Hoping that this one can interest the community!

Have a nice day

## maplibre-theme

This repos contain css for themes who are designed to mimic the actual theme with some improvements.

light : actually 20ko-30ko minified
support dark mode
support CSS variables for easy optimisation.

## maplibre-react-components
binding for React, it is very light (about 30kB) and only compatible with MapLibre, therefore as close as possible to its typing and its features.

---


pr links on awesome for more informations
[maplibre/awesome-maplibre#56 maplibre-react-components](https://github.com/maplibre/awesome-maplibre/pull/56)
[maplibre/awesome-maplibre#45 maplibre-theme](https://github.com/maplibre/awesome-maplibre/pull/45)