### PR TITLE
Use platform consistently instead of jest done

### DIFF
--- a/src/source/canvas_source.test.ts
+++ b/src/source/canvas_source.test.ts
@@ -53,7 +53,7 @@ describe('CanvasSource', () => {
         map = new StubMap();
     });
 
-    test('constructor', () => new Promise(done => {
+    test('constructor', () => new Promise<void>(done => {
         const source = createSource();
 
         expect(source.minzoom).toBe(0);
@@ -95,7 +95,7 @@ describe('CanvasSource', () => {
 
     });
 
-    test('can be initialized with HTML element', () => new Promise(done => {
+    test('can be initialized with HTML element', () => new Promise<void>(done => {
         const el = window.document.createElement('canvas');
         const source = createSource({
             canvas: el
@@ -111,7 +111,7 @@ describe('CanvasSource', () => {
         source.onAdd(map);
     }));
 
-    test('rerenders if animated', () => new Promise(done => {
+    test('rerenders if animated', () => new Promise<void>(done => {
         const source = createSource();
 
         map.on('rerender', () => {
@@ -122,7 +122,7 @@ describe('CanvasSource', () => {
         source.onAdd(map);
     }));
 
-    test('can be static', () => new Promise(done => {
+    test('can be static', () => new Promise<void>(done => {
         const source = createSource({
             animate: false
         });
@@ -177,7 +177,7 @@ describe('CanvasSource', () => {
 
     });
 
-    test('fires idle event on prepare call when there is at least one not loaded tile', () => new Promise(done => {
+    test('fires idle event on prepare call when there is at least one not loaded tile', () => new Promise<void>(done => {
         const source = createSource();
         const tile = new Tile(new OverscaledTileID(1, 0, 1, 0, 0), 512);
         source.on('data', (e) => {

--- a/src/source/canvas_source.test.ts
+++ b/src/source/canvas_source.test.ts
@@ -53,7 +53,7 @@ describe('CanvasSource', () => {
         map = new StubMap();
     });
 
-    test('constructor', done => {
+    test('constructor', () => new Promise(done => {
         const source = createSource();
 
         expect(source.minzoom).toBe(0);
@@ -68,7 +68,7 @@ describe('CanvasSource', () => {
         });
 
         source.onAdd(map);
-    });
+    }));
 
     test('self-validates', () => {
         const stub = jest.spyOn(console, 'error').mockImplementation(() => {});
@@ -95,7 +95,7 @@ describe('CanvasSource', () => {
 
     });
 
-    test('can be initialized with HTML element', done => {
+    test('can be initialized with HTML element', () => new Promise(done => {
         const el = window.document.createElement('canvas');
         const source = createSource({
             canvas: el
@@ -109,9 +109,9 @@ describe('CanvasSource', () => {
         });
 
         source.onAdd(map);
-    });
+    }));
 
-    test('rerenders if animated', done => {
+    test('rerenders if animated', () => new Promise(done => {
         const source = createSource();
 
         map.on('rerender', () => {
@@ -120,9 +120,9 @@ describe('CanvasSource', () => {
         });
 
         source.onAdd(map);
-    });
+    }));
 
-    test('can be static', done => {
+    test('can be static', () => new Promise(done => {
         const source = createSource({
             animate: false
         });
@@ -141,7 +141,7 @@ describe('CanvasSource', () => {
         });
 
         source.onAdd(map);
-    });
+    }));
 
     test('onRemove stops animation', () => {
         const source = createSource();
@@ -177,7 +177,7 @@ describe('CanvasSource', () => {
 
     });
 
-    test('fires idle event on prepare call when there is at least one not loaded tile', done => {
+    test('fires idle event on prepare call when there is at least one not loaded tile', () => new Promise(done => {
         const source = createSource();
         const tile = new Tile(new OverscaledTileID(1, 0, 1, 0, 0), 512);
         source.on('data', (e) => {
@@ -196,7 +196,7 @@ describe('CanvasSource', () => {
             update: () => {}
         } as any;
         source.prepare();
-    });
+    }));
 
 });
 

--- a/src/source/geojson_source.test.ts
+++ b/src/source/geojson_source.test.ts
@@ -102,7 +102,7 @@ describe('GeoJSONSource#setData', () => {
         await setDataPromise;
     });
 
-    test('fires "dataloading" event', () => new Promise(done => {
+    test('fires "dataloading" event', () => new Promise<void>(done => {
         const source = createSource();
         source.on('dataloading', () => {
             done();
@@ -110,7 +110,7 @@ describe('GeoJSONSource#setData', () => {
         source.load();
     }));
 
-    test('fires "dataabort" event', () => new Promise(done => {
+    test('fires "dataabort" event', () => new Promise<void>(done => {
         const source = new GeoJSONSource('id', {} as any, wrapDispatcher({
             sendAsync(_message) {
                 return new Promise((resolve) => {
@@ -124,7 +124,7 @@ describe('GeoJSONSource#setData', () => {
         source.load();
     }));
 
-    test('respects collectResourceTiming parameter on source', () => new Promise(done => {
+    test('respects collectResourceTiming parameter on source', () => new Promise<void>(done => {
         const source = createSource({collectResourceTiming: true});
         source.map = {
             _requestManager: {
@@ -171,7 +171,7 @@ describe('GeoJSONSource#setData', () => {
         expect(source.loaded()).toBeTruthy();
     });
 
-    test('marks source as loaded before firing "dataabort" event', () => new Promise(done => {
+    test('marks source as loaded before firing "dataabort" event', () => new Promise<void>(done => {
         const source = new GeoJSONSource('id', {} as any, wrapDispatcher({
             sendAsync(_message: ActorMessage<MessageType>) {
                 return new Promise((resolve) => {
@@ -188,7 +188,7 @@ describe('GeoJSONSource#setData', () => {
 });
 
 describe('GeoJSONSource#onRemove', () => {
-    test('broadcasts "removeSource" event', () => new Promise(done => {
+    test('broadcasts "removeSource" event', () => new Promise<void>(done => {
         const source = new GeoJSONSource('id', {data: {}} as GeoJSONSourceOptions, wrapDispatcher({
             sendAsync(message: ActorMessage<MessageType>) {
                 expect(message.type).toBe(MessageType.removeSource);
@@ -212,7 +212,7 @@ describe('GeoJSONSource#update', () => {
     transform.zoom = 15;
     transform.setLocationAtPoint(lngLat, point);
 
-    test('sends initial loadData request to dispatcher', () => new Promise(done => {
+    test('sends initial loadData request to dispatcher', () => new Promise<void>(done => {
         const mockDispatcher = wrapDispatcher({
             sendAsync(message: ActorMessage<MessageType>) {
                 expect(message.type).toBe(MessageType.loadData);
@@ -224,7 +224,7 @@ describe('GeoJSONSource#update', () => {
         new GeoJSONSource('id', {data: {}} as GeoJSONSourceOptions, mockDispatcher, undefined).load();
     }));
 
-    test('forwards geojson-vt options with worker request', () => new Promise(done => {
+    test('forwards geojson-vt options with worker request', () => new Promise<void>(done => {
         const mockDispatcher = wrapDispatcher({
             sendAsync(message: ActorMessage<any>) {
                 expect(message.type).toBe(MessageType.loadData);
@@ -250,7 +250,7 @@ describe('GeoJSONSource#update', () => {
         } as GeoJSONSourceOptions, mockDispatcher, undefined).load();
     }));
 
-    test('forwards Supercluster options with worker request', () => new Promise(done => {
+    test('forwards Supercluster options with worker request', () => new Promise<void>(done => {
         const mockDispatcher = wrapDispatcher({
             sendAsync(message) {
                 expect(message.type).toBe(MessageType.loadData);
@@ -277,7 +277,7 @@ describe('GeoJSONSource#update', () => {
         } as GeoJSONSourceOptions, mockDispatcher, undefined).load();
     }));
 
-    test('modifying cluster properties after adding a source', () => new Promise(done => {
+    test('modifying cluster properties after adding a source', () => new Promise<void>(done => {
         // test setCluster function on GeoJSONSource
         const mockDispatcher = wrapDispatcher({
             sendAsync(message) {
@@ -299,7 +299,7 @@ describe('GeoJSONSource#update', () => {
         } as GeoJSONSourceOptions, mockDispatcher, undefined).setClusterOptions({cluster: true, clusterRadius: 80, clusterMaxZoom: 16});
     }));
 
-    test('forwards Supercluster options with worker request, ignore max zoom of source', () => new Promise(done => {
+    test('forwards Supercluster options with worker request, ignore max zoom of source', () => new Promise<void>(done => {
         const mockDispatcher = wrapDispatcher({
             sendAsync(message) {
                 expect(message.type).toBe(MessageType.loadData);
@@ -339,7 +339,7 @@ describe('GeoJSONSource#update', () => {
         expect(transformSpy).toHaveBeenCalledTimes(1);
         expect(transformSpy.mock.calls[0][0]).toBe('https://example.com/data.geojson');
     });
-    test('fires event when metadata loads', () => new Promise(done => {
+    test('fires event when metadata loads', () => new Promise<void>(done => {
         const mockDispatcher = wrapDispatcher({
             sendAsync(_message: ActorMessage<MessageType>) {
                 return new Promise((resolve) => {
@@ -357,7 +357,7 @@ describe('GeoJSONSource#update', () => {
         source.load();
     }));
 
-    test('fires metadata data event even when initial request is aborted', () => new Promise(done => {
+    test('fires metadata data event even when initial request is aborted', () => new Promise<void>(done => {
         let requestCount = 0;
         const mockDispatcher = wrapDispatcher({
             sendAsync(_message) {
@@ -377,7 +377,7 @@ describe('GeoJSONSource#update', () => {
         source.setData({} as GeoJSON.GeoJSON);
     }));
 
-    test('fires "error"', () => new Promise(done => {
+    test('fires "error"', () => new Promise<void>(done => {
         const mockDispatcher = wrapDispatcher({
             sendAsync(_message) {
                 return Promise.reject('error'); // eslint-disable-line prefer-promise-reject-errors
@@ -394,7 +394,7 @@ describe('GeoJSONSource#update', () => {
         source.load();
     }));
 
-    test('sends loadData request to dispatcher after data update', () => new Promise(done => {
+    test('sends loadData request to dispatcher after data update', () => new Promise<void>(done => {
         let expectedLoadDataCalls = 2;
         const mockDispatcher = wrapDispatcher({
             sendAsync(message) {

--- a/src/source/geojson_source.test.ts
+++ b/src/source/geojson_source.test.ts
@@ -102,15 +102,15 @@ describe('GeoJSONSource#setData', () => {
         await setDataPromise;
     });
 
-    test('fires "dataloading" event', done => {
+    test('fires "dataloading" event', () => new Promise(done => {
         const source = createSource();
         source.on('dataloading', () => {
             done();
         });
         source.load();
-    });
+    }));
 
-    test('fires "dataabort" event', done => {
+    test('fires "dataabort" event', () => new Promise(done => {
         const source = new GeoJSONSource('id', {} as any, wrapDispatcher({
             sendAsync(_message) {
                 return new Promise((resolve) => {
@@ -122,9 +122,9 @@ describe('GeoJSONSource#setData', () => {
             done();
         });
         source.load();
-    });
+    }));
 
-    test('respects collectResourceTiming parameter on source', done => {
+    test('respects collectResourceTiming parameter on source', () => new Promise(done => {
         const source = createSource({collectResourceTiming: true});
         source.map = {
             _requestManager: {
@@ -141,7 +141,7 @@ describe('GeoJSONSource#setData', () => {
             });
         };
         source.setData('http://localhost/nonexistent');
-    });
+    }));
 
     test('only marks source as loaded when there are no pending loads', async () => {
         const source = createSource();
@@ -171,7 +171,7 @@ describe('GeoJSONSource#setData', () => {
         expect(source.loaded()).toBeTruthy();
     });
 
-    test('marks source as loaded before firing "dataabort" event', done => {
+    test('marks source as loaded before firing "dataabort" event', () => new Promise(done => {
         const source = new GeoJSONSource('id', {} as any, wrapDispatcher({
             sendAsync(_message: ActorMessage<MessageType>) {
                 return new Promise((resolve) => {
@@ -184,11 +184,11 @@ describe('GeoJSONSource#setData', () => {
             done();
         });
         source.setData({} as GeoJSON.GeoJSON);
-    });
+    }));
 });
 
 describe('GeoJSONSource#onRemove', () => {
-    test('broadcasts "removeSource" event', done => {
+    test('broadcasts "removeSource" event', () => new Promise(done => {
         const source = new GeoJSONSource('id', {data: {}} as GeoJSONSourceOptions, wrapDispatcher({
             sendAsync(message: ActorMessage<MessageType>) {
                 expect(message.type).toBe(MessageType.removeSource);
@@ -201,7 +201,7 @@ describe('GeoJSONSource#onRemove', () => {
             }
         }), undefined);
         source.onRemove();
-    });
+    }));
 });
 
 describe('GeoJSONSource#update', () => {
@@ -212,7 +212,7 @@ describe('GeoJSONSource#update', () => {
     transform.zoom = 15;
     transform.setLocationAtPoint(lngLat, point);
 
-    test('sends initial loadData request to dispatcher', done => {
+    test('sends initial loadData request to dispatcher', () => new Promise(done => {
         const mockDispatcher = wrapDispatcher({
             sendAsync(message: ActorMessage<MessageType>) {
                 expect(message.type).toBe(MessageType.loadData);
@@ -222,9 +222,9 @@ describe('GeoJSONSource#update', () => {
         });
 
         new GeoJSONSource('id', {data: {}} as GeoJSONSourceOptions, mockDispatcher, undefined).load();
-    });
+    }));
 
-    test('forwards geojson-vt options with worker request', done => {
+    test('forwards geojson-vt options with worker request', () => new Promise(done => {
         const mockDispatcher = wrapDispatcher({
             sendAsync(message: ActorMessage<any>) {
                 expect(message.type).toBe(MessageType.loadData);
@@ -248,9 +248,9 @@ describe('GeoJSONSource#update', () => {
             buffer: 16,
             generateId: true
         } as GeoJSONSourceOptions, mockDispatcher, undefined).load();
-    });
+    }));
 
-    test('forwards Supercluster options with worker request', done => {
+    test('forwards Supercluster options with worker request', () => new Promise(done => {
         const mockDispatcher = wrapDispatcher({
             sendAsync(message) {
                 expect(message.type).toBe(MessageType.loadData);
@@ -275,9 +275,9 @@ describe('GeoJSONSource#update', () => {
             clusterMinPoints: 3,
             generateId: true
         } as GeoJSONSourceOptions, mockDispatcher, undefined).load();
-    });
+    }));
 
-    test('modifying cluster properties after adding a source', done => {
+    test('modifying cluster properties after adding a source', () => new Promise(done => {
         // test setCluster function on GeoJSONSource
         const mockDispatcher = wrapDispatcher({
             sendAsync(message) {
@@ -297,9 +297,9 @@ describe('GeoJSONSource#update', () => {
             clusterMinPoints: 3,
             generateId: true
         } as GeoJSONSourceOptions, mockDispatcher, undefined).setClusterOptions({cluster: true, clusterRadius: 80, clusterMaxZoom: 16});
-    });
+    }));
 
-    test('forwards Supercluster options with worker request, ignore max zoom of source', done => {
+    test('forwards Supercluster options with worker request, ignore max zoom of source', () => new Promise(done => {
         const mockDispatcher = wrapDispatcher({
             sendAsync(message) {
                 expect(message.type).toBe(MessageType.loadData);
@@ -325,7 +325,7 @@ describe('GeoJSONSource#update', () => {
             clusterMinPoints: 3,
             generateId: true
         } as GeoJSONSourceOptions, mockDispatcher, undefined).load();
-    });
+    }));
 
     test('transforms url before making request', () => {
         const mapStub = {
@@ -339,7 +339,7 @@ describe('GeoJSONSource#update', () => {
         expect(transformSpy).toHaveBeenCalledTimes(1);
         expect(transformSpy.mock.calls[0][0]).toBe('https://example.com/data.geojson');
     });
-    test('fires event when metadata loads', done => {
+    test('fires event when metadata loads', () => new Promise(done => {
         const mockDispatcher = wrapDispatcher({
             sendAsync(_message: ActorMessage<MessageType>) {
                 return new Promise((resolve) => {
@@ -355,9 +355,9 @@ describe('GeoJSONSource#update', () => {
         });
 
         source.load();
-    });
+    }));
 
-    test('fires metadata data event even when initial request is aborted', done => {
+    test('fires metadata data event even when initial request is aborted', () => new Promise(done => {
         let requestCount = 0;
         const mockDispatcher = wrapDispatcher({
             sendAsync(_message) {
@@ -375,9 +375,9 @@ describe('GeoJSONSource#update', () => {
 
         source.load();
         source.setData({} as GeoJSON.GeoJSON);
-    });
+    }));
 
-    test('fires "error"', done => {
+    test('fires "error"', () => new Promise(done => {
         const mockDispatcher = wrapDispatcher({
             sendAsync(_message) {
                 return Promise.reject('error'); // eslint-disable-line prefer-promise-reject-errors
@@ -392,9 +392,9 @@ describe('GeoJSONSource#update', () => {
         });
 
         source.load();
-    });
+    }));
 
-    test('sends loadData request to dispatcher after data update', done => {
+    test('sends loadData request to dispatcher after data update', () => new Promise(done => {
         let expectedLoadDataCalls = 2;
         const mockDispatcher = wrapDispatcher({
             sendAsync(message) {
@@ -419,7 +419,7 @@ describe('GeoJSONSource#update', () => {
         });
 
         source.load();
-    });
+    }));
 });
 
 describe('GeoJSONSource#getData', () => {

--- a/src/source/geojson_source_diff.test.ts
+++ b/src/source/geojson_source_diff.test.ts
@@ -6,7 +6,7 @@ beforeEach(() => {
 });
 
 describe('isUpdateableGeoJSON', () => {
-    test('feature without id is not updateable', done => {
+    test('feature without id is not updateable', () => new Promise(done => {
         // no feature id -> false
         expect(isUpdateableGeoJSON({
             type: 'Feature',
@@ -17,9 +17,9 @@ describe('isUpdateableGeoJSON', () => {
             properties: {},
         })).toBe(false);
         done();
-    });
+    }));
 
-    test('feature with id is updateable', done => {
+    test('feature with id is updateable', () => new Promise(done => {
         // has a feature id -> true
         expect(isUpdateableGeoJSON({
             type: 'Feature',
@@ -31,9 +31,9 @@ describe('isUpdateableGeoJSON', () => {
             properties: {},
         })).toBe(true);
         done();
-    });
+    }));
 
-    test('promoteId missing is not updateable', done => {
+    test('promoteId missing is not updateable', () => new Promise(done => {
         expect(isUpdateableGeoJSON({
             type: 'Feature',
             id: 'feature_id',
@@ -44,9 +44,9 @@ describe('isUpdateableGeoJSON', () => {
             properties: {},
         }, 'propId')).toBe(false);
         done();
-    });
+    }));
 
-    test('promoteId present is updateable', done => {
+    test('promoteId present is updateable', () => new Promise(done => {
         expect(isUpdateableGeoJSON({
             type: 'Feature',
             geometry: {
@@ -58,9 +58,9 @@ describe('isUpdateableGeoJSON', () => {
             },
         }, 'propId')).toBe(true);
         done();
-    });
+    }));
 
-    test('feature collection with unique ids is updateable', done => {
+    test('feature collection with unique ids is updateable', () => new Promise(done => {
         expect(isUpdateableGeoJSON({
             type: 'FeatureCollection',
             features: [{
@@ -82,9 +82,9 @@ describe('isUpdateableGeoJSON', () => {
             }]
         })).toBe(true);
         done();
-    });
+    }));
 
-    test('feature collection with unique promoteIds is updateable', done => {
+    test('feature collection with unique promoteIds is updateable', () => new Promise(done => {
         expect(isUpdateableGeoJSON({
             type: 'FeatureCollection',
             features: [{
@@ -108,9 +108,9 @@ describe('isUpdateableGeoJSON', () => {
             }]
         }, 'propId')).toBe(true);
         done();
-    });
+    }));
 
-    test('feature collection without unique ids is not updateable', done => {
+    test('feature collection without unique ids is not updateable', () => new Promise(done => {
         expect(isUpdateableGeoJSON({
             type: 'FeatureCollection',
             features: [{
@@ -123,9 +123,9 @@ describe('isUpdateableGeoJSON', () => {
             }]
         })).toBe(false);
         done();
-    });
+    }));
 
-    test('feature collection with duplicate feature ids is not updateable', done => {
+    test('feature collection with duplicate feature ids is not updateable', () => new Promise(done => {
         expect(isUpdateableGeoJSON({
             type: 'FeatureCollection',
             features: [{
@@ -147,16 +147,16 @@ describe('isUpdateableGeoJSON', () => {
             }]
         })).toBe(false);
         done();
-    });
+    }));
 
-    test('geometries are not updateable', done => {
+    test('geometries are not updateable', () => new Promise(done => {
         expect(isUpdateableGeoJSON({type: 'Point', coordinates: [0, 0]})).toBe(false);
         done();
-    });
+    }));
 });
 
 describe('toUpdateable', () => {
-    test('works with a single feature - feature id', done => {
+    test('works with a single feature - feature id', () => new Promise(done => {
         const updateable = toUpdateable({
             type: 'Feature',
             id: 'point',
@@ -167,9 +167,9 @@ describe('toUpdateable', () => {
         expect(updateable.size).toBe(1);
         expect(updateable.has('point')).toBeTruthy();
         done();
-    });
+    }));
 
-    test('works with a single feature - promoteId', done => {
+    test('works with a single feature - promoteId', () => new Promise(done => {
         const updateable2 = toUpdateable({
             type: 'Feature',
             geometry: {
@@ -181,9 +181,9 @@ describe('toUpdateable', () => {
         expect(updateable2.size).toBe(1);
         expect(updateable2.has('point')).toBeTruthy();
         done();
-    });
+    }));
 
-    test('works with a FeatureCollection - feature id', done => {
+    test('works with a FeatureCollection - feature id', () => new Promise(done => {
         const updateable = toUpdateable({
             type: 'FeatureCollection',
             features: [
@@ -207,9 +207,9 @@ describe('toUpdateable', () => {
         expect(updateable.has('point')).toBeTruthy();
         expect(updateable.has('point2')).toBeTruthy();
         done();
-    });
+    }));
 
-    test('works with a FeatureCollection - promoteId', done => {
+    test('works with a FeatureCollection - promoteId', () => new Promise(done => {
         const updateable2 = toUpdateable({
             type: 'FeatureCollection',
             features: [
@@ -235,7 +235,7 @@ describe('toUpdateable', () => {
         expect(updateable2.has('point')).toBeTruthy();
         expect(updateable2.has('point2')).toBeTruthy();
         done();
-    });
+    }));
 });
 
 describe('applySourceDiff', () => {
@@ -270,7 +270,7 @@ describe('applySourceDiff', () => {
     Object.freeze((point2.geometry as GeoJSON.Point).coordinates);
     Object.freeze(point2.properties);
 
-    test('adds a feature using the feature id', done => {
+    test('adds a feature using the feature id', () => new Promise(done => {
         const updateable = new Map<GeoJSONFeatureId, GeoJSON.Feature>();
 
         applySourceDiff(updateable, {
@@ -279,9 +279,9 @@ describe('applySourceDiff', () => {
         expect(updateable.size).toBe(1);
         expect(updateable.has('point')).toBeTruthy();
         done();
-    });
+    }));
 
-    test('adds a feature using the promoteId', done => {
+    test('adds a feature using the promoteId', () => new Promise(done => {
         const updateable = new Map<GeoJSONFeatureId, GeoJSON.Feature>();
         applySourceDiff(updateable, {
             add: [point2]
@@ -289,9 +289,9 @@ describe('applySourceDiff', () => {
         expect(updateable.size).toBe(1);
         expect(updateable.has('point2')).toBeTruthy();
         done();
-    });
+    }));
 
-    test('removes a feature by its id', done => {
+    test('removes a feature by its id', () => new Promise(done => {
         const updateable = new Map([['point', point], ['point2', point2]]);
         applySourceDiff(updateable, {
             remove: ['point2'],
@@ -299,9 +299,9 @@ describe('applySourceDiff', () => {
         expect(updateable.size).toBe(1);
         expect(updateable.has('point2')).toBeFalsy();
         done();
-    });
+    }));
 
-    test('updates a feature geometry', done => {
+    test('updates a feature geometry', () => new Promise(done => {
         const updateable = new Map([['point', point]]);
         // update -> new geometry
         applySourceDiff(updateable, {
@@ -316,9 +316,9 @@ describe('applySourceDiff', () => {
         expect(updateable.size).toBe(1);
         expect((updateable.get('point')?.geometry as GeoJSON.Point).coordinates[0]).toBe(1);
         done();
-    });
+    }));
 
-    test('adds properties', done => {
+    test('adds properties', () => new Promise(done => {
         const updateable = new Map([['point', point]]);
         applySourceDiff(updateable, {
             update: [{
@@ -335,9 +335,9 @@ describe('applySourceDiff', () => {
         expect(properties.prop).toBe('value');
         expect(properties.prop2).toBe('value2');
         done();
-    });
+    }));
 
-    test('updates properties', done => {
+    test('updates properties', () => new Promise(done => {
         const updateable = new Map([['point', {...point, properties: {prop: 'value', prop2: 'value2'}}]]);
         applySourceDiff(updateable, {
             update: [{
@@ -353,9 +353,9 @@ describe('applySourceDiff', () => {
         expect(properties2.prop).toBe('value');
         expect(properties2.prop2).toBe('value3');
         done();
-    });
+    }));
 
-    test('removes properties', done => {
+    test('removes properties', () => new Promise(done => {
         const updateable = new Map([['point', {...point, properties: {prop: 'value', prop2: 'value2'}}]]);
         applySourceDiff(updateable, {
             update: [{
@@ -368,9 +368,9 @@ describe('applySourceDiff', () => {
         expect(Object.keys(properties3)).toHaveLength(1);
         expect(properties3.prop).toBe('value');
         done();
-    });
+    }));
 
-    test('removes all properties', done => {
+    test('removes all properties', () => new Promise(done => {
         const updateable = new Map([['point', {...point, properties: {prop: 'value', prop2: 'value2'}}]]);
         applySourceDiff(updateable, {
             update: [{
@@ -381,5 +381,5 @@ describe('applySourceDiff', () => {
         expect(updateable.size).toBe(1);
         expect(Object.keys(updateable.get('point')?.properties!)).toHaveLength(0);
         done();
-    });
+    }));
 });

--- a/src/source/geojson_source_diff.test.ts
+++ b/src/source/geojson_source_diff.test.ts
@@ -6,7 +6,7 @@ beforeEach(() => {
 });
 
 describe('isUpdateableGeoJSON', () => {
-    test('feature without id is not updateable', () => new Promise(done => {
+    test('feature without id is not updateable', () => new Promise<void>(done => {
         // no feature id -> false
         expect(isUpdateableGeoJSON({
             type: 'Feature',
@@ -19,7 +19,7 @@ describe('isUpdateableGeoJSON', () => {
         done();
     }));
 
-    test('feature with id is updateable', () => new Promise(done => {
+    test('feature with id is updateable', () => new Promise<void>(done => {
         // has a feature id -> true
         expect(isUpdateableGeoJSON({
             type: 'Feature',
@@ -33,7 +33,7 @@ describe('isUpdateableGeoJSON', () => {
         done();
     }));
 
-    test('promoteId missing is not updateable', () => new Promise(done => {
+    test('promoteId missing is not updateable', () => new Promise<void>(done => {
         expect(isUpdateableGeoJSON({
             type: 'Feature',
             id: 'feature_id',
@@ -46,7 +46,7 @@ describe('isUpdateableGeoJSON', () => {
         done();
     }));
 
-    test('promoteId present is updateable', () => new Promise(done => {
+    test('promoteId present is updateable', () => new Promise<void>(done => {
         expect(isUpdateableGeoJSON({
             type: 'Feature',
             geometry: {
@@ -60,7 +60,7 @@ describe('isUpdateableGeoJSON', () => {
         done();
     }));
 
-    test('feature collection with unique ids is updateable', () => new Promise(done => {
+    test('feature collection with unique ids is updateable', () => new Promise<void>(done => {
         expect(isUpdateableGeoJSON({
             type: 'FeatureCollection',
             features: [{
@@ -84,7 +84,7 @@ describe('isUpdateableGeoJSON', () => {
         done();
     }));
 
-    test('feature collection with unique promoteIds is updateable', () => new Promise(done => {
+    test('feature collection with unique promoteIds is updateable', () => new Promise<void>(done => {
         expect(isUpdateableGeoJSON({
             type: 'FeatureCollection',
             features: [{
@@ -110,7 +110,7 @@ describe('isUpdateableGeoJSON', () => {
         done();
     }));
 
-    test('feature collection without unique ids is not updateable', () => new Promise(done => {
+    test('feature collection without unique ids is not updateable', () => new Promise<void>(done => {
         expect(isUpdateableGeoJSON({
             type: 'FeatureCollection',
             features: [{
@@ -125,7 +125,7 @@ describe('isUpdateableGeoJSON', () => {
         done();
     }));
 
-    test('feature collection with duplicate feature ids is not updateable', () => new Promise(done => {
+    test('feature collection with duplicate feature ids is not updateable', () => new Promise<void>(done => {
         expect(isUpdateableGeoJSON({
             type: 'FeatureCollection',
             features: [{
@@ -149,14 +149,14 @@ describe('isUpdateableGeoJSON', () => {
         done();
     }));
 
-    test('geometries are not updateable', () => new Promise(done => {
+    test('geometries are not updateable', () => new Promise<void>(done => {
         expect(isUpdateableGeoJSON({type: 'Point', coordinates: [0, 0]})).toBe(false);
         done();
     }));
 });
 
 describe('toUpdateable', () => {
-    test('works with a single feature - feature id', () => new Promise(done => {
+    test('works with a single feature - feature id', () => new Promise<void>(done => {
         const updateable = toUpdateable({
             type: 'Feature',
             id: 'point',
@@ -169,7 +169,7 @@ describe('toUpdateable', () => {
         done();
     }));
 
-    test('works with a single feature - promoteId', () => new Promise(done => {
+    test('works with a single feature - promoteId', () => new Promise<void>(done => {
         const updateable2 = toUpdateable({
             type: 'Feature',
             geometry: {
@@ -183,7 +183,7 @@ describe('toUpdateable', () => {
         done();
     }));
 
-    test('works with a FeatureCollection - feature id', () => new Promise(done => {
+    test('works with a FeatureCollection - feature id', () => new Promise<void>(done => {
         const updateable = toUpdateable({
             type: 'FeatureCollection',
             features: [
@@ -209,7 +209,7 @@ describe('toUpdateable', () => {
         done();
     }));
 
-    test('works with a FeatureCollection - promoteId', () => new Promise(done => {
+    test('works with a FeatureCollection - promoteId', () => new Promise<void>(done => {
         const updateable2 = toUpdateable({
             type: 'FeatureCollection',
             features: [
@@ -270,7 +270,7 @@ describe('applySourceDiff', () => {
     Object.freeze((point2.geometry as GeoJSON.Point).coordinates);
     Object.freeze(point2.properties);
 
-    test('adds a feature using the feature id', () => new Promise(done => {
+    test('adds a feature using the feature id', () => new Promise<void>(done => {
         const updateable = new Map<GeoJSONFeatureId, GeoJSON.Feature>();
 
         applySourceDiff(updateable, {
@@ -281,7 +281,7 @@ describe('applySourceDiff', () => {
         done();
     }));
 
-    test('adds a feature using the promoteId', () => new Promise(done => {
+    test('adds a feature using the promoteId', () => new Promise<void>(done => {
         const updateable = new Map<GeoJSONFeatureId, GeoJSON.Feature>();
         applySourceDiff(updateable, {
             add: [point2]
@@ -291,7 +291,7 @@ describe('applySourceDiff', () => {
         done();
     }));
 
-    test('removes a feature by its id', () => new Promise(done => {
+    test('removes a feature by its id', () => new Promise<void>(done => {
         const updateable = new Map([['point', point], ['point2', point2]]);
         applySourceDiff(updateable, {
             remove: ['point2'],
@@ -301,7 +301,7 @@ describe('applySourceDiff', () => {
         done();
     }));
 
-    test('updates a feature geometry', () => new Promise(done => {
+    test('updates a feature geometry', () => new Promise<void>(done => {
         const updateable = new Map([['point', point]]);
         // update -> new geometry
         applySourceDiff(updateable, {
@@ -318,7 +318,7 @@ describe('applySourceDiff', () => {
         done();
     }));
 
-    test('adds properties', () => new Promise(done => {
+    test('adds properties', () => new Promise<void>(done => {
         const updateable = new Map([['point', point]]);
         applySourceDiff(updateable, {
             update: [{
@@ -337,7 +337,7 @@ describe('applySourceDiff', () => {
         done();
     }));
 
-    test('updates properties', () => new Promise(done => {
+    test('updates properties', () => new Promise<void>(done => {
         const updateable = new Map([['point', {...point, properties: {prop: 'value', prop2: 'value2'}}]]);
         applySourceDiff(updateable, {
             update: [{
@@ -355,7 +355,7 @@ describe('applySourceDiff', () => {
         done();
     }));
 
-    test('removes properties', () => new Promise(done => {
+    test('removes properties', () => new Promise<void>(done => {
         const updateable = new Map([['point', {...point, properties: {prop: 'value', prop2: 'value2'}}]]);
         applySourceDiff(updateable, {
             update: [{
@@ -370,7 +370,7 @@ describe('applySourceDiff', () => {
         done();
     }));
 
-    test('removes all properties', () => new Promise(done => {
+    test('removes all properties', () => new Promise<void>(done => {
         const updateable = new Map([['point', {...point, properties: {prop: 'value', prop2: 'value2'}}]]);
         applySourceDiff(updateable, {
             update: [{

--- a/src/source/geojson_source_diff.test.ts
+++ b/src/source/geojson_source_diff.test.ts
@@ -6,7 +6,7 @@ beforeEach(() => {
 });
 
 describe('isUpdateableGeoJSON', () => {
-    test('feature without id is not updateable', () => new Promise<void>(done => {
+    test('feature without id is not updateable', () => {
         // no feature id -> false
         expect(isUpdateableGeoJSON({
             type: 'Feature',
@@ -16,10 +16,9 @@ describe('isUpdateableGeoJSON', () => {
             },
             properties: {},
         })).toBe(false);
-        done();
-    }));
+    });
 
-    test('feature with id is updateable', () => new Promise<void>(done => {
+    test('feature with id is updateable', () => {
         // has a feature id -> true
         expect(isUpdateableGeoJSON({
             type: 'Feature',
@@ -30,10 +29,9 @@ describe('isUpdateableGeoJSON', () => {
             },
             properties: {},
         })).toBe(true);
-        done();
-    }));
+    });
 
-    test('promoteId missing is not updateable', () => new Promise<void>(done => {
+    test('promoteId missing is not updateable', () => {
         expect(isUpdateableGeoJSON({
             type: 'Feature',
             id: 'feature_id',
@@ -43,10 +41,9 @@ describe('isUpdateableGeoJSON', () => {
             },
             properties: {},
         }, 'propId')).toBe(false);
-        done();
-    }));
+    });
 
-    test('promoteId present is updateable', () => new Promise<void>(done => {
+    test('promoteId present is updateable', () => {
         expect(isUpdateableGeoJSON({
             type: 'Feature',
             geometry: {
@@ -57,10 +54,9 @@ describe('isUpdateableGeoJSON', () => {
                 propId: 'feature_id',
             },
         }, 'propId')).toBe(true);
-        done();
-    }));
+    });
 
-    test('feature collection with unique ids is updateable', () => new Promise<void>(done => {
+    test('feature collection with unique ids is updateable', () => {
         expect(isUpdateableGeoJSON({
             type: 'FeatureCollection',
             features: [{
@@ -81,10 +77,9 @@ describe('isUpdateableGeoJSON', () => {
                 properties: {},
             }]
         })).toBe(true);
-        done();
-    }));
+    });
 
-    test('feature collection with unique promoteIds is updateable', () => new Promise<void>(done => {
+    test('feature collection with unique promoteIds is updateable', () => {
         expect(isUpdateableGeoJSON({
             type: 'FeatureCollection',
             features: [{
@@ -107,10 +102,9 @@ describe('isUpdateableGeoJSON', () => {
                 },
             }]
         }, 'propId')).toBe(true);
-        done();
-    }));
+    });
 
-    test('feature collection without unique ids is not updateable', () => new Promise<void>(done => {
+    test('feature collection without unique ids is not updateable', () => {
         expect(isUpdateableGeoJSON({
             type: 'FeatureCollection',
             features: [{
@@ -122,10 +116,9 @@ describe('isUpdateableGeoJSON', () => {
                 properties: {},
             }]
         })).toBe(false);
-        done();
-    }));
+    });
 
-    test('feature collection with duplicate feature ids is not updateable', () => new Promise<void>(done => {
+    test('feature collection with duplicate feature ids is not updateable', () => {
         expect(isUpdateableGeoJSON({
             type: 'FeatureCollection',
             features: [{
@@ -146,17 +139,15 @@ describe('isUpdateableGeoJSON', () => {
                 properties: {},
             }]
         })).toBe(false);
-        done();
-    }));
+    });
 
-    test('geometries are not updateable', () => new Promise<void>(done => {
+    test('geometries are not updateable', () => {
         expect(isUpdateableGeoJSON({type: 'Point', coordinates: [0, 0]})).toBe(false);
-        done();
-    }));
+    });
 });
 
 describe('toUpdateable', () => {
-    test('works with a single feature - feature id', () => new Promise<void>(done => {
+    test('works with a single feature - feature id', () => {
         const updateable = toUpdateable({
             type: 'Feature',
             id: 'point',
@@ -166,10 +157,9 @@ describe('toUpdateable', () => {
             }, properties: {}});
         expect(updateable.size).toBe(1);
         expect(updateable.has('point')).toBeTruthy();
-        done();
-    }));
+    });
 
-    test('works with a single feature - promoteId', () => new Promise<void>(done => {
+    test('works with a single feature - promoteId', () => {
         const updateable2 = toUpdateable({
             type: 'Feature',
             geometry: {
@@ -180,10 +170,9 @@ describe('toUpdateable', () => {
             }}, 'promoteId');
         expect(updateable2.size).toBe(1);
         expect(updateable2.has('point')).toBeTruthy();
-        done();
-    }));
+    });
 
-    test('works with a FeatureCollection - feature id', () => new Promise<void>(done => {
+    test('works with a FeatureCollection - feature id', () => {
         const updateable = toUpdateable({
             type: 'FeatureCollection',
             features: [
@@ -206,10 +195,9 @@ describe('toUpdateable', () => {
         expect(updateable.size).toBe(2);
         expect(updateable.has('point')).toBeTruthy();
         expect(updateable.has('point2')).toBeTruthy();
-        done();
-    }));
+    });
 
-    test('works with a FeatureCollection - promoteId', () => new Promise<void>(done => {
+    test('works with a FeatureCollection - promoteId', () => {
         const updateable2 = toUpdateable({
             type: 'FeatureCollection',
             features: [
@@ -234,8 +222,7 @@ describe('toUpdateable', () => {
         expect(updateable2.size).toBe(2);
         expect(updateable2.has('point')).toBeTruthy();
         expect(updateable2.has('point2')).toBeTruthy();
-        done();
-    }));
+    });
 });
 
 describe('applySourceDiff', () => {
@@ -270,7 +257,7 @@ describe('applySourceDiff', () => {
     Object.freeze((point2.geometry as GeoJSON.Point).coordinates);
     Object.freeze(point2.properties);
 
-    test('adds a feature using the feature id', () => new Promise<void>(done => {
+    test('adds a feature using the feature id', () => {
         const updateable = new Map<GeoJSONFeatureId, GeoJSON.Feature>();
 
         applySourceDiff(updateable, {
@@ -278,30 +265,27 @@ describe('applySourceDiff', () => {
         });
         expect(updateable.size).toBe(1);
         expect(updateable.has('point')).toBeTruthy();
-        done();
-    }));
+    });
 
-    test('adds a feature using the promoteId', () => new Promise<void>(done => {
+    test('adds a feature using the promoteId', () => {
         const updateable = new Map<GeoJSONFeatureId, GeoJSON.Feature>();
         applySourceDiff(updateable, {
             add: [point2]
         }, 'promoteId');
         expect(updateable.size).toBe(1);
         expect(updateable.has('point2')).toBeTruthy();
-        done();
-    }));
+    });
 
-    test('removes a feature by its id', () => new Promise<void>(done => {
+    test('removes a feature by its id', () => {
         const updateable = new Map([['point', point], ['point2', point2]]);
         applySourceDiff(updateable, {
             remove: ['point2'],
         });
         expect(updateable.size).toBe(1);
         expect(updateable.has('point2')).toBeFalsy();
-        done();
-    }));
+    });
 
-    test('updates a feature geometry', () => new Promise<void>(done => {
+    test('updates a feature geometry', () => {
         const updateable = new Map([['point', point]]);
         // update -> new geometry
         applySourceDiff(updateable, {
@@ -315,10 +299,9 @@ describe('applySourceDiff', () => {
         });
         expect(updateable.size).toBe(1);
         expect((updateable.get('point')?.geometry as GeoJSON.Point).coordinates[0]).toBe(1);
-        done();
-    }));
+    });
 
-    test('adds properties', () => new Promise<void>(done => {
+    test('adds properties', () => {
         const updateable = new Map([['point', point]]);
         applySourceDiff(updateable, {
             update: [{
@@ -334,10 +317,9 @@ describe('applySourceDiff', () => {
         expect(Object.keys(properties)).toHaveLength(2);
         expect(properties.prop).toBe('value');
         expect(properties.prop2).toBe('value2');
-        done();
-    }));
+    });
 
-    test('updates properties', () => new Promise<void>(done => {
+    test('updates properties', () => {
         const updateable = new Map([['point', {...point, properties: {prop: 'value', prop2: 'value2'}}]]);
         applySourceDiff(updateable, {
             update: [{
@@ -352,10 +334,9 @@ describe('applySourceDiff', () => {
         expect(Object.keys(properties2)).toHaveLength(2);
         expect(properties2.prop).toBe('value');
         expect(properties2.prop2).toBe('value3');
-        done();
-    }));
+    });
 
-    test('removes properties', () => new Promise<void>(done => {
+    test('removes properties', () => {
         const updateable = new Map([['point', {...point, properties: {prop: 'value', prop2: 'value2'}}]]);
         applySourceDiff(updateable, {
             update: [{
@@ -367,10 +348,9 @@ describe('applySourceDiff', () => {
         const properties3 = updateable.get('point')?.properties!;
         expect(Object.keys(properties3)).toHaveLength(1);
         expect(properties3.prop).toBe('value');
-        done();
-    }));
+    });
 
-    test('removes all properties', () => new Promise<void>(done => {
+    test('removes all properties', () => {
         const updateable = new Map([['point', {...point, properties: {prop: 'value', prop2: 'value2'}}]]);
         applySourceDiff(updateable, {
             update: [{
@@ -380,6 +360,5 @@ describe('applySourceDiff', () => {
         });
         expect(updateable.size).toBe(1);
         expect(Object.keys(updateable.get('point')?.properties!)).toHaveLength(0);
-        done();
-    }));
+    });
 });

--- a/src/source/image_source.test.ts
+++ b/src/source/image_source.test.ts
@@ -128,7 +128,7 @@ describe('ImageSource', () => {
         expect(afterSerialized.coordinates).toEqual([[0, 0], [-1, 0], [-1, -1], [0, -1]]);
     });
 
-    test('fires data event when content is loaded', () => new Promise(done => {
+    test('fires data event when content is loaded', () => new Promise<void>(done => {
         const source = createSource({url: '/image.png'});
         source.on('data', (e) => {
             if (e.dataType === 'source' && e.sourceDataType === 'content') {
@@ -140,7 +140,7 @@ describe('ImageSource', () => {
         server.respond();
     }));
 
-    test('fires data event when metadata is loaded', () => new Promise(done => {
+    test('fires data event when metadata is loaded', () => new Promise<void>(done => {
         const source = createSource({url: '/image.png'});
         source.on('data', (e) => {
             if (e.dataType === 'source' && e.sourceDataType === 'metadata') {
@@ -151,7 +151,7 @@ describe('ImageSource', () => {
         server.respond();
     }));
 
-    test('fires idle event on prepare call when there is at least one not loaded tile', () => new Promise(done => {
+    test('fires idle event on prepare call when there is at least one not loaded tile', () => new Promise<void>(done => {
         const source = createSource({url: '/image.png'});
         const tile = new Tile(new OverscaledTileID(1, 0, 1, 0, 0), 512);
         source.on('data', (e) => {

--- a/src/source/image_source.test.ts
+++ b/src/source/image_source.test.ts
@@ -128,7 +128,7 @@ describe('ImageSource', () => {
         expect(afterSerialized.coordinates).toEqual([[0, 0], [-1, 0], [-1, -1], [0, -1]]);
     });
 
-    test('fires data event when content is loaded', done => {
+    test('fires data event when content is loaded', () => new Promise(done => {
         const source = createSource({url: '/image.png'});
         source.on('data', (e) => {
             if (e.dataType === 'source' && e.sourceDataType === 'content') {
@@ -138,9 +138,9 @@ describe('ImageSource', () => {
         });
         source.onAdd(new StubMap() as any);
         server.respond();
-    });
+    }));
 
-    test('fires data event when metadata is loaded', done => {
+    test('fires data event when metadata is loaded', () => new Promise(done => {
         const source = createSource({url: '/image.png'});
         source.on('data', (e) => {
             if (e.dataType === 'source' && e.sourceDataType === 'metadata') {
@@ -149,9 +149,9 @@ describe('ImageSource', () => {
         });
         source.onAdd(new StubMap() as any);
         server.respond();
-    });
+    }));
 
-    test('fires idle event on prepare call when there is at least one not loaded tile', done => {
+    test('fires idle event on prepare call when there is at least one not loaded tile', () => new Promise(done => {
         const source = createSource({url: '/image.png'});
         const tile = new Tile(new OverscaledTileID(1, 0, 1, 0, 0), 512);
         source.on('data', (e) => {
@@ -170,7 +170,7 @@ describe('ImageSource', () => {
         source.boundsSegments = {} as SegmentVector;
         source.texture = {} as Texture;
         source.prepare();
-    });
+    }));
 
     test('serialize url and coordinates', () => {
         const source = createSource({url: '/image.png'});

--- a/src/source/raster_tile_source.test.ts
+++ b/src/source/raster_tile_source.test.ts
@@ -50,7 +50,7 @@ describe('RasterTileSource', () => {
         expect(transformSpy.mock.calls[0][1]).toBe('Source');
     });
 
-    test('respects TileJSON.bounds', done => {
+    test('respects TileJSON.bounds', () => new Promise(done => {
         const source = createSource({
             minzoom: 0,
             maxzoom: 22,
@@ -65,9 +65,9 @@ describe('RasterTileSource', () => {
                 done();
             }
         });
-    });
+    }));
 
-    test('does not error on invalid bounds', done => {
+    test('does not error on invalid bounds', () => new Promise(done => {
         const source = createSource({
             minzoom: 0,
             maxzoom: 22,
@@ -82,9 +82,9 @@ describe('RasterTileSource', () => {
                 done();
             }
         });
-    });
+    }));
 
-    test('respects TileJSON.bounds when loaded from TileJSON', done => {
+    test('respects TileJSON.bounds when loaded from TileJSON', () => new Promise(done => {
         server.respondWith('/source.json', JSON.stringify({
             minzoom: 0,
             maxzoom: 22,
@@ -102,9 +102,9 @@ describe('RasterTileSource', () => {
             }
         });
         server.respond();
-    });
+    }));
 
-    test('transforms tile urls before requesting', done => {
+    test('transforms tile urls before requesting', () => new Promise(done => {
         server.respondWith('/source.json', JSON.stringify({
             minzoom: 0,
             maxzoom: 22,
@@ -130,9 +130,9 @@ describe('RasterTileSource', () => {
             }
         });
         server.respond();
-    });
+    }));
 
-    test('HttpImageElement used to get image when refreshExpiredTiles is false', done => {
+    test('HttpImageElement used to get image when refreshExpiredTiles is false', () => new Promise(done => {
         stubAjaxGetImage(undefined);
         server.respondWith('/source.json', JSON.stringify({
             minzoom: 0,
@@ -160,7 +160,7 @@ describe('RasterTileSource', () => {
             }
         });
         server.respond();
-    });
+    }));
 
     test('supports updating tiles', () => {
         const source = createSource({url: '/source.json'});

--- a/src/source/raster_tile_source.test.ts
+++ b/src/source/raster_tile_source.test.ts
@@ -50,7 +50,7 @@ describe('RasterTileSource', () => {
         expect(transformSpy.mock.calls[0][1]).toBe('Source');
     });
 
-    test('respects TileJSON.bounds', () => new Promise(done => {
+    test('respects TileJSON.bounds', () => new Promise<void>(done => {
         const source = createSource({
             minzoom: 0,
             maxzoom: 22,
@@ -67,7 +67,7 @@ describe('RasterTileSource', () => {
         });
     }));
 
-    test('does not error on invalid bounds', () => new Promise(done => {
+    test('does not error on invalid bounds', () => new Promise<void>(done => {
         const source = createSource({
             minzoom: 0,
             maxzoom: 22,
@@ -84,7 +84,7 @@ describe('RasterTileSource', () => {
         });
     }));
 
-    test('respects TileJSON.bounds when loaded from TileJSON', () => new Promise(done => {
+    test('respects TileJSON.bounds when loaded from TileJSON', () => new Promise<void>(done => {
         server.respondWith('/source.json', JSON.stringify({
             minzoom: 0,
             maxzoom: 22,
@@ -104,7 +104,7 @@ describe('RasterTileSource', () => {
         server.respond();
     }));
 
-    test('transforms tile urls before requesting', () => new Promise(done => {
+    test('transforms tile urls before requesting', () => new Promise<void>(done => {
         server.respondWith('/source.json', JSON.stringify({
             minzoom: 0,
             maxzoom: 22,
@@ -132,7 +132,7 @@ describe('RasterTileSource', () => {
         server.respond();
     }));
 
-    test('HttpImageElement used to get image when refreshExpiredTiles is false', () => new Promise(done => {
+    test('HttpImageElement used to get image when refreshExpiredTiles is false', () => new Promise<void>(done => {
         stubAjaxGetImage(undefined);
         server.respondWith('/source.json', JSON.stringify({
             minzoom: 0,

--- a/src/source/source_cache.test.ts
+++ b/src/source/source_cache.test.ts
@@ -1709,7 +1709,7 @@ describe('source cache get ids', () => {
             new OverscaledTileID(3, 0, 3, 0, 0).key
         ]);
         done();
-    });
+    }));
 });
 
 describe('SourceCache#findLoadedParent', () => {

--- a/src/source/source_cache.test.ts
+++ b/src/source/source_cache.test.ts
@@ -103,7 +103,7 @@ afterEach(() => {
 });
 
 describe('SourceCache#addTile', () => {
-    test('loads tile when uncached', done => {
+    test('loads tile when uncached', () => new Promise(done => {
         const tileID = new OverscaledTileID(0, 0, 0, 0, 0);
         const sourceCache = createSourceCache();
         sourceCache._source.loadTile = async (tile) => {
@@ -113,9 +113,9 @@ describe('SourceCache#addTile', () => {
         };
         sourceCache.onAdd(undefined);
         sourceCache._addTile(tileID);
-    });
+    }));
 
-    test('adds tile when uncached', done => {
+    test('adds tile when uncached', () => new Promise(done => {
         const tileID = new OverscaledTileID(0, 0, 0, 0, 0);
         const sourceCache = createSourceCache({}).on('dataloading', (data) => {
             expect(data.tile.tileID).toEqual(tileID);
@@ -124,9 +124,9 @@ describe('SourceCache#addTile', () => {
         });
         sourceCache.onAdd(undefined);
         sourceCache._addTile(tileID);
-    });
+    }));
 
-    test('updates feature state on added uncached tile', done => {
+    test('updates feature state on added uncached tile', () => new Promise(done => {
         const tileID = new OverscaledTileID(0, 0, 0, 0, 0);
         let updateFeaturesSpy;
         const sourceCache = createSourceCache({});
@@ -140,7 +140,7 @@ describe('SourceCache#addTile', () => {
         };
         sourceCache.onAdd(undefined);
         sourceCache._addTile(tileID);
-    });
+    }));
 
     test('uses cached tile', () => {
         const tileID = new OverscaledTileID(0, 0, 0, 0, 0);
@@ -278,7 +278,7 @@ describe('SourceCache#addTile', () => {
 });
 
 describe('SourceCache#removeTile', () => {
-    test('removes tile', done => {
+    test('removes tile', () => new Promise(done => {
         const tileID = new OverscaledTileID(0, 0, 0, 0, 0);
         const sourceCache = createSourceCache({});
         sourceCache._addTile(tileID);
@@ -287,7 +287,7 @@ describe('SourceCache#removeTile', () => {
             expect(sourceCache._tiles[tileID.key]).toBeFalsy();
             done();
         });
-    });
+    }));
 
     test('caches (does not unload) loaded tile', () => {
         const tileID = new OverscaledTileID(0, 0, 0, 0, 0);
@@ -390,52 +390,52 @@ describe('SourceCache#removeTile', () => {
 });
 
 describe('SourceCache / Source lifecycle', () => {
-    test('does not fire load or change before source load event', done => {
+    test('does not fire load or change before source load event', () => new Promise(done => {
         const sourceCache = createSourceCache({noLoad: true})
             .on('data', () => done('test failed: data event fired'));
         sourceCache.onAdd(undefined);
         setTimeout(() => done(), 1);
-    });
+    }));
 
-    test('forward load event', done => {
+    test('forward load event', () => new Promise(done => {
         const sourceCache = createSourceCache({}).on('data', (e) => {
             if (e.sourceDataType === 'metadata') done();
         });
         sourceCache.onAdd(undefined);
-    });
+    }));
 
-    test('forward change event', done => {
+    test('forward change event', () => new Promise(done => {
         const sourceCache = createSourceCache().on('data', (e) => {
             if (e.sourceDataType === 'metadata') done();
         });
         sourceCache.onAdd(undefined);
         sourceCache.getSource().fire(new Event('data'));
-    });
+    }));
 
-    test('forward error event', done => {
+    test('forward error event', () => new Promise(done => {
         const sourceCache = createSourceCache({error: 'Error loading source'}).on('error', (err) => {
             expect(err.error).toBe('Error loading source');
             done();
         });
         sourceCache.onAdd(undefined);
-    });
+    }));
 
-    test('suppress 404 errors', done => {
+    test('suppress 404 errors', () => new Promise(done => {
         const sourceCache = createSourceCache({status: 404, message: 'Not found'})
             .on('error', () => done('test failed: error event fired'));
         sourceCache.onAdd(undefined);
         done();
-    });
+    }));
 
-    test('loaded() true after source error', done => {
+    test('loaded() true after source error', () => new Promise(done => {
         const sourceCache = createSourceCache({error: 'Error loading source'}).on('error', () => {
             expect(sourceCache.loaded()).toBeTruthy();
             done();
         });
         sourceCache.onAdd(undefined);
-    });
+    }));
 
-    test('loaded() true after tile error', done => {
+    test('loaded() true after tile error', () => new Promise(done => {
         const transform = new Transform();
         transform.resize(511, 511);
         transform.zoom = 0;
@@ -453,9 +453,9 @@ describe('SourceCache / Source lifecycle', () => {
         });
 
         sourceCache.onAdd(undefined);
-    });
+    }));
 
-    test('loaded() false after source begins loading following error', done => {
+    test('loaded() false after source begins loading following error', () => new Promise(done => {
         const sourceCache = createSourceCache({error: 'Error loading source'}).on('error', () => {
             sourceCache.on('dataloading', () => {
                 expect(sourceCache.loaded()).toBeFalsy();
@@ -465,9 +465,9 @@ describe('SourceCache / Source lifecycle', () => {
         });
 
         sourceCache.onAdd(undefined);
-    });
+    }));
 
-    test('loaded() false when error occurs while source is not loaded', done => {
+    test('loaded() false when error occurs while source is not loaded', () => new Promise(done => {
         const sourceCache = createSourceCache({
             error: 'Error loading source',
 
@@ -480,7 +480,7 @@ describe('SourceCache / Source lifecycle', () => {
         });
 
         sourceCache.onAdd(undefined);
-    });
+    }));
 
     test('reloads tiles after a data event where source is updated', () => {
         const transform = new Transform();
@@ -535,7 +535,7 @@ describe('SourceCache / Source lifecycle', () => {
 });
 
 describe('SourceCache#update', () => {
-    test('loads no tiles if used is false', done => {
+    test('loads no tiles if used is false', () => new Promise(done => {
         const transform = new Transform();
         transform.resize(512, 512);
         transform.zoom = 0;
@@ -549,9 +549,9 @@ describe('SourceCache#update', () => {
             }
         });
         sourceCache.onAdd(undefined);
-    });
+    }));
 
-    test('loads covering tiles', done => {
+    test('loads covering tiles', () => new Promise(done => {
         const transform = new Transform();
         transform.resize(511, 511);
         transform.zoom = 0;
@@ -565,9 +565,9 @@ describe('SourceCache#update', () => {
             }
         });
         sourceCache.onAdd(undefined);
-    });
+    }));
 
-    test('respects Source#hasTile method if it is present', done => {
+    test('respects Source#hasTile method if it is present', () => new Promise(done => {
         const transform = new Transform();
         transform.resize(511, 511);
         transform.zoom = 1;
@@ -586,9 +586,9 @@ describe('SourceCache#update', () => {
             }
         });
         sourceCache.onAdd(undefined);
-    });
+    }));
 
-    test('removes unused tiles', done => {
+    test('removes unused tiles', () => new Promise(done => {
         const transform = new Transform();
         transform.resize(511, 511);
         transform.zoom = 0;
@@ -617,9 +617,9 @@ describe('SourceCache#update', () => {
         });
 
         sourceCache.onAdd(undefined);
-    });
+    }));
 
-    test('retains parent tiles for pending children', done => {
+    test('retains parent tiles for pending children', () => new Promise(done => {
         const transform = new Transform();
         (transform as any)._test = 'retains';
         transform.resize(511, 511);
@@ -649,9 +649,9 @@ describe('SourceCache#update', () => {
             }
         });
         sourceCache.onAdd(undefined);
-    });
+    }));
 
-    test('retains parent tiles for pending children (wrapped)', done => {
+    test('retains parent tiles for pending children (wrapped)', () => new Promise(done => {
         const transform = new Transform();
         transform.resize(511, 511);
         transform.zoom = 0;
@@ -681,9 +681,9 @@ describe('SourceCache#update', () => {
             }
         });
         sourceCache.onAdd(undefined);
-    });
+    }));
 
-    test('retains covered child tiles while parent tile is fading in', done => {
+    test('retains covered child tiles while parent tile is fading in', () => new Promise(done => {
         const transform = new Transform();
         transform.resize(511, 511);
         transform.zoom = 2;
@@ -715,9 +715,9 @@ describe('SourceCache#update', () => {
             }
         });
         sourceCache.onAdd(undefined);
-    });
+    }));
 
-    test('retains a parent tile for fading even if a tile is partially covered by children', done => {
+    test('retains a parent tile for fading even if a tile is partially covered by children', () => new Promise(done => {
         const transform = new Transform();
         transform.resize(511, 511);
         transform.zoom = 0;
@@ -746,9 +746,9 @@ describe('SourceCache#update', () => {
             }
         });
         sourceCache.onAdd(undefined);
-    });
+    }));
 
-    test('retain children for fading fadeEndTime is 0 (added but registerFadeDuration() is not called yet)', done => {
+    test('retain children for fading fadeEndTime is 0 (added but registerFadeDuration() is not called yet)', () => new Promise(done => {
         const transform = new Transform();
         transform.resize(511, 511);
         transform.zoom = 1;
@@ -774,9 +774,9 @@ describe('SourceCache#update', () => {
             }
         });
         sourceCache.onAdd(undefined);
-    });
+    }));
 
-    test('retains children when tile.fadeEndTime is in the future', done => {
+    test('retains children when tile.fadeEndTime is in the future', () => new Promise(done => {
         const transform = new Transform();
         transform.resize(511, 511);
         transform.zoom = 1;
@@ -818,9 +818,9 @@ describe('SourceCache#update', () => {
         });
 
         sourceCache.onAdd(undefined);
-    });
+    }));
 
-    test('retains overscaled loaded children', done => {
+    test('retains overscaled loaded children', () => new Promise(done => {
         const transform = new Transform();
         transform.resize(511, 511);
         transform.zoom = 16;
@@ -856,9 +856,9 @@ describe('SourceCache#update', () => {
             }
         });
         sourceCache.onAdd(undefined);
-    });
+    }));
 
-    test('reassigns tiles for large jumps in longitude', done => {
+    test('reassigns tiles for large jumps in longitude', () => new Promise(done => {
 
         const transform = new Transform();
         transform.resize(511, 511);
@@ -882,7 +882,7 @@ describe('SourceCache#update', () => {
             }
         });
         sourceCache.onAdd(undefined);
-    });
+    }));
 
 });
 
@@ -1392,7 +1392,7 @@ describe('SourceCache#tilesIn', () => {
         });
     }
 
-    test('regular tiles', done => {
+    test('regular tiles', () => new Promise(done => {
         const transform = new Transform();
         transform.resize(512, 512);
         transform.zoom = 1;
@@ -1437,7 +1437,7 @@ describe('SourceCache#tilesIn', () => {
             }
         });
         sourceCache.onAdd(undefined);
-    });
+    }));
 
     test('reparsed overscaled tiles', () => {
         const sourceCache = createSourceCache({
@@ -1488,7 +1488,7 @@ describe('SourceCache#tilesIn', () => {
         sourceCache.onAdd(undefined);
     });
 
-    test('overscaled tiles', done => {
+    test('overscaled tiles', () => new Promise(done => {
         const sourceCache = createSourceCache({
             reparseOverscaled: false,
             minzoom: 1,
@@ -1510,11 +1510,11 @@ describe('SourceCache#tilesIn', () => {
             }
         });
         sourceCache.onAdd(undefined);
-    });
+    }));
 });
 
 describe('source cache loaded', () => {
-    test('SourceCache#loaded (no errors)', done => {
+    test('SourceCache#loaded (no errors)', () => new Promise(done => {
         const sourceCache = createSourceCache();
         sourceCache._source.loadTile = async (tile) => {
             tile.state = 'loaded';
@@ -1534,9 +1534,9 @@ describe('source cache loaded', () => {
             }
         });
         sourceCache.onAdd(undefined);
-    });
+    }));
 
-    test('SourceCache#loaded (with errors)', done => {
+    test('SourceCache#loaded (with errors)', () => new Promise(done => {
         const sourceCache = createSourceCache();
         sourceCache._source.loadTile = async (tile) => {
             tile.state = 'errored';
@@ -1557,9 +1557,9 @@ describe('source cache loaded', () => {
             }
         });
         sourceCache.onAdd(undefined);
-    });
+    }));
 
-    test('SourceCache#loaded (unused)', done => {
+    test('SourceCache#loaded (unused)', () => new Promise(done => {
         const sourceCache = createSourceCache(undefined, false);
         sourceCache._source.loadTile = async (tile) => {
             tile.state = 'errored';
@@ -1573,9 +1573,9 @@ describe('source cache loaded', () => {
             }
         });
         sourceCache.onAdd(undefined);
-    });
+    }));
 
-    test('SourceCache#loaded (unusedForTerrain)', done => {
+    test('SourceCache#loaded (unusedForTerrain)', () => new Promise(done => {
         const sourceCache = createSourceCache(undefined, false);
         sourceCache._source.loadTile = async (tile) => {
             tile.state = 'errored';
@@ -1590,9 +1590,9 @@ describe('source cache loaded', () => {
             }
         });
         sourceCache.onAdd(undefined);
-    });
+    }));
 
-    test('SourceCache#loaded (not loaded when no update)', done => {
+    test('SourceCache#loaded (not loaded when no update)', () => new Promise(done => {
         const sourceCache = createSourceCache();
         sourceCache._source.loadTile = async (tile) => {
             tile.state = 'errored';
@@ -1606,9 +1606,9 @@ describe('source cache loaded', () => {
             }
         });
         sourceCache.onAdd(undefined);
-    });
+    }));
 
-    test('SourceCache#loaded (on last tile load)', done => {
+    test('SourceCache#loaded (on last tile load)', () => new Promise(done => {
         const sourceCache = createSourceCache();
         sourceCache._source.loadTile = async (tile) => {
             tile.state = 'loading';
@@ -1643,9 +1643,9 @@ describe('source cache loaded', () => {
 
         sourceCache.onAdd(undefined);
         sourceCache.update(tr);
-    });
+    }));
 
-    test('SourceCache#loaded (tiles outside bounds, idle)', done => {
+    test('SourceCache#loaded (tiles outside bounds, idle)', () => new Promise(done => {
         const japan = new TileBounds([122.74, 19.33, 149.0, 45.67]);
         const sourceCache = createSourceCache();
         sourceCache._source.loadTile = async (tile) => {
@@ -1685,11 +1685,11 @@ describe('source cache loaded', () => {
         tr.zoom = 10;
         tr.resize(512, 512);
         sourceCache.update(tr);
-    });
+    }));
 });
 
 describe('source cache get ids', () => {
-    test('SourceCache#getIds (ascending order by zoom level)', done => {
+    test('SourceCache#getIds (ascending order by zoom level)', () => new Promise(done => {
         const ids = [
             new OverscaledTileID(0, 0, 0, 0, 0),
             new OverscaledTileID(3, 0, 3, 0, 0),
@@ -1917,7 +1917,7 @@ describe('SourceCache#reload', () => {
 });
 
 describe('SourceCache reloads expiring tiles', () => {
-    test('calls reloadTile when tile expires', done => {
+    test('calls reloadTile when tile expires', () => new Promise(done => {
         const coord = new OverscaledTileID(1, 0, 1, 0, 1);
 
         const expiryDate = new Date();
@@ -1930,7 +1930,7 @@ describe('SourceCache reloads expiring tiles', () => {
         };
 
         sourceCache._addTile(coord);
-    });
+    }));
 
 });
 
@@ -1988,7 +1988,7 @@ describe('SourceCache#onRemove', () => {
 });
 
 describe('SourceCache#usedForTerrain', () => {
-    test('loads covering tiles with usedForTerrain with source zoom 0-14', done => {
+    test('loads covering tiles with usedForTerrain with source zoom 0-14', () => new Promise(done => {
         const transform = new Transform();
         transform.resize(511, 511);
         transform.zoom = 10;
@@ -2007,9 +2007,9 @@ describe('SourceCache#usedForTerrain', () => {
             }
         });
         sourceCache.onAdd(undefined);
-    });
+    }));
 
-    test('loads covering tiles with usedForTerrain with source zoom 8-14', done => {
+    test('loads covering tiles with usedForTerrain with source zoom 8-14', () => new Promise(done => {
         const transform = new Transform();
         transform.resize(511, 511);
         transform.zoom = 10;
@@ -2027,9 +2027,9 @@ describe('SourceCache#usedForTerrain', () => {
             }
         });
         sourceCache.onAdd(undefined);
-    });
+    }));
 
-    test('loads covering tiles with usedForTerrain with source zoom 0-4', done => {
+    test('loads covering tiles with usedForTerrain with source zoom 0-4', () => new Promise(done => {
         const transform = new Transform();
         transform.resize(511, 511);
         transform.zoom = 10;
@@ -2047,9 +2047,9 @@ describe('SourceCache#usedForTerrain', () => {
             }
         });
         sourceCache.onAdd(undefined);
-    });
+    }));
 
-    test('loads covering tiles with usedForTerrain with source zoom 4-4', done => {
+    test('loads covering tiles with usedForTerrain with source zoom 4-4', () => new Promise(done => {
         const transform = new Transform();
         transform.resize(511, 511);
         transform.zoom = 10;
@@ -2067,5 +2067,5 @@ describe('SourceCache#usedForTerrain', () => {
             }
         });
         sourceCache.onAdd(undefined);
-    });
+    }));
 });

--- a/src/source/source_cache.test.ts
+++ b/src/source/source_cache.test.ts
@@ -420,12 +420,11 @@ describe('SourceCache / Source lifecycle', () => {
         sourceCache.onAdd(undefined);
     }));
 
-    test('suppress 404 errors', () => new Promise<void>((done, fail) => {
+    test('suppress 404 errors', () => {
         const sourceCache = createSourceCache({status: 404, message: 'Not found'})
             .on('error', () => fail(new Error('test failed: error event fired')));
         sourceCache.onAdd(undefined);
-        done();
-    }));
+    });
 
     test('loaded() true after source error', () => new Promise<void>(done => {
         const sourceCache = createSourceCache({error: 'Error loading source'}).on('error', () => {
@@ -1689,7 +1688,7 @@ describe('source cache loaded', () => {
 });
 
 describe('source cache get ids', () => {
-    test('SourceCache#getIds (ascending order by zoom level)', () => new Promise<void>(done => {
+    test('SourceCache#getIds (ascending order by zoom level)', () => {
         const ids = [
             new OverscaledTileID(0, 0, 0, 0, 0),
             new OverscaledTileID(3, 0, 3, 0, 0),
@@ -1708,8 +1707,7 @@ describe('source cache get ids', () => {
             new OverscaledTileID(2, 0, 2, 0, 0).key,
             new OverscaledTileID(3, 0, 3, 0, 0).key
         ]);
-        done();
-    }));
+    });
 });
 
 describe('SourceCache#findLoadedParent', () => {

--- a/src/source/source_cache.test.ts
+++ b/src/source/source_cache.test.ts
@@ -103,7 +103,7 @@ afterEach(() => {
 });
 
 describe('SourceCache#addTile', () => {
-    test('loads tile when uncached', () => new Promise(done => {
+    test('loads tile when uncached', () => new Promise<void>(done => {
         const tileID = new OverscaledTileID(0, 0, 0, 0, 0);
         const sourceCache = createSourceCache();
         sourceCache._source.loadTile = async (tile) => {
@@ -115,7 +115,7 @@ describe('SourceCache#addTile', () => {
         sourceCache._addTile(tileID);
     }));
 
-    test('adds tile when uncached', () => new Promise(done => {
+    test('adds tile when uncached', () => new Promise<void>(done => {
         const tileID = new OverscaledTileID(0, 0, 0, 0, 0);
         const sourceCache = createSourceCache({}).on('dataloading', (data) => {
             expect(data.tile.tileID).toEqual(tileID);
@@ -126,7 +126,7 @@ describe('SourceCache#addTile', () => {
         sourceCache._addTile(tileID);
     }));
 
-    test('updates feature state on added uncached tile', () => new Promise(done => {
+    test('updates feature state on added uncached tile', () => new Promise<void>(done => {
         const tileID = new OverscaledTileID(0, 0, 0, 0, 0);
         let updateFeaturesSpy;
         const sourceCache = createSourceCache({});
@@ -278,7 +278,7 @@ describe('SourceCache#addTile', () => {
 });
 
 describe('SourceCache#removeTile', () => {
-    test('removes tile', () => new Promise(done => {
+    test('removes tile', () => new Promise<void>(done => {
         const tileID = new OverscaledTileID(0, 0, 0, 0, 0);
         const sourceCache = createSourceCache({});
         sourceCache._addTile(tileID);
@@ -390,21 +390,21 @@ describe('SourceCache#removeTile', () => {
 });
 
 describe('SourceCache / Source lifecycle', () => {
-    test('does not fire load or change before source load event', () => new Promise(done => {
+    test('does not fire load or change before source load event', () => new Promise<void>((done, fail) => {
         const sourceCache = createSourceCache({noLoad: true})
-            .on('data', () => done('test failed: data event fired'));
+            .on('data', () => fail(new Error('test failed: data event fired')));
         sourceCache.onAdd(undefined);
         setTimeout(() => done(), 1);
     }));
 
-    test('forward load event', () => new Promise(done => {
+    test('forward load event', () => new Promise<void>(done => {
         const sourceCache = createSourceCache({}).on('data', (e) => {
             if (e.sourceDataType === 'metadata') done();
         });
         sourceCache.onAdd(undefined);
     }));
 
-    test('forward change event', () => new Promise(done => {
+    test('forward change event', () => new Promise<void>(done => {
         const sourceCache = createSourceCache().on('data', (e) => {
             if (e.sourceDataType === 'metadata') done();
         });
@@ -412,7 +412,7 @@ describe('SourceCache / Source lifecycle', () => {
         sourceCache.getSource().fire(new Event('data'));
     }));
 
-    test('forward error event', () => new Promise(done => {
+    test('forward error event', () => new Promise<void>(done => {
         const sourceCache = createSourceCache({error: 'Error loading source'}).on('error', (err) => {
             expect(err.error).toBe('Error loading source');
             done();
@@ -420,14 +420,14 @@ describe('SourceCache / Source lifecycle', () => {
         sourceCache.onAdd(undefined);
     }));
 
-    test('suppress 404 errors', () => new Promise(done => {
+    test('suppress 404 errors', () => new Promise<void>((done, fail) => {
         const sourceCache = createSourceCache({status: 404, message: 'Not found'})
-            .on('error', () => done('test failed: error event fired'));
+            .on('error', () => fail(new Error('test failed: error event fired')));
         sourceCache.onAdd(undefined);
         done();
     }));
 
-    test('loaded() true after source error', () => new Promise(done => {
+    test('loaded() true after source error', () => new Promise<void>(done => {
         const sourceCache = createSourceCache({error: 'Error loading source'}).on('error', () => {
             expect(sourceCache.loaded()).toBeTruthy();
             done();
@@ -435,7 +435,7 @@ describe('SourceCache / Source lifecycle', () => {
         sourceCache.onAdd(undefined);
     }));
 
-    test('loaded() true after tile error', () => new Promise(done => {
+    test('loaded() true after tile error', () => new Promise<void>(done => {
         const transform = new Transform();
         transform.resize(511, 511);
         transform.zoom = 0;
@@ -455,7 +455,7 @@ describe('SourceCache / Source lifecycle', () => {
         sourceCache.onAdd(undefined);
     }));
 
-    test('loaded() false after source begins loading following error', () => new Promise(done => {
+    test('loaded() false after source begins loading following error', () => new Promise<void>(done => {
         const sourceCache = createSourceCache({error: 'Error loading source'}).on('error', () => {
             sourceCache.on('dataloading', () => {
                 expect(sourceCache.loaded()).toBeFalsy();
@@ -467,7 +467,7 @@ describe('SourceCache / Source lifecycle', () => {
         sourceCache.onAdd(undefined);
     }));
 
-    test('loaded() false when error occurs while source is not loaded', () => new Promise(done => {
+    test('loaded() false when error occurs while source is not loaded', () => new Promise<void>(done => {
         const sourceCache = createSourceCache({
             error: 'Error loading source',
 
@@ -535,7 +535,7 @@ describe('SourceCache / Source lifecycle', () => {
 });
 
 describe('SourceCache#update', () => {
-    test('loads no tiles if used is false', () => new Promise(done => {
+    test('loads no tiles if used is false', () => new Promise<void>(done => {
         const transform = new Transform();
         transform.resize(512, 512);
         transform.zoom = 0;
@@ -551,7 +551,7 @@ describe('SourceCache#update', () => {
         sourceCache.onAdd(undefined);
     }));
 
-    test('loads covering tiles', () => new Promise(done => {
+    test('loads covering tiles', () => new Promise<void>(done => {
         const transform = new Transform();
         transform.resize(511, 511);
         transform.zoom = 0;
@@ -567,7 +567,7 @@ describe('SourceCache#update', () => {
         sourceCache.onAdd(undefined);
     }));
 
-    test('respects Source#hasTile method if it is present', () => new Promise(done => {
+    test('respects Source#hasTile method if it is present', () => new Promise<void>(done => {
         const transform = new Transform();
         transform.resize(511, 511);
         transform.zoom = 1;
@@ -588,7 +588,7 @@ describe('SourceCache#update', () => {
         sourceCache.onAdd(undefined);
     }));
 
-    test('removes unused tiles', () => new Promise(done => {
+    test('removes unused tiles', () => new Promise<void>(done => {
         const transform = new Transform();
         transform.resize(511, 511);
         transform.zoom = 0;
@@ -619,7 +619,7 @@ describe('SourceCache#update', () => {
         sourceCache.onAdd(undefined);
     }));
 
-    test('retains parent tiles for pending children', () => new Promise(done => {
+    test('retains parent tiles for pending children', () => new Promise<void>(done => {
         const transform = new Transform();
         (transform as any)._test = 'retains';
         transform.resize(511, 511);
@@ -651,7 +651,7 @@ describe('SourceCache#update', () => {
         sourceCache.onAdd(undefined);
     }));
 
-    test('retains parent tiles for pending children (wrapped)', () => new Promise(done => {
+    test('retains parent tiles for pending children (wrapped)', () => new Promise<void>(done => {
         const transform = new Transform();
         transform.resize(511, 511);
         transform.zoom = 0;
@@ -683,7 +683,7 @@ describe('SourceCache#update', () => {
         sourceCache.onAdd(undefined);
     }));
 
-    test('retains covered child tiles while parent tile is fading in', () => new Promise(done => {
+    test('retains covered child tiles while parent tile is fading in', () => new Promise<void>(done => {
         const transform = new Transform();
         transform.resize(511, 511);
         transform.zoom = 2;
@@ -717,7 +717,7 @@ describe('SourceCache#update', () => {
         sourceCache.onAdd(undefined);
     }));
 
-    test('retains a parent tile for fading even if a tile is partially covered by children', () => new Promise(done => {
+    test('retains a parent tile for fading even if a tile is partially covered by children', () => new Promise<void>(done => {
         const transform = new Transform();
         transform.resize(511, 511);
         transform.zoom = 0;
@@ -748,7 +748,7 @@ describe('SourceCache#update', () => {
         sourceCache.onAdd(undefined);
     }));
 
-    test('retain children for fading fadeEndTime is 0 (added but registerFadeDuration() is not called yet)', () => new Promise(done => {
+    test('retain children for fading fadeEndTime is 0 (added but registerFadeDuration() is not called yet)', () => new Promise<void>(done => {
         const transform = new Transform();
         transform.resize(511, 511);
         transform.zoom = 1;
@@ -776,7 +776,7 @@ describe('SourceCache#update', () => {
         sourceCache.onAdd(undefined);
     }));
 
-    test('retains children when tile.fadeEndTime is in the future', () => new Promise(done => {
+    test('retains children when tile.fadeEndTime is in the future', () => new Promise<void>(done => {
         const transform = new Transform();
         transform.resize(511, 511);
         transform.zoom = 1;
@@ -820,7 +820,7 @@ describe('SourceCache#update', () => {
         sourceCache.onAdd(undefined);
     }));
 
-    test('retains overscaled loaded children', () => new Promise(done => {
+    test('retains overscaled loaded children', () => new Promise<void>(done => {
         const transform = new Transform();
         transform.resize(511, 511);
         transform.zoom = 16;
@@ -858,7 +858,7 @@ describe('SourceCache#update', () => {
         sourceCache.onAdd(undefined);
     }));
 
-    test('reassigns tiles for large jumps in longitude', () => new Promise(done => {
+    test('reassigns tiles for large jumps in longitude', () => new Promise<void>(done => {
 
         const transform = new Transform();
         transform.resize(511, 511);
@@ -1392,7 +1392,7 @@ describe('SourceCache#tilesIn', () => {
         });
     }
 
-    test('regular tiles', () => new Promise(done => {
+    test('regular tiles', () => new Promise<void>(done => {
         const transform = new Transform();
         transform.resize(512, 512);
         transform.zoom = 1;
@@ -1488,7 +1488,7 @@ describe('SourceCache#tilesIn', () => {
         sourceCache.onAdd(undefined);
     });
 
-    test('overscaled tiles', () => new Promise(done => {
+    test('overscaled tiles', () => new Promise<void>(done => {
         const sourceCache = createSourceCache({
             reparseOverscaled: false,
             minzoom: 1,
@@ -1514,7 +1514,7 @@ describe('SourceCache#tilesIn', () => {
 });
 
 describe('source cache loaded', () => {
-    test('SourceCache#loaded (no errors)', () => new Promise(done => {
+    test('SourceCache#loaded (no errors)', () => new Promise<void>(done => {
         const sourceCache = createSourceCache();
         sourceCache._source.loadTile = async (tile) => {
             tile.state = 'loaded';
@@ -1536,7 +1536,7 @@ describe('source cache loaded', () => {
         sourceCache.onAdd(undefined);
     }));
 
-    test('SourceCache#loaded (with errors)', () => new Promise(done => {
+    test('SourceCache#loaded (with errors)', () => new Promise<void>(done => {
         const sourceCache = createSourceCache();
         sourceCache._source.loadTile = async (tile) => {
             tile.state = 'errored';
@@ -1559,7 +1559,7 @@ describe('source cache loaded', () => {
         sourceCache.onAdd(undefined);
     }));
 
-    test('SourceCache#loaded (unused)', () => new Promise(done => {
+    test('SourceCache#loaded (unused)', () => new Promise<void>(done => {
         const sourceCache = createSourceCache(undefined, false);
         sourceCache._source.loadTile = async (tile) => {
             tile.state = 'errored';
@@ -1575,7 +1575,7 @@ describe('source cache loaded', () => {
         sourceCache.onAdd(undefined);
     }));
 
-    test('SourceCache#loaded (unusedForTerrain)', () => new Promise(done => {
+    test('SourceCache#loaded (unusedForTerrain)', () => new Promise<void>(done => {
         const sourceCache = createSourceCache(undefined, false);
         sourceCache._source.loadTile = async (tile) => {
             tile.state = 'errored';
@@ -1592,7 +1592,7 @@ describe('source cache loaded', () => {
         sourceCache.onAdd(undefined);
     }));
 
-    test('SourceCache#loaded (not loaded when no update)', () => new Promise(done => {
+    test('SourceCache#loaded (not loaded when no update)', () => new Promise<void>(done => {
         const sourceCache = createSourceCache();
         sourceCache._source.loadTile = async (tile) => {
             tile.state = 'errored';
@@ -1608,7 +1608,7 @@ describe('source cache loaded', () => {
         sourceCache.onAdd(undefined);
     }));
 
-    test('SourceCache#loaded (on last tile load)', () => new Promise(done => {
+    test('SourceCache#loaded (on last tile load)', () => new Promise<void>(done => {
         const sourceCache = createSourceCache();
         sourceCache._source.loadTile = async (tile) => {
             tile.state = 'loading';
@@ -1645,7 +1645,7 @@ describe('source cache loaded', () => {
         sourceCache.update(tr);
     }));
 
-    test('SourceCache#loaded (tiles outside bounds, idle)', () => new Promise(done => {
+    test('SourceCache#loaded (tiles outside bounds, idle)', () => new Promise<void>(done => {
         const japan = new TileBounds([122.74, 19.33, 149.0, 45.67]);
         const sourceCache = createSourceCache();
         sourceCache._source.loadTile = async (tile) => {
@@ -1689,7 +1689,7 @@ describe('source cache loaded', () => {
 });
 
 describe('source cache get ids', () => {
-    test('SourceCache#getIds (ascending order by zoom level)', () => new Promise(done => {
+    test('SourceCache#getIds (ascending order by zoom level)', () => new Promise<void>(done => {
         const ids = [
             new OverscaledTileID(0, 0, 0, 0, 0),
             new OverscaledTileID(3, 0, 3, 0, 0),
@@ -1917,7 +1917,7 @@ describe('SourceCache#reload', () => {
 });
 
 describe('SourceCache reloads expiring tiles', () => {
-    test('calls reloadTile when tile expires', () => new Promise(done => {
+    test('calls reloadTile when tile expires', () => new Promise<void>(done => {
         const coord = new OverscaledTileID(1, 0, 1, 0, 1);
 
         const expiryDate = new Date();
@@ -1988,7 +1988,7 @@ describe('SourceCache#onRemove', () => {
 });
 
 describe('SourceCache#usedForTerrain', () => {
-    test('loads covering tiles with usedForTerrain with source zoom 0-14', () => new Promise(done => {
+    test('loads covering tiles with usedForTerrain with source zoom 0-14', () => new Promise<void>(done => {
         const transform = new Transform();
         transform.resize(511, 511);
         transform.zoom = 10;
@@ -2009,7 +2009,7 @@ describe('SourceCache#usedForTerrain', () => {
         sourceCache.onAdd(undefined);
     }));
 
-    test('loads covering tiles with usedForTerrain with source zoom 8-14', () => new Promise(done => {
+    test('loads covering tiles with usedForTerrain with source zoom 8-14', () => new Promise<void>(done => {
         const transform = new Transform();
         transform.resize(511, 511);
         transform.zoom = 10;
@@ -2029,7 +2029,7 @@ describe('SourceCache#usedForTerrain', () => {
         sourceCache.onAdd(undefined);
     }));
 
-    test('loads covering tiles with usedForTerrain with source zoom 0-4', () => new Promise(done => {
+    test('loads covering tiles with usedForTerrain with source zoom 0-4', () => new Promise<void>(done => {
         const transform = new Transform();
         transform.resize(511, 511);
         transform.zoom = 10;
@@ -2049,7 +2049,7 @@ describe('SourceCache#usedForTerrain', () => {
         sourceCache.onAdd(undefined);
     }));
 
-    test('loads covering tiles with usedForTerrain with source zoom 4-4', () => new Promise(done => {
+    test('loads covering tiles with usedForTerrain with source zoom 4-4', () => new Promise<void>(done => {
         const transform = new Transform();
         transform.resize(511, 511);
         transform.zoom = 10;

--- a/src/source/source_cache.test.ts
+++ b/src/source/source_cache.test.ts
@@ -390,9 +390,9 @@ describe('SourceCache#removeTile', () => {
 });
 
 describe('SourceCache / Source lifecycle', () => {
-    test('does not fire load or change before source load event', () => new Promise<void>((done, fail) => {
+    test('does not fire load or change before source load event', () => new Promise<void>((done) => {
         const sourceCache = createSourceCache({noLoad: true})
-            .on('data', () => fail(new Error('test failed: data event fired')));
+            .on('data', () => { throw new Error('test failed: data event fired'); });
         sourceCache.onAdd(undefined);
         setTimeout(() => done(), 1);
     }));
@@ -422,7 +422,7 @@ describe('SourceCache / Source lifecycle', () => {
 
     test('suppress 404 errors', () => {
         const sourceCache = createSourceCache({status: 404, message: 'Not found'})
-            .on('error', () => fail(new Error('test failed: error event fired')));
+            .on('error', () => { throw new Error('test failed: error event fired'); });
         sourceCache.onAdd(undefined);
     });
 

--- a/src/source/source_cache.test.ts
+++ b/src/source/source_cache.test.ts
@@ -41,7 +41,7 @@ class SourceMock extends Evented implements Source {
                 expires: this.sourceOptions.expires
             });
         }
-        return new Promise(resolve => setTimeout(resolve, 0));
+        return sleep(0);
     }
     loaded() {
         return true;

--- a/src/source/terrain_source_cache.test.ts
+++ b/src/source/terrain_source_cache.test.ts
@@ -55,7 +55,7 @@ describe('TerrainSourceCache', () => {
     let style: Style;
     let tsc: TerrainSourceCache;
 
-    beforeAll(() => new Promise(done => {
+    beforeAll(() => new Promise<void>(done => {
         global.fetch = null;
         server = fakeServer.create();
         server.respondWith('/source.json', JSON.stringify({

--- a/src/source/terrain_source_cache.test.ts
+++ b/src/source/terrain_source_cache.test.ts
@@ -55,7 +55,7 @@ describe('TerrainSourceCache', () => {
     let style: Style;
     let tsc: TerrainSourceCache;
 
-    beforeAll(done => {
+    beforeAll(() => new Promise(done => {
         global.fetch = null;
         server = fakeServer.create();
         server.respondWith('/source.json', JSON.stringify({
@@ -79,7 +79,7 @@ describe('TerrainSourceCache', () => {
             'sources': {},
             'layers': []
         });
-    });
+    }));
 
     afterAll(() => {
         server.restore();

--- a/src/source/tile_cache.test.ts
+++ b/src/source/tile_cache.test.ts
@@ -30,7 +30,7 @@ describe('TileCache', () => {
         keysExpected(cache, []);
     });
 
-    test('get without removing', done => {
+    test('get without removing', () => new Promise(done => {
         const cache = new TileCache(10, () => {
             done('test "get without removing" failed');
         });
@@ -39,9 +39,9 @@ describe('TileCache', () => {
         keysExpected(cache, [idA]);
         expect(cache.get(idA)).toBe(tileA);
         done();
-    });
+    }));
 
-    test('duplicate add', done => {
+    test('duplicate add', () => new Promise(done => {
         const cache = new TileCache(10, () => {
             done('test "duplicate add" failed');
         });
@@ -55,7 +55,7 @@ describe('TileCache', () => {
         expect(cache.has(idA)).toBeTruthy();
         expect(cache.getAndRemove(idA)).toBe(tileA2);
         done();
-    });
+    }));
 
     test('expiry', () => {
         const cache = new TileCache(10, (removed) => {

--- a/src/source/tile_cache.test.ts
+++ b/src/source/tile_cache.test.ts
@@ -30,9 +30,9 @@ describe('TileCache', () => {
         keysExpected(cache, []);
     });
 
-    test('get without removing', () => new Promise(done => {
+    test('get without removing', () => new Promise<void>((done, fail) => {
         const cache = new TileCache(10, () => {
-            done('test "get without removing" failed');
+            fail(new Error('test "get without removing" failed'));
         });
         expect(cache.add(idA, tileA)).toBe(cache);
         expect(cache.get(idA)).toBe(tileA);
@@ -41,9 +41,9 @@ describe('TileCache', () => {
         done();
     }));
 
-    test('duplicate add', () => new Promise(done => {
+    test('duplicate add', () => new Promise<void>((done, fail) => {
         const cache = new TileCache(10, () => {
-            done('test "duplicate add" failed');
+            fail(new Error('test "duplicate add" failed'));
         });
 
         cache.add(idA, tileA);

--- a/src/source/tile_cache.test.ts
+++ b/src/source/tile_cache.test.ts
@@ -30,7 +30,7 @@ describe('TileCache', () => {
         keysExpected(cache, []);
     });
 
-    test('get without removing', () => new Promise<void>((done, fail) => {
+    test('get without removing', () => {
         const cache = new TileCache(10, () => {
             fail(new Error('test "get without removing" failed'));
         });
@@ -38,14 +38,12 @@ describe('TileCache', () => {
         expect(cache.get(idA)).toBe(tileA);
         keysExpected(cache, [idA]);
         expect(cache.get(idA)).toBe(tileA);
-        done();
-    }));
+    });
 
-    test('duplicate add', () => new Promise<void>((done, fail) => {
+    test('duplicate add', () => {
         const cache = new TileCache(10, () => {
-            fail(new Error('test "duplicate add" failed'));
+            throw (new Error('test "duplicate add" failed'));
         });
-
         cache.add(idA, tileA);
         cache.add(idA, tileA2);
 
@@ -54,8 +52,7 @@ describe('TileCache', () => {
         expect(cache.getAndRemove(idA)).toBe(tileA);
         expect(cache.has(idA)).toBeTruthy();
         expect(cache.getAndRemove(idA)).toBe(tileA2);
-        done();
-    }));
+    });
 
     test('expiry', () => {
         const cache = new TileCache(10, (removed) => {

--- a/src/source/tile_cache.test.ts
+++ b/src/source/tile_cache.test.ts
@@ -32,7 +32,7 @@ describe('TileCache', () => {
 
     test('get without removing', () => {
         const cache = new TileCache(10, () => {
-            fail(new Error('test "get without removing" failed'));
+            throw new Error('test "get without removing" failed');
         });
         expect(cache.add(idA, tileA)).toBe(cache);
         expect(cache.get(idA)).toBe(tileA);
@@ -42,7 +42,7 @@ describe('TileCache', () => {
 
     test('duplicate add', () => {
         const cache = new TileCache(10, () => {
-            throw (new Error('test "duplicate add" failed'));
+            throw new Error('test "duplicate add" failed');
         });
         cache.add(idA, tileA);
         cache.add(idA, tileA2);

--- a/src/source/vector_tile_source.test.ts
+++ b/src/source/vector_tile_source.test.ts
@@ -78,14 +78,14 @@ describe('VectorTileSource', () => {
         expect(transformSpy).toHaveBeenCalledWith('/source.json', 'Source');
     });
 
-    test('fires event with metadata property', done => {
+    test('fires event with metadata property', () => new Promise(done => {
         server.respondWith('/source.json', JSON.stringify(fixturesSource));
         const source = createSource({url: '/source.json'});
         source.on('data', (e) => {
             if (e.sourceDataType === 'content') done();
         });
         server.respond();
-    });
+    }));
 
     test('fires "dataloading" event', async () => {
         server.respondWith('/source.json', JSON.stringify(fixturesSource));

--- a/src/source/vector_tile_source.test.ts
+++ b/src/source/vector_tile_source.test.ts
@@ -78,7 +78,7 @@ describe('VectorTileSource', () => {
         expect(transformSpy).toHaveBeenCalledWith('/source.json', 'Source');
     });
 
-    test('fires event with metadata property', () => new Promise(done => {
+    test('fires event with metadata property', () => new Promise<void>(done => {
         server.respondWith('/source.json', JSON.stringify(fixturesSource));
         const source = createSource({url: '/source.json'});
         source.on('data', (e) => {

--- a/src/source/vector_tile_worker_source.test.ts
+++ b/src/source/vector_tile_worker_source.test.ts
@@ -241,7 +241,7 @@ describe('vector tile worker source', () => {
         expect(await promise).toBeNull();
     });
 
-    test('VectorTileWorkerSource#returns a good error message when failing to parse a tile', done => {
+    test('VectorTileWorkerSource#returns a good error message when failing to parse a tile', () => new Promise(done => {
         const source = new VectorTileWorkerSource(actor, new StyleLayerIndex(), []);
         const parse = jest.fn();
 
@@ -262,9 +262,9 @@ describe('vector tile worker source', () => {
         server.respond();
 
         expect(parse).not.toHaveBeenCalled();
-    });
+    }));
 
-    test('VectorTileWorkerSource#returns a good error message when failing to parse a gzipped tile', done => {
+    test('VectorTileWorkerSource#returns a good error message when failing to parse a gzipped tile', () => new Promise(done => {
         const source = new VectorTileWorkerSource(actor, new StyleLayerIndex(), []);
         const parse = jest.fn();
 
@@ -283,7 +283,7 @@ describe('vector tile worker source', () => {
         server.respond();
 
         expect(parse).not.toHaveBeenCalled();
-    });
+    }));
 
     test('VectorTileWorkerSource provides resource timing information', async () => {
         const rawTileData = fs.readFileSync(path.join(__dirname, '/../../test/unit/assets/mbsv5-6-18-23.vector.pbf'));

--- a/src/source/vector_tile_worker_source.test.ts
+++ b/src/source/vector_tile_worker_source.test.ts
@@ -241,7 +241,7 @@ describe('vector tile worker source', () => {
         expect(await promise).toBeNull();
     });
 
-    test('VectorTileWorkerSource#returns a good error message when failing to parse a tile', () => new Promise(done => {
+    test('VectorTileWorkerSource#returns a good error message when failing to parse a tile', () => new Promise<void>(done => {
         const source = new VectorTileWorkerSource(actor, new StyleLayerIndex(), []);
         const parse = jest.fn();
 
@@ -264,7 +264,7 @@ describe('vector tile worker source', () => {
         expect(parse).not.toHaveBeenCalled();
     }));
 
-    test('VectorTileWorkerSource#returns a good error message when failing to parse a gzipped tile', () => new Promise(done => {
+    test('VectorTileWorkerSource#returns a good error message when failing to parse a gzipped tile', () => new Promise<void>(done => {
         const source = new VectorTileWorkerSource(actor, new StyleLayerIndex(), []);
         const parse = jest.fn();
 

--- a/src/source/video_source.test.ts
+++ b/src/source/video_source.test.ts
@@ -87,7 +87,7 @@ describe('VideoSource', () => {
         expect(source.getVideo()).toBe(el);
     });
 
-    test('fires idle event on prepare call when there is at least one not loaded tile', () => new Promise(done => {
+    test('fires idle event on prepare call when there is at least one not loaded tile', () => new Promise<void>(done => {
         const source = createSource({
             type: 'video',
             urls: [],

--- a/src/source/video_source.test.ts
+++ b/src/source/video_source.test.ts
@@ -87,7 +87,7 @@ describe('VideoSource', () => {
         expect(source.getVideo()).toBe(el);
     });
 
-    test('fires idle event on prepare call when there is at least one not loaded tile', done => {
+    test('fires idle event on prepare call when there is at least one not loaded tile', () => new Promise(done => {
         const source = createSource({
             type: 'video',
             urls: [],
@@ -120,5 +120,5 @@ describe('VideoSource', () => {
             bind: () => {}
         } as any;
         source.prepare();
-    });
+    }));
 });

--- a/src/source/worker.test.ts
+++ b/src/source/worker.test.ts
@@ -154,7 +154,7 @@ describe('Worker generic testing', () => {
         global.fetch = null;
     });
 
-    test('should validate handlers execution in worker for load tile', () => new Promise(done => {
+    test('should validate handlers execution in worker for load tile', () => new Promise<void>(done => {
         const server = fakeServer.create();
         worker.actor.messageHandlers[MessageType.loadTile]('0', {
             type: 'vector',
@@ -183,7 +183,7 @@ describe('Worker generic testing', () => {
         expect(worker.layerIndexes[0]).not.toBe(worker.layerIndexes[1]);
     });
 
-    test('worker source messages dispatched to the correct map instance', () => new Promise(done => {
+    test('worker source messages dispatched to the correct map instance', () => new Promise<void>(done => {
         const externalSourceName = 'test';
 
         worker.actor.sendAsync = (message, abortController) => {
@@ -208,7 +208,7 @@ describe('Worker generic testing', () => {
         expect(worker.referrer).toBe('myMap');
     });
 
-    test('calls callback on error', () => new Promise(done => {
+    test('calls callback on error', () => new Promise<void>(done => {
         const server = fakeServer.create();
         worker.actor.messageHandlers[MessageType.importScript]('0', '/error').catch((err) => {
             expect(err).toBeTruthy();

--- a/src/source/worker.test.ts
+++ b/src/source/worker.test.ts
@@ -154,7 +154,7 @@ describe('Worker generic testing', () => {
         global.fetch = null;
     });
 
-    test('should validate handlers execution in worker for load tile', done => {
+    test('should validate handlers execution in worker for load tile', () => new Promise(done => {
         const server = fakeServer.create();
         worker.actor.messageHandlers[MessageType.loadTile]('0', {
             type: 'vector',
@@ -168,7 +168,7 @@ describe('Worker generic testing', () => {
             done();
         });
         server.respond();
-    });
+    }));
 
     test('isolates different instances\' data', () => {
         worker.actor.messageHandlers[MessageType.setLayers]('0', [
@@ -183,7 +183,7 @@ describe('Worker generic testing', () => {
         expect(worker.layerIndexes[0]).not.toBe(worker.layerIndexes[1]);
     });
 
-    test('worker source messages dispatched to the correct map instance', done => {
+    test('worker source messages dispatched to the correct map instance', () => new Promise(done => {
         const externalSourceName = 'test';
 
         worker.actor.sendAsync = (message, abortController) => {
@@ -201,14 +201,14 @@ describe('Worker generic testing', () => {
         }).toThrow(`Worker source with name "${externalSourceName}" already registered.`);
 
         worker.actor.messageHandlers[MessageType.loadTile]('999', {type: externalSourceName} as WorkerTileParameters);
-    });
+    }));
 
     test('Referrer is set', () => {
         worker.actor.messageHandlers[MessageType.setReferrer]('fakeId', 'myMap');
         expect(worker.referrer).toBe('myMap');
     });
 
-    test('calls callback on error', done => {
+    test('calls callback on error', () => new Promise(done => {
         const server = fakeServer.create();
         worker.actor.messageHandlers[MessageType.importScript]('0', '/error').catch((err) => {
             expect(err).toBeTruthy();
@@ -216,7 +216,7 @@ describe('Worker generic testing', () => {
             done();
         });
         server.respond();
-    });
+    }));
 
     test('set images', () => {
         expect(worker.availableImages['0']).toBeUndefined();

--- a/src/style/style.test.ts
+++ b/src/style/style.test.ts
@@ -1358,7 +1358,7 @@ describe('Style#addLayer', () => {
         });
     }));
 
-    test('#3895 reloads source (instead of clearing) if adding this layer with the same type, immediately after removing it', () => new Promise<void>((done, fail) => {
+    test('#3895 reloads source (instead of clearing) if adding this layer with the same type, immediately after removing it', () => new Promise<void>((done) => {
         const style = createStyle();
         style.loadJSON(extend(createStyleJSON(), {
             'sources': {
@@ -1386,7 +1386,7 @@ describe('Style#addLayer', () => {
         style.on('data', (e) => {
             if (e.dataType === 'source' && e.sourceDataType === 'content') {
                 style.sourceCaches['mapLibre'].reload = () => { done(); };
-                style.sourceCaches['mapLibre'].clearTiles =  () => { fail(new Error('test failed')); };
+                style.sourceCaches['mapLibre'].clearTiles =  () => { throw new Error('test failed'); };
                 style.removeLayer('my-layer');
                 style.addLayer(layer);
                 style.update({} as EvaluationParameters);
@@ -1395,7 +1395,7 @@ describe('Style#addLayer', () => {
 
     }));
 
-    test('clears source (instead of reloading) if adding this layer with a different type, immediately after removing it', () => new Promise<void>((done, fail) => {
+    test('clears source (instead of reloading) if adding this layer with a different type, immediately after removing it', () => new Promise<void>((done) => {
         const style = createStyle();
         style.loadJSON(extend(createStyleJSON(), {
             'sources': {
@@ -1421,7 +1421,7 @@ describe('Style#addLayer', () => {
         }as LayerSpecification;
         style.on('data', (e) => {
             if (e.dataType === 'source' && e.sourceDataType === 'content') {
-                style.sourceCaches['mapLibre'].reload =  () => { fail(new Error('test failed')); };
+                style.sourceCaches['mapLibre'].reload =  () => { throw new Error('test failed'); };
                 style.sourceCaches['mapLibre'].clearTiles = () => { done(); };
                 style.removeLayer('my-layer');
                 style.addLayer(layer);
@@ -1570,7 +1570,7 @@ describe('Style#removeLayer', () => {
         await dataPromise;
     });
 
-    test('tears down layer event forwarding', () => new Promise<void>((done, fail) => {
+    test('tears down layer event forwarding', () => new Promise<void>((done) => {
         const style = new Style(getStubMap());
         style.loadJSON(createStyleJSON({
             layers: [{
@@ -1580,7 +1580,7 @@ describe('Style#removeLayer', () => {
         }));
 
         style.on('error', () => {
-            fail(new Error('test failed'));
+            throw new Error('test failed');
         });
 
         style.on('style.load', () => {

--- a/src/style/style.test.ts
+++ b/src/style/style.test.ts
@@ -152,7 +152,7 @@ describe('Style#loadURL', () => {
         expect(spy.mock.calls[0][1]).toBe('Style');
     });
 
-    test('validates the style', done => {
+    test('validates the style', () => new Promise(done => {
         const style = new Style(getStubMap());
 
         style.on('error', ({error}) => {
@@ -164,7 +164,7 @@ describe('Style#loadURL', () => {
         style.loadURL('style.json');
         server.respondWith(JSON.stringify(createStyleJSON({version: 'invalid'})));
         server.respond();
-    });
+    }));
 
     test('cancels pending requests if removed', () => {
         const style = new Style(getStubMap());
@@ -371,7 +371,7 @@ describe('Style#loadJSON', () => {
         expect(transformSpy.mock.calls[1][1]).toBe('SpriteImage');
     });
 
-    test('emits an error on non-existant vector source layer', done => {
+    test('emits an error on non-existant vector source layer', () => new Promise(done => {
         const style = createStyle();
         style.loadJSON(createStyleJSON({
             sources: {
@@ -404,9 +404,9 @@ describe('Style#loadJSON', () => {
 
             done();
         });
-    });
+    }));
 
-    test('sets up layer event forwarding', done => {
+    test('sets up layer event forwarding', () => new Promise(done => {
         const style = new Style(getStubMap());
         style.loadJSON(createStyleJSON({
             layers: [{
@@ -424,7 +424,7 @@ describe('Style#loadJSON', () => {
         style.on('style.load', () => {
             style._layers.background.fire(new Event('error', {mapLibre: true}));
         });
-    });
+    }));
 
     test('sets terrain if defined', async () => {
         const map = getStubMap();
@@ -618,7 +618,7 @@ describe('Style#_remove', () => {
 });
 
 describe('Style#update', () => {
-    test('on error', done => {
+    test('on error', () => new Promise(done => {
         const style = createStyle();
         style.loadJSON({
             'version': 8,
@@ -652,7 +652,7 @@ describe('Style#update', () => {
 
             style.update({} as EvaluationParameters);
         });
-    });
+    }));
 });
 
 describe('Style#setState', () => {
@@ -1167,7 +1167,7 @@ describe('Style#removeSprite', () => {
         expect(() => style.removeSprite('test')).toThrow(/load/i);
     });
 
-    test('fires an error when trying to delete an non-existing sprite (sprite: undefined)', done => {
+    test('fires an error when trying to delete an non-existing sprite (sprite: undefined)', () => new Promise(done => {
         const style = new Style(getStubMap());
         style.loadJSON(createStyleJSON());
         style.on('style.load', () => {
@@ -1178,9 +1178,9 @@ describe('Style#removeSprite', () => {
 
             style.removeSprite('test');
         });
-    });
+    }));
 
-    test('fires an error when trying to delete an non-existing sprite (sprite: single url)', done => {
+    test('fires an error when trying to delete an non-existing sprite (sprite: single url)', () => new Promise(done => {
         const style = new Style(getStubMap());
         style.loadJSON(createStyleJSON({sprite: 'https://example.com/sprite'}));
         style.on('style.load', () => {
@@ -1191,9 +1191,9 @@ describe('Style#removeSprite', () => {
 
             style.removeSprite('test');
         });
-    });
+    }));
 
-    test('fires an error when trying to delete an non-existing sprite (sprite: array)', done => {
+    test('fires an error when trying to delete an non-existing sprite (sprite: array)', () => new Promise(done => {
         const style = new Style(getStubMap());
         style.loadJSON(createStyleJSON({sprite: [{id: 'default', url: 'https://example.com/sprite'}]}));
         style.on('style.load', () => {
@@ -1204,7 +1204,7 @@ describe('Style#removeSprite', () => {
 
             style.removeSprite('test');
         });
-    });
+    }));
 
     test('removes the sprite when it\'s a single URL', async () => {
         const style = new Style(getStubMap());
@@ -1245,7 +1245,7 @@ describe('Style#addLayer', () => {
         expect(() => style.addLayer({id: 'background', type: 'background'})).toThrow(/load/i);
     });
 
-    test('sets up layer event forwarding', done => {
+    test('sets up layer event forwarding', () => new Promise(done => {
         const style = new Style(getStubMap());
         style.loadJSON(createStyleJSON());
 
@@ -1262,9 +1262,9 @@ describe('Style#addLayer', () => {
             });
             style._layers.background.fire(new Event('error', {mapLibre: true}));
         });
-    });
+    }));
 
-    test('throws on non-existant vector source layer', done => {
+    test('throws on non-existant vector source layer', () => new Promise(done => {
         const style = createStyle();
         style.loadJSON(createStyleJSON({
             sources: {
@@ -1295,9 +1295,9 @@ describe('Style#addLayer', () => {
 
             done();
         });
-    });
+    }));
 
-    test('emits error on invalid layer', done => {
+    test('emits error on invalid layer', () => new Promise(done => {
         const style = new Style(getStubMap());
         style.loadJSON(createStyleJSON());
         style.on('style.load', () => {
@@ -1313,7 +1313,7 @@ describe('Style#addLayer', () => {
                 }
             });
         });
-    });
+    }));
 
     test('#4040 does not mutate source property when provided inline', async () => {
         const style = new Style(getStubMap());
@@ -1331,7 +1331,7 @@ describe('Style#addLayer', () => {
         expect((layer as any).source).toEqual(source);
     });
 
-    test('reloads source', done => {
+    test('reloads source', () => new Promise(done => {
         const style = createStyle();
         style.loadJSON(extend(createStyleJSON(), {
             'sources': {
@@ -1356,9 +1356,9 @@ describe('Style#addLayer', () => {
                 style.update({} as EvaluationParameters);
             }
         });
-    });
+    }));
 
-    test('#3895 reloads source (instead of clearing) if adding this layer with the same type, immediately after removing it', done => {
+    test('#3895 reloads source (instead of clearing) if adding this layer with the same type, immediately after removing it', () => new Promise(done => {
         const style = createStyle();
         style.loadJSON(extend(createStyleJSON(), {
             'sources': {
@@ -1393,9 +1393,9 @@ describe('Style#addLayer', () => {
             }
         });
 
-    });
+    }));
 
-    test('clears source (instead of reloading) if adding this layer with a different type, immediately after removing it', done => {
+    test('clears source (instead of reloading) if adding this layer with a different type, immediately after removing it', () => new Promise(done => {
         const style = createStyle();
         style.loadJSON(extend(createStyleJSON(), {
             'sources': {
@@ -1429,7 +1429,7 @@ describe('Style#addLayer', () => {
             }
         });
 
-    });
+    }));
 
     test('fires "data" event', async () => {
         const style = new Style(getStubMap());
@@ -1445,7 +1445,7 @@ describe('Style#addLayer', () => {
         await dataPromise;
     });
 
-    test('emits error on duplicates', done => {
+    test('emits error on duplicates', () => new Promise(done => {
         const style = new Style(getStubMap());
         style.loadJSON(createStyleJSON());
         const layer = {id: 'background', type: 'background'} as LayerSpecification;
@@ -1459,7 +1459,7 @@ describe('Style#addLayer', () => {
             style.addLayer(layer);
             style.addLayer(layer);
         });
-    });
+    }));
 
     test('adds to the end by default', async () => {
         const style = new Style(getStubMap());
@@ -1497,7 +1497,7 @@ describe('Style#addLayer', () => {
         expect(style._order).toEqual(['c', 'a', 'b']);
     });
 
-    test('fire error if before layer does not exist', done => {
+    test('fire error if before layer does not exist', () => new Promise(done => {
         const style = new Style(getStubMap());
         style.loadJSON(createStyleJSON({
             layers: [{
@@ -1517,9 +1517,9 @@ describe('Style#addLayer', () => {
             });
             style.addLayer(layer, 'z');
         });
-    });
+    }));
 
-    test('fires an error on non-existant source layer', done => {
+    test('fires an error on non-existant source layer', () => new Promise(done => {
         const style = new Style(getStubMap());
         style.loadJSON(extend(createStyleJSON(), {
             sources: {
@@ -1545,7 +1545,7 @@ describe('Style#addLayer', () => {
             style.addLayer(layer);
         });
 
-    });
+    }));
 });
 
 describe('Style#removeLayer', () => {
@@ -1570,7 +1570,7 @@ describe('Style#removeLayer', () => {
         await dataPromise;
     });
 
-    test('tears down layer event forwarding', done => {
+    test('tears down layer event forwarding', () => new Promise(done => {
         const style = new Style(getStubMap());
         style.loadJSON(createStyleJSON({
             layers: [{
@@ -1593,7 +1593,7 @@ describe('Style#removeLayer', () => {
             layer.fire(new Event('error', {mapLibre: true}));
             done();
         });
-    });
+    }));
 
     test('fires an error on non-existence', async () => {
         const style = new Style(getStubMap());
@@ -1705,7 +1705,7 @@ describe('Style#moveLayer', () => {
 });
 
 describe('Style#setPaintProperty', () => {
-    test('#4738 postpones source reload until layers have been broadcast to workers', done => {
+    test('#4738 postpones source reload until layers have been broadcast to workers', () => new Promise(done => {
         const style = new Style(getStubMap());
         style.loadJSON(extend(createStyleJSON(), {
             'sources': {
@@ -1758,7 +1758,7 @@ describe('Style#setPaintProperty', () => {
                 }
             }));
         });
-    });
+    }));
 
     test('#5802 clones the input', async () => {
         const style = new Style(getStubMap());
@@ -1973,7 +1973,7 @@ describe('Style#setFilter', () => {
         return style;
     }
 
-    test('sets filter', done => {
+    test('sets filter', () => new Promise(done => {
         const style = createStyle();
 
         style.on('style.load', () => {
@@ -1989,7 +1989,7 @@ describe('Style#setFilter', () => {
             expect(style.getFilter('symbol')).toEqual(['==', 'id', 1]);
             style.update({} as EvaluationParameters); // trigger dispatcher broadcast
         });
-    });
+    }));
 
     test('gets a clone of the filter', async () => {
         const style = createStyle();
@@ -2005,7 +2005,7 @@ describe('Style#setFilter', () => {
         expect(filter2).not.toBe(filter3);
     });
 
-    test('sets again mutated filter', done => {
+    test('sets again mutated filter', () => new Promise(done => {
         const style = createStyle();
 
         style.on('style.load', () => {
@@ -2024,7 +2024,7 @@ describe('Style#setFilter', () => {
             style.setFilter('symbol', filter);
             style.update({} as EvaluationParameters); // trigger dispatcher broadcast
         });
-    });
+    }));
 
     test('unsets filter', async () => {
         const style = createStyle();
@@ -2061,7 +2061,7 @@ describe('Style#setFilter', () => {
         style.update({} as EvaluationParameters); // trigger dispatcher broadcast
     });
 
-    test('respects validate option', done => {
+    test('respects validate option', () => new Promise(done => {
         const style = createStyle();
 
         style.on('style.load', () => {
@@ -2077,7 +2077,7 @@ describe('Style#setFilter', () => {
             expect(style.getFilter('symbol')).toBe('notafilter');
             style.update({} as EvaluationParameters); // trigger dispatcher broadcast
         });
-    });
+    }));
 });
 
 describe('Style#setLayerZoomRange', () => {
@@ -2102,7 +2102,7 @@ describe('Style#setLayerZoomRange', () => {
         return style;
     }
 
-    test('sets zoom range', done => {
+    test('sets zoom range', () => new Promise(done => {
         const style = createStyle();
 
         style.on('style.load', () => {
@@ -2117,7 +2117,7 @@ describe('Style#setLayerZoomRange', () => {
             expect(style.getLayer('symbol').maxzoom).toBe(12);
             style.update({} as EvaluationParameters); // trigger dispatcher broadcast
         });
-    });
+    }));
 
     test('fires an error if layer not found', async () => {
         const style = createStyle();

--- a/src/style/style.test.ts
+++ b/src/style/style.test.ts
@@ -2187,7 +2187,7 @@ describe('Style#queryRenderedFeatures', () => {
     let style;
     let transform;
 
-    beforeEach((callback) => {
+    beforeEach(() => new Promise(callback => {
         style = new Style(getStubMap());
         transform = new Transform();
         transform.resize(512, 512);
@@ -2301,7 +2301,7 @@ describe('Style#queryRenderedFeatures', () => {
             style._updateSources(transform);
             callback();
         });
-    });
+    }));
 
     afterEach(() => {
         style = undefined;
@@ -2421,7 +2421,7 @@ describe('Style#query*Features', () => {
     let onError;
     let transform;
 
-    beforeEach((callback) => {
+    beforeEach(() => new Promise(callback => {
         transform = new Transform();
         transform.resize(100, 100);
         style = new Style(getStubMap());
@@ -2443,7 +2443,7 @@ describe('Style#query*Features', () => {
             .on('style.load', () => {
                 callback();
             });
-    });
+    }));
 
     test('querySourceFeatures emits an error on incorrect filter', () => {
         expect(style.querySourceFeatures([10, 100], {filter: 7}, transform)).toEqual([]);

--- a/src/style/style.test.ts
+++ b/src/style/style.test.ts
@@ -2187,7 +2187,7 @@ describe('Style#queryRenderedFeatures', () => {
     let style;
     let transform;
 
-    beforeEach(() => new Promise(callback => {
+    beforeEach(() => new Promise<void>(callback => {
         style = new Style(getStubMap());
         transform = new Transform();
         transform.resize(512, 512);
@@ -2421,7 +2421,7 @@ describe('Style#query*Features', () => {
     let onError;
     let transform;
 
-    beforeEach(() => new Promise(callback => {
+    beforeEach(() => new Promise<void>(callback => {
         transform = new Transform();
         transform.resize(100, 100);
         style = new Style(getStubMap());

--- a/src/style/style.test.ts
+++ b/src/style/style.test.ts
@@ -152,7 +152,7 @@ describe('Style#loadURL', () => {
         expect(spy.mock.calls[0][1]).toBe('Style');
     });
 
-    test('validates the style', () => new Promise(done => {
+    test('validates the style', () => new Promise<void>(done => {
         const style = new Style(getStubMap());
 
         style.on('error', ({error}) => {
@@ -371,7 +371,7 @@ describe('Style#loadJSON', () => {
         expect(transformSpy.mock.calls[1][1]).toBe('SpriteImage');
     });
 
-    test('emits an error on non-existant vector source layer', () => new Promise(done => {
+    test('emits an error on non-existant vector source layer', () => new Promise<void>(done => {
         const style = createStyle();
         style.loadJSON(createStyleJSON({
             sources: {
@@ -406,7 +406,7 @@ describe('Style#loadJSON', () => {
         });
     }));
 
-    test('sets up layer event forwarding', () => new Promise(done => {
+    test('sets up layer event forwarding', () => new Promise<void>(done => {
         const style = new Style(getStubMap());
         style.loadJSON(createStyleJSON({
             layers: [{
@@ -618,7 +618,7 @@ describe('Style#_remove', () => {
 });
 
 describe('Style#update', () => {
-    test('on error', () => new Promise(done => {
+    test('on error', () => new Promise<void>(done => {
         const style = createStyle();
         style.loadJSON({
             'version': 8,
@@ -1167,7 +1167,7 @@ describe('Style#removeSprite', () => {
         expect(() => style.removeSprite('test')).toThrow(/load/i);
     });
 
-    test('fires an error when trying to delete an non-existing sprite (sprite: undefined)', () => new Promise(done => {
+    test('fires an error when trying to delete an non-existing sprite (sprite: undefined)', () => new Promise<void>(done => {
         const style = new Style(getStubMap());
         style.loadJSON(createStyleJSON());
         style.on('style.load', () => {
@@ -1180,7 +1180,7 @@ describe('Style#removeSprite', () => {
         });
     }));
 
-    test('fires an error when trying to delete an non-existing sprite (sprite: single url)', () => new Promise(done => {
+    test('fires an error when trying to delete an non-existing sprite (sprite: single url)', () => new Promise<void>(done => {
         const style = new Style(getStubMap());
         style.loadJSON(createStyleJSON({sprite: 'https://example.com/sprite'}));
         style.on('style.load', () => {
@@ -1193,7 +1193,7 @@ describe('Style#removeSprite', () => {
         });
     }));
 
-    test('fires an error when trying to delete an non-existing sprite (sprite: array)', () => new Promise(done => {
+    test('fires an error when trying to delete an non-existing sprite (sprite: array)', () => new Promise<void>(done => {
         const style = new Style(getStubMap());
         style.loadJSON(createStyleJSON({sprite: [{id: 'default', url: 'https://example.com/sprite'}]}));
         style.on('style.load', () => {
@@ -1245,7 +1245,7 @@ describe('Style#addLayer', () => {
         expect(() => style.addLayer({id: 'background', type: 'background'})).toThrow(/load/i);
     });
 
-    test('sets up layer event forwarding', () => new Promise(done => {
+    test('sets up layer event forwarding', () => new Promise<void>(done => {
         const style = new Style(getStubMap());
         style.loadJSON(createStyleJSON());
 
@@ -1264,7 +1264,7 @@ describe('Style#addLayer', () => {
         });
     }));
 
-    test('throws on non-existant vector source layer', () => new Promise(done => {
+    test('throws on non-existant vector source layer', () => new Promise<void>(done => {
         const style = createStyle();
         style.loadJSON(createStyleJSON({
             sources: {
@@ -1297,7 +1297,7 @@ describe('Style#addLayer', () => {
         });
     }));
 
-    test('emits error on invalid layer', () => new Promise(done => {
+    test('emits error on invalid layer', () => new Promise<void>(done => {
         const style = new Style(getStubMap());
         style.loadJSON(createStyleJSON());
         style.on('style.load', () => {
@@ -1331,7 +1331,7 @@ describe('Style#addLayer', () => {
         expect((layer as any).source).toEqual(source);
     });
 
-    test('reloads source', () => new Promise(done => {
+    test('reloads source', () => new Promise<void>(done => {
         const style = createStyle();
         style.loadJSON(extend(createStyleJSON(), {
             'sources': {
@@ -1358,7 +1358,7 @@ describe('Style#addLayer', () => {
         });
     }));
 
-    test('#3895 reloads source (instead of clearing) if adding this layer with the same type, immediately after removing it', () => new Promise(done => {
+    test('#3895 reloads source (instead of clearing) if adding this layer with the same type, immediately after removing it', () => new Promise<void>((done, fail) => {
         const style = createStyle();
         style.loadJSON(extend(createStyleJSON(), {
             'sources': {
@@ -1386,7 +1386,7 @@ describe('Style#addLayer', () => {
         style.on('data', (e) => {
             if (e.dataType === 'source' && e.sourceDataType === 'content') {
                 style.sourceCaches['mapLibre'].reload = () => { done(); };
-                style.sourceCaches['mapLibre'].clearTiles =  () => { done('test failed'); };
+                style.sourceCaches['mapLibre'].clearTiles =  () => { fail(new Error('test failed')); };
                 style.removeLayer('my-layer');
                 style.addLayer(layer);
                 style.update({} as EvaluationParameters);
@@ -1395,7 +1395,7 @@ describe('Style#addLayer', () => {
 
     }));
 
-    test('clears source (instead of reloading) if adding this layer with a different type, immediately after removing it', () => new Promise(done => {
+    test('clears source (instead of reloading) if adding this layer with a different type, immediately after removing it', () => new Promise<void>((done, fail) => {
         const style = createStyle();
         style.loadJSON(extend(createStyleJSON(), {
             'sources': {
@@ -1421,7 +1421,7 @@ describe('Style#addLayer', () => {
         }as LayerSpecification;
         style.on('data', (e) => {
             if (e.dataType === 'source' && e.sourceDataType === 'content') {
-                style.sourceCaches['mapLibre'].reload =  () => { done('test failed'); };
+                style.sourceCaches['mapLibre'].reload =  () => { fail(new Error('test failed')); };
                 style.sourceCaches['mapLibre'].clearTiles = () => { done(); };
                 style.removeLayer('my-layer');
                 style.addLayer(layer);
@@ -1445,7 +1445,7 @@ describe('Style#addLayer', () => {
         await dataPromise;
     });
 
-    test('emits error on duplicates', () => new Promise(done => {
+    test('emits error on duplicates', () => new Promise<void>(done => {
         const style = new Style(getStubMap());
         style.loadJSON(createStyleJSON());
         const layer = {id: 'background', type: 'background'} as LayerSpecification;
@@ -1497,7 +1497,7 @@ describe('Style#addLayer', () => {
         expect(style._order).toEqual(['c', 'a', 'b']);
     });
 
-    test('fire error if before layer does not exist', () => new Promise(done => {
+    test('fire error if before layer does not exist', () => new Promise<void>(done => {
         const style = new Style(getStubMap());
         style.loadJSON(createStyleJSON({
             layers: [{
@@ -1519,7 +1519,7 @@ describe('Style#addLayer', () => {
         });
     }));
 
-    test('fires an error on non-existant source layer', () => new Promise(done => {
+    test('fires an error on non-existant source layer', () => new Promise<void>(done => {
         const style = new Style(getStubMap());
         style.loadJSON(extend(createStyleJSON(), {
             sources: {
@@ -1570,7 +1570,7 @@ describe('Style#removeLayer', () => {
         await dataPromise;
     });
 
-    test('tears down layer event forwarding', () => new Promise(done => {
+    test('tears down layer event forwarding', () => new Promise<void>((done, fail) => {
         const style = new Style(getStubMap());
         style.loadJSON(createStyleJSON({
             layers: [{
@@ -1580,7 +1580,7 @@ describe('Style#removeLayer', () => {
         }));
 
         style.on('error', () => {
-            done('test failed');
+            fail(new Error('test failed'));
         });
 
         style.on('style.load', () => {
@@ -1705,7 +1705,7 @@ describe('Style#moveLayer', () => {
 });
 
 describe('Style#setPaintProperty', () => {
-    test('#4738 postpones source reload until layers have been broadcast to workers', () => new Promise(done => {
+    test('#4738 postpones source reload until layers have been broadcast to workers', () => new Promise<void>(done => {
         const style = new Style(getStubMap());
         style.loadJSON(extend(createStyleJSON(), {
             'sources': {
@@ -1973,7 +1973,7 @@ describe('Style#setFilter', () => {
         return style;
     }
 
-    test('sets filter', () => new Promise(done => {
+    test('sets filter', () => new Promise<void>(done => {
         const style = createStyle();
 
         style.on('style.load', () => {
@@ -2005,7 +2005,7 @@ describe('Style#setFilter', () => {
         expect(filter2).not.toBe(filter3);
     });
 
-    test('sets again mutated filter', () => new Promise(done => {
+    test('sets again mutated filter', () => new Promise<void>(done => {
         const style = createStyle();
 
         style.on('style.load', () => {
@@ -2061,7 +2061,7 @@ describe('Style#setFilter', () => {
         style.update({} as EvaluationParameters); // trigger dispatcher broadcast
     });
 
-    test('respects validate option', () => new Promise(done => {
+    test('respects validate option', () => new Promise<void>(done => {
         const style = createStyle();
 
         style.on('style.load', () => {
@@ -2102,7 +2102,7 @@ describe('Style#setLayerZoomRange', () => {
         return style;
     }
 
-    test('sets zoom range', () => new Promise(done => {
+    test('sets zoom range', () => new Promise<void>(done => {
         const style = createStyle();
 
         style.on('style.load', () => {

--- a/src/style/style_layer.test.ts
+++ b/src/style/style_layer.test.ts
@@ -92,7 +92,7 @@ describe('StyleLayer#setPaintProperty', () => {
         expect(layer.getPaintProperty('background-color-transition')).toEqual({duration: 400});
     });
 
-    test('emits on an invalid property value', done => {
+    test('emits on an invalid property value', () => new Promise(done => {
         const layer = createStyleLayer({
             'id': 'background',
             'type': 'background'
@@ -104,9 +104,9 @@ describe('StyleLayer#setPaintProperty', () => {
         });
 
         layer.setPaintProperty('background-opacity', 5);
-    });
+    }));
 
-    test('emits on an invalid transition property value', done => {
+    test('emits on an invalid transition property value', () => new Promise(done => {
         const layer = createStyleLayer({
             'id': 'background',
             'type': 'background'
@@ -119,7 +119,7 @@ describe('StyleLayer#setPaintProperty', () => {
         layer.setPaintProperty('background-opacity-transition', {
             duration: -10
         });
-    });
+    }));
 
     test('can unset fill-outline-color #2886', () => {
         const layer = createStyleLayer({
@@ -198,7 +198,7 @@ describe('StyleLayer#setLayoutProperty', () => {
         expect(layer.getLayoutProperty('text-transform')).toBe('lowercase');
     });
 
-    test('emits on an invalid property value', done => {
+    test('emits on an invalid property value', () => new Promise(done => {
         const layer = createStyleLayer({
             'id': 'symbol',
             'type': 'symbol'
@@ -209,7 +209,7 @@ describe('StyleLayer#setLayoutProperty', () => {
         });
 
         layer.setLayoutProperty('text-transform', 'invalidValue');
-    });
+    }));
 
     test('updates property value', () => {
         const layer = createStyleLayer({

--- a/src/style/style_layer.test.ts
+++ b/src/style/style_layer.test.ts
@@ -92,7 +92,7 @@ describe('StyleLayer#setPaintProperty', () => {
         expect(layer.getPaintProperty('background-color-transition')).toEqual({duration: 400});
     });
 
-    test('emits on an invalid property value', () => new Promise(done => {
+    test('emits on an invalid property value', () => new Promise<void>(done => {
         const layer = createStyleLayer({
             'id': 'background',
             'type': 'background'
@@ -106,7 +106,7 @@ describe('StyleLayer#setPaintProperty', () => {
         layer.setPaintProperty('background-opacity', 5);
     }));
 
-    test('emits on an invalid transition property value', () => new Promise(done => {
+    test('emits on an invalid transition property value', () => new Promise<void>(done => {
         const layer = createStyleLayer({
             'id': 'background',
             'type': 'background'
@@ -198,7 +198,7 @@ describe('StyleLayer#setLayoutProperty', () => {
         expect(layer.getLayoutProperty('text-transform')).toBe('lowercase');
     });
 
-    test('emits on an invalid property value', () => new Promise(done => {
+    test('emits on an invalid property value', () => new Promise<void>(done => {
         const layer = createStyleLayer({
             'id': 'symbol',
             'type': 'symbol'

--- a/src/ui/camera.test.ts
+++ b/src/ui/camera.test.ts
@@ -186,7 +186,7 @@ describe('#jumpTo', () => {
         expect(camera.getPitch()).toBe(60);
     });
 
-    test('emits move events, preserving eventData', () => new Promise<void>(done => {
+    test('emits move events, preserving eventData', () => {
         let started, moved, ended;
         const eventData = {data: 'ok'};
 
@@ -199,10 +199,9 @@ describe('#jumpTo', () => {
         expect(started).toBe('ok');
         expect(moved).toBe('ok');
         expect(ended).toBe('ok');
-        done();
-    }));
+    });
 
-    test('emits zoom events, preserving eventData', () => new Promise<void>(done => {
+    test('emits zoom events, preserving eventData', () => {
         let started, zoomed, ended;
         const eventData = {data: 'ok'};
 
@@ -215,10 +214,9 @@ describe('#jumpTo', () => {
         expect(started).toBe('ok');
         expect(zoomed).toBe('ok');
         expect(ended).toBe('ok');
-        done();
-    }));
+    });
 
-    test('emits rotate events, preserving eventData', () => new Promise<void>(done => {
+    test('emits rotate events, preserving eventData', () => {
         let started, rotated, ended;
         const eventData = {data: 'ok'};
 
@@ -231,10 +229,9 @@ describe('#jumpTo', () => {
         expect(started).toBe('ok');
         expect(rotated).toBe('ok');
         expect(ended).toBe('ok');
-        done();
-    }));
+    });
 
-    test('emits pitch events, preserving eventData', () => new Promise<void>(done => {
+    test('emits pitch events, preserving eventData', () => {
         let started, pitched, ended;
         const eventData = {data: 'ok'};
 
@@ -247,8 +244,7 @@ describe('#jumpTo', () => {
         expect(started).toBe('ok');
         expect(pitched).toBe('ok');
         expect(ended).toBe('ok');
-        done();
-    }));
+    });
 
     test('cancels in-progress easing', () => {
         camera.panTo([3, 4]);
@@ -273,7 +269,7 @@ describe('#setCenter', () => {
         }).toThrow(Error);
     });
 
-    test('emits move events, preserving eventData', () => new Promise<void>(done => {
+    test('emits move events, preserving eventData', () => {
         let started, moved, ended;
         const eventData = {data: 'ok'};
 
@@ -285,8 +281,7 @@ describe('#setCenter', () => {
         expect(started).toBe('ok');
         expect(moved).toBe('ok');
         expect(ended).toBe('ok');
-        done();
-    }));
+    });
 
     test('cancels in-progress easing', () => {
         camera.panTo([3, 4]);
@@ -304,7 +299,7 @@ describe('#setZoom', () => {
         expect(camera.getZoom()).toBe(3);
     });
 
-    test('emits move and zoom events, preserving eventData', () => new Promise<void>(done => {
+    test('emits move and zoom events, preserving eventData', () => {
         let movestarted, moved, moveended, zoomstarted, zoomed, zoomended;
         const eventData = {data: 'ok'};
 
@@ -323,8 +318,7 @@ describe('#setZoom', () => {
         expect(zoomstarted).toBe('ok');
         expect(zoomed).toBe('ok');
         expect(zoomended).toBe('ok');
-        done();
-    }));
+    });
 
     test('cancels in-progress easing', () => {
         camera.panTo([3, 4]);
@@ -342,7 +336,7 @@ describe('#setBearing', () => {
         expect(camera.getBearing()).toBe(4);
     });
 
-    test('emits move and rotate events, preserving eventData', () => new Promise<void>(done => {
+    test('emits move and rotate events, preserving eventData', () => {
         let movestarted, moved, moveended, rotatestarted, rotated, rotateended;
         const eventData = {data: 'ok'};
 
@@ -361,8 +355,7 @@ describe('#setBearing', () => {
         expect(rotatestarted).toBe('ok');
         expect(rotated).toBe('ok');
         expect(rotateended).toBe('ok');
-        done();
-    }));
+    });
 
     test('cancels in-progress easing', () => {
         camera.panTo([3, 4]);
@@ -545,7 +538,7 @@ describe('#zoomTo', () => {
         expect(fixedLngLat(camera.getCenter())).toEqual(fixedLngLat({lng: -62.66117668978012, lat: 0}));
     });
 
-    test('emits move and zoom events, preserving eventData', () => new Promise<void>(done => {
+    test('emits move and zoom events, preserving eventData', () => {
         const camera = createCamera();
         let movestarted, moved, zoomstarted, zoomed;
         const eventData = {data: 'ok'};
@@ -571,8 +564,7 @@ describe('#zoomTo', () => {
             });
 
         camera.zoomTo(5, {duration: 0}, eventData);
-        done();
-    }));
+    });
 });
 
 describe('#rotateTo', () => {
@@ -617,7 +609,7 @@ describe('#rotateTo', () => {
         expect(fixedLngLat(camera.getCenter())).toEqual(fixedLngLat({lng: -70.3125, lat: 57.3265212252}));
     });
 
-    test('emits move and rotate events, preserving eventData', () => new Promise<void>(done => {
+    test('emits move and rotate events, preserving eventData', () => {
         const camera = createCamera();
         let movestarted, moved, rotatestarted, rotated;
         const eventData = {data: 'ok'};
@@ -643,8 +635,7 @@ describe('#rotateTo', () => {
             });
 
         camera.rotateTo(90, {duration: 0}, eventData);
-        done();
-    }));
+    });
 });
 
 describe('#easeTo', () => {
@@ -764,7 +755,7 @@ describe('#easeTo', () => {
         expect(fixedLngLat(camera.getCenter())).toEqual(fixedLngLat({lng: -70.3125, lat: 0.000002552471840999715}));
     });
 
-    test('emits move, zoom, rotate, and pitch events, preserving eventData', () => new Promise<void>(done => {
+    test('emits move, zoom, rotate, and pitch events, preserving eventData', () => {
         const camera = createCamera();
         let movestarted, moved, zoomstarted, zoomed, rotatestarted, rotated, pitchstarted, pitched;
         const eventData = {data: 'ok'};
@@ -817,8 +808,7 @@ describe('#easeTo', () => {
         camera.easeTo(
             {center: [100, 0], zoom: 3.2, bearing: 90, duration: 0, pitch: 45},
             eventData);
-        done();
-    }));
+    });
 
     test('does not emit zoom events if not zooming', () => new Promise<void>((done, fail) => {
         const camera = createCamera();
@@ -1208,7 +1198,7 @@ describe('#flyTo', () => {
         expect(fixedLngLat(camera.getCenter())).toEqual({lng: 170.3125, lat: 0});
     });
 
-    test('emits move, zoom, rotate, and pitch events, preserving eventData', () => new Promise<void>(done => {
+    test('emits move, zoom, rotate, and pitch events, preserving eventData', () => {
         expect.assertions(18);
 
         const camera = createCamera();
@@ -1263,8 +1253,7 @@ describe('#flyTo', () => {
         camera.flyTo(
             {center: [100, 0], zoom: 3.2, bearing: 90, duration: 0, pitch: 45, animate: false},
             eventData);
-        done();
-    }));
+    });
 
     test('for short flights, emits (solely) move events, preserving eventData', () => new Promise<void>(done => {
         //As I type this, the code path for guiding super-short flights is (and will probably remain) different.
@@ -1324,13 +1313,12 @@ describe('#flyTo', () => {
         }, 0);
     }));
 
-    test('stops existing ease', () => new Promise<void>(done => {
+    test('stops existing ease', () => {
         const camera = createCamera();
         camera.flyTo({center: [200, 0], duration: 100});
         camera.flyTo({center: [100, 0], duration: 0});
         expect(fixedLngLat(camera.getCenter())).toEqual({lng: 100, lat: 0});
-        done();
-    }));
+    });
 
     test('can be called from within a moveend event handler', () => new Promise<void>(done => {
         const camera = createCamera();
@@ -1777,7 +1765,7 @@ describe('#flyTo', () => {
         expect(terrainCallbacks.finalize).toBe(1);
     });
 
-    test('check elevation callbacks', () => new Promise<void>(done => {
+    test('check elevation callbacks', () => {
         const camera = createCamera();
         camera.terrain = {
             getElevationForLngLatZoom: () => 100,
@@ -1801,10 +1789,7 @@ describe('#flyTo', () => {
 
         camera._finalizeElevation();
         expect(camera._elevationFreeze).toBeFalsy();
-
-        done();
-    }));
-
+    });
 });
 
 describe('#isEasing', () => {

--- a/src/ui/camera.test.ts
+++ b/src/ui/camera.test.ts
@@ -186,7 +186,7 @@ describe('#jumpTo', () => {
         expect(camera.getPitch()).toBe(60);
     });
 
-    test('emits move events, preserving eventData', done => {
+    test('emits move events, preserving eventData', () => new Promise(done => {
         let started, moved, ended;
         const eventData = {data: 'ok'};
 
@@ -200,9 +200,9 @@ describe('#jumpTo', () => {
         expect(moved).toBe('ok');
         expect(ended).toBe('ok');
         done();
-    });
+    }));
 
-    test('emits zoom events, preserving eventData', done => {
+    test('emits zoom events, preserving eventData', () => new Promise(done => {
         let started, zoomed, ended;
         const eventData = {data: 'ok'};
 
@@ -216,9 +216,9 @@ describe('#jumpTo', () => {
         expect(zoomed).toBe('ok');
         expect(ended).toBe('ok');
         done();
-    });
+    }));
 
-    test('emits rotate events, preserving eventData', done => {
+    test('emits rotate events, preserving eventData', () => new Promise(done => {
         let started, rotated, ended;
         const eventData = {data: 'ok'};
 
@@ -232,9 +232,9 @@ describe('#jumpTo', () => {
         expect(rotated).toBe('ok');
         expect(ended).toBe('ok');
         done();
-    });
+    }));
 
-    test('emits pitch events, preserving eventData', done => {
+    test('emits pitch events, preserving eventData', () => new Promise(done => {
         let started, pitched, ended;
         const eventData = {data: 'ok'};
 
@@ -248,7 +248,7 @@ describe('#jumpTo', () => {
         expect(pitched).toBe('ok');
         expect(ended).toBe('ok');
         done();
-    });
+    }));
 
     test('cancels in-progress easing', () => {
         camera.panTo([3, 4]);
@@ -273,7 +273,7 @@ describe('#setCenter', () => {
         }).toThrow(Error);
     });
 
-    test('emits move events, preserving eventData', done => {
+    test('emits move events, preserving eventData', () => new Promise(done => {
         let started, moved, ended;
         const eventData = {data: 'ok'};
 
@@ -286,7 +286,7 @@ describe('#setCenter', () => {
         expect(moved).toBe('ok');
         expect(ended).toBe('ok');
         done();
-    });
+    }));
 
     test('cancels in-progress easing', () => {
         camera.panTo([3, 4]);
@@ -304,7 +304,7 @@ describe('#setZoom', () => {
         expect(camera.getZoom()).toBe(3);
     });
 
-    test('emits move and zoom events, preserving eventData', done => {
+    test('emits move and zoom events, preserving eventData', () => new Promise(done => {
         let movestarted, moved, moveended, zoomstarted, zoomed, zoomended;
         const eventData = {data: 'ok'};
 
@@ -324,7 +324,7 @@ describe('#setZoom', () => {
         expect(zoomed).toBe('ok');
         expect(zoomended).toBe('ok');
         done();
-    });
+    }));
 
     test('cancels in-progress easing', () => {
         camera.panTo([3, 4]);
@@ -342,7 +342,7 @@ describe('#setBearing', () => {
         expect(camera.getBearing()).toBe(4);
     });
 
-    test('emits move and rotate events, preserving eventData', done => {
+    test('emits move and rotate events, preserving eventData', () => new Promise(done => {
         let movestarted, moved, moveended, rotatestarted, rotated, rotateended;
         const eventData = {data: 'ok'};
 
@@ -362,7 +362,7 @@ describe('#setBearing', () => {
         expect(rotated).toBe('ok');
         expect(rotateended).toBe('ok');
         done();
-    });
+    }));
 
     test('cancels in-progress easing', () => {
         camera.panTo([3, 4]);
@@ -419,7 +419,7 @@ describe('#panBy', () => {
         expect(fixedLngLat(camera.getCenter())).toEqual({lng: -70.3125, lat: 0});
     });
 
-    test('emits move events, preserving eventData', done => {
+    test('emits move events, preserving eventData', () => new Promise(done => {
         const camera = createCamera();
         let started, moved;
         const eventData = {data: 'ok'};
@@ -435,9 +435,9 @@ describe('#panBy', () => {
             });
 
         camera.panBy([100, 0], {duration: 0}, eventData);
-    });
+    }));
 
-    test('suppresses movestart if noMoveStart option is true', done => {
+    test('suppresses movestart if noMoveStart option is true', () => new Promise(done => {
         const camera = createCamera();
         let started;
 
@@ -452,7 +452,7 @@ describe('#panBy', () => {
             });
 
         camera.panBy([100, 0], {duration: 0, noMoveStart: true});
-    });
+    }));
 });
 
 describe('#panTo', () => {
@@ -481,7 +481,7 @@ describe('#panTo', () => {
         expect(fixedLngLat(camera.getCenter())).toEqual({lng: 170.3125, lat: 0});
     });
 
-    test('emits move events, preserving eventData', done => {
+    test('emits move events, preserving eventData', () => new Promise(done => {
         const camera = createCamera();
         let started, moved;
         const eventData = {data: 'ok'};
@@ -497,9 +497,9 @@ describe('#panTo', () => {
             });
 
         camera.panTo([100, 0], {duration: 0}, eventData);
-    });
+    }));
 
-    test('suppresses movestart if noMoveStart option is true', done => {
+    test('suppresses movestart if noMoveStart option is true', () => new Promise(done => {
         const camera = createCamera();
         let started;
 
@@ -514,7 +514,7 @@ describe('#panTo', () => {
             });
 
         camera.panTo([100, 0], {duration: 0, noMoveStart: true});
-    });
+    }));
 });
 
 describe('#zoomTo', () => {
@@ -545,7 +545,7 @@ describe('#zoomTo', () => {
         expect(fixedLngLat(camera.getCenter())).toEqual(fixedLngLat({lng: -62.66117668978012, lat: 0}));
     });
 
-    test('emits move and zoom events, preserving eventData', done => {
+    test('emits move and zoom events, preserving eventData', () => new Promise(done => {
         const camera = createCamera();
         let movestarted, moved, zoomstarted, zoomed;
         const eventData = {data: 'ok'};
@@ -572,7 +572,7 @@ describe('#zoomTo', () => {
 
         camera.zoomTo(5, {duration: 0}, eventData);
         done();
-    });
+    }));
 });
 
 describe('#rotateTo', () => {
@@ -617,7 +617,7 @@ describe('#rotateTo', () => {
         expect(fixedLngLat(camera.getCenter())).toEqual(fixedLngLat({lng: -70.3125, lat: 57.3265212252}));
     });
 
-    test('emits move and rotate events, preserving eventData', done => {
+    test('emits move and rotate events, preserving eventData', () => new Promise(done => {
         const camera = createCamera();
         let movestarted, moved, rotatestarted, rotated;
         const eventData = {data: 'ok'};
@@ -644,7 +644,7 @@ describe('#rotateTo', () => {
 
         camera.rotateTo(90, {duration: 0}, eventData);
         done();
-    });
+    }));
 });
 
 describe('#easeTo', () => {
@@ -764,7 +764,7 @@ describe('#easeTo', () => {
         expect(fixedLngLat(camera.getCenter())).toEqual(fixedLngLat({lng: -70.3125, lat: 0.000002552471840999715}));
     });
 
-    test('emits move, zoom, rotate, and pitch events, preserving eventData', done => {
+    test('emits move, zoom, rotate, and pitch events, preserving eventData', () => new Promise(done => {
         const camera = createCamera();
         let movestarted, moved, zoomstarted, zoomed, rotatestarted, rotated, pitchstarted, pitched;
         const eventData = {data: 'ok'};
@@ -818,9 +818,9 @@ describe('#easeTo', () => {
             {center: [100, 0], zoom: 3.2, bearing: 90, duration: 0, pitch: 45},
             eventData);
         done();
-    });
+    }));
 
-    test('does not emit zoom events if not zooming', done => {
+    test('does not emit zoom events if not zooming', () => new Promise(done => {
         const camera = createCamera();
 
         camera
@@ -830,7 +830,7 @@ describe('#easeTo', () => {
             .on('moveend', () => { done(); });
 
         camera.easeTo({center: [100, 0], duration: 0});
-    });
+    }));
 
     test('stops existing ease', () => {
         const camera = createCamera();
@@ -839,7 +839,7 @@ describe('#easeTo', () => {
         expect(camera.getCenter()).toEqual({lng: 100, lat: 0});
     });
 
-    test('can be called from within a moveend event handler', done => {
+    test('can be called from within a moveend event handler', () => new Promise(done => {
         const camera = createCamera();
         const stub = jest.spyOn(browser, 'now');
 
@@ -872,9 +872,9 @@ describe('#easeTo', () => {
             stub.mockImplementation(() => 10);
             camera.simulateFrame();
         }, 0);
-    });
+    }));
 
-    test('pans eastward across the antimeridian', done => {
+    test('pans eastward across the antimeridian', () => new Promise(done => {
         const camera = createCamera();
         const stub = jest.spyOn(browser, 'now');
 
@@ -904,9 +904,9 @@ describe('#easeTo', () => {
                 camera.simulateFrame();
             }, 0);
         }, 0);
-    });
+    }));
 
-    test('does not pan eastward across the antimeridian on a single-globe mercator map', done => {
+    test('does not pan eastward across the antimeridian on a single-globe mercator map', () => new Promise(done => {
         const camera = createCamera({renderWorldCopies: false, zoom: 2});
         camera.setCenter([170, 0]);
         const initialLng = camera.getCenter().lng;
@@ -915,9 +915,9 @@ describe('#easeTo', () => {
             done();
         });
         camera.easeTo({center: [210, 0], duration: 0});
-    });
+    }));
 
-    test('pans westward across the antimeridian', done => {
+    test('pans westward across the antimeridian', () => new Promise(done => {
         const camera = createCamera();
         const stub = jest.spyOn(browser, 'now');
 
@@ -947,9 +947,9 @@ describe('#easeTo', () => {
                 camera.simulateFrame();
             }, 0);
         }, 0);
-    });
+    }));
 
-    test('does not pan westward across the antimeridian on a single-globe mercator map', done => {
+    test('does not pan westward across the antimeridian on a single-globe mercator map', () => new Promise(done => {
         const camera = createCamera({renderWorldCopies: false, zoom: 2});
         camera.setCenter([-170, 0]);
         const initialLng = camera.getCenter().lng;
@@ -958,9 +958,9 @@ describe('#easeTo', () => {
             done();
         });
         camera.easeTo({center: [-210, 0], duration: 0});
-    });
+    }));
 
-    test('animation occurs when prefers-reduced-motion: reduce is set but overridden by essential: true', done => {
+    test('animation occurs when prefers-reduced-motion: reduce is set but overridden by essential: true', () => new Promise(done => {
         const camera = createCamera();
         Object.defineProperty(browser, 'prefersReducedMotion', {value: true});
         const stubNow = jest.spyOn(browser, 'now');
@@ -991,16 +991,16 @@ describe('#easeTo', () => {
                 camera.simulateFrame();
             }, 0);
         }, 0);
-    });
+    }));
 
-    test('duration is 0 when prefers-reduced-motion: reduce is set', done => {
+    test('duration is 0 when prefers-reduced-motion: reduce is set', () => new Promise(done => {
         const camera = createCamera();
         Object.defineProperty(browser, 'prefersReducedMotion', {value: true});
         assertTransitionTime(done, camera, 0, 10);
         camera.easeTo({center: [100, 0], zoom: 3.2, bearing: 90, duration: 1000});
-    });
+    }));
 
-    test('jumpTo on("move") during easeTo with zoom, pitch, etc', (done) => {
+    test('jumpTo on("move") during easeTo with zoom, pitch, etc', () => new Promise(done => {
         const camera = createCamera();
 
         camera.on('moveend', (e: Event & {done?: true}) => {
@@ -1018,9 +1018,9 @@ describe('#easeTo', () => {
 
         camera.simulateFrame();
         camera.simulateFrame();
-    });
+    }));
 
-    test('jumpTo on("zoom") during easeTo', (done) => {
+    test('jumpTo on("zoom") during easeTo', () => new Promise(done => {
         const camera = createCamera();
 
         camera.on('moveend', (e: Event & {done?: true}) => {
@@ -1038,9 +1038,9 @@ describe('#easeTo', () => {
 
         camera.simulateFrame();
         camera.simulateFrame();
-    });
+    }));
 
-    test('jumpTo on("pitch") during easeTo', (done) => {
+    test('jumpTo on("pitch") during easeTo', () => new Promise(done => {
         const camera = createCamera();
 
         camera.on('moveend', (e: Event & {done?: true}) => {
@@ -1058,9 +1058,9 @@ describe('#easeTo', () => {
 
         camera.simulateFrame();
         camera.simulateFrame();
-    });
+    }));
 
-    test('jumpTo on("rotate") during easeTo', (done) => {
+    test('jumpTo on("rotate") during easeTo', () => new Promise(done => {
         const camera = createCamera();
 
         camera.on('moveend', (e: Event & {done?: true}) => {
@@ -1078,7 +1078,7 @@ describe('#easeTo', () => {
 
         camera.simulateFrame();
         camera.simulateFrame();
-    });
+    }));
 });
 
 describe('#flyTo', () => {
@@ -1121,7 +1121,7 @@ describe('#flyTo', () => {
         expect(camera.getZoom()).toBe(2);
     });
 
-    test('Zoom out from the same position to the same position with animation', done => {
+    test('Zoom out from the same position to the same position with animation', () => new Promise(done => {
         const pos = {lng: 0, lat: 0};
         const camera = createCamera({zoom: 20, center: pos});
         const stub = jest.spyOn(browser, 'now');
@@ -1137,7 +1137,7 @@ describe('#flyTo', () => {
 
         stub.mockImplementation(() => 3);
         camera.simulateFrame();
-    });
+    }));
 
     test('rotates to specified bearing', () => {
         const camera = createCamera();
@@ -1208,7 +1208,7 @@ describe('#flyTo', () => {
         expect(fixedLngLat(camera.getCenter())).toEqual({lng: 170.3125, lat: 0});
     });
 
-    test('emits move, zoom, rotate, and pitch events, preserving eventData', done => {
+    test('emits move, zoom, rotate, and pitch events, preserving eventData', () => new Promise(done => {
         expect.assertions(18);
 
         const camera = createCamera();
@@ -1264,9 +1264,9 @@ describe('#flyTo', () => {
             {center: [100, 0], zoom: 3.2, bearing: 90, duration: 0, pitch: 45, animate: false},
             eventData);
         done();
-    });
+    }));
 
-    test('for short flights, emits (solely) move events, preserving eventData', done => {
+    test('for short flights, emits (solely) move events, preserving eventData', () => new Promise(done => {
         //As I type this, the code path for guiding super-short flights is (and will probably remain) different.
         //As such; it deserves a separate test case. This test case flies the map from A to A.
         const camera = createCamera({center: [100, 0]});
@@ -1322,17 +1322,17 @@ describe('#flyTo', () => {
                 camera.simulateFrame();
             }, 0);
         }, 0);
-    });
+    }));
 
-    test('stops existing ease', done => {
+    test('stops existing ease', () => new Promise(done => {
         const camera = createCamera();
         camera.flyTo({center: [200, 0], duration: 100});
         camera.flyTo({center: [100, 0], duration: 0});
         expect(fixedLngLat(camera.getCenter())).toEqual({lng: 100, lat: 0});
         done();
-    });
+    }));
 
-    test('can be called from within a moveend event handler', done => {
+    test('can be called from within a moveend event handler', () => new Promise(done => {
         const camera = createCamera();
         const stub = jest.spyOn(browser, 'now');
         stub.mockImplementation(() => 0);
@@ -1362,9 +1362,9 @@ describe('#flyTo', () => {
                 }, 0);
             }, 0);
         }, 0);
-    });
+    }));
 
-    test('ascends', done => {
+    test('ascends', () => new Promise(done => {
         const camera = createCamera();
         camera.setZoom(18);
         let ascended;
@@ -1394,9 +1394,9 @@ describe('#flyTo', () => {
                 camera.simulateFrame();
             }, 0);
         }, 0);
-    });
+    }));
 
-    test('pans eastward across the prime meridian', done => {
+    test('pans eastward across the prime meridian', () => new Promise(done => {
         const camera = createCamera();
         const stub = jest.spyOn(browser, 'now');
 
@@ -1426,9 +1426,9 @@ describe('#flyTo', () => {
                 camera.simulateFrame();
             }, 0);
         }, 0);
-    });
+    }));
 
-    test('pans westward across the prime meridian', done => {
+    test('pans westward across the prime meridian', () => new Promise(done => {
         const camera = createCamera();
         const stub = jest.spyOn(browser, 'now');
 
@@ -1458,9 +1458,9 @@ describe('#flyTo', () => {
                 camera.simulateFrame();
             }, 0);
         }, 0);
-    });
+    }));
 
-    test('pans eastward across the antimeridian', done => {
+    test('pans eastward across the antimeridian', () => new Promise(done => {
         const camera = createCamera();
         const stub = jest.spyOn(browser, 'now');
 
@@ -1490,9 +1490,9 @@ describe('#flyTo', () => {
                 camera.simulateFrame();
             }, 0);
         }, 0);
-    });
+    }));
 
-    test('pans westward across the antimeridian', done => {
+    test('pans westward across the antimeridian', () => new Promise(done => {
         const camera = createCamera();
         const stub = jest.spyOn(browser, 'now');
 
@@ -1522,9 +1522,9 @@ describe('#flyTo', () => {
                 camera.simulateFrame();
             }, 0);
         }, 0);
-    });
+    }));
 
-    test('does not pan eastward across the antimeridian if no world copies', done => {
+    test('does not pan eastward across the antimeridian if no world copies', () => new Promise(done => {
         const camera = createCamera({renderWorldCopies: false});
         const stub = jest.spyOn(browser, 'now');
 
@@ -1554,9 +1554,9 @@ describe('#flyTo', () => {
                 camera.simulateFrame();
             }, 0);
         }, 0);
-    });
+    }));
 
-    test('does not pan westward across the antimeridian if no world copies', done => {
+    test('does not pan westward across the antimeridian if no world copies', () => new Promise(done => {
         const camera = createCamera({renderWorldCopies: false});
         const stub = jest.spyOn(browser, 'now');
 
@@ -1586,9 +1586,9 @@ describe('#flyTo', () => {
                 camera.simulateFrame();
             }, 0);
         }, 0);
-    });
+    }));
 
-    test('jumps back to world 0 when crossing the antimeridian', done => {
+    test('jumps back to world 0 when crossing the antimeridian', () => new Promise(done => {
         const camera = createCamera();
         const stub = jest.spyOn(browser, 'now');
 
@@ -1617,9 +1617,9 @@ describe('#flyTo', () => {
                 camera.simulateFrame();
             }, 0);
         }, 0);
-    });
+    }));
 
-    test('peaks at the specified zoom level', done => {
+    test('peaks at the specified zoom level', () => new Promise(done => {
         const camera = createCamera({zoom: 20});
         const stub = jest.spyOn(browser, 'now');
 
@@ -1654,9 +1654,9 @@ describe('#flyTo', () => {
                 camera.simulateFrame();
             }, 0);
         }, 0);
-    });
+    }));
 
-    test('respects transform\'s maxZoom', done => {
+    test('respects transform\'s maxZoom', () => new Promise(done => {
         const transform = new Transform(2, 10, 0, 60, false);
         transform.resize(512, 512);
 
@@ -1679,9 +1679,9 @@ describe('#flyTo', () => {
             stub.mockImplementation(() => 10);
             camera.simulateFrame();
         }, 0);
-    });
+    }));
 
-    test('respects transform\'s minZoom', done => {
+    test('respects transform\'s minZoom', () => new Promise(done => {
         const transform = new Transform(2, 10, 0, 60, false);
         transform.resize(512, 512);
 
@@ -1704,9 +1704,9 @@ describe('#flyTo', () => {
             stub.mockImplementation(() => 10);
             camera.simulateFrame();
         }, 0);
-    });
+    }));
 
-    test('resets duration to 0 if it exceeds maxDuration', done => {
+    test('resets duration to 0 if it exceeds maxDuration', () => new Promise(done => {
         let startTime, endTime, timeDiff;
         const camera = createCamera({center: [37.63454, 55.75868], zoom: 18});
 
@@ -1720,14 +1720,14 @@ describe('#flyTo', () => {
             });
 
         camera.flyTo({center: [-122.3998631, 37.7884307], maxDuration: 100});
-    });
+    }));
 
-    test('flys instantly when prefers-reduce-motion:reduce is set', done => {
+    test('flys instantly when prefers-reduce-motion:reduce is set', () => new Promise(done => {
         const camera = createCamera();
         Object.defineProperty(browser, 'prefersReducedMotion', {value: true});
         assertTransitionTime(done, camera, 0, 10);
         camera.flyTo({center: [100, 0], bearing: 90, animate: true});
-    });
+    }));
 
     test('check elevation events freezeElevation=false', async () => {
         const camera = createCamera();
@@ -1777,7 +1777,7 @@ describe('#flyTo', () => {
         expect(terrainCallbacks.finalize).toBe(1);
     });
 
-    test('check elevation callbacks', done => {
+    test('check elevation callbacks', () => new Promise(done => {
         const camera = createCamera();
         camera.terrain = {
             getElevationForLngLatZoom: () => 100,
@@ -1803,7 +1803,7 @@ describe('#flyTo', () => {
         expect(camera._elevationFreeze).toBeFalsy();
 
         done();
-    });
+    }));
 
 });
 
@@ -1819,7 +1819,7 @@ describe('#isEasing', () => {
         expect(camera.isEasing()).toBeTruthy();
     });
 
-    test('returns false when done panning', done => {
+    test('returns false when done panning', () => new Promise(done => {
         const camera = createCamera();
         camera.on('moveend', () => {
             expect(!camera.isEasing()).toBeTruthy();
@@ -1832,7 +1832,7 @@ describe('#isEasing', () => {
             stub.mockImplementation(() => 1);
             camera.simulateFrame();
         }, 0);
-    });
+    }));
 
     test('returns true when zooming', () => {
         const camera = createCamera();
@@ -1841,7 +1841,7 @@ describe('#isEasing', () => {
         expect(camera.isEasing()).toBeTruthy();
     });
 
-    test('returns false when done zooming', done => {
+    test('returns false when done zooming', () => new Promise(done => {
         const camera = createCamera();
         camera.on('moveend', () => {
             expect(!camera.isEasing()).toBeTruthy();
@@ -1854,7 +1854,7 @@ describe('#isEasing', () => {
             stub.mockImplementation(() => 1);
             camera.simulateFrame();
         }, 0);
-    });
+    }));
 
     test('returns true when rotating', () => {
         const camera = createCamera();
@@ -1862,7 +1862,7 @@ describe('#isEasing', () => {
         expect(camera.isEasing()).toBeTruthy();
     });
 
-    test('returns false when done rotating', done => {
+    test('returns false when done rotating', () => new Promise(done => {
         const camera = createCamera();
         camera.on('moveend', () => {
             expect(!camera.isEasing()).toBeTruthy();
@@ -1875,7 +1875,7 @@ describe('#isEasing', () => {
             stub.mockImplementation(() => 1);
             camera.simulateFrame();
         }, 0);
-    });
+    }));
 });
 
 describe('#stop', () => {
@@ -1893,7 +1893,7 @@ describe('#stop', () => {
         expect(!camera._rotating).toBeTruthy();
     });
 
-    test('emits moveend if panning, preserving eventData', done => {
+    test('emits moveend if panning, preserving eventData', () => new Promise(done => {
         const camera = createCamera();
         const eventData = {data: 'ok'};
 
@@ -1904,9 +1904,9 @@ describe('#stop', () => {
 
         camera.panTo([100, 0], {}, eventData);
         camera.stop();
-    });
+    }));
 
-    test('emits moveend if zooming, preserving eventData', done => {
+    test('emits moveend if zooming, preserving eventData', () => new Promise(done => {
         const camera = createCamera();
         const eventData = {data: 'ok'};
 
@@ -1917,9 +1917,9 @@ describe('#stop', () => {
 
         camera.zoomTo(3.2, {}, eventData);
         camera.stop();
-    });
+    }));
 
-    test('emits moveend if rotating, preserving eventData', done => {
+    test('emits moveend if rotating, preserving eventData', () => new Promise(done => {
         const camera = createCamera();
         const eventData = {data: 'ok'};
 
@@ -1930,9 +1930,9 @@ describe('#stop', () => {
 
         camera.rotateTo(90, {}, eventData);
         camera.stop();
-    });
+    }));
 
-    test('does not emit moveend if not moving', done => {
+    test('does not emit moveend if not moving', () => new Promise(done => {
         const camera = createCamera();
         const eventData = {data: 'ok'};
 
@@ -1950,7 +1950,7 @@ describe('#stop', () => {
             stub.mockImplementation(() => 1);
             camera.simulateFrame();
         }, 0);
-    });
+    }));
 });
 
 describe('#cameraForBounds', () => {
@@ -2204,7 +2204,7 @@ describe('queryTerrainElevation', () => {
 
 describe('#transformCameraUpdate', () => {
 
-    test('invoke transformCameraUpdate callback during jumpTo', done => {
+    test('invoke transformCameraUpdate callback during jumpTo', () => new Promise(done => {
         const camera = createCamera();
 
         let callbackCount = 0;
@@ -2225,9 +2225,9 @@ describe('#transformCameraUpdate', () => {
             });
 
         camera.jumpTo({center: [100, 0]});
-    });
+    }));
 
-    test('invoke transformCameraUpdate callback during easeTo', done => {
+    test('invoke transformCameraUpdate callback during easeTo', () => new Promise(done => {
         expect.assertions(2);
         const camera = createCamera();
         const stub = jest.spyOn(browser, 'now');
@@ -2261,9 +2261,9 @@ describe('#transformCameraUpdate', () => {
                 camera.simulateFrame();
             }, 0);
         }, 0);
-    });
+    }));
 
-    test('invoke transformCameraUpdate callback during flyTo', done => {
+    test('invoke transformCameraUpdate callback during flyTo', () => new Promise(done => {
         expect.assertions(2);
         const camera = createCamera();
         const stub = jest.spyOn(browser, 'now');
@@ -2297,7 +2297,7 @@ describe('#transformCameraUpdate', () => {
                 camera.simulateFrame();
             }, 0);
         }, 0);
-    });
+    }));
 
     test('transformCameraUpdate overrides proposed camera settings', () => {
         const camera = createCamera();

--- a/src/ui/camera.test.ts
+++ b/src/ui/camera.test.ts
@@ -810,13 +810,13 @@ describe('#easeTo', () => {
             eventData);
     });
 
-    test('does not emit zoom events if not zooming', () => new Promise<void>((done, fail) => {
+    test('does not emit zoom events if not zooming', () => new Promise<void>((done) => {
         const camera = createCamera();
 
         camera
-            .on('zoomstart', () => { fail(new Error('zoomstart failed')); })
-            .on('zoom', () => { fail(new Error('zoom failed')); })
-            .on('zoomend', () => { fail(new Error('zoomend failed')); })
+            .on('zoomstart', () => { throw new Error('zoomstart failed'); })
+            .on('zoom', () => { throw new Error('zoom failed'); })
+            .on('zoomend', () => { throw new Error('zoomend failed'); })
             .on('moveend', () => { done(); });
 
         camera.easeTo({center: [100, 0], duration: 0});
@@ -1617,7 +1617,7 @@ describe('#flyTo', () => {
         camera.on('zoom', () => {
             const zoom = camera.getZoom();
             if (zoom < 1) {
-                fail(`${zoom} should be >= ${minZoom} during flyTo`);
+                throw new Error(`${zoom} should be >= ${minZoom} during flyTo`);
             }
 
             if (camera.getZoom() < (minZoom + 1)) {

--- a/src/ui/camera.test.ts
+++ b/src/ui/camera.test.ts
@@ -186,7 +186,7 @@ describe('#jumpTo', () => {
         expect(camera.getPitch()).toBe(60);
     });
 
-    test('emits move events, preserving eventData', () => new Promise(done => {
+    test('emits move events, preserving eventData', () => new Promise<void>(done => {
         let started, moved, ended;
         const eventData = {data: 'ok'};
 
@@ -202,7 +202,7 @@ describe('#jumpTo', () => {
         done();
     }));
 
-    test('emits zoom events, preserving eventData', () => new Promise(done => {
+    test('emits zoom events, preserving eventData', () => new Promise<void>(done => {
         let started, zoomed, ended;
         const eventData = {data: 'ok'};
 
@@ -218,7 +218,7 @@ describe('#jumpTo', () => {
         done();
     }));
 
-    test('emits rotate events, preserving eventData', () => new Promise(done => {
+    test('emits rotate events, preserving eventData', () => new Promise<void>(done => {
         let started, rotated, ended;
         const eventData = {data: 'ok'};
 
@@ -234,7 +234,7 @@ describe('#jumpTo', () => {
         done();
     }));
 
-    test('emits pitch events, preserving eventData', () => new Promise(done => {
+    test('emits pitch events, preserving eventData', () => new Promise<void>(done => {
         let started, pitched, ended;
         const eventData = {data: 'ok'};
 
@@ -273,7 +273,7 @@ describe('#setCenter', () => {
         }).toThrow(Error);
     });
 
-    test('emits move events, preserving eventData', () => new Promise(done => {
+    test('emits move events, preserving eventData', () => new Promise<void>(done => {
         let started, moved, ended;
         const eventData = {data: 'ok'};
 
@@ -304,7 +304,7 @@ describe('#setZoom', () => {
         expect(camera.getZoom()).toBe(3);
     });
 
-    test('emits move and zoom events, preserving eventData', () => new Promise(done => {
+    test('emits move and zoom events, preserving eventData', () => new Promise<void>(done => {
         let movestarted, moved, moveended, zoomstarted, zoomed, zoomended;
         const eventData = {data: 'ok'};
 
@@ -342,7 +342,7 @@ describe('#setBearing', () => {
         expect(camera.getBearing()).toBe(4);
     });
 
-    test('emits move and rotate events, preserving eventData', () => new Promise(done => {
+    test('emits move and rotate events, preserving eventData', () => new Promise<void>(done => {
         let movestarted, moved, moveended, rotatestarted, rotated, rotateended;
         const eventData = {data: 'ok'};
 
@@ -419,7 +419,7 @@ describe('#panBy', () => {
         expect(fixedLngLat(camera.getCenter())).toEqual({lng: -70.3125, lat: 0});
     });
 
-    test('emits move events, preserving eventData', () => new Promise(done => {
+    test('emits move events, preserving eventData', () => new Promise<void>(done => {
         const camera = createCamera();
         let started, moved;
         const eventData = {data: 'ok'};
@@ -437,7 +437,7 @@ describe('#panBy', () => {
         camera.panBy([100, 0], {duration: 0}, eventData);
     }));
 
-    test('suppresses movestart if noMoveStart option is true', () => new Promise(done => {
+    test('suppresses movestart if noMoveStart option is true', () => new Promise<void>(done => {
         const camera = createCamera();
         let started;
 
@@ -481,7 +481,7 @@ describe('#panTo', () => {
         expect(fixedLngLat(camera.getCenter())).toEqual({lng: 170.3125, lat: 0});
     });
 
-    test('emits move events, preserving eventData', () => new Promise(done => {
+    test('emits move events, preserving eventData', () => new Promise<void>(done => {
         const camera = createCamera();
         let started, moved;
         const eventData = {data: 'ok'};
@@ -499,7 +499,7 @@ describe('#panTo', () => {
         camera.panTo([100, 0], {duration: 0}, eventData);
     }));
 
-    test('suppresses movestart if noMoveStart option is true', () => new Promise(done => {
+    test('suppresses movestart if noMoveStart option is true', () => new Promise<void>(done => {
         const camera = createCamera();
         let started;
 
@@ -545,7 +545,7 @@ describe('#zoomTo', () => {
         expect(fixedLngLat(camera.getCenter())).toEqual(fixedLngLat({lng: -62.66117668978012, lat: 0}));
     });
 
-    test('emits move and zoom events, preserving eventData', () => new Promise(done => {
+    test('emits move and zoom events, preserving eventData', () => new Promise<void>(done => {
         const camera = createCamera();
         let movestarted, moved, zoomstarted, zoomed;
         const eventData = {data: 'ok'};
@@ -617,7 +617,7 @@ describe('#rotateTo', () => {
         expect(fixedLngLat(camera.getCenter())).toEqual(fixedLngLat({lng: -70.3125, lat: 57.3265212252}));
     });
 
-    test('emits move and rotate events, preserving eventData', () => new Promise(done => {
+    test('emits move and rotate events, preserving eventData', () => new Promise<void>(done => {
         const camera = createCamera();
         let movestarted, moved, rotatestarted, rotated;
         const eventData = {data: 'ok'};
@@ -764,7 +764,7 @@ describe('#easeTo', () => {
         expect(fixedLngLat(camera.getCenter())).toEqual(fixedLngLat({lng: -70.3125, lat: 0.000002552471840999715}));
     });
 
-    test('emits move, zoom, rotate, and pitch events, preserving eventData', () => new Promise(done => {
+    test('emits move, zoom, rotate, and pitch events, preserving eventData', () => new Promise<void>(done => {
         const camera = createCamera();
         let movestarted, moved, zoomstarted, zoomed, rotatestarted, rotated, pitchstarted, pitched;
         const eventData = {data: 'ok'};
@@ -820,13 +820,13 @@ describe('#easeTo', () => {
         done();
     }));
 
-    test('does not emit zoom events if not zooming', () => new Promise(done => {
+    test('does not emit zoom events if not zooming', () => new Promise<void>((done, fail) => {
         const camera = createCamera();
 
         camera
-            .on('zoomstart', () => { done('zoomstart failed'); })
-            .on('zoom', () => { done('zoom failed'); })
-            .on('zoomend', () => { done('zoomend failed'); })
+            .on('zoomstart', () => { fail(new Error('zoomstart failed')); })
+            .on('zoom', () => { fail(new Error('zoom failed')); })
+            .on('zoomend', () => { fail(new Error('zoomend failed')); })
             .on('moveend', () => { done(); });
 
         camera.easeTo({center: [100, 0], duration: 0});
@@ -839,7 +839,7 @@ describe('#easeTo', () => {
         expect(camera.getCenter()).toEqual({lng: 100, lat: 0});
     });
 
-    test('can be called from within a moveend event handler', () => new Promise(done => {
+    test('can be called from within a moveend event handler', () => new Promise<void>(done => {
         const camera = createCamera();
         const stub = jest.spyOn(browser, 'now');
 
@@ -874,7 +874,7 @@ describe('#easeTo', () => {
         }, 0);
     }));
 
-    test('pans eastward across the antimeridian', () => new Promise(done => {
+    test('pans eastward across the antimeridian', () => new Promise<void>(done => {
         const camera = createCamera();
         const stub = jest.spyOn(browser, 'now');
 
@@ -906,7 +906,7 @@ describe('#easeTo', () => {
         }, 0);
     }));
 
-    test('does not pan eastward across the antimeridian on a single-globe mercator map', () => new Promise(done => {
+    test('does not pan eastward across the antimeridian on a single-globe mercator map', () => new Promise<void>(done => {
         const camera = createCamera({renderWorldCopies: false, zoom: 2});
         camera.setCenter([170, 0]);
         const initialLng = camera.getCenter().lng;
@@ -917,7 +917,7 @@ describe('#easeTo', () => {
         camera.easeTo({center: [210, 0], duration: 0});
     }));
 
-    test('pans westward across the antimeridian', () => new Promise(done => {
+    test('pans westward across the antimeridian', () => new Promise<void>(done => {
         const camera = createCamera();
         const stub = jest.spyOn(browser, 'now');
 
@@ -949,7 +949,7 @@ describe('#easeTo', () => {
         }, 0);
     }));
 
-    test('does not pan westward across the antimeridian on a single-globe mercator map', () => new Promise(done => {
+    test('does not pan westward across the antimeridian on a single-globe mercator map', () => new Promise<void>(done => {
         const camera = createCamera({renderWorldCopies: false, zoom: 2});
         camera.setCenter([-170, 0]);
         const initialLng = camera.getCenter().lng;
@@ -960,7 +960,7 @@ describe('#easeTo', () => {
         camera.easeTo({center: [-210, 0], duration: 0});
     }));
 
-    test('animation occurs when prefers-reduced-motion: reduce is set but overridden by essential: true', () => new Promise(done => {
+    test('animation occurs when prefers-reduced-motion: reduce is set but overridden by essential: true', () => new Promise<void>(done => {
         const camera = createCamera();
         Object.defineProperty(browser, 'prefersReducedMotion', {value: true});
         const stubNow = jest.spyOn(browser, 'now');
@@ -993,14 +993,14 @@ describe('#easeTo', () => {
         }, 0);
     }));
 
-    test('duration is 0 when prefers-reduced-motion: reduce is set', () => new Promise(done => {
+    test('duration is 0 when prefers-reduced-motion: reduce is set', () => new Promise<void>(done => {
         const camera = createCamera();
         Object.defineProperty(browser, 'prefersReducedMotion', {value: true});
         assertTransitionTime(done, camera, 0, 10);
         camera.easeTo({center: [100, 0], zoom: 3.2, bearing: 90, duration: 1000});
     }));
 
-    test('jumpTo on("move") during easeTo with zoom, pitch, etc', () => new Promise(done => {
+    test('jumpTo on("move") during easeTo with zoom, pitch, etc', () => new Promise<void>(done => {
         const camera = createCamera();
 
         camera.on('moveend', (e: Event & {done?: true}) => {
@@ -1020,7 +1020,7 @@ describe('#easeTo', () => {
         camera.simulateFrame();
     }));
 
-    test('jumpTo on("zoom") during easeTo', () => new Promise(done => {
+    test('jumpTo on("zoom") during easeTo', () => new Promise<void>(done => {
         const camera = createCamera();
 
         camera.on('moveend', (e: Event & {done?: true}) => {
@@ -1040,7 +1040,7 @@ describe('#easeTo', () => {
         camera.simulateFrame();
     }));
 
-    test('jumpTo on("pitch") during easeTo', () => new Promise(done => {
+    test('jumpTo on("pitch") during easeTo', () => new Promise<void>(done => {
         const camera = createCamera();
 
         camera.on('moveend', (e: Event & {done?: true}) => {
@@ -1060,7 +1060,7 @@ describe('#easeTo', () => {
         camera.simulateFrame();
     }));
 
-    test('jumpTo on("rotate") during easeTo', () => new Promise(done => {
+    test('jumpTo on("rotate") during easeTo', () => new Promise<void>(done => {
         const camera = createCamera();
 
         camera.on('moveend', (e: Event & {done?: true}) => {
@@ -1121,7 +1121,7 @@ describe('#flyTo', () => {
         expect(camera.getZoom()).toBe(2);
     });
 
-    test('Zoom out from the same position to the same position with animation', () => new Promise(done => {
+    test('Zoom out from the same position to the same position with animation', () => new Promise<void>(done => {
         const pos = {lng: 0, lat: 0};
         const camera = createCamera({zoom: 20, center: pos});
         const stub = jest.spyOn(browser, 'now');
@@ -1208,7 +1208,7 @@ describe('#flyTo', () => {
         expect(fixedLngLat(camera.getCenter())).toEqual({lng: 170.3125, lat: 0});
     });
 
-    test('emits move, zoom, rotate, and pitch events, preserving eventData', () => new Promise(done => {
+    test('emits move, zoom, rotate, and pitch events, preserving eventData', () => new Promise<void>(done => {
         expect.assertions(18);
 
         const camera = createCamera();
@@ -1266,7 +1266,7 @@ describe('#flyTo', () => {
         done();
     }));
 
-    test('for short flights, emits (solely) move events, preserving eventData', () => new Promise(done => {
+    test('for short flights, emits (solely) move events, preserving eventData', () => new Promise<void>(done => {
         //As I type this, the code path for guiding super-short flights is (and will probably remain) different.
         //As such; it deserves a separate test case. This test case flies the map from A to A.
         const camera = createCamera({center: [100, 0]});
@@ -1324,7 +1324,7 @@ describe('#flyTo', () => {
         }, 0);
     }));
 
-    test('stops existing ease', () => new Promise(done => {
+    test('stops existing ease', () => new Promise<void>(done => {
         const camera = createCamera();
         camera.flyTo({center: [200, 0], duration: 100});
         camera.flyTo({center: [100, 0], duration: 0});
@@ -1332,7 +1332,7 @@ describe('#flyTo', () => {
         done();
     }));
 
-    test('can be called from within a moveend event handler', () => new Promise(done => {
+    test('can be called from within a moveend event handler', () => new Promise<void>(done => {
         const camera = createCamera();
         const stub = jest.spyOn(browser, 'now');
         stub.mockImplementation(() => 0);
@@ -1364,7 +1364,7 @@ describe('#flyTo', () => {
         }, 0);
     }));
 
-    test('ascends', () => new Promise(done => {
+    test('ascends', () => new Promise<void>(done => {
         const camera = createCamera();
         camera.setZoom(18);
         let ascended;
@@ -1396,7 +1396,7 @@ describe('#flyTo', () => {
         }, 0);
     }));
 
-    test('pans eastward across the prime meridian', () => new Promise(done => {
+    test('pans eastward across the prime meridian', () => new Promise<void>(done => {
         const camera = createCamera();
         const stub = jest.spyOn(browser, 'now');
 
@@ -1428,7 +1428,7 @@ describe('#flyTo', () => {
         }, 0);
     }));
 
-    test('pans westward across the prime meridian', () => new Promise(done => {
+    test('pans westward across the prime meridian', () => new Promise<void>(done => {
         const camera = createCamera();
         const stub = jest.spyOn(browser, 'now');
 
@@ -1460,7 +1460,7 @@ describe('#flyTo', () => {
         }, 0);
     }));
 
-    test('pans eastward across the antimeridian', () => new Promise(done => {
+    test('pans eastward across the antimeridian', () => new Promise<void>(done => {
         const camera = createCamera();
         const stub = jest.spyOn(browser, 'now');
 
@@ -1492,7 +1492,7 @@ describe('#flyTo', () => {
         }, 0);
     }));
 
-    test('pans westward across the antimeridian', () => new Promise(done => {
+    test('pans westward across the antimeridian', () => new Promise<void>(done => {
         const camera = createCamera();
         const stub = jest.spyOn(browser, 'now');
 
@@ -1524,7 +1524,7 @@ describe('#flyTo', () => {
         }, 0);
     }));
 
-    test('does not pan eastward across the antimeridian if no world copies', () => new Promise(done => {
+    test('does not pan eastward across the antimeridian if no world copies', () => new Promise<void>(done => {
         const camera = createCamera({renderWorldCopies: false});
         const stub = jest.spyOn(browser, 'now');
 
@@ -1556,7 +1556,7 @@ describe('#flyTo', () => {
         }, 0);
     }));
 
-    test('does not pan westward across the antimeridian if no world copies', () => new Promise(done => {
+    test('does not pan westward across the antimeridian if no world copies', () => new Promise<void>(done => {
         const camera = createCamera({renderWorldCopies: false});
         const stub = jest.spyOn(browser, 'now');
 
@@ -1588,7 +1588,7 @@ describe('#flyTo', () => {
         }, 0);
     }));
 
-    test('jumps back to world 0 when crossing the antimeridian', () => new Promise(done => {
+    test('jumps back to world 0 when crossing the antimeridian', () => new Promise<void>(done => {
         const camera = createCamera();
         const stub = jest.spyOn(browser, 'now');
 
@@ -1619,7 +1619,7 @@ describe('#flyTo', () => {
         }, 0);
     }));
 
-    test('peaks at the specified zoom level', () => new Promise(done => {
+    test('peaks at the specified zoom level', () => new Promise<void>(done => {
         const camera = createCamera({zoom: 20});
         const stub = jest.spyOn(browser, 'now');
 
@@ -1656,7 +1656,7 @@ describe('#flyTo', () => {
         }, 0);
     }));
 
-    test('respects transform\'s maxZoom', () => new Promise(done => {
+    test('respects transform\'s maxZoom', () => new Promise<void>(done => {
         const transform = new Transform(2, 10, 0, 60, false);
         transform.resize(512, 512);
 
@@ -1681,7 +1681,7 @@ describe('#flyTo', () => {
         }, 0);
     }));
 
-    test('respects transform\'s minZoom', () => new Promise(done => {
+    test('respects transform\'s minZoom', () => new Promise<void>(done => {
         const transform = new Transform(2, 10, 0, 60, false);
         transform.resize(512, 512);
 
@@ -1706,7 +1706,7 @@ describe('#flyTo', () => {
         }, 0);
     }));
 
-    test('resets duration to 0 if it exceeds maxDuration', () => new Promise(done => {
+    test('resets duration to 0 if it exceeds maxDuration', () => new Promise<void>(done => {
         let startTime, endTime, timeDiff;
         const camera = createCamera({center: [37.63454, 55.75868], zoom: 18});
 
@@ -1722,7 +1722,7 @@ describe('#flyTo', () => {
         camera.flyTo({center: [-122.3998631, 37.7884307], maxDuration: 100});
     }));
 
-    test('flys instantly when prefers-reduce-motion:reduce is set', () => new Promise(done => {
+    test('flys instantly when prefers-reduce-motion:reduce is set', () => new Promise<void>(done => {
         const camera = createCamera();
         Object.defineProperty(browser, 'prefersReducedMotion', {value: true});
         assertTransitionTime(done, camera, 0, 10);
@@ -1777,7 +1777,7 @@ describe('#flyTo', () => {
         expect(terrainCallbacks.finalize).toBe(1);
     });
 
-    test('check elevation callbacks', () => new Promise(done => {
+    test('check elevation callbacks', () => new Promise<void>(done => {
         const camera = createCamera();
         camera.terrain = {
             getElevationForLngLatZoom: () => 100,
@@ -1819,7 +1819,7 @@ describe('#isEasing', () => {
         expect(camera.isEasing()).toBeTruthy();
     });
 
-    test('returns false when done panning', () => new Promise(done => {
+    test('returns false when done panning', () => new Promise<void>(done => {
         const camera = createCamera();
         camera.on('moveend', () => {
             expect(!camera.isEasing()).toBeTruthy();
@@ -1841,7 +1841,7 @@ describe('#isEasing', () => {
         expect(camera.isEasing()).toBeTruthy();
     });
 
-    test('returns false when done zooming', () => new Promise(done => {
+    test('returns false when done zooming', () => new Promise<void>(done => {
         const camera = createCamera();
         camera.on('moveend', () => {
             expect(!camera.isEasing()).toBeTruthy();
@@ -1862,7 +1862,7 @@ describe('#isEasing', () => {
         expect(camera.isEasing()).toBeTruthy();
     });
 
-    test('returns false when done rotating', () => new Promise(done => {
+    test('returns false when done rotating', () => new Promise<void>(done => {
         const camera = createCamera();
         camera.on('moveend', () => {
             expect(!camera.isEasing()).toBeTruthy();
@@ -1893,7 +1893,7 @@ describe('#stop', () => {
         expect(!camera._rotating).toBeTruthy();
     });
 
-    test('emits moveend if panning, preserving eventData', () => new Promise(done => {
+    test('emits moveend if panning, preserving eventData', () => new Promise<void>(done => {
         const camera = createCamera();
         const eventData = {data: 'ok'};
 
@@ -1906,7 +1906,7 @@ describe('#stop', () => {
         camera.stop();
     }));
 
-    test('emits moveend if zooming, preserving eventData', () => new Promise(done => {
+    test('emits moveend if zooming, preserving eventData', () => new Promise<void>(done => {
         const camera = createCamera();
         const eventData = {data: 'ok'};
 
@@ -1919,7 +1919,7 @@ describe('#stop', () => {
         camera.stop();
     }));
 
-    test('emits moveend if rotating, preserving eventData', () => new Promise(done => {
+    test('emits moveend if rotating, preserving eventData', () => new Promise<void>(done => {
         const camera = createCamera();
         const eventData = {data: 'ok'};
 
@@ -1932,7 +1932,7 @@ describe('#stop', () => {
         camera.stop();
     }));
 
-    test('does not emit moveend if not moving', () => new Promise(done => {
+    test('does not emit moveend if not moving', () => new Promise<void>(done => {
         const camera = createCamera();
         const eventData = {data: 'ok'};
 
@@ -2204,7 +2204,7 @@ describe('queryTerrainElevation', () => {
 
 describe('#transformCameraUpdate', () => {
 
-    test('invoke transformCameraUpdate callback during jumpTo', () => new Promise(done => {
+    test('invoke transformCameraUpdate callback during jumpTo', () => new Promise<void>(done => {
         const camera = createCamera();
 
         let callbackCount = 0;
@@ -2227,7 +2227,7 @@ describe('#transformCameraUpdate', () => {
         camera.jumpTo({center: [100, 0]});
     }));
 
-    test('invoke transformCameraUpdate callback during easeTo', () => new Promise(done => {
+    test('invoke transformCameraUpdate callback during easeTo', () => new Promise<void>(done => {
         expect.assertions(2);
         const camera = createCamera();
         const stub = jest.spyOn(browser, 'now');
@@ -2263,7 +2263,7 @@ describe('#transformCameraUpdate', () => {
         }, 0);
     }));
 
-    test('invoke transformCameraUpdate callback during flyTo', () => new Promise(done => {
+    test('invoke transformCameraUpdate callback during flyTo', () => new Promise<void>(done => {
         expect.assertions(2);
         const camera = createCamera();
         const stub = jest.spyOn(browser, 'now');

--- a/src/ui/control/geolocate_control.test.ts
+++ b/src/ui/control/geolocate_control.test.ts
@@ -85,11 +85,7 @@ describe('GeolocateControl with no options', () => {
     test('does not throw if removed quickly', () => {
         (checkGeolocationSupport as any as jest.SpyInstance).mockReset()
             .mockImplementationOnce(() => {
-                return new Promise(resolve => {
-                    setTimeout(() => {
-                        resolve(true);
-                    }, 10);
-                });
+                return sleep(10);
             });
 
         const geolocate = new GeolocateControl(undefined);

--- a/src/ui/control/logo_control.test.ts
+++ b/src/ui/control/logo_control.test.ts
@@ -28,7 +28,7 @@ describe('LogoControl', () => {
         )).toHaveLength(0);
     });
 
-    test('is not displayed when the maplibreLogo property is false', done => {
+    test('is not displayed when the maplibreLogo property is false', () => new Promise(done => {
         const map = createMap(undefined, false);
         map.on('load', () => {
             expect(map.getContainer().querySelectorAll(
@@ -36,9 +36,9 @@ describe('LogoControl', () => {
             )).toHaveLength(0);
             done();
         });
-    });
+    }));
 
-    test('appears in bottom-left when maplibreLogo is true and logoPosition is undefined', done => {
+    test('appears in bottom-left when maplibreLogo is true and logoPosition is undefined', () => new Promise(done => {
         const map = createMap(undefined, true);
         map.on('load', () => {
             expect(map.getContainer().querySelectorAll(
@@ -46,9 +46,9 @@ describe('LogoControl', () => {
             )).toHaveLength(1);
             done();
         });
-    });
+    }));
 
-    test('appears in the position specified by the position option', done => {
+    test('appears in the position specified by the position option', () => new Promise(done => {
         const map = createMap('top-left', true);
         map.on('load', () => {
             expect(map.getContainer().querySelectorAll(
@@ -56,7 +56,7 @@ describe('LogoControl', () => {
             )).toHaveLength(1);
             done();
         });
-    });
+    }));
 
     test('appears in compact mode if container is less then 640 pixel wide', () => {
         const map = createMap(undefined, true);
@@ -75,7 +75,7 @@ describe('LogoControl', () => {
         ).toHaveLength(1);
     });
 
-    test('has `rel` noopener and nofollow', done => {
+    test('has `rel` noopener and nofollow', () => new Promise(done => {
         const map = createMap(undefined, true);
 
         map.on('load', () => {
@@ -84,5 +84,5 @@ describe('LogoControl', () => {
             expect(logo).toHaveProperty('rel', 'noopener nofollow');
             done();
         });
-    });
+    }));
 });

--- a/src/ui/control/logo_control.test.ts
+++ b/src/ui/control/logo_control.test.ts
@@ -28,7 +28,7 @@ describe('LogoControl', () => {
         )).toHaveLength(0);
     });
 
-    test('is not displayed when the maplibreLogo property is false', () => new Promise(done => {
+    test('is not displayed when the maplibreLogo property is false', () => new Promise<void>(done => {
         const map = createMap(undefined, false);
         map.on('load', () => {
             expect(map.getContainer().querySelectorAll(
@@ -38,7 +38,7 @@ describe('LogoControl', () => {
         });
     }));
 
-    test('appears in bottom-left when maplibreLogo is true and logoPosition is undefined', () => new Promise(done => {
+    test('appears in bottom-left when maplibreLogo is true and logoPosition is undefined', () => new Promise<void>(done => {
         const map = createMap(undefined, true);
         map.on('load', () => {
             expect(map.getContainer().querySelectorAll(
@@ -48,7 +48,7 @@ describe('LogoControl', () => {
         });
     }));
 
-    test('appears in the position specified by the position option', () => new Promise(done => {
+    test('appears in the position specified by the position option', () => new Promise<void>(done => {
         const map = createMap('top-left', true);
         map.on('load', () => {
             expect(map.getContainer().querySelectorAll(
@@ -75,7 +75,7 @@ describe('LogoControl', () => {
         ).toHaveLength(1);
     });
 
-    test('has `rel` noopener and nofollow', () => new Promise(done => {
+    test('has `rel` noopener and nofollow', () => new Promise<void>(done => {
         const map = createMap(undefined, true);
 
         map.on('load', () => {

--- a/src/ui/handler/dblclick_zoom.test.ts
+++ b/src/ui/handler/dblclick_zoom.test.ts
@@ -6,18 +6,17 @@ function createMap() {
     return new Map({container: window.document.createElement('div')} as any as MapOptions);
 }
 
-function simulateDoubleTap(map, delay = 100) {
+async function simulateDoubleTap(map, delay = 100) {
     const canvas = map.getCanvas();
-    return new Promise(resolve => {
-        simulate.touchstart(canvas, {touches: [{target: canvas, clientX: 0, clientY: 0}]});
-        simulate.touchend(canvas);
-        setTimeout(() => {
-            simulate.touchstart(canvas, {touches: [{target: canvas, clientX: 0, clientY: 0}]});
-            simulate.touchend(canvas);
-            map._renderTaskQueue.run();
-            resolve(undefined);
-        }, delay);
-    });
+
+    simulate.touchstart(canvas, {touches: [{target: canvas, clientX: 0, clientY: 0}]});
+    simulate.touchend(canvas);
+
+    await new Promise(resolve => setTimeout(resolve, delay));
+
+    simulate.touchstart(canvas, {touches: [{target: canvas, clientX: 0, clientY: 0}]});
+    simulate.touchend(canvas);
+    map._renderTaskQueue.run();
 }
 
 beforeEach(() => {
@@ -87,16 +86,12 @@ describe('dbclick_zoom', () => {
 
         const canvas = map.getCanvas();
 
-        await new Promise(resolve => {
-            simulate.touchstart(canvas, {touches: [{clientX: 0, clientY: 0}]});
-            simulate.touchend(canvas);
-            setTimeout(() => {
-                simulate.touchstart(canvas, {touches: [{clientX: 30.5, clientY: 30.5}]});
-                simulate.touchend(canvas);
-                map._renderTaskQueue.run();
-                resolve(undefined);
-            }, 100);
-        });
+        simulate.touchstart(canvas, {touches: [{clientX: 0, clientY: 0}]});
+        simulate.touchend(canvas);
+        await new Promise(resolve => setTimeout(resolve, 100));
+        simulate.touchstart(canvas, {touches: [{clientX: 30.5, clientY: 30.5}]});
+        simulate.touchend(canvas);
+        map._renderTaskQueue.run();
 
         expect(zoom).not.toHaveBeenCalled();
 
@@ -145,17 +140,12 @@ describe('dbclick_zoom', () => {
 
         const canvas = map.getCanvas();
 
-        await new Promise(resolve => {
-            simulate.touchstart(canvas);
-            simulate.touchend(canvas);
-            simulate.touchstart(canvas);
-            setTimeout(() => {
-                simulate.touchend(canvas);
-                map._renderTaskQueue.run();
-                resolve(undefined);
-            }, 300);
-        });
-
+        simulate.touchstart(canvas);
+        simulate.touchend(canvas);
+        simulate.touchstart(canvas);
+        await new Promise(resolve => setTimeout(resolve, 300));
+        simulate.touchend(canvas);
+        map._renderTaskQueue.run();
         expect(zoom).not.toHaveBeenCalled();
     });
 });

--- a/src/ui/handler/dblclick_zoom.test.ts
+++ b/src/ui/handler/dblclick_zoom.test.ts
@@ -1,5 +1,5 @@
 import simulate from '../../../test/unit/lib/simulate_interaction';
-import {beforeMapTest} from '../../util/test/util';
+import {beforeMapTest, sleep} from '../../util/test/util';
 import {Map, MapOptions} from '../map';
 
 function createMap() {
@@ -12,7 +12,7 @@ async function simulateDoubleTap(map, delay = 100) {
     simulate.touchstart(canvas, {touches: [{target: canvas, clientX: 0, clientY: 0}]});
     simulate.touchend(canvas);
 
-    await new Promise(resolve => setTimeout(resolve, delay));
+    await sleep(delay);
 
     simulate.touchstart(canvas, {touches: [{target: canvas, clientX: 0, clientY: 0}]});
     simulate.touchend(canvas);
@@ -88,7 +88,7 @@ describe('dbclick_zoom', () => {
 
         simulate.touchstart(canvas, {touches: [{clientX: 0, clientY: 0}]});
         simulate.touchend(canvas);
-        await new Promise(resolve => setTimeout(resolve, 100));
+        await sleep(100);
         simulate.touchstart(canvas, {touches: [{clientX: 30.5, clientY: 30.5}]});
         simulate.touchend(canvas);
         map._renderTaskQueue.run();
@@ -143,7 +143,7 @@ describe('dbclick_zoom', () => {
         simulate.touchstart(canvas);
         simulate.touchend(canvas);
         simulate.touchstart(canvas);
-        await new Promise(resolve => setTimeout(resolve, 300));
+        await sleep(300);
         simulate.touchend(canvas);
         map._renderTaskQueue.run();
         expect(zoom).not.toHaveBeenCalled();

--- a/src/ui/handler/scroll_zoom.test.ts
+++ b/src/ui/handler/scroll_zoom.test.ts
@@ -70,7 +70,7 @@ describe('ScrollZoomHandler', () => {
         map.remove();
     });
 
-    test('Zooms for single mouse wheel tick with non-magical deltaY', () => new Promise(done => {
+    test('Zooms for single mouse wheel tick with non-magical deltaY', () => new Promise<void>(done => {
         const browserNow = jest.spyOn(browser, 'now');
         const now = 1555555555555;
         browserNow.mockReturnValue(now);

--- a/src/ui/handler/scroll_zoom.test.ts
+++ b/src/ui/handler/scroll_zoom.test.ts
@@ -70,7 +70,7 @@ describe('ScrollZoomHandler', () => {
         map.remove();
     });
 
-    test('Zooms for single mouse wheel tick with non-magical deltaY', done => {
+    test('Zooms for single mouse wheel tick with non-magical deltaY', () => new Promise(done => {
         const browserNow = jest.spyOn(browser, 'now');
         const now = 1555555555555;
         browserNow.mockReturnValue(now);
@@ -86,7 +86,7 @@ describe('ScrollZoomHandler', () => {
             map.remove();
             done();
         });
-    });
+    }));
 
     test('Zooms for multiple mouse wheel ticks', () => {
         const browserNow = jest.spyOn(browser, 'now');

--- a/src/ui/handler/tap_drag_zoom.test.ts
+++ b/src/ui/handler/tap_drag_zoom.test.ts
@@ -62,7 +62,7 @@ describe('tap_drag_zoom', () => {
 
     });
 
-    test('TapDragZoomHandler does not fire zoom on tap and drag if touchstart events are > 500ms apart', () => new Promise(done => {
+    test('TapDragZoomHandler does not fire zoom on tap and drag if touchstart events are > 500ms apart', () => new Promise<void>(done => {
         const map = createMap();
         const target = map.getCanvas();
 

--- a/src/ui/handler/tap_drag_zoom.test.ts
+++ b/src/ui/handler/tap_drag_zoom.test.ts
@@ -62,7 +62,7 @@ describe('tap_drag_zoom', () => {
 
     });
 
-    test('TapDragZoomHandler does not fire zoom on tap and drag if touchstart events are > 500ms apart', done => {
+    test('TapDragZoomHandler does not fire zoom on tap and drag if touchstart events are > 500ms apart', () => new Promise(done => {
         const map = createMap();
         const target = map.getCanvas();
 
@@ -86,7 +86,7 @@ describe('tap_drag_zoom', () => {
             expect(zoomend).not.toHaveBeenCalled();
             done();
         }, 510);
-    });
+    }));
 
     test('TapDragZoomHandler does not zoom on double-tap and drag if touchstart events are in different locations (>30px apart)', () => {
         const map = createMap();

--- a/src/ui/handler/tap_drag_zoom.test.ts
+++ b/src/ui/handler/tap_drag_zoom.test.ts
@@ -62,7 +62,7 @@ describe('tap_drag_zoom', () => {
 
     });
 
-    test('TapDragZoomHandler does not fire zoom on tap and drag if touchstart events are > 500ms apart', () => new Promise<void>(done => {
+    test('TapDragZoomHandler does not fire zoom on tap and drag if touchstart events are > 500ms apart', async () => {
         const map = createMap();
         const target = map.getCanvas();
 
@@ -74,19 +74,19 @@ describe('tap_drag_zoom', () => {
 
         simulate.touchstart(target, pointTouchOptions);
         simulate.touchend(target);
-        setTimeout(() => {
-            simulate.touchstart(target, pointTouchOptions);
-            simulate.touchmove(target, {
-                touches: [{target, clientX: 100, clientY: 110}]
-            });
-            map._renderTaskQueue.run();
 
-            expect(zoomstart).not.toHaveBeenCalled();
-            expect(zoom).not.toHaveBeenCalled();
-            expect(zoomend).not.toHaveBeenCalled();
-            done();
-        }, 510);
-    }));
+        await new Promise(resolve => setTimeout(resolve, 510));
+
+        simulate.touchstart(target, pointTouchOptions);
+        simulate.touchmove(target, {
+            touches: [{target, clientX: 100, clientY: 110}]
+        });
+        map._renderTaskQueue.run();
+
+        expect(zoomstart).not.toHaveBeenCalled();
+        expect(zoom).not.toHaveBeenCalled();
+        expect(zoomend).not.toHaveBeenCalled();
+    });
 
     test('TapDragZoomHandler does not zoom on double-tap and drag if touchstart events are in different locations (>30px apart)', () => {
         const map = createMap();

--- a/src/ui/handler/tap_drag_zoom.test.ts
+++ b/src/ui/handler/tap_drag_zoom.test.ts
@@ -1,4 +1,4 @@
-import {beforeMapTest} from '../../util/test/util';
+import {beforeMapTest, sleep} from '../../util/test/util';
 import simulate from '../../../test/unit/lib/simulate_interaction';
 import {Map, MapOptions} from '../map';
 
@@ -75,7 +75,7 @@ describe('tap_drag_zoom', () => {
         simulate.touchstart(target, pointTouchOptions);
         simulate.touchend(target);
 
-        await new Promise(resolve => setTimeout(resolve, 510));
+        await sleep(510);
 
         simulate.touchstart(target, pointTouchOptions);
         simulate.touchmove(target, {

--- a/src/ui/map_tests/map_basic.test.ts
+++ b/src/ui/map_tests/map_basic.test.ts
@@ -110,7 +110,7 @@ describe('Map', () => {
             await promise;
         });
 
-        test('Map#isStyleLoaded', done => {
+        test('Map#isStyleLoaded', () => new Promise(done => {
             const style = createStyle();
             const map = createMap({style});
 
@@ -119,9 +119,9 @@ describe('Map', () => {
                 expect(map.isStyleLoaded()).toBe(true);
                 done();
             });
-        });
+        }));
 
-        test('Map#areTilesLoaded', done => {
+        test('Map#areTilesLoaded', () => new Promise(done => {
             const style = createStyle();
             const map = createMap({style});
             expect(map.areTilesLoaded()).toBe(true);
@@ -134,7 +134,7 @@ describe('Map', () => {
                 expect(map.areTilesLoaded()).toBe(true);
                 done();
             });
-        });
+        }));
     });
 
     test('#remove', () => {
@@ -162,7 +162,7 @@ describe('Map', () => {
         expect(control.onRemove).toHaveBeenCalledTimes(1);
     });
 
-    test('#remove calls onRemove on added controls before style is destroyed', done => {
+    test('#remove calls onRemove on added controls before style is destroyed', () => new Promise(done => {
         const map = createMap();
         let onRemoveCalled = 0;
         let style;
@@ -184,7 +184,7 @@ describe('Map', () => {
             expect(onRemoveCalled).toBe(1);
             done();
         });
-    });
+    }));
 
     test('#remove broadcasts removeMap to worker', () => {
         const map = createMap();

--- a/src/ui/map_tests/map_basic.test.ts
+++ b/src/ui/map_tests/map_basic.test.ts
@@ -110,7 +110,7 @@ describe('Map', () => {
             await promise;
         });
 
-        test('Map#isStyleLoaded', () => new Promise(done => {
+        test('Map#isStyleLoaded', () => new Promise<void>(done => {
             const style = createStyle();
             const map = createMap({style});
 
@@ -121,7 +121,7 @@ describe('Map', () => {
             });
         }));
 
-        test('Map#areTilesLoaded', () => new Promise(done => {
+        test('Map#areTilesLoaded', () => new Promise<void>(done => {
             const style = createStyle();
             const map = createMap({style});
             expect(map.areTilesLoaded()).toBe(true);
@@ -162,7 +162,7 @@ describe('Map', () => {
         expect(control.onRemove).toHaveBeenCalledTimes(1);
     });
 
-    test('#remove calls onRemove on added controls before style is destroyed', () => new Promise(done => {
+    test('#remove calls onRemove on added controls before style is destroyed', () => new Promise<void>(done => {
         const map = createMap();
         let onRemoveCalled = 0;
         let style;

--- a/src/ui/map_tests/map_events.test.ts
+++ b/src/ui/map_tests/map_events.test.ts
@@ -924,10 +924,10 @@ describe('map events', () => {
         map.remove();
     });
 
-    test('emits load event after a style is set', () => new Promise<void>((done, failTest) => {
+    test('emits load event after a style is set', () => new Promise<void>((done) => {
         const map = new Map({container: window.document.createElement('div')} as any as MapOptions);
 
-        const fail = () => failTest(new Error('test failed'));
+        const fail = () => { throw new Error('test failed'); };
         const pass = () => done();
 
         map.on('load', fail);

--- a/src/ui/map_tests/map_events.test.ts
+++ b/src/ui/map_tests/map_events.test.ts
@@ -924,10 +924,10 @@ describe('map events', () => {
         map.remove();
     });
 
-    test('emits load event after a style is set', () => new Promise(done => {
+    test('emits load event after a style is set', () => new Promise<void>((done, failTest) => {
         const map = new Map({container: window.document.createElement('div')} as any as MapOptions);
 
-        const fail = () => done('test failed');
+        const fail = () => failTest(new Error('test failed'));
         const pass = () => done();
 
         map.on('load', fail);
@@ -987,7 +987,7 @@ describe('map events', () => {
             expect(stub.mock.calls[0][0]).toBe(error);
         });
 
-        test('calls listeners', () => new Promise(done => {
+        test('calls listeners', () => new Promise<void>(done => {
             const map = createMap();
             const error = new Error('test');
             map.on('error', (event) => {

--- a/src/ui/map_tests/map_events.test.ts
+++ b/src/ui/map_tests/map_events.test.ts
@@ -924,7 +924,7 @@ describe('map events', () => {
         map.remove();
     });
 
-    test('emits load event after a style is set', done => {
+    test('emits load event after a style is set', () => new Promise(done => {
         const map = new Map({container: window.document.createElement('div')} as any as MapOptions);
 
         const fail = () => done('test failed');
@@ -937,7 +937,7 @@ describe('map events', () => {
             map.on('load', pass);
             map.setStyle(createStyle());
         }, 1);
-    });
+    }));
 
     test('no idle event during move', async () => {
         const style = createStyle();
@@ -987,7 +987,7 @@ describe('map events', () => {
             expect(stub.mock.calls[0][0]).toBe(error);
         });
 
-        test('calls listeners', done => {
+        test('calls listeners', () => new Promise(done => {
             const map = createMap();
             const error = new Error('test');
             map.on('error', (event) => {
@@ -995,7 +995,7 @@ describe('map events', () => {
                 done();
             });
             map.fire(new ErrorEvent(error));
-        });
+        }));
 
     });
 });

--- a/src/ui/map_tests/map_feature_state.test.ts
+++ b/src/ui/map_tests/map_feature_state.test.ts
@@ -57,7 +57,7 @@ describe('#setFeatureState', () => {
             done();
         });
     }));
-    test('throw before loaded', () => new Promise<void>(done => {
+    test('throw before loaded', () => {
         const map = createMap({
             style: {
                 'version': 8,
@@ -70,9 +70,7 @@ describe('#setFeatureState', () => {
         expect(() => {
             map.setFeatureState({source: 'geojson', id: 12345}, {'hover': true});
         }).toThrow(Error);
-
-        done();
-    }));
+    });
     test('fires an error if source not found', () => new Promise<void>(done => {
         const map = createMap({
             style: {
@@ -346,7 +344,7 @@ describe('#removeFeatureState', () => {
             done();
         });
     }));
-    test('throw before loaded', () => new Promise<void>(done => {
+    test('throw before loaded', () => {
         const map = createMap({
             style: {
                 'version': 8,
@@ -359,9 +357,7 @@ describe('#removeFeatureState', () => {
         expect(() => {
             (map as any).removeFeatureState({source: 'geojson', id: 12345}, {'hover': true});
         }).toThrow(Error);
-
-        done();
-    }));
+    });
     test('fires an error if source not found', () => new Promise<void>(done => {
         const map = createMap({
             style: {

--- a/src/ui/map_tests/map_feature_state.test.ts
+++ b/src/ui/map_tests/map_feature_state.test.ts
@@ -6,7 +6,7 @@ beforeEach(() => {
 });
 
 describe('#setFeatureState', () => {
-    test('sets state', done => {
+    test('sets state', () => new Promise(done => {
         const map = createMap({
             style: {
                 'version': 8,
@@ -22,8 +22,8 @@ describe('#setFeatureState', () => {
             expect(fState.hover).toBe(true);
             done();
         });
-    });
-    test('works with string ids', done => {
+    }));
+    test('works with string ids', () => new Promise(done => {
         const map = createMap({
             style: {
                 'version': 8,
@@ -39,8 +39,8 @@ describe('#setFeatureState', () => {
             expect(fState.hover).toBe(true);
             done();
         });
-    });
-    test('parses feature id as an int', done => {
+    }));
+    test('parses feature id as an int', () => new Promise(done => {
         const map = createMap({
             style: {
                 'version': 8,
@@ -56,8 +56,8 @@ describe('#setFeatureState', () => {
             expect(fState.hover).toBe(true);
             done();
         });
-    });
-    test('throw before loaded', done => {
+    }));
+    test('throw before loaded', () => new Promise(done => {
         const map = createMap({
             style: {
                 'version': 8,
@@ -72,8 +72,8 @@ describe('#setFeatureState', () => {
         }).toThrow(Error);
 
         done();
-    });
-    test('fires an error if source not found', done => {
+    }));
+    test('fires an error if source not found', () => new Promise(done => {
         const map = createMap({
             style: {
                 'version': 8,
@@ -90,8 +90,8 @@ describe('#setFeatureState', () => {
             });
             map.setFeatureState({source: 'vector', id: 12345}, {'hover': true});
         });
-    });
-    test('fires an error if sourceLayer not provided for a vector source', done => {
+    }));
+    test('fires an error if sourceLayer not provided for a vector source', () => new Promise(done => {
         const map = createMap({
             style: {
                 'version': 8,
@@ -111,8 +111,8 @@ describe('#setFeatureState', () => {
             });
             (map as any).setFeatureState({source: 'vector', sourceLayer: 0, id: 12345}, {'hover': true});
         });
-    });
-    test('fires an error if id not provided', done => {
+    }));
+    test('fires an error if id not provided', () => new Promise(done => {
         const map = createMap({
             style: {
                 'version': 8,
@@ -132,12 +132,12 @@ describe('#setFeatureState', () => {
             });
             (map as any).setFeatureState({source: 'vector', sourceLayer: '1'}, {'hover': true});
         });
-    });
+    }));
 });
 
 describe('#removeFeatureState', () => {
 
-    test('accepts "0" id', done => {
+    test('accepts "0" id', () => new Promise(done => {
         const map = createMap({
             style: {
                 'version': 8,
@@ -155,8 +155,8 @@ describe('#removeFeatureState', () => {
             expect(fState.click).toBe(true);
             done();
         });
-    });
-    test('accepts string id', done => {
+    }));
+    test('accepts string id', () => new Promise(done => {
         const map = createMap({
             style: {
                 'version': 8,
@@ -174,8 +174,8 @@ describe('#removeFeatureState', () => {
             expect(fState.click).toBe(true);
             done();
         });
-    });
-    test('remove specific state property', done => {
+    }));
+    test('remove specific state property', () => new Promise(done => {
         const map = createMap({
             style: {
                 'version': 8,
@@ -192,8 +192,8 @@ describe('#removeFeatureState', () => {
             expect(fState.hover).toBeUndefined();
             done();
         });
-    });
-    test('remove all state properties of one feature', done => {
+    }));
+    test('remove all state properties of one feature', () => new Promise(done => {
         const map = createMap({
             style: {
                 'version': 8,
@@ -213,8 +213,8 @@ describe('#removeFeatureState', () => {
 
             done();
         });
-    });
-    test('remove properties for zero-based feature IDs.', done => {
+    }));
+    test('remove properties for zero-based feature IDs.', () => new Promise(done => {
         const map = createMap({
             style: {
                 'version': 8,
@@ -234,8 +234,8 @@ describe('#removeFeatureState', () => {
 
             done();
         });
-    });
-    test('other properties persist when removing specific property', done => {
+    }));
+    test('other properties persist when removing specific property', () => new Promise(done => {
         const map = createMap({
             style: {
                 'version': 8,
@@ -254,8 +254,8 @@ describe('#removeFeatureState', () => {
 
             done();
         });
-    });
-    test('remove all state properties of all features in source', done => {
+    }));
+    test('remove all state properties of all features in source', () => new Promise(done => {
         const map = createMap({
             style: {
                 'version': 8,
@@ -281,8 +281,8 @@ describe('#removeFeatureState', () => {
 
             done();
         });
-    });
-    test('specific state deletion should not interfere with broader state deletion', done => {
+    }));
+    test('specific state deletion should not interfere with broader state deletion', () => new Promise(done => {
         const map = createMap({
             style: {
                 'version': 8,
@@ -318,8 +318,8 @@ describe('#removeFeatureState', () => {
 
             done();
         });
-    });
-    test('add/remove and remove/add state', done => {
+    }));
+    test('add/remove and remove/add state', () => new Promise(done => {
         const map = createMap({
             style: {
                 'version': 8,
@@ -345,8 +345,8 @@ describe('#removeFeatureState', () => {
 
             done();
         });
-    });
-    test('throw before loaded', done => {
+    }));
+    test('throw before loaded', () => new Promise(done => {
         const map = createMap({
             style: {
                 'version': 8,
@@ -361,8 +361,8 @@ describe('#removeFeatureState', () => {
         }).toThrow(Error);
 
         done();
-    });
-    test('fires an error if source not found', done => {
+    }));
+    test('fires an error if source not found', () => new Promise(done => {
         const map = createMap({
             style: {
                 'version': 8,
@@ -379,8 +379,8 @@ describe('#removeFeatureState', () => {
             });
             (map as any).removeFeatureState({source: 'vector', id: 12345}, {'hover': true});
         });
-    });
-    test('fires an error if sourceLayer not provided for a vector source', done => {
+    }));
+    test('fires an error if sourceLayer not provided for a vector source', () => new Promise(done => {
         const map = createMap({
             style: {
                 'version': 8,
@@ -400,8 +400,8 @@ describe('#removeFeatureState', () => {
             });
             (map as any).removeFeatureState({source: 'vector', sourceLayer: 0, id: 12345}, {'hover': true});
         });
-    });
-    test('fires an error if state property is provided without a feature id', done => {
+    }));
+    test('fires an error if state property is provided without a feature id', () => new Promise(done => {
         const map = createMap({
             style: {
                 'version': 8,
@@ -421,5 +421,5 @@ describe('#removeFeatureState', () => {
             });
             (map as any).removeFeatureState({source: 'vector', sourceLayer: '1'}, {'hover': true});
         });
-    });
+    }));
 });

--- a/src/ui/map_tests/map_feature_state.test.ts
+++ b/src/ui/map_tests/map_feature_state.test.ts
@@ -6,7 +6,7 @@ beforeEach(() => {
 });
 
 describe('#setFeatureState', () => {
-    test('sets state', () => new Promise(done => {
+    test('sets state', () => new Promise<void>(done => {
         const map = createMap({
             style: {
                 'version': 8,
@@ -23,7 +23,7 @@ describe('#setFeatureState', () => {
             done();
         });
     }));
-    test('works with string ids', () => new Promise(done => {
+    test('works with string ids', () => new Promise<void>(done => {
         const map = createMap({
             style: {
                 'version': 8,
@@ -40,7 +40,7 @@ describe('#setFeatureState', () => {
             done();
         });
     }));
-    test('parses feature id as an int', () => new Promise(done => {
+    test('parses feature id as an int', () => new Promise<void>(done => {
         const map = createMap({
             style: {
                 'version': 8,
@@ -57,7 +57,7 @@ describe('#setFeatureState', () => {
             done();
         });
     }));
-    test('throw before loaded', () => new Promise(done => {
+    test('throw before loaded', () => new Promise<void>(done => {
         const map = createMap({
             style: {
                 'version': 8,
@@ -73,7 +73,7 @@ describe('#setFeatureState', () => {
 
         done();
     }));
-    test('fires an error if source not found', () => new Promise(done => {
+    test('fires an error if source not found', () => new Promise<void>(done => {
         const map = createMap({
             style: {
                 'version': 8,
@@ -91,7 +91,7 @@ describe('#setFeatureState', () => {
             map.setFeatureState({source: 'vector', id: 12345}, {'hover': true});
         });
     }));
-    test('fires an error if sourceLayer not provided for a vector source', () => new Promise(done => {
+    test('fires an error if sourceLayer not provided for a vector source', () => new Promise<void>(done => {
         const map = createMap({
             style: {
                 'version': 8,
@@ -112,7 +112,7 @@ describe('#setFeatureState', () => {
             (map as any).setFeatureState({source: 'vector', sourceLayer: 0, id: 12345}, {'hover': true});
         });
     }));
-    test('fires an error if id not provided', () => new Promise(done => {
+    test('fires an error if id not provided', () => new Promise<void>(done => {
         const map = createMap({
             style: {
                 'version': 8,
@@ -137,7 +137,7 @@ describe('#setFeatureState', () => {
 
 describe('#removeFeatureState', () => {
 
-    test('accepts "0" id', () => new Promise(done => {
+    test('accepts "0" id', () => new Promise<void>(done => {
         const map = createMap({
             style: {
                 'version': 8,
@@ -156,7 +156,7 @@ describe('#removeFeatureState', () => {
             done();
         });
     }));
-    test('accepts string id', () => new Promise(done => {
+    test('accepts string id', () => new Promise<void>(done => {
         const map = createMap({
             style: {
                 'version': 8,
@@ -175,7 +175,7 @@ describe('#removeFeatureState', () => {
             done();
         });
     }));
-    test('remove specific state property', () => new Promise(done => {
+    test('remove specific state property', () => new Promise<void>(done => {
         const map = createMap({
             style: {
                 'version': 8,
@@ -193,7 +193,7 @@ describe('#removeFeatureState', () => {
             done();
         });
     }));
-    test('remove all state properties of one feature', () => new Promise(done => {
+    test('remove all state properties of one feature', () => new Promise<void>(done => {
         const map = createMap({
             style: {
                 'version': 8,
@@ -214,7 +214,7 @@ describe('#removeFeatureState', () => {
             done();
         });
     }));
-    test('remove properties for zero-based feature IDs.', () => new Promise(done => {
+    test('remove properties for zero-based feature IDs.', () => new Promise<void>(done => {
         const map = createMap({
             style: {
                 'version': 8,
@@ -235,7 +235,7 @@ describe('#removeFeatureState', () => {
             done();
         });
     }));
-    test('other properties persist when removing specific property', () => new Promise(done => {
+    test('other properties persist when removing specific property', () => new Promise<void>(done => {
         const map = createMap({
             style: {
                 'version': 8,
@@ -255,7 +255,7 @@ describe('#removeFeatureState', () => {
             done();
         });
     }));
-    test('remove all state properties of all features in source', () => new Promise(done => {
+    test('remove all state properties of all features in source', () => new Promise<void>(done => {
         const map = createMap({
             style: {
                 'version': 8,
@@ -282,7 +282,7 @@ describe('#removeFeatureState', () => {
             done();
         });
     }));
-    test('specific state deletion should not interfere with broader state deletion', () => new Promise(done => {
+    test('specific state deletion should not interfere with broader state deletion', () => new Promise<void>(done => {
         const map = createMap({
             style: {
                 'version': 8,
@@ -319,7 +319,7 @@ describe('#removeFeatureState', () => {
             done();
         });
     }));
-    test('add/remove and remove/add state', () => new Promise(done => {
+    test('add/remove and remove/add state', () => new Promise<void>(done => {
         const map = createMap({
             style: {
                 'version': 8,
@@ -346,7 +346,7 @@ describe('#removeFeatureState', () => {
             done();
         });
     }));
-    test('throw before loaded', () => new Promise(done => {
+    test('throw before loaded', () => new Promise<void>(done => {
         const map = createMap({
             style: {
                 'version': 8,
@@ -362,7 +362,7 @@ describe('#removeFeatureState', () => {
 
         done();
     }));
-    test('fires an error if source not found', () => new Promise(done => {
+    test('fires an error if source not found', () => new Promise<void>(done => {
         const map = createMap({
             style: {
                 'version': 8,
@@ -380,7 +380,7 @@ describe('#removeFeatureState', () => {
             (map as any).removeFeatureState({source: 'vector', id: 12345}, {'hover': true});
         });
     }));
-    test('fires an error if sourceLayer not provided for a vector source', () => new Promise(done => {
+    test('fires an error if sourceLayer not provided for a vector source', () => new Promise<void>(done => {
         const map = createMap({
             style: {
                 'version': 8,
@@ -401,7 +401,7 @@ describe('#removeFeatureState', () => {
             (map as any).removeFeatureState({source: 'vector', sourceLayer: 0, id: 12345}, {'hover': true});
         });
     }));
-    test('fires an error if state property is provided without a feature id', () => new Promise(done => {
+    test('fires an error if state property is provided without a feature id', () => new Promise<void>(done => {
         const map = createMap({
             style: {
                 'version': 8,

--- a/src/ui/map_tests/map_images.test.ts
+++ b/src/ui/map_tests/map_images.test.ts
@@ -6,7 +6,7 @@ beforeEach(() => {
     global.fetch = null;
 });
 
-test('#listImages', () => new Promise(done => {
+test('#listImages', () => new Promise<void>(done => {
     const map = createMap();
 
     map.on('load', () => {
@@ -147,7 +147,7 @@ test('map getImage matches addImage, StyleImageInterface SDF', () => {
     expect(gotImage.sdf).toBe(true);
 });
 
-test('map does not fire `styleimagemissing` for empty icon values', () => new Promise(done => {
+test('map does not fire `styleimagemissing` for empty icon values', () => new Promise<void>((done, fail) => {
     const map = createMap();
 
     map.on('load', () => {
@@ -169,7 +169,7 @@ test('map does not fire `styleimagemissing` for empty icon values', () => new Pr
         });
 
         map.on('styleimagemissing', ({id}) => {
-            done(`styleimagemissing fired for value ${id}`);
+            fail(new Error(`styleimagemissing fired for value ${id}`));
         });
     });
 }));

--- a/src/ui/map_tests/map_images.test.ts
+++ b/src/ui/map_tests/map_images.test.ts
@@ -6,7 +6,7 @@ beforeEach(() => {
     global.fetch = null;
 });
 
-test('#listImages', done => {
+test('#listImages', () => new Promise(done => {
     const map = createMap();
 
     map.on('load', () => {
@@ -19,7 +19,7 @@ test('#listImages', done => {
         expect(images[0]).toBe('img');
         done();
     });
-});
+}));
 
 test('#listImages throws an error if called before "load"', () => {
     const map = createMap();
@@ -147,7 +147,7 @@ test('map getImage matches addImage, StyleImageInterface SDF', () => {
     expect(gotImage.sdf).toBe(true);
 });
 
-test('map does not fire `styleimagemissing` for empty icon values', done => {
+test('map does not fire `styleimagemissing` for empty icon values', () => new Promise(done => {
     const map = createMap();
 
     map.on('load', () => {
@@ -172,4 +172,4 @@ test('map does not fire `styleimagemissing` for empty icon values', done => {
             done(`styleimagemissing fired for value ${id}`);
         });
     });
-});
+}));

--- a/src/ui/map_tests/map_images.test.ts
+++ b/src/ui/map_tests/map_images.test.ts
@@ -147,7 +147,7 @@ test('map getImage matches addImage, StyleImageInterface SDF', () => {
     expect(gotImage.sdf).toBe(true);
 });
 
-test('map does not fire `styleimagemissing` for empty icon values', () => new Promise<void>((done, fail) => {
+test('map does not fire `styleimagemissing` for empty icon values', () => new Promise<void>((done) => {
     const map = createMap();
 
     map.on('load', () => {
@@ -169,7 +169,7 @@ test('map does not fire `styleimagemissing` for empty icon values', () => new Pr
         });
 
         map.on('styleimagemissing', ({id}) => {
-            fail(new Error(`styleimagemissing fired for value ${id}`));
+            throw new Error(`styleimagemissing fired for value ${id}`);
         });
     });
 }));

--- a/src/ui/map_tests/map_is_moving.test.ts
+++ b/src/ui/map_tests/map_is_moving.test.ts
@@ -27,7 +27,7 @@ describe('Map#isMoving', () => {
         expect(map.isMoving()).toBe(false);
     });
 
-    test('returns true during a camera zoom animation', () => new Promise(done => {
+    test('returns true during a camera zoom animation', () => new Promise<void>(done => {
         map.on('zoomstart', () => {
             expect(map.isMoving()).toBe(true);
         });
@@ -40,7 +40,7 @@ describe('Map#isMoving', () => {
         map.zoomTo(5, {duration: 0});
     }));
 
-    test('returns true when drag panning', () => new Promise(done => {
+    test('returns true when drag panning', () => new Promise<void>(done => {
         map.on('movestart', () => {
             expect(map.isMoving()).toBe(true);
         });
@@ -66,7 +66,7 @@ describe('Map#isMoving', () => {
         map._renderTaskQueue.run();
     }));
 
-    test('returns true when drag rotating', () => new Promise(done => {
+    test('returns true when drag rotating', () => new Promise<void>(done => {
         // Prevent inertial rotation.
         jest.spyOn(browser, 'now').mockImplementation(() => { return 0; });
 
@@ -97,7 +97,7 @@ describe('Map#isMoving', () => {
         map._renderTaskQueue.run();
     }));
 
-    test('returns true when scroll zooming', () => new Promise(done => {
+    test('returns true when scroll zooming', () => new Promise<void>(done => {
         map.on('zoomstart', () => {
             expect(map.isMoving()).toBe(true);
         });
@@ -119,7 +119,7 @@ describe('Map#isMoving', () => {
         }, 400);
     }));
 
-    test('returns true when drag panning and scroll zooming interleave', () => new Promise(done => {
+    test('returns true when drag panning and scroll zooming interleave', () => new Promise<void>(done => {
         map.on('dragstart', () => {
             expect(map.isMoving()).toBe(true);
         });

--- a/src/ui/map_tests/map_is_moving.test.ts
+++ b/src/ui/map_tests/map_is_moving.test.ts
@@ -27,7 +27,7 @@ describe('Map#isMoving', () => {
         expect(map.isMoving()).toBe(false);
     });
 
-    test('returns true during a camera zoom animation', done => {
+    test('returns true during a camera zoom animation', () => new Promise(done => {
         map.on('zoomstart', () => {
             expect(map.isMoving()).toBe(true);
         });
@@ -38,9 +38,9 @@ describe('Map#isMoving', () => {
         });
 
         map.zoomTo(5, {duration: 0});
-    });
+    }));
 
-    test('returns true when drag panning', done => {
+    test('returns true when drag panning', () => new Promise(done => {
         map.on('movestart', () => {
             expect(map.isMoving()).toBe(true);
         });
@@ -64,9 +64,9 @@ describe('Map#isMoving', () => {
 
         simulate.mouseup(map.getCanvas());
         map._renderTaskQueue.run();
-    });
+    }));
 
-    test('returns true when drag rotating', done => {
+    test('returns true when drag rotating', () => new Promise(done => {
         // Prevent inertial rotation.
         jest.spyOn(browser, 'now').mockImplementation(() => { return 0; });
 
@@ -95,9 +95,9 @@ describe('Map#isMoving', () => {
 
         simulate.mouseup(map.getCanvas(),   {buttons: 0, button: 2});
         map._renderTaskQueue.run();
-    });
+    }));
 
-    test('returns true when scroll zooming', done => {
+    test('returns true when scroll zooming', () => new Promise(done => {
         map.on('zoomstart', () => {
             expect(map.isMoving()).toBe(true);
         });
@@ -117,9 +117,9 @@ describe('Map#isMoving', () => {
         setTimeout(() => {
             map._renderTaskQueue.run();
         }, 400);
-    });
+    }));
 
-    test('returns true when drag panning and scroll zooming interleave', done => {
+    test('returns true when drag panning and scroll zooming interleave', () => new Promise(done => {
         map.on('dragstart', () => {
             expect(map.isMoving()).toBe(true);
         });
@@ -160,5 +160,5 @@ describe('Map#isMoving', () => {
         setTimeout(() => {
             map._renderTaskQueue.run();
         }, 400);
-    });
+    }));
 });

--- a/src/ui/map_tests/map_is_rotating.test.ts
+++ b/src/ui/map_tests/map_is_rotating.test.ts
@@ -24,7 +24,7 @@ describe('Map#isRotating', () => {
         expect(map.isRotating()).toBe(false);
     });
 
-    test('returns true during a camera rotate animation', () => new Promise(done => {
+    test('returns true during a camera rotate animation', () => new Promise<void>(done => {
         map.on('rotatestart', () => {
             expect(map.isRotating()).toBe(true);
         });
@@ -37,7 +37,7 @@ describe('Map#isRotating', () => {
         map.rotateTo(5, {duration: 0});
     }));
 
-    test('returns true when drag rotating', () => new Promise(done => {
+    test('returns true when drag rotating', () => new Promise<void>(done => {
         // Prevent inertial rotation.
         jest.spyOn(browser, 'now').mockImplementation(() => { return 0; });
 

--- a/src/ui/map_tests/map_is_rotating.test.ts
+++ b/src/ui/map_tests/map_is_rotating.test.ts
@@ -24,7 +24,7 @@ describe('Map#isRotating', () => {
         expect(map.isRotating()).toBe(false);
     });
 
-    test('returns true during a camera rotate animation', done => {
+    test('returns true during a camera rotate animation', () => new Promise(done => {
         map.on('rotatestart', () => {
             expect(map.isRotating()).toBe(true);
         });
@@ -35,9 +35,9 @@ describe('Map#isRotating', () => {
         });
 
         map.rotateTo(5, {duration: 0});
-    });
+    }));
 
-    test('returns true when drag rotating', done => {
+    test('returns true when drag rotating', () => new Promise(done => {
         // Prevent inertial rotation.
         jest.spyOn(browser, 'now').mockImplementation(() => { return 0; });
 
@@ -58,5 +58,5 @@ describe('Map#isRotating', () => {
 
         simulate.mouseup(map.getCanvas(),   {buttons: 0, button: 2});
         map._renderTaskQueue.run();
-    });
+    }));
 });

--- a/src/ui/map_tests/map_is_zooming.test.ts
+++ b/src/ui/map_tests/map_is_zooming.test.ts
@@ -14,14 +14,14 @@ beforeEach(() => {
 
 describe('Map#isZooming', () => {
 
-    test('returns false by default', done => {
+    test('returns false by default', () => new Promise(done => {
         const map = createMap();
         expect(map.isZooming()).toBe(false);
         map.remove();
         done();
-    });
+    }));
 
-    test('returns true during a camera zoom animation', done => {
+    test('returns true during a camera zoom animation', () => new Promise(done => {
         const map = createMap();
 
         map.on('zoomstart', () => {
@@ -35,9 +35,9 @@ describe('Map#isZooming', () => {
         });
 
         map.zoomTo(5, {duration: 0});
-    });
+    }));
 
-    test('returns true when scroll zooming', done => {
+    test('returns true when scroll zooming', () => new Promise(done => {
         const map = createMap();
 
         map.on('zoomstart', () => {
@@ -60,9 +60,9 @@ describe('Map#isZooming', () => {
         setTimeout(() => {
             map._renderTaskQueue.run();
         }, 400);
-    });
+    }));
 
-    test('returns true when double-click zooming', done => {
+    test('returns true when double-click zooming', () => new Promise(done => {
         const map = createMap();
 
         map.on('zoomstart', () => {
@@ -83,5 +83,5 @@ describe('Map#isZooming', () => {
 
         now += 500;
         map._renderTaskQueue.run();
-    });
+    }));
 });

--- a/src/ui/map_tests/map_is_zooming.test.ts
+++ b/src/ui/map_tests/map_is_zooming.test.ts
@@ -14,12 +14,11 @@ beforeEach(() => {
 
 describe('Map#isZooming', () => {
 
-    test('returns false by default', () => new Promise<void>(done => {
+    test('returns false by default', () => {
         const map = createMap();
         expect(map.isZooming()).toBe(false);
         map.remove();
-        done();
-    }));
+    });
 
     test('returns true during a camera zoom animation', () => new Promise<void>(done => {
         const map = createMap();

--- a/src/ui/map_tests/map_is_zooming.test.ts
+++ b/src/ui/map_tests/map_is_zooming.test.ts
@@ -14,14 +14,14 @@ beforeEach(() => {
 
 describe('Map#isZooming', () => {
 
-    test('returns false by default', () => new Promise(done => {
+    test('returns false by default', () => new Promise<void>(done => {
         const map = createMap();
         expect(map.isZooming()).toBe(false);
         map.remove();
         done();
     }));
 
-    test('returns true during a camera zoom animation', () => new Promise(done => {
+    test('returns true during a camera zoom animation', () => new Promise<void>(done => {
         const map = createMap();
 
         map.on('zoomstart', () => {
@@ -37,7 +37,7 @@ describe('Map#isZooming', () => {
         map.zoomTo(5, {duration: 0});
     }));
 
-    test('returns true when scroll zooming', () => new Promise(done => {
+    test('returns true when scroll zooming', () => new Promise<void>(done => {
         const map = createMap();
 
         map.on('zoomstart', () => {
@@ -62,7 +62,7 @@ describe('Map#isZooming', () => {
         }, 400);
     }));
 
-    test('returns true when double-click zooming', () => new Promise(done => {
+    test('returns true when double-click zooming', () => new Promise<void>(done => {
         const map = createMap();
 
         map.on('zoomstart', () => {

--- a/src/ui/map_tests/map_layer.test.ts
+++ b/src/ui/map_tests/map_layer.test.ts
@@ -75,7 +75,7 @@ test('#getLayer', async () => {
     expect(mapLayer.source).toBe(layer.source);
 });
 
-test('#removeLayer restores Map#loaded() to true', done => {
+test('#removeLayer restores Map#loaded() to true', () => new Promise(done => {
     const map = createMap({
         style: extend(createStyle(), {
             sources: {
@@ -104,10 +104,10 @@ test('#removeLayer restores Map#loaded() to true', done => {
             }
         });
     });
-});
+}));
 
 describe('#getLayersOrder', () => {
-    test('returns ids of layers in the correct order', done => {
+    test('returns ids of layers in the correct order', () => new Promise(done => {
         const map = createMap({
             style: extend(createStyle(), {
                 'sources': {
@@ -133,11 +133,11 @@ describe('#getLayersOrder', () => {
             expect(map.getLayersOrder()).toEqual(['custom', 'raster']);
             done();
         });
-    });
+    }));
 });
 
 describe('#setLayoutProperty', () => {
-    test('sets property', done => {
+    test('sets property', () => new Promise(done => {
         const map = createMap({
             style: {
                 'version': 8,
@@ -173,7 +173,7 @@ describe('#setLayoutProperty', () => {
             expect(map.getLayoutProperty('symbol', 'text-transform')).toBe('lowercase');
             done();
         });
-    });
+    }));
 
     test('throw before loaded', () => {
         const map = createMap({
@@ -190,7 +190,7 @@ describe('#setLayoutProperty', () => {
 
     });
 
-    test('fires an error if layer not found', done => {
+    test('fires an error if layer not found', () => new Promise(done => {
         const map = createMap({
             style: {
                 version: 8,
@@ -206,7 +206,7 @@ describe('#setLayoutProperty', () => {
             });
             map.setLayoutProperty('non-existant', 'text-transform', 'lowercase');
         });
-    });
+    }));
 
     test('fires a data event', async () => {
         // background layers do not have a source
@@ -231,7 +231,7 @@ describe('#setLayoutProperty', () => {
         expect(e.dataType).toBe('style');
     });
 
-    test('sets visibility on background layer', done => {
+    test('sets visibility on background layer', () => new Promise(done => {
         // background layers do not have a source
         const map = createMap({
             style: {
@@ -252,9 +252,9 @@ describe('#setLayoutProperty', () => {
             expect(map.getLayoutProperty('background', 'visibility')).toBe('visible');
             done();
         });
-    });
+    }));
 
-    test('sets visibility on raster layer', done => {
+    test('sets visibility on raster layer', () => new Promise(done => {
         const map = createMap({
             style: {
                 'version': 8,
@@ -283,9 +283,9 @@ describe('#setLayoutProperty', () => {
             expect(map.getLayoutProperty('satellite', 'visibility')).toBe('visible');
             done();
         });
-    });
+    }));
 
-    test('sets visibility on video layer', done => {
+    test('sets visibility on video layer', () => new Promise(done => {
         const map = createMap({
             style: {
                 'version': 8,
@@ -317,9 +317,9 @@ describe('#setLayoutProperty', () => {
             expect(map.getLayoutProperty('shore', 'visibility')).toBe('visible');
             done();
         });
-    });
+    }));
 
-    test('sets visibility on image layer', done => {
+    test('sets visibility on image layer', () => new Promise(done => {
         const map = createMap({
             style: {
                 'version': 8,
@@ -351,12 +351,12 @@ describe('#setLayoutProperty', () => {
             expect(map.getLayoutProperty('image', 'visibility')).toBe('visible');
             done();
         });
-    });
+    }));
 
 });
 
 describe('#getLayoutProperty', () => {
-    test('fires an error if layer not found', done => {
+    test('fires an error if layer not found', () => new Promise(done => {
         const map = createMap({
             style: {
                 version: 8,
@@ -372,12 +372,12 @@ describe('#getLayoutProperty', () => {
             });
             (map as any).getLayoutProperty('non-existant', 'text-transform', 'lowercase');
         });
-    });
+    }));
 
 });
 
 describe('#setPaintProperty', () => {
-    test('sets property', done => {
+    test('sets property', () => new Promise(done => {
         const map = createMap({
             style: {
                 'version': 8,
@@ -394,7 +394,7 @@ describe('#setPaintProperty', () => {
             expect(map.getPaintProperty('background', 'background-color')).toBe('red');
             done();
         });
-    });
+    }));
 
     test('#3373 paint property should be synchronized with an update', async () => {
         const colors = ['red', 'blue'];
@@ -436,7 +436,7 @@ describe('#setPaintProperty', () => {
 
     });
 
-    test('fires an error if layer not found', done => {
+    test('fires an error if layer not found', () => new Promise(done => {
         const map = createMap({
             style: {
                 version: 8,
@@ -452,6 +452,6 @@ describe('#setPaintProperty', () => {
             });
             map.setPaintProperty('non-existant', 'background-color', 'red');
         });
-    });
+    }));
 
 });

--- a/src/ui/map_tests/map_layer.test.ts
+++ b/src/ui/map_tests/map_layer.test.ts
@@ -75,7 +75,7 @@ test('#getLayer', async () => {
     expect(mapLayer.source).toBe(layer.source);
 });
 
-test('#removeLayer restores Map#loaded() to true', () => new Promise(done => {
+test('#removeLayer restores Map#loaded() to true', () => new Promise<void>(done => {
     const map = createMap({
         style: extend(createStyle(), {
             sources: {
@@ -107,7 +107,7 @@ test('#removeLayer restores Map#loaded() to true', () => new Promise(done => {
 }));
 
 describe('#getLayersOrder', () => {
-    test('returns ids of layers in the correct order', () => new Promise(done => {
+    test('returns ids of layers in the correct order', () => new Promise<void>(done => {
         const map = createMap({
             style: extend(createStyle(), {
                 'sources': {
@@ -137,7 +137,7 @@ describe('#getLayersOrder', () => {
 });
 
 describe('#setLayoutProperty', () => {
-    test('sets property', () => new Promise(done => {
+    test('sets property', () => new Promise<void>(done => {
         const map = createMap({
             style: {
                 'version': 8,
@@ -190,7 +190,7 @@ describe('#setLayoutProperty', () => {
 
     });
 
-    test('fires an error if layer not found', () => new Promise(done => {
+    test('fires an error if layer not found', () => new Promise<void>(done => {
         const map = createMap({
             style: {
                 version: 8,
@@ -231,7 +231,7 @@ describe('#setLayoutProperty', () => {
         expect(e.dataType).toBe('style');
     });
 
-    test('sets visibility on background layer', () => new Promise(done => {
+    test('sets visibility on background layer', () => new Promise<void>(done => {
         // background layers do not have a source
         const map = createMap({
             style: {
@@ -254,7 +254,7 @@ describe('#setLayoutProperty', () => {
         });
     }));
 
-    test('sets visibility on raster layer', () => new Promise(done => {
+    test('sets visibility on raster layer', () => new Promise<void>(done => {
         const map = createMap({
             style: {
                 'version': 8,
@@ -285,7 +285,7 @@ describe('#setLayoutProperty', () => {
         });
     }));
 
-    test('sets visibility on video layer', () => new Promise(done => {
+    test('sets visibility on video layer', () => new Promise<void>(done => {
         const map = createMap({
             style: {
                 'version': 8,
@@ -319,7 +319,7 @@ describe('#setLayoutProperty', () => {
         });
     }));
 
-    test('sets visibility on image layer', () => new Promise(done => {
+    test('sets visibility on image layer', () => new Promise<void>(done => {
         const map = createMap({
             style: {
                 'version': 8,
@@ -356,7 +356,7 @@ describe('#setLayoutProperty', () => {
 });
 
 describe('#getLayoutProperty', () => {
-    test('fires an error if layer not found', () => new Promise(done => {
+    test('fires an error if layer not found', () => new Promise<void>(done => {
         const map = createMap({
             style: {
                 version: 8,
@@ -377,7 +377,7 @@ describe('#getLayoutProperty', () => {
 });
 
 describe('#setPaintProperty', () => {
-    test('sets property', () => new Promise(done => {
+    test('sets property', () => new Promise<void>(done => {
         const map = createMap({
             style: {
                 'version': 8,
@@ -436,7 +436,7 @@ describe('#setPaintProperty', () => {
 
     });
 
-    test('fires an error if layer not found', () => new Promise(done => {
+    test('fires an error if layer not found', () => new Promise<void>(done => {
         const map = createMap({
             style: {
                 version: 8,

--- a/src/ui/map_tests/map_query_rendered_features.test.ts
+++ b/src/ui/map_tests/map_query_rendered_features.test.ts
@@ -8,7 +8,7 @@ beforeEach(() => {
 
 describe('#queryRenderedFeatures', () => {
 
-    test('if no arguments provided', () => new Promise(done => {
+    test('if no arguments provided', () => new Promise<void>(done => {
         createMap({}, (err, map) => {
             expect(err).toBeFalsy();
             const spy = jest.spyOn(map.style, 'queryRenderedFeatures');
@@ -24,7 +24,7 @@ describe('#queryRenderedFeatures', () => {
         });
     }));
 
-    test('if only "geometry" provided', () => new Promise(done => {
+    test('if only "geometry" provided', () => new Promise<void>(done => {
         createMap({}, (err, map) => {
             expect(err).toBeFalsy();
             const spy = jest.spyOn(map.style, 'queryRenderedFeatures');
@@ -41,7 +41,7 @@ describe('#queryRenderedFeatures', () => {
         });
     }));
 
-    test('if only "params" provided', () => new Promise(done => {
+    test('if only "params" provided', () => new Promise<void>(done => {
         createMap({}, (err, map) => {
             expect(err).toBeFalsy();
             const spy = jest.spyOn(map.style, 'queryRenderedFeatures');
@@ -57,7 +57,7 @@ describe('#queryRenderedFeatures', () => {
         });
     }));
 
-    test('if both "geometry" and "params" provided', () => new Promise(done => {
+    test('if both "geometry" and "params" provided', () => new Promise<void>(done => {
         createMap({}, (err, map) => {
             expect(err).toBeFalsy();
             const spy = jest.spyOn(map.style, 'queryRenderedFeatures');
@@ -73,7 +73,7 @@ describe('#queryRenderedFeatures', () => {
         });
     }));
 
-    test('if "geometry" with unwrapped coords provided', () => new Promise(done => {
+    test('if "geometry" with unwrapped coords provided', () => new Promise<void>(done => {
         createMap({}, (err, map) => {
             expect(err).toBeFalsy();
             const spy = jest.spyOn(map.style, 'queryRenderedFeatures');

--- a/src/ui/map_tests/map_query_rendered_features.test.ts
+++ b/src/ui/map_tests/map_query_rendered_features.test.ts
@@ -8,7 +8,7 @@ beforeEach(() => {
 
 describe('#queryRenderedFeatures', () => {
 
-    test('if no arguments provided', done => {
+    test('if no arguments provided', () => new Promise(done => {
         createMap({}, (err, map) => {
             expect(err).toBeFalsy();
             const spy = jest.spyOn(map.style, 'queryRenderedFeatures');
@@ -22,9 +22,9 @@ describe('#queryRenderedFeatures', () => {
 
             done();
         });
-    });
+    }));
 
-    test('if only "geometry" provided', done => {
+    test('if only "geometry" provided', () => new Promise(done => {
         createMap({}, (err, map) => {
             expect(err).toBeFalsy();
             const spy = jest.spyOn(map.style, 'queryRenderedFeatures');
@@ -39,9 +39,9 @@ describe('#queryRenderedFeatures', () => {
 
             done();
         });
-    });
+    }));
 
-    test('if only "params" provided', done => {
+    test('if only "params" provided', () => new Promise(done => {
         createMap({}, (err, map) => {
             expect(err).toBeFalsy();
             const spy = jest.spyOn(map.style, 'queryRenderedFeatures');
@@ -55,9 +55,9 @@ describe('#queryRenderedFeatures', () => {
 
             done();
         });
-    });
+    }));
 
-    test('if both "geometry" and "params" provided', done => {
+    test('if both "geometry" and "params" provided', () => new Promise(done => {
         createMap({}, (err, map) => {
             expect(err).toBeFalsy();
             const spy = jest.spyOn(map.style, 'queryRenderedFeatures');
@@ -71,9 +71,9 @@ describe('#queryRenderedFeatures', () => {
 
             done();
         });
-    });
+    }));
 
-    test('if "geometry" with unwrapped coords provided', done => {
+    test('if "geometry" with unwrapped coords provided', () => new Promise(done => {
         createMap({}, (err, map) => {
             expect(err).toBeFalsy();
             const spy = jest.spyOn(map.style, 'queryRenderedFeatures');
@@ -83,7 +83,7 @@ describe('#queryRenderedFeatures', () => {
             expect(spy.mock.calls[0][0]).toEqual([{x: 612, y: 100}]);
             done();
         });
-    });
+    }));
 
     test('returns an empty array when no style is loaded', () => {
         const map = createMap({style: undefined});

--- a/src/ui/map_tests/map_render.test.ts
+++ b/src/ui/map_tests/map_render.test.ts
@@ -13,7 +13,7 @@ afterEach(() => {
     server.restore();
 });
 
-test('render stabilizes', () => new Promise(done => {
+test('render stabilizes', () => new Promise<void>((done, fail) => {
     const style = createStyle();
     style.sources.mapbox = {
         type: 'vector',
@@ -35,7 +35,7 @@ test('render stabilizes', () => new Promise(done => {
         timer = setTimeout(() => {
             map.off('render', undefined);
             map.on('render', () => {
-                done('test failed');
+                fail(new Error('test failed'));
             });
             expect((map as any)._frameId).toBeFalsy();
             done();
@@ -43,12 +43,12 @@ test('render stabilizes', () => new Promise(done => {
     });
 }));
 
-test('no render after idle event', () => new Promise(done => {
+test('no render after idle event', () => new Promise<void>((done, fail) => {
     const style = createStyle();
     const map = createMap({style});
     map.on('idle', () => {
         map.on('render', () => {
-            done('test failed');
+            fail(new Error('test failed'));
         });
         setTimeout(() => {
             done();
@@ -56,20 +56,20 @@ test('no render after idle event', () => new Promise(done => {
     });
 }));
 
-test('no render before style loaded', () => new Promise(done => {
+test('no render before style loaded', () => new Promise<void>((done, fail) => {
     server.respondWith('/styleUrl', JSON.stringify(createStyle()));
     const map = createMap({style: '/styleUrl'});
 
     jest.spyOn(map, 'triggerRepaint').mockImplementationOnce(() => {
         if (!map.style._loaded) {
-            done('test failed');
+            fail(new Error('test failed'));
         }
     });
     map.on('render', () => {
         if (map.style._loaded) {
             done();
         } else {
-            done('test failed');
+            fail(new Error('test failed'));
         }
     });
 

--- a/src/ui/map_tests/map_render.test.ts
+++ b/src/ui/map_tests/map_render.test.ts
@@ -13,7 +13,7 @@ afterEach(() => {
     server.restore();
 });
 
-test('render stabilizes', () => new Promise<void>((done, fail) => {
+test('render stabilizes', () => new Promise<void>((done) => {
     const style = createStyle();
     style.sources.mapbox = {
         type: 'vector',
@@ -35,7 +35,7 @@ test('render stabilizes', () => new Promise<void>((done, fail) => {
         timer = setTimeout(() => {
             map.off('render', undefined);
             map.on('render', () => {
-                fail(new Error('test failed'));
+                throw new Error('test failed');
             });
             expect((map as any)._frameId).toBeFalsy();
             done();
@@ -43,12 +43,12 @@ test('render stabilizes', () => new Promise<void>((done, fail) => {
     });
 }));
 
-test('no render after idle event', () => new Promise<void>((done, fail) => {
+test('no render after idle event', () => new Promise<void>((done) => {
     const style = createStyle();
     const map = createMap({style});
     map.on('idle', () => {
         map.on('render', () => {
-            fail(new Error('test failed'));
+            throw new Error('test failed');
         });
         setTimeout(() => {
             done();
@@ -56,20 +56,20 @@ test('no render after idle event', () => new Promise<void>((done, fail) => {
     });
 }));
 
-test('no render before style loaded', () => new Promise<void>((done, fail) => {
+test('no render before style loaded', () => new Promise<void>((done) => {
     server.respondWith('/styleUrl', JSON.stringify(createStyle()));
     const map = createMap({style: '/styleUrl'});
 
     jest.spyOn(map, 'triggerRepaint').mockImplementationOnce(() => {
         if (!map.style._loaded) {
-            fail(new Error('test failed'));
+            throw new Error('test failed');
         }
     });
     map.on('render', () => {
         if (map.style._loaded) {
             done();
         } else {
-            fail(new Error('test failed'));
+            throw new Error('test failed');
         }
     });
 

--- a/src/ui/map_tests/map_render.test.ts
+++ b/src/ui/map_tests/map_render.test.ts
@@ -13,7 +13,7 @@ afterEach(() => {
     server.restore();
 });
 
-test('render stabilizes', done => {
+test('render stabilizes', () => new Promise(done => {
     const style = createStyle();
     style.sources.mapbox = {
         type: 'vector',
@@ -41,9 +41,9 @@ test('render stabilizes', done => {
             done();
         }, 100);
     });
-});
+}));
 
-test('no render after idle event', done => {
+test('no render after idle event', () => new Promise(done => {
     const style = createStyle();
     const map = createMap({style});
     map.on('idle', () => {
@@ -54,9 +54,9 @@ test('no render after idle event', done => {
             done();
         }, 100);
     });
-});
+}));
 
-test('no render before style loaded', done => {
+test('no render before style loaded', () => new Promise(done => {
     server.respondWith('/styleUrl', JSON.stringify(createStyle()));
     const map = createMap({style: '/styleUrl'});
 
@@ -77,7 +77,7 @@ test('no render before style loaded', done => {
     // Once style is loaded, it will trigger the update.
     map._update();
     server.respond();
-});
+}));
 
 test('#redraw', async () => {
     const map = createMap();

--- a/src/ui/map_tests/map_request_render_frame.test.ts
+++ b/src/ui/map_tests/map_request_render_frame.test.ts
@@ -6,7 +6,7 @@ beforeEach(() => {
 
 describe('requestRenderFrame', () => {
 
-    test('Map#_requestRenderFrame schedules a new render frame if necessary', () => new Promise(done => {
+    test('Map#_requestRenderFrame schedules a new render frame if necessary', () => new Promise<void>(done => {
         const map = createMap();
         const spy = jest.spyOn(map, 'triggerRepaint');
         map._requestRenderFrame(() => {});

--- a/src/ui/map_tests/map_request_render_frame.test.ts
+++ b/src/ui/map_tests/map_request_render_frame.test.ts
@@ -6,7 +6,7 @@ beforeEach(() => {
 
 describe('requestRenderFrame', () => {
 
-    test('Map#_requestRenderFrame schedules a new render frame if necessary', (done) => {
+    test('Map#_requestRenderFrame schedules a new render frame if necessary', () => new Promise(done => {
         const map = createMap();
         const spy = jest.spyOn(map, 'triggerRepaint');
         map._requestRenderFrame(() => {});
@@ -20,7 +20,7 @@ describe('requestRenderFrame', () => {
             map.remove();
             done();
         });
-    });
+    }));
 
     test('Map#_requestRenderFrame should not schedule a render frame before style load', () => {
         const map = createMap();

--- a/src/ui/map_tests/map_style.test.ts
+++ b/src/ui/map_tests/map_style.test.ts
@@ -342,12 +342,11 @@ describe('#setStyle', () => {
 });
 
 describe('#getStyle', () => {
-    test('returns undefined if the style has not loaded yet', () => new Promise<void>(done => {
+    test('returns undefined if the style has not loaded yet', () => {
         const style = createStyle();
         const map = createMap({style});
         expect(map.getStyle()).toBeUndefined();
-        done();
-    }));
+    });
 
     test('returns the style', () => new Promise<void>(done => {
         const style = createStyle();

--- a/src/ui/map_tests/map_style.test.ts
+++ b/src/ui/map_tests/map_style.test.ts
@@ -111,7 +111,7 @@ describe('#setStyle', () => {
         spy.mockRestore();
     });
 
-    test('style transform overrides unmodified map transform', () => new Promise(done => {
+    test('style transform overrides unmodified map transform', () => new Promise<void>(done => {
         const map = new Map({container: window.document.createElement('div')} as any as MapOptions);
         map.transform.lngRange = [-120, 140];
         map.transform.latRange = [-60, 80];
@@ -128,7 +128,7 @@ describe('#setStyle', () => {
         });
     }));
 
-    test('style transform does not override map transform modified via options', () => new Promise(done => {
+    test('style transform does not override map transform modified via options', () => new Promise<void>(done => {
         const map = new Map({container: window.document.createElement('div'), zoom: 10, center: [-77.0186, 38.8888]} as any as MapOptions);
         expect(map.transform.unmodified).toBeFalsy();
         map.setStyle(createStyle());
@@ -141,7 +141,7 @@ describe('#setStyle', () => {
         });
     }));
 
-    test('style transform does not override map transform modified via setters', () => new Promise(done => {
+    test('style transform does not override map transform modified via setters', () => new Promise<void>(done => {
         const map = new Map({container: window.document.createElement('div')} as any as MapOptions);
         expect(map.transform.unmodified).toBeTruthy();
         map.setZoom(10);
@@ -185,7 +185,7 @@ describe('#setStyle', () => {
         spyWorkerPoolRelease.mockClear();
     });
 
-    test('transformStyle should copy the source and the layer into next style', () => new Promise(done => {
+    test('transformStyle should copy the source and the layer into next style', () => new Promise<void>(done => {
         const style = extend(createStyle(), {
             sources: {
                 maplibre: {
@@ -233,7 +233,7 @@ describe('#setStyle', () => {
         });
     }));
 
-    test('delayed setStyle with transformStyle should copy the source and the layer into next style with diffing', () => new Promise(done => {
+    test('delayed setStyle with transformStyle should copy the source and the layer into next style with diffing', () => new Promise<void>(done => {
         const style = extend(createStyle(), {
             sources: {
                 maplibre: {
@@ -281,7 +281,7 @@ describe('#setStyle', () => {
         }, 100);
     }));
 
-    test('transformStyle should get called when passed to setStyle after the map is initialised without a style', () => new Promise(done => {
+    test('transformStyle should get called when passed to setStyle after the map is initialised without a style', () => new Promise<void>(done => {
         const map = createMap({deleteStyle: true});
         map.setStyle(createStyle(), {
             diff: true,
@@ -316,7 +316,7 @@ describe('#setStyle', () => {
         });
     }));
 
-    test('map load should be fired when transformStyle is used on setStyle after the map is initialised without a style', () => new Promise(done => {
+    test('map load should be fired when transformStyle is used on setStyle after the map is initialised without a style', () => new Promise<void>(done => {
         const map = createMap({deleteStyle: true});
         map.setStyle({version: 8, sources: {}, layers: []}, {
             diff: true,
@@ -342,14 +342,14 @@ describe('#setStyle', () => {
 });
 
 describe('#getStyle', () => {
-    test('returns undefined if the style has not loaded yet', () => new Promise(done => {
+    test('returns undefined if the style has not loaded yet', () => new Promise<void>(done => {
         const style = createStyle();
         const map = createMap({style});
         expect(map.getStyle()).toBeUndefined();
         done();
     }));
 
-    test('returns the style', () => new Promise(done => {
+    test('returns the style', () => new Promise<void>(done => {
         const style = createStyle();
         const map = createMap({style});
 
@@ -383,7 +383,7 @@ describe('#getStyle', () => {
         expect(map.getStyle()).toEqual(style);
     });
 
-    test('returns the style with added sources', () => new Promise(done => {
+    test('returns the style with added sources', () => new Promise<void>(done => {
         const style = createStyle();
         const map = createMap({style});
 
@@ -396,7 +396,7 @@ describe('#getStyle', () => {
         });
     }));
 
-    test('fires an error on checking if non-existant source is loaded', () => new Promise(done => {
+    test('fires an error on checking if non-existant source is loaded', () => new Promise<void>(done => {
         const style = createStyle();
         const map = createMap({style});
 
@@ -409,7 +409,7 @@ describe('#getStyle', () => {
         });
     }));
 
-    test('returns the style with added layers', () => new Promise(done => {
+    test('returns the style with added layers', () => new Promise<void>(done => {
         const style = createStyle();
         const map = createMap({style});
         const layer = {
@@ -454,7 +454,7 @@ describe('#getStyle', () => {
         });
     });
 
-    test('returns the style with added source and layer', () => new Promise(done => {
+    test('returns the style with added source and layer', () => new Promise<void>(done => {
         const style = createStyle();
         const map = createMap({style});
         const source = createStyleSource();

--- a/src/ui/map_tests/map_style.test.ts
+++ b/src/ui/map_tests/map_style.test.ts
@@ -111,7 +111,7 @@ describe('#setStyle', () => {
         spy.mockRestore();
     });
 
-    test('style transform overrides unmodified map transform', done => {
+    test('style transform overrides unmodified map transform', () => new Promise(done => {
         const map = new Map({container: window.document.createElement('div')} as any as MapOptions);
         map.transform.lngRange = [-120, 140];
         map.transform.latRange = [-60, 80];
@@ -126,9 +126,9 @@ describe('#setStyle', () => {
             expect(fixedNum(map.transform.pitch)).toBe(50);
             done();
         });
-    });
+    }));
 
-    test('style transform does not override map transform modified via options', done => {
+    test('style transform does not override map transform modified via options', () => new Promise(done => {
         const map = new Map({container: window.document.createElement('div'), zoom: 10, center: [-77.0186, 38.8888]} as any as MapOptions);
         expect(map.transform.unmodified).toBeFalsy();
         map.setStyle(createStyle());
@@ -139,9 +139,9 @@ describe('#setStyle', () => {
             expect(fixedNum(map.transform.pitch)).toBe(0);
             done();
         });
-    });
+    }));
 
-    test('style transform does not override map transform modified via setters', done => {
+    test('style transform does not override map transform modified via setters', () => new Promise(done => {
         const map = new Map({container: window.document.createElement('div')} as any as MapOptions);
         expect(map.transform.unmodified).toBeTruthy();
         map.setZoom(10);
@@ -155,7 +155,7 @@ describe('#setStyle', () => {
             expect(fixedNum(map.transform.pitch)).toBe(0);
             done();
         });
-    });
+    }));
 
     test('passing null removes style', () => {
         const map = createMap();
@@ -185,7 +185,7 @@ describe('#setStyle', () => {
         spyWorkerPoolRelease.mockClear();
     });
 
-    test('transformStyle should copy the source and the layer into next style', done => {
+    test('transformStyle should copy the source and the layer into next style', () => new Promise(done => {
         const style = extend(createStyle(), {
             sources: {
                 maplibre: {
@@ -231,9 +231,9 @@ describe('#setStyle', () => {
             expect(loadedStyle.layers).toHaveLength(1);
             done();
         });
-    });
+    }));
 
-    test('delayed setStyle with transformStyle should copy the source and the layer into next style with diffing', done => {
+    test('delayed setStyle with transformStyle should copy the source and the layer into next style with diffing', () => new Promise(done => {
         const style = extend(createStyle(), {
             sources: {
                 maplibre: {
@@ -279,9 +279,9 @@ describe('#setStyle', () => {
             expect(loadedStyle.layers).toHaveLength(1);
             done();
         }, 100);
-    });
+    }));
 
-    test('transformStyle should get called when passed to setStyle after the map is initialised without a style', done => {
+    test('transformStyle should get called when passed to setStyle after the map is initialised without a style', () => new Promise(done => {
         const map = createMap({deleteStyle: true});
         map.setStyle(createStyle(), {
             diff: true,
@@ -314,9 +314,9 @@ describe('#setStyle', () => {
             expect(loadedStyle.layers[0].id).toBe('layerId0');
             done();
         });
-    });
+    }));
 
-    test('map load should be fired when transformStyle is used on setStyle after the map is initialised without a style', done => {
+    test('map load should be fired when transformStyle is used on setStyle after the map is initialised without a style', () => new Promise(done => {
         const map = createMap({deleteStyle: true});
         map.setStyle({version: 8, sources: {}, layers: []}, {
             diff: true,
@@ -327,7 +327,7 @@ describe('#setStyle', () => {
             }
         });
         map.on('load', () => done());
-    });
+    }));
 
     test('Override default style validation', () => {
         let validationOption = true;
@@ -342,14 +342,14 @@ describe('#setStyle', () => {
 });
 
 describe('#getStyle', () => {
-    test('returns undefined if the style has not loaded yet', done => {
+    test('returns undefined if the style has not loaded yet', () => new Promise(done => {
         const style = createStyle();
         const map = createMap({style});
         expect(map.getStyle()).toBeUndefined();
         done();
-    });
+    }));
 
-    test('returns the style', done => {
+    test('returns the style', () => new Promise(done => {
         const style = createStyle();
         const map = createMap({style});
 
@@ -357,7 +357,7 @@ describe('#getStyle', () => {
             expect(map.getStyle()).toEqual(style);
             done();
         });
-    });
+    }));
 
     test('returns the previous style even if modified', async () => {
         const style = {
@@ -383,7 +383,7 @@ describe('#getStyle', () => {
         expect(map.getStyle()).toEqual(style);
     });
 
-    test('returns the style with added sources', done => {
+    test('returns the style with added sources', () => new Promise(done => {
         const style = createStyle();
         const map = createMap({style});
 
@@ -394,9 +394,9 @@ describe('#getStyle', () => {
             }));
             done();
         });
-    });
+    }));
 
-    test('fires an error on checking if non-existant source is loaded', done => {
+    test('fires an error on checking if non-existant source is loaded', () => new Promise(done => {
         const style = createStyle();
         const map = createMap({style});
 
@@ -407,9 +407,9 @@ describe('#getStyle', () => {
             });
             map.isSourceLoaded('geojson');
         });
-    });
+    }));
 
-    test('returns the style with added layers', done => {
+    test('returns the style with added layers', () => new Promise(done => {
         const style = createStyle();
         const map = createMap({style});
         const layer = {
@@ -424,7 +424,7 @@ describe('#getStyle', () => {
             }));
             done();
         });
-    });
+    }));
 
     test('a layer can be added even if a map is created without a style', () => {
         const map = createMap({deleteStyle: true});
@@ -454,7 +454,7 @@ describe('#getStyle', () => {
         });
     });
 
-    test('returns the style with added source and layer', done => {
+    test('returns the style with added source and layer', () => new Promise(done => {
         const style = createStyle();
         const map = createMap({style});
         const source = createStyleSource();
@@ -473,7 +473,7 @@ describe('#getStyle', () => {
             }));
             done();
         });
-    });
+    }));
 
     test('creates a new Style if diff fails', () => {
         const style = createStyle();

--- a/src/ui/map_tests/map_terrian.test.ts
+++ b/src/ui/map_tests/map_terrian.test.ts
@@ -17,7 +17,7 @@ afterEach(() => {
 });
 
 describe('#setTerrain', () => {
-    test('warn when terrain and hillshade source identical', () => new Promise(done => {
+    test('warn when terrain and hillshade source identical', () => new Promise<void>(done => {
         server.respondWith('/source.json', JSON.stringify({
             minzoom: 5,
             maxzoom: 12,

--- a/src/ui/map_tests/map_terrian.test.ts
+++ b/src/ui/map_tests/map_terrian.test.ts
@@ -17,7 +17,7 @@ afterEach(() => {
 });
 
 describe('#setTerrain', () => {
-    test('warn when terrain and hillshade source identical', done => {
+    test('warn when terrain and hillshade source identical', () => new Promise(done => {
         server.respondWith('/source.json', JSON.stringify({
             minzoom: 5,
             maxzoom: 12,
@@ -40,7 +40,7 @@ describe('#setTerrain', () => {
             expect(console.warn).toHaveBeenCalledTimes(1);
             done();
         });
-    });
+    }));
 });
 
 describe('#getTerrain', () => {

--- a/src/ui/map_tests/map_webgl.test.ts
+++ b/src/ui/map_tests/map_webgl.test.ts
@@ -5,10 +5,10 @@ beforeEach(() => {
     global.fetch = null;
 });
 
-test('does not fire "webglcontextlost" after #remove has been called', () => new Promise<void>((done, fail) => {
+test('does not fire "webglcontextlost" after #remove has been called', () => new Promise<void>((done) => {
     const map = createMap();
     const canvas = map.getCanvas();
-    map.once('webglcontextlost', () => fail(new Error('"webglcontextlost" fired after #remove has been called')));
+    map.once('webglcontextlost', () => { throw new Error('"webglcontextlost" fired after #remove has been called'); });
     map.remove();
     // Dispatch the event manually because at the time of this writing, gl does not support
     // the WEBGL_lose_context extension.
@@ -16,12 +16,12 @@ test('does not fire "webglcontextlost" after #remove has been called', () => new
     done();
 }));
 
-test('does not fire "webglcontextrestored" after #remove has been called', () => new Promise<void>((done, fail) => {
+test('does not fire "webglcontextrestored" after #remove has been called', () => new Promise<void>((done) => {
     const map = createMap();
     const canvas = map.getCanvas();
 
     map.once('webglcontextlost', () => {
-        map.once('webglcontextrestored', () => fail(new Error('"webglcontextrestored" fired after #remove has been called')));
+        map.once('webglcontextrestored', () => { throw new Error('"webglcontextrestored" fired after #remove has been called'); });
         map.remove();
         canvas.dispatchEvent(new window.Event('webglcontextrestored'));
         done();

--- a/src/ui/map_tests/map_webgl.test.ts
+++ b/src/ui/map_tests/map_webgl.test.ts
@@ -5,7 +5,7 @@ beforeEach(() => {
     global.fetch = null;
 });
 
-test('does not fire "webglcontextlost" after #remove has been called', done => {
+test('does not fire "webglcontextlost" after #remove has been called', () => new Promise(done => {
     const map = createMap();
     const canvas = map.getCanvas();
     map.once('webglcontextlost', () => done('"webglcontextlost" fired after #remove has been called'));
@@ -14,9 +14,9 @@ test('does not fire "webglcontextlost" after #remove has been called', done => {
     // the WEBGL_lose_context extension.
     canvas.dispatchEvent(new window.Event('webglcontextlost'));
     done();
-});
+}));
 
-test('does not fire "webglcontextrestored" after #remove has been called', done => {
+test('does not fire "webglcontextrestored" after #remove has been called', () => new Promise(done => {
     const map = createMap();
     const canvas = map.getCanvas();
 
@@ -30,7 +30,7 @@ test('does not fire "webglcontextrestored" after #remove has been called', done 
     // Dispatch the event manually because at the time of this writing, gl does not support
     // the WEBGL_lose_context extension.
     canvas.dispatchEvent(new window.Event('webglcontextlost'));
-});
+}));
 
 test('WebGL error while creating map', () => {
     const original = HTMLCanvasElement.prototype.getContext;

--- a/src/ui/map_tests/map_webgl.test.ts
+++ b/src/ui/map_tests/map_webgl.test.ts
@@ -5,10 +5,10 @@ beforeEach(() => {
     global.fetch = null;
 });
 
-test('does not fire "webglcontextlost" after #remove has been called', () => new Promise(done => {
+test('does not fire "webglcontextlost" after #remove has been called', () => new Promise<void>((done, fail) => {
     const map = createMap();
     const canvas = map.getCanvas();
-    map.once('webglcontextlost', () => done('"webglcontextlost" fired after #remove has been called'));
+    map.once('webglcontextlost', () => fail(new Error('"webglcontextlost" fired after #remove has been called')));
     map.remove();
     // Dispatch the event manually because at the time of this writing, gl does not support
     // the WEBGL_lose_context extension.
@@ -16,12 +16,12 @@ test('does not fire "webglcontextlost" after #remove has been called', () => new
     done();
 }));
 
-test('does not fire "webglcontextrestored" after #remove has been called', () => new Promise(done => {
+test('does not fire "webglcontextrestored" after #remove has been called', () => new Promise<void>((done, fail) => {
     const map = createMap();
     const canvas = map.getCanvas();
 
     map.once('webglcontextlost', () => {
-        map.once('webglcontextrestored', () => done('"webglcontextrestored" fired after #remove has been called'));
+        map.once('webglcontextrestored', () => fail(new Error('"webglcontextrestored" fired after #remove has been called')));
         map.remove();
         canvas.dispatchEvent(new window.Event('webglcontextrestored'));
         done();

--- a/src/util/actor.test.ts
+++ b/src/util/actor.test.ts
@@ -116,7 +116,7 @@ describe('Actor', () => {
         expect(spy).not.toHaveBeenCalled();
     });
 
-    test('#remove unbinds event listener', done => {
+    test('#remove unbinds event listener', () => new Promise(done => {
         const actor = new Actor({
             addEventListener(type, callback, useCapture) {
                 this._addEventListenerArgs = [type, callback, useCapture];
@@ -127,7 +127,7 @@ describe('Actor', () => {
             }
         } as ActorTarget, null);
         actor.remove();
-    });
+    }));
 
     test('send a message that is rejected', async () => {
         const worker = workerFactory() as any as WorkerGlobalScopeInterface & ActorTarget;

--- a/src/util/actor.test.ts
+++ b/src/util/actor.test.ts
@@ -116,7 +116,7 @@ describe('Actor', () => {
         expect(spy).not.toHaveBeenCalled();
     });
 
-    test('#remove unbinds event listener', () => new Promise(done => {
+    test('#remove unbinds event listener', () => new Promise<void>(done => {
         const actor = new Actor({
             addEventListener(type, callback, useCapture) {
                 this._addEventListenerArgs = [type, callback, useCapture];

--- a/src/util/evented.test.ts
+++ b/src/util/evented.test.ts
@@ -105,14 +105,13 @@ describe('Evented', () => {
 
     });
 
-    test('does not immediately call listeners added within another listener', () => new Promise<void>((done, fail) => {
+    test('does not immediately call listeners added within another listener', () => {
         const evented = new Evented();
         evented.on('a', () => {
-            evented.on('a', () => fail(new Error('fail')));
+            evented.on('a', () => { throw (new Error('fail')); });
         });
         evented.fire(new Event('a'));
-        done();
-    }));
+    });
 
     test('has backward compatibility for fire(string, object) API', () => {
         const evented = new Evented();

--- a/src/util/evented.test.ts
+++ b/src/util/evented.test.ts
@@ -105,14 +105,14 @@ describe('Evented', () => {
 
     });
 
-    test('does not immediately call listeners added within another listener', done => {
+    test('does not immediately call listeners added within another listener', () => new Promise(done => {
         const evented = new Evented();
         evented.on('a', () => {
             evented.on('a', () => done('fail'));
         });
         evented.fire(new Event('a'));
         done();
-    });
+    }));
 
     test('has backward compatibility for fire(string, object) API', () => {
         const evented = new Evented();

--- a/src/util/evented.test.ts
+++ b/src/util/evented.test.ts
@@ -108,7 +108,7 @@ describe('Evented', () => {
     test('does not immediately call listeners added within another listener', () => {
         const evented = new Evented();
         evented.on('a', () => {
-            evented.on('a', () => { throw (new Error('fail')); });
+            evented.on('a', () => { throw new Error('fail'); });
         });
         evented.fire(new Event('a'));
     });

--- a/src/util/evented.test.ts
+++ b/src/util/evented.test.ts
@@ -105,10 +105,10 @@ describe('Evented', () => {
 
     });
 
-    test('does not immediately call listeners added within another listener', () => new Promise(done => {
+    test('does not immediately call listeners added within another listener', () => new Promise<void>((done, fail) => {
         const evented = new Evented();
         evented.on('a', () => {
-            evented.on('a', () => done('fail'));
+            evented.on('a', () => fail(new Error('fail')));
         });
         evented.fire(new Event('a'));
         done();

--- a/src/util/test/util.ts
+++ b/src/util/test/util.ts
@@ -149,7 +149,7 @@ export function bufferToArrayBuffer(data: Buffer): ArrayBuffer {
  * @returns - a promise that resolves after the specified amount of time
  */
 export const sleep = (milliseconds: number = 0) => {
-    return new Promise(resolve => setTimeout(resolve, milliseconds));
+    return new Promise<void>(resolve => setTimeout(resolve, milliseconds));
 };
 
 export function waitForMetadataEvent(source: Evented): Promise<void> {

--- a/src/util/throttle.test.ts
+++ b/src/util/throttle.test.ts
@@ -8,19 +8,17 @@ describe('throttle', () => {
         expect(executionCount).toBe(0);
     });
 
-    test('executes unthrottled function once per tick when period is 0', () => new Promise<void>(done => {
+    test('executes unthrottled function once per tick when period is 0', async () => {
         let executionCount = 0;
         const throttledFunction = throttle(() => { executionCount++; }, 0);
         throttledFunction();
         throttledFunction();
         expect(executionCount).toBe(1);
-        setTimeout(() => {
-            throttledFunction();
-            throttledFunction();
-            expect(executionCount).toBe(2);
-            done();
-        }, 0);
-    }));
+        await new Promise(resolve => setTimeout(resolve, 0));
+        throttledFunction();
+        throttledFunction();
+        expect(executionCount).toBe(2);
+    });
 
     test('executes unthrottled function immediately once when period is > 0', () => {
         let executionCount = 0;
@@ -31,15 +29,13 @@ describe('throttle', () => {
         expect(executionCount).toBe(1);
     });
 
-    test('queues exactly one execution of unthrottled function when period is > 0', () => new Promise<void>(done => {
+    test('queues exactly one execution of unthrottled function when period is > 0', async () => {
         let executionCount = 0;
         const throttledFunction = throttle(() => { executionCount++; }, 5);
         throttledFunction();
         throttledFunction();
         throttledFunction();
-        setTimeout(() => {
-            expect(executionCount).toBe(2);
-            done();
-        }, 10);
-    }));
+        await new Promise(resolve => setTimeout(resolve, 10));
+        expect(executionCount).toBe(2);
+    });
 });

--- a/src/util/throttle.test.ts
+++ b/src/util/throttle.test.ts
@@ -8,7 +8,7 @@ describe('throttle', () => {
         expect(executionCount).toBe(0);
     });
 
-    test('executes unthrottled function once per tick when period is 0', () => new Promise(done => {
+    test('executes unthrottled function once per tick when period is 0', () => new Promise<void>(done => {
         let executionCount = 0;
         const throttledFunction = throttle(() => { executionCount++; }, 0);
         throttledFunction();
@@ -31,7 +31,7 @@ describe('throttle', () => {
         expect(executionCount).toBe(1);
     });
 
-    test('queues exactly one execution of unthrottled function when period is > 0', () => new Promise(done => {
+    test('queues exactly one execution of unthrottled function when period is > 0', () => new Promise<void>(done => {
         let executionCount = 0;
         const throttledFunction = throttle(() => { executionCount++; }, 5);
         throttledFunction();

--- a/src/util/throttle.test.ts
+++ b/src/util/throttle.test.ts
@@ -8,7 +8,7 @@ describe('throttle', () => {
         expect(executionCount).toBe(0);
     });
 
-    test('executes unthrottled function once per tick when period is 0', done => {
+    test('executes unthrottled function once per tick when period is 0', () => new Promise(done => {
         let executionCount = 0;
         const throttledFunction = throttle(() => { executionCount++; }, 0);
         throttledFunction();
@@ -20,7 +20,7 @@ describe('throttle', () => {
             expect(executionCount).toBe(2);
             done();
         }, 0);
-    });
+    }));
 
     test('executes unthrottled function immediately once when period is > 0', () => {
         let executionCount = 0;
@@ -31,7 +31,7 @@ describe('throttle', () => {
         expect(executionCount).toBe(1);
     });
 
-    test('queues exactly one execution of unthrottled function when period is > 0', done => {
+    test('queues exactly one execution of unthrottled function when period is > 0', () => new Promise(done => {
         let executionCount = 0;
         const throttledFunction = throttle(() => { executionCount++; }, 5);
         throttledFunction();
@@ -41,5 +41,5 @@ describe('throttle', () => {
             expect(executionCount).toBe(2);
             done();
         }, 10);
-    });
+    }));
 });

--- a/src/util/throttle.test.ts
+++ b/src/util/throttle.test.ts
@@ -1,3 +1,4 @@
+import { sleep } from './test/util';
 import {throttle} from './throttle';
 
 describe('throttle', () => {
@@ -14,7 +15,7 @@ describe('throttle', () => {
         throttledFunction();
         throttledFunction();
         expect(executionCount).toBe(1);
-        await new Promise(resolve => setTimeout(resolve, 0));
+        await sleep(0);
         throttledFunction();
         throttledFunction();
         expect(executionCount).toBe(2);
@@ -35,7 +36,7 @@ describe('throttle', () => {
         throttledFunction();
         throttledFunction();
         throttledFunction();
-        await new Promise(resolve => setTimeout(resolve, 10));
+        await sleep(10);
         expect(executionCount).toBe(2);
     });
 });

--- a/src/util/throttle.test.ts
+++ b/src/util/throttle.test.ts
@@ -1,4 +1,4 @@
-import { sleep } from './test/util';
+import {sleep} from './test/util';
 import {throttle} from './throttle';
 
 describe('throttle', () => {

--- a/src/util/util.test.ts
+++ b/src/util/util.test.ts
@@ -14,7 +14,7 @@ describe('util', () => {
     expect(pick({a: 1, b: 2, c: 3}, ['a', 'c', 'd'] as any)).toEqual({a: 1, c: 3});
     expect(typeof uniqueId() === 'number').toBeTruthy();
 
-    test('isPowerOfTwo', done => {
+    test('isPowerOfTwo', () => new Promise(done => {
         expect(isPowerOfTwo(1)).toBe(true);
         expect(isPowerOfTwo(2)).toBe(true);
         expect(isPowerOfTwo(256)).toBe(true);
@@ -23,9 +23,9 @@ describe('util', () => {
         expect(isPowerOfTwo(-42)).toBe(false);
         expect(isPowerOfTwo(42)).toBe(false);
         done();
-    });
+    }));
 
-    test('nextPowerOfTwo', done => {
+    test('nextPowerOfTwo', () => new Promise(done => {
         expect(nextPowerOfTwo(1)).toBe(1);
         expect(nextPowerOfTwo(2)).toBe(2);
         expect(nextPowerOfTwo(256)).toBe(256);
@@ -34,9 +34,9 @@ describe('util', () => {
         expect(nextPowerOfTwo(-42)).toBe(1);
         expect(nextPowerOfTwo(42)).toBe(64);
         done();
-    });
+    }));
 
-    test('nextPowerOfTwo', done => {
+    test('nextPowerOfTwo', () => new Promise(done => {
         expect(isPowerOfTwo(nextPowerOfTwo(1))).toBe(true);
         expect(isPowerOfTwo(nextPowerOfTwo(2))).toBe(true);
         expect(isPowerOfTwo(nextPowerOfTwo(256))).toBe(true);
@@ -45,32 +45,32 @@ describe('util', () => {
         expect(isPowerOfTwo(nextPowerOfTwo(-42))).toBe(true);
         expect(isPowerOfTwo(nextPowerOfTwo(42))).toBe(true);
         done();
-    });
+    }));
 
-    test('clamp', done => {
+    test('clamp', () => new Promise(done => {
         expect(clamp(0, 0, 1)).toBe(0);
         expect(clamp(1, 0, 1)).toBe(1);
         expect(clamp(200, 0, 180)).toBe(180);
         expect(clamp(-200, 0, 180)).toBe(0);
         done();
-    });
+    }));
 
-    test('wrap', done => {
+    test('wrap', () => new Promise(done => {
         expect(wrap(0, 0, 1)).toBe(1);
         expect(wrap(1, 0, 1)).toBe(1);
         expect(wrap(200, 0, 180)).toBe(20);
         expect(wrap(-200, 0, 180)).toBe(160);
         done();
-    });
+    }));
 
-    test('bezier', done => {
+    test('bezier', () => new Promise(done => {
         const curve = bezier(0, 0, 0.25, 1);
         expect(curve instanceof Function).toBeTruthy();
         expect(curve(0)).toBe(0);
         expect(curve(1)).toBe(1);
         expect(curve(0.5)).toBe(0.8230854638965502);
         done();
-    });
+    }));
 
     test('mapObject', () => {
         expect.assertions(5);
@@ -84,7 +84,7 @@ describe('util', () => {
         }, that)).toEqual({map: 'BOX'});
     });
 
-    test('filterObject', done => {
+    test('filterObject', () => new Promise(done => {
         expect.assertions(6);
         expect(filterObject({}, () => { expect(false).toBeTruthy(); })).toEqual({});
         const that = {};
@@ -99,9 +99,9 @@ describe('util', () => {
             return value === 'box';
         })).toEqual({map: 'box'});
         done();
-    });
+    }));
 
-    test('deepEqual', done => {
+    test('deepEqual', () => new Promise(done => {
         const a = {
             foo: 'bar',
             bar: {
@@ -120,84 +120,84 @@ describe('util', () => {
         expect(deepEqual(null, null)).toBeTruthy();
 
         done();
-    });
+    }));
 });
 
 describe('util clone', () => {
-    test('array', done => {
+    test('array', () => new Promise(done => {
         const input = [false, 1, 'two'];
         const output = clone(input);
         expect(input).not.toBe(output);
         expect(input).toEqual(output);
         done();
-    });
+    }));
 
-    test('object', done => {
+    test('object', () => new Promise(done => {
         const input = {a: false, b: 1, c: 'two'};
         const output = clone(input);
         expect(input).not.toBe(output);
         expect(input).toEqual(output);
         done();
-    });
+    }));
 
-    test('deep object', done => {
+    test('deep object', () => new Promise(done => {
         const input = {object: {a: false, b: 1, c: 'two'}};
         const output = clone(input);
         expect(input.object).not.toBe(output.object);
         expect(input.object).toEqual(output.object);
         done();
-    });
+    }));
 
-    test('deep array', done => {
+    test('deep array', () => new Promise(done => {
         const input = {array: [false, 1, 'two']};
         const output = clone(input);
         expect(input.array).not.toBe(output.array);
         expect(input.array).toEqual(output.array);
         done();
-    });
+    }));
 });
 
 describe('util arraysIntersect', () => {
-    test('intersection', done => {
+    test('intersection', () => new Promise(done => {
         const a = ['1', '2', '3'];
         const b = ['5', '4', '3'];
 
         expect(arraysIntersect(a, b)).toBe(true);
         done();
-    });
+    }));
 
-    test('no intersection', done => {
+    test('no intersection', () => new Promise(done => {
         const a = ['1', '2', '3'];
         const b = ['4', '5', '6'];
 
         expect(arraysIntersect(a, b)).toBe(false);
         done();
-    });
+    }));
 
 });
 
 describe('util isCounterClockwise', () => {
-    test('counter clockwise', done => {
+    test('counter clockwise', () => new Promise(done => {
         const a = new Point(0, 0);
         const b = new Point(1, 0);
         const c = new Point(1, 1);
 
         expect(isCounterClockwise(a, b, c)).toBe(true);
         done();
-    });
+    }));
 
-    test('clockwise', done => {
+    test('clockwise', () => new Promise(done => {
         const a = new Point(0, 0);
         const b = new Point(1, 0);
         const c = new Point(1, 1);
 
         expect(isCounterClockwise(c, b, a)).toBe(false);
         done();
-    });
+    }));
 });
 
 describe('util parseCacheControl', () => {
-    test('max-age', done => {
+    test('max-age', () => new Promise(done => {
         expect(parseCacheControl('max-age=123456789')).toEqual({
             'max-age': 123456789
         });
@@ -209,7 +209,7 @@ describe('util parseCacheControl', () => {
         expect(parseCacheControl('max-age=null')).toEqual({});
 
         done();
-    });
+    }));
 
 });
 

--- a/src/util/util.test.ts
+++ b/src/util/util.test.ts
@@ -14,7 +14,7 @@ describe('util', () => {
     expect(pick({a: 1, b: 2, c: 3}, ['a', 'c', 'd'] as any)).toEqual({a: 1, c: 3});
     expect(typeof uniqueId() === 'number').toBeTruthy();
 
-    test('isPowerOfTwo', () => new Promise(done => {
+    test('isPowerOfTwo', () => new Promise<void>(done => {
         expect(isPowerOfTwo(1)).toBe(true);
         expect(isPowerOfTwo(2)).toBe(true);
         expect(isPowerOfTwo(256)).toBe(true);
@@ -25,7 +25,7 @@ describe('util', () => {
         done();
     }));
 
-    test('nextPowerOfTwo', () => new Promise(done => {
+    test('nextPowerOfTwo', () => new Promise<void>(done => {
         expect(nextPowerOfTwo(1)).toBe(1);
         expect(nextPowerOfTwo(2)).toBe(2);
         expect(nextPowerOfTwo(256)).toBe(256);
@@ -36,7 +36,7 @@ describe('util', () => {
         done();
     }));
 
-    test('nextPowerOfTwo', () => new Promise(done => {
+    test('nextPowerOfTwo', () => new Promise<void>(done => {
         expect(isPowerOfTwo(nextPowerOfTwo(1))).toBe(true);
         expect(isPowerOfTwo(nextPowerOfTwo(2))).toBe(true);
         expect(isPowerOfTwo(nextPowerOfTwo(256))).toBe(true);
@@ -47,7 +47,7 @@ describe('util', () => {
         done();
     }));
 
-    test('clamp', () => new Promise(done => {
+    test('clamp', () => new Promise<void>(done => {
         expect(clamp(0, 0, 1)).toBe(0);
         expect(clamp(1, 0, 1)).toBe(1);
         expect(clamp(200, 0, 180)).toBe(180);
@@ -55,7 +55,7 @@ describe('util', () => {
         done();
     }));
 
-    test('wrap', () => new Promise(done => {
+    test('wrap', () => new Promise<void>(done => {
         expect(wrap(0, 0, 1)).toBe(1);
         expect(wrap(1, 0, 1)).toBe(1);
         expect(wrap(200, 0, 180)).toBe(20);
@@ -63,7 +63,7 @@ describe('util', () => {
         done();
     }));
 
-    test('bezier', () => new Promise(done => {
+    test('bezier', () => new Promise<void>(done => {
         const curve = bezier(0, 0, 0.25, 1);
         expect(curve instanceof Function).toBeTruthy();
         expect(curve(0)).toBe(0);
@@ -84,7 +84,7 @@ describe('util', () => {
         }, that)).toEqual({map: 'BOX'});
     });
 
-    test('filterObject', () => new Promise(done => {
+    test('filterObject', () => new Promise<void>(done => {
         expect.assertions(6);
         expect(filterObject({}, () => { expect(false).toBeTruthy(); })).toEqual({});
         const that = {};
@@ -101,7 +101,7 @@ describe('util', () => {
         done();
     }));
 
-    test('deepEqual', () => new Promise(done => {
+    test('deepEqual', () => new Promise<void>(done => {
         const a = {
             foo: 'bar',
             bar: {
@@ -124,7 +124,7 @@ describe('util', () => {
 });
 
 describe('util clone', () => {
-    test('array', () => new Promise(done => {
+    test('array', () => new Promise<void>(done => {
         const input = [false, 1, 'two'];
         const output = clone(input);
         expect(input).not.toBe(output);
@@ -132,7 +132,7 @@ describe('util clone', () => {
         done();
     }));
 
-    test('object', () => new Promise(done => {
+    test('object', () => new Promise<void>(done => {
         const input = {a: false, b: 1, c: 'two'};
         const output = clone(input);
         expect(input).not.toBe(output);
@@ -140,7 +140,7 @@ describe('util clone', () => {
         done();
     }));
 
-    test('deep object', () => new Promise(done => {
+    test('deep object', () => new Promise<void>(done => {
         const input = {object: {a: false, b: 1, c: 'two'}};
         const output = clone(input);
         expect(input.object).not.toBe(output.object);
@@ -148,7 +148,7 @@ describe('util clone', () => {
         done();
     }));
 
-    test('deep array', () => new Promise(done => {
+    test('deep array', () => new Promise<void>(done => {
         const input = {array: [false, 1, 'two']};
         const output = clone(input);
         expect(input.array).not.toBe(output.array);
@@ -158,7 +158,7 @@ describe('util clone', () => {
 });
 
 describe('util arraysIntersect', () => {
-    test('intersection', () => new Promise(done => {
+    test('intersection', () => new Promise<void>(done => {
         const a = ['1', '2', '3'];
         const b = ['5', '4', '3'];
 
@@ -166,7 +166,7 @@ describe('util arraysIntersect', () => {
         done();
     }));
 
-    test('no intersection', () => new Promise(done => {
+    test('no intersection', () => new Promise<void>(done => {
         const a = ['1', '2', '3'];
         const b = ['4', '5', '6'];
 
@@ -177,7 +177,7 @@ describe('util arraysIntersect', () => {
 });
 
 describe('util isCounterClockwise', () => {
-    test('counter clockwise', () => new Promise(done => {
+    test('counter clockwise', () => new Promise<void>(done => {
         const a = new Point(0, 0);
         const b = new Point(1, 0);
         const c = new Point(1, 1);
@@ -186,7 +186,7 @@ describe('util isCounterClockwise', () => {
         done();
     }));
 
-    test('clockwise', () => new Promise(done => {
+    test('clockwise', () => new Promise<void>(done => {
         const a = new Point(0, 0);
         const b = new Point(1, 0);
         const c = new Point(1, 1);
@@ -197,7 +197,7 @@ describe('util isCounterClockwise', () => {
 });
 
 describe('util parseCacheControl', () => {
-    test('max-age', () => new Promise(done => {
+    test('max-age', () => new Promise<void>(done => {
         expect(parseCacheControl('max-age=123456789')).toEqual({
             'max-age': 123456789
         });

--- a/src/util/util.test.ts
+++ b/src/util/util.test.ts
@@ -14,7 +14,7 @@ describe('util', () => {
     expect(pick({a: 1, b: 2, c: 3}, ['a', 'c', 'd'] as any)).toEqual({a: 1, c: 3});
     expect(typeof uniqueId() === 'number').toBeTruthy();
 
-    test('isPowerOfTwo', () => new Promise<void>(done => {
+    test('isPowerOfTwo', () => {
         expect(isPowerOfTwo(1)).toBe(true);
         expect(isPowerOfTwo(2)).toBe(true);
         expect(isPowerOfTwo(256)).toBe(true);
@@ -22,10 +22,9 @@ describe('util', () => {
         expect(isPowerOfTwo(0)).toBe(false);
         expect(isPowerOfTwo(-42)).toBe(false);
         expect(isPowerOfTwo(42)).toBe(false);
-        done();
-    }));
+    });
 
-    test('nextPowerOfTwo', () => new Promise<void>(done => {
+    test('nextPowerOfTwo', () => {
         expect(nextPowerOfTwo(1)).toBe(1);
         expect(nextPowerOfTwo(2)).toBe(2);
         expect(nextPowerOfTwo(256)).toBe(256);
@@ -33,10 +32,9 @@ describe('util', () => {
         expect(nextPowerOfTwo(0)).toBe(1);
         expect(nextPowerOfTwo(-42)).toBe(1);
         expect(nextPowerOfTwo(42)).toBe(64);
-        done();
-    }));
+    });
 
-    test('nextPowerOfTwo', () => new Promise<void>(done => {
+    test('nextPowerOfTwo', () => {
         expect(isPowerOfTwo(nextPowerOfTwo(1))).toBe(true);
         expect(isPowerOfTwo(nextPowerOfTwo(2))).toBe(true);
         expect(isPowerOfTwo(nextPowerOfTwo(256))).toBe(true);
@@ -44,33 +42,29 @@ describe('util', () => {
         expect(isPowerOfTwo(nextPowerOfTwo(0))).toBe(true);
         expect(isPowerOfTwo(nextPowerOfTwo(-42))).toBe(true);
         expect(isPowerOfTwo(nextPowerOfTwo(42))).toBe(true);
-        done();
-    }));
+    });
 
-    test('clamp', () => new Promise<void>(done => {
+    test('clamp', () => {
         expect(clamp(0, 0, 1)).toBe(0);
         expect(clamp(1, 0, 1)).toBe(1);
         expect(clamp(200, 0, 180)).toBe(180);
         expect(clamp(-200, 0, 180)).toBe(0);
-        done();
-    }));
+    });
 
-    test('wrap', () => new Promise<void>(done => {
+    test('wrap', () => {
         expect(wrap(0, 0, 1)).toBe(1);
         expect(wrap(1, 0, 1)).toBe(1);
         expect(wrap(200, 0, 180)).toBe(20);
         expect(wrap(-200, 0, 180)).toBe(160);
-        done();
-    }));
+    });
 
-    test('bezier', () => new Promise<void>(done => {
+    test('bezier', () => {
         const curve = bezier(0, 0, 0.25, 1);
         expect(curve instanceof Function).toBeTruthy();
         expect(curve(0)).toBe(0);
         expect(curve(1)).toBe(1);
         expect(curve(0.5)).toBe(0.8230854638965502);
-        done();
-    }));
+    });
 
     test('mapObject', () => {
         expect.assertions(5);
@@ -84,7 +78,7 @@ describe('util', () => {
         }, that)).toEqual({map: 'BOX'});
     });
 
-    test('filterObject', () => new Promise<void>(done => {
+    test('filterObject', () => {
         expect.assertions(6);
         expect(filterObject({}, () => { expect(false).toBeTruthy(); })).toEqual({});
         const that = {};
@@ -98,10 +92,9 @@ describe('util', () => {
         expect(filterObject({map: 'box', box: 'map'}, (value) => {
             return value === 'box';
         })).toEqual({map: 'box'});
-        done();
-    }));
+    });
 
-    test('deepEqual', () => new Promise<void>(done => {
+    test('deepEqual', () => {
         const a = {
             foo: 'bar',
             bar: {
@@ -118,86 +111,75 @@ describe('util', () => {
         expect(deepEqual(a, null)).toBeFalsy();
         expect(deepEqual(null, c)).toBeFalsy();
         expect(deepEqual(null, null)).toBeTruthy();
-
-        done();
-    }));
+    });
 });
 
 describe('util clone', () => {
-    test('array', () => new Promise<void>(done => {
+    test('array', () => {
         const input = [false, 1, 'two'];
         const output = clone(input);
         expect(input).not.toBe(output);
         expect(input).toEqual(output);
-        done();
-    }));
+    });
 
-    test('object', () => new Promise<void>(done => {
+    test('object', () => {
         const input = {a: false, b: 1, c: 'two'};
         const output = clone(input);
         expect(input).not.toBe(output);
         expect(input).toEqual(output);
-        done();
-    }));
+    });
 
-    test('deep object', () => new Promise<void>(done => {
+    test('deep object', () => {
         const input = {object: {a: false, b: 1, c: 'two'}};
         const output = clone(input);
         expect(input.object).not.toBe(output.object);
         expect(input.object).toEqual(output.object);
-        done();
-    }));
+    });
 
-    test('deep array', () => new Promise<void>(done => {
+    test('deep array', () => {
         const input = {array: [false, 1, 'two']};
         const output = clone(input);
         expect(input.array).not.toBe(output.array);
         expect(input.array).toEqual(output.array);
-        done();
-    }));
+    });
 });
 
 describe('util arraysIntersect', () => {
-    test('intersection', () => new Promise<void>(done => {
+    test('intersection', () => {
         const a = ['1', '2', '3'];
         const b = ['5', '4', '3'];
 
         expect(arraysIntersect(a, b)).toBe(true);
-        done();
-    }));
+    });
 
-    test('no intersection', () => new Promise<void>(done => {
+    test('no intersection', () => {
         const a = ['1', '2', '3'];
         const b = ['4', '5', '6'];
 
         expect(arraysIntersect(a, b)).toBe(false);
-        done();
-    }));
-
+    });
 });
 
 describe('util isCounterClockwise', () => {
-    test('counter clockwise', () => new Promise<void>(done => {
+    test('counter clockwise', () => {
         const a = new Point(0, 0);
         const b = new Point(1, 0);
         const c = new Point(1, 1);
 
         expect(isCounterClockwise(a, b, c)).toBe(true);
-        done();
-    }));
+    });
 
-    test('clockwise', () => new Promise<void>(done => {
+    test('clockwise', () => {
         const a = new Point(0, 0);
         const b = new Point(1, 0);
         const c = new Point(1, 1);
 
         expect(isCounterClockwise(c, b, a)).toBe(false);
-        done();
-    }));
+    });
 });
 
 describe('util parseCacheControl', () => {
-    test('max-age', () => new Promise<void>(done => {
+    test('max-age', () => {
         expect(parseCacheControl('max-age=123456789')).toEqual({
             'max-age': 123456789
         });
@@ -207,10 +189,7 @@ describe('util parseCacheControl', () => {
         });
 
         expect(parseCacheControl('max-age=null')).toEqual({});
-
-        done();
-    }));
-
+    });
 });
 
 describe('util findLineIntersection', () => {

--- a/test/integration/browser/browser.test.ts
+++ b/test/integration/browser/browser.test.ts
@@ -287,7 +287,7 @@ describe('Browser tests', () => {
     test('Fullscreen control should work in shadowdom as well', async () => {
         const fullscreenButtonTitle = await page.evaluate(async () => {
             function sleepInBrowser(milliseconds: number) {
-                return sleep(milliseconds);
+                return new Promise(resolve => setTimeout(resolve, milliseconds));
             }
 
             let map: Map;

--- a/test/integration/browser/browser.test.ts
+++ b/test/integration/browser/browser.test.ts
@@ -287,7 +287,7 @@ describe('Browser tests', () => {
     test('Fullscreen control should work in shadowdom as well', async () => {
         const fullscreenButtonTitle = await page.evaluate(async () => {
             function sleepInBrowser(milliseconds: number) {
-                return new Promise(resolve => setTimeout(resolve, milliseconds));
+                return sleep(milliseconds);
             }
 
             let map: Map;


### PR DESCRIPTION
When Jest was created some 12-13 years ago, there weren't promises nor await/async around, and therefore they added the custom done() api instead. Newer tooling [just use the platform](https://vitest.dev/guide/migration.html#done-callback), instead of having these two test modes (1. done/done('error'), 2. async/await/Promise/Error).

I've here updated our unit test suite to be consistent in using the platform mode, instead of jest.done(), and focused on keeping a minimal line diff to avoid merge conflicts (e.g. no change in indentation or order of logic anywhere). 

Related to (see https://github.com/maplibre/maplibre-gl-js/pull/4684#issuecomment-2340716107):
- #1595 
- #977 

 - [X] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!