### PR TITLE
Fix Node 22 and Deno build error

### DIFF
--- a/build/banner.ts
+++ b/build/banner.ts
@@ -1,4 +1,9 @@
-import packageJSON from '../package.json' with {type: 'json'};
+import {readFileSync} from 'fs';
+import {fileURLToPath} from 'url';
+import {dirname, join} from 'path';
+
+const packageJSONPath = join(dirname(fileURLToPath(import.meta.url)), '../package.json');
+const packageJSON = JSON.parse(readFileSync(packageJSONPath, 'utf8'));
 
 export default
 `/**


### PR DESCRIPTION
Closes #4547 

The  with/assert { type: "json" } stuff for JSON modules is quite the headache - in fact, this is the third consecutive (18, 20, 22) node release where it's been rather time-consuming to debug and resolve. The banner has a `with {type:"json"}` but rollup still breaks with an error about hitting an `assert` as if it is somehow auto-transformed into an `assert {type:'json'}` in the process... and removing the `with/assert {type:"json"}` will give an error that it's absent.

Until the JSON module feature works properly, we can in this case readily fall back to the old-school way of just reading the package.json with the 'fs' module, and parsing it.

 - [X] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
