### PR TITLE
improve unpkg instructions

### DIFF
--- a/build/generate-docs.ts
+++ b/build/generate-docs.ts
@@ -166,22 +166,16 @@ ${groups['JAVASCRIPT-BINDINGS']}
 }
 
 function updateMapLibreVersionForUNPKG() {
-    // Read the version from package.json
-    const packageJsonPath = path.join(process.cwd(), 'package.json');
-    const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'));
-    const maplibreVersion = packageJson.version;
 
-    // Read the index.md file
+    // Read index.md
     const indexPath = path.join(process.cwd(), 'docs/index.md');
     let indexContent = fs.readFileSync(indexPath, 'utf-8');
 
-    // Replace the version number in the unpkg.com URL with the actual version
-    indexContent = indexContent.replace(/unpkg\.com\/maplibre-gl@\^(\d+\.\d+\.\d+)/g, `unpkg.com/maplibre-gl@^${maplibreVersion}`);
+    // Replace the version number
+    indexContent = indexContent.replace(/unpkg\.com\/maplibre-gl@\^(\d+\.\d+\.\d+)/g, `unpkg.com/maplibre-gl@^${packageJson.version}`);
 
-    // Write the updated content back to the index.md file
+    // Save index.md
     fs.writeFileSync(indexPath, indexContent);
-
-    console.log(`Updated MapLibre version to ${maplibreVersion} in docs/index.md`);
 }
 
 // !!Main flow start here!!

--- a/build/generate-docs.ts
+++ b/build/generate-docs.ts
@@ -168,7 +168,7 @@ ${groups['JAVASCRIPT-BINDINGS']}
 function updateMapLibreVersionForUNPKG() {
 
     // Read index.md
-    const indexPath = path.join(process.cwd(), 'docs/index.md');
+    const indexPath = 'docs/index.md';
     let indexContent = fs.readFileSync(indexPath, 'utf-8');
 
     // Replace the version number

--- a/build/generate-docs.ts
+++ b/build/generate-docs.ts
@@ -165,6 +165,25 @@ ${groups['JAVASCRIPT-BINDINGS']}
     fs.writeFileSync('docs/plugins.md', pluginsContent, {encoding: 'utf-8'});
 }
 
