### PR TITLE
doc: updated maplibre-gl-terradraw plugin example

### DIFF
--- a/test/examples/maplibre-gl-terradraw.html
+++ b/test/examples/maplibre-gl-terradraw.html
@@ -14,10 +14,10 @@
 </head>
 <body>
 
-<script src="https://cdn.jsdelivr.net/npm/@watergis/maplibre-gl-terradraw@0.0.3/dist/maplibre-gl-terradraw.umd.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/@watergis/maplibre-gl-terradraw@0.1.1/dist/maplibre-gl-terradraw.umd.js"></script>
 <link
     rel="stylesheet"
-    href="https://cdn.jsdelivr.net/npm/@watergis/maplibre-gl-terradraw@0.0.3/dist/maplibre-gl-terradraw.css"
+    href="https://cdn.jsdelivr.net/npm/@watergis/maplibre-gl-terradraw@0.1.1/dist/maplibre-gl-terradraw.css"
 />
 <div id="map"></div>
 
@@ -33,14 +33,17 @@
     // By default, all terra-draw drawing modes are enabled.
     // you can disable some of modes in the constructor options if you want.
     const draw = new MaplibreTerradrawControl({
-        point: true,
-        line: true,
-        polygon: true,
-        rectangle: true,
-        circle: true,
-        freehand: true,
-        angledRectangle: true,
-        select: true
+        modes: [
+            'point',
+            'linestring',
+            'polygon',
+            'rectangle',
+            'angled-rectangle',
+            'circle',
+            'freehand',
+            'select'
+        ],
+        open: true,
     });
     map.addControl(draw, 'top-right');
 </script>


### PR DESCRIPTION
I did some interface changes on [maplibre-gl-terradraw](https://github.com/watergis/maplibre-gl-terradraw) to make the plugin for flexible and customizable. I updated the example page for the plugin.

- before

It collapsed the plugin menu as default

![image](https://github.com/user-attachments/assets/97d1df89-8bb1-451d-821e-f2f070f8734b)


- after

now it can expand the menu as default. I added `open` property in the option.

![image](https://github.com/user-attachments/assets/4949c94c-33ad-4ef9-8a38-c9564cdcef8e)

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [ ] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [ ] Link to related issues.
 - [x] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [ ] Add an entry to `CHANGELOG.md` under the `## main` section.
