### PR TITLE
Swap 0.0.0.0 with localhost on dev server

### DIFF
--- a/package.json
+++ b/package.json
@@ -157,7 +157,7 @@
     "watch-css": "postcss --watch -o dist/maplibre-gl.css src/css/maplibre-gl.css",
     "build-benchmarks": "npm run build-dev && rollup --configPlugin @rollup/plugin-typescript -c test/bench/rollup_config_benchmarks.ts",
     "watch-benchmarks": "rollup --configPlugin @rollup/plugin-typescript -c test/bench/rollup_config_benchmarks.ts --watch",
-    "start-server": "st --no-cache -H 0.0.0.0 --port 9966 .",
+    "start-server": "st --no-cache -H localhost --port 9966 .",
     "start-docs": "docker run --rm -it -p 8000:8000 -v ${PWD}:/docs squidfunk/mkdocs-material",
     "start": "run-p watch-css watch-dev start-server",
     "start-bench": "run-p watch-css watch-benchmarks start-server",


### PR DESCRIPTION
This makes the dev server examples load properly - they tile servers are open to calls from exactly `localhost` , not 0.0.0.0  or similar alternatives.

Before:
<img width="292" alt="Screenshot 2024-09-07 at 21 02 29" src="https://github.com/user-attachments/assets/bb36db52-8168-4056-b31b-4437ac06a162">



After:

<img width="288" alt="Screenshot 2024-09-07 at 21 02 07" src="https://github.com/user-attachments/assets/756655ae-006b-47bd-b883-39497ba0e44f">