+function updateMapLibreVersionForUNPKG() {
+    // Read the version from package.json
+    const packageJsonPath = path.join(process.cwd(), 'package.json');
+    const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'));
+    const maplibreVersion = packageJson.version;
+
+    // Read the index.md file
+    const indexPath = path.join(process.cwd(), 'docs/index.md');
+    let indexContent = fs.readFileSync(indexPath, 'utf-8');
+
+    // Replace the version number in the unpkg.com URL with the actual version
+    indexContent = indexContent.replace(/unpkg\.com\/maplibre-gl@\^(\d+\.\d+\.\d+)/g, `unpkg.com/maplibre-gl@^${maplibreVersion}`);
+
+    // Write the updated content back to the index.md file
+    fs.writeFileSync(indexPath, indexContent);
+
+    console.log(`Updated MapLibre version to ${maplibreVersion} in docs/index.md`);
+}
+
 // !!Main flow start here!!
 if (!fs.existsSync(typedocConfig.out)) {
     throw new Error('Please run typedoc generation first!');
@@ -173,4 +192,5 @@ fs.rmSync(path.join(typedocConfig.out, 'README.md'));
 generateReadme();
 generateExamplesFolder();
 await generatePluginsPage();
+updateMapLibreVersionForUNPKG();
 console.log('Docs generation completed, to see it in action run\n npm run start-docs');

--- a/docs/index.md
+++ b/docs/index.md
@@ -94,6 +94,6 @@ Note too that if the CSS isn't available by the first render, as soon as the CSS
 MapLibre GL JS is also distributed via UNPKG. Our latest version can installed by adding below tags this in the html `<head>`. Further instructions on how to select specific versions and semver ranges can be found on at [unpkg.com](https://unpkg.com).
 
 ```html
-<script src="https://unpkg.com/maplibre-gl/dist/maplibre-gl.js"></script>
-<link href="https://unpkg.com/maplibre-gl/dist/maplibre-gl.css" rel="stylesheet" />
+<script src="https://unpkg.com/maplibre-gl@^4/dist/maplibre-gl.js"></script>
+<link href="https://unpkg.com/maplibre-gl@^4/dist/maplibre-gl.css" rel="stylesheet" />
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -91,7 +91,7 @@ Note too that if the CSS isn't available by the first render, as soon as the CSS
 
 ## CDN
 
-MapLibre GL JS is also distributed via UNPKG. Our latest version can installed by adding below tags this in the html `<head>`. Further instructions on how to select specific versions and semver ranges can be found on at [unpkg.com](https://unpkg.com):
+MapLibre GL JS is also distributed via UNPKG. Our latest version can installed by adding below tags this in the html `<head>`. Further instructions on how to select specific versions and semver ranges can be found on at [unpkg.com](https://unpkg.com).
 
 ```html
 <script src="https://unpkg.com/maplibre-gl/dist/maplibre-gl.js"></script>

--- a/docs/index.md
+++ b/docs/index.md
@@ -91,12 +91,9 @@ Note too that if the CSS isn't available by the first render, as soon as the CSS
 
 ## CDN
 
-The MapLibre GL JS (`.js` & `.css`) are distributed via [UNPKG.com](https://unpkg.com).
-You can view a listing of all the files in the MapLibre GL JS package by appending a `/` at the end of the MapLibre slug. This is useful to review other revisions or to review the files at UNPKG or the LICENSE. See examples in the following table:
+MapLibre GL JS is also distributed via UNPKG. Our latest version can installed by adding below tags this in the html `<head>`. Further instructions on how to select specific versions and semver ranges can be found on at [unpkg.com](https://unpkg.com):
 
-### Examples
-
-| Use Case  | `.js` | `.css` |
-| :------- | :---: | :----: |
-| `latest` | <https://unpkg.com/maplibre-gl/dist/maplibre-gl.js> | <https://unpkg.com/maplibre-gl/dist/maplibre-gl.css> |
-| Use at least `2.4.x` | <https://unpkg.com/maplibre-gl@^2.4/dist/maplibre-gl.js> | <https://unpkg.com/maplibre-gl@^2.4/dist/maplibre-gl.css> |
+```html
+<script src="https://unpkg.com/maplibre-gl/dist/maplibre-gl.js"></script>
+<link href="https://unpkg.com/maplibre-gl/dist/maplibre-gl.css" rel="stylesheet" />
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -94,6 +94,6 @@ Note too that if the CSS isn't available by the first render, as soon as the CSS
 MapLibre GL JS is also distributed via UNPKG. Our latest version can installed by adding below tags this in the html `<head>`. Further instructions on how to select specific versions and semver ranges can be found on at [unpkg.com](https://unpkg.com).
 
 ```html
-<script src="https://unpkg.com/maplibre-gl@^4/dist/maplibre-gl.js"></script>
-<link href="https://unpkg.com/maplibre-gl@^4/dist/maplibre-gl.css" rel="stylesheet" />
+<script src="https://unpkg.com/maplibre-gl@^4.7.0/dist/maplibre-gl.js"></script>
+<link href="https://unpkg.com/maplibre-gl@^4.7.0/dist/maplibre-gl.css" rel="stylesheet" />
 ```


### PR DESCRIPTION
Closes #4273
- #4273

This PR automatically sets the version in the unpkg script the latest such as `^4.7.0` allowing for minor/patch updates. 

Before
<img width="709" alt="Screenshot 2024-09-15 at 15 36 21" src="https://github.com/user-attachments/assets/41d7e94e-2ae3-4c2c-b74e-8874b303ee95">


After
<img width="735" alt="Screenshot 2024-09-19 at 21 27 25" src="https://github.com/user-attachments/assets/1716b2be-661e-451f-b1c0-b16703b5f212">



 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
