### PR TITLE
Fix hash router for urls ending with a hash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### 🐞 Bug fixes
 - Fix circle won't render on mesa 24.1 with AMD GPU ([#4062](https://github.com/maplibre/maplibre-gl-js/issues/4062))
+- Fix hash router for urls ending with a hashtag ([#4730](https://github.com/maplibre/maplibre-gl-js/pull/4730))
 - _...Add new stuff here..._
 
 ## 4.7.0

--- a/src/ui/hash.test.ts
+++ b/src/ui/hash.test.ts
@@ -327,6 +327,13 @@ describe('hash', () => {
         expect(window.location.hash).toBe('#baz&foo=bar');
     });
 
+    test('url ending with hash', ()=>{
+        window.location.href = 'http://localhost/#';
+        createHash().addTo(map);
+        map.setZoom(3);
+        expect(window.location.hash).toBe('#3/0/0');
+    });
+
     test('map#remove', () => {
         const container = window.document.createElement('div');
         Object.defineProperty(container, 'clientWidth', {value: 512});

--- a/src/ui/hash.test.ts
+++ b/src/ui/hash.test.ts
@@ -327,11 +327,69 @@ describe('hash', () => {
         expect(window.location.hash).toBe('#baz&foo=bar');
     });
 
-    test('url ending with hash', () => {
+    test('initialize http://localhost/#', () => {
         window.location.href = 'http://localhost/#';
         createHash().addTo(map);
         map.setZoom(3);
         expect(window.location.hash).toBe('#3/0/0');
+        expect(window.location.href).toBe('http://localhost/#3/0/0');
+        map.setCenter([2.0, 1.0]);
+        expect(window.location.hash).toBe('#3/1/2');
+        expect(window.location.href).toBe('http://localhost/#3/1/2');
+    });
+
+    test('initialize http://localhost/##', () => {
+        window.location.href = 'http://localhost/##';
+        createHash().addTo(map);
+        map.setZoom(3);
+        expect(window.location.hash).toBe('#3/0/0');
+        expect(window.location.href).toBe('http://localhost/#3/0/0');
+        map.setCenter([2.0, 1.0]);
+        expect(window.location.hash).toBe('#3/1/2');
+        expect(window.location.href).toBe('http://localhost/#3/1/2');
+    });
+
+    test('initialize http://localhost#', () => {
+        window.location.href = 'http://localhost#';
+        createHash().addTo(map);
+        map.setZoom(4);
+        expect(window.location.hash).toBe('#4/0/0');
+        expect(window.location.href).toBe('http://localhost/#4/0/0');
+        map.setCenter([2.0, 1.0]);
+        expect(window.location.hash).toBe('#4/1/2');
+        expect(window.location.href).toBe('http://localhost/#4/1/2');
+    });
+
+    test('initialize http://localhost/', () => {
+        window.location.href = 'http://localhost/';
+        createHash().addTo(map);
+        map.setZoom(5);
+        expect(window.location.hash).toBe('#5/0/0');
+        expect(window.location.href).toBe('http://localhost/#5/0/0');
+        map.setCenter([2.0, 1.0]);
+        expect(window.location.hash).toBe('#5/1/2');
+        expect(window.location.href).toBe('http://localhost/#5/1/2');
+    });
+
+    test('initialize default value for window.location.href', () => {
+        createHash().addTo(map);
+        map.setZoom(5);
+        expect(window.location.hash).toBe('#5/0/0');
+        expect(window.location.href).toBe('http://localhost/#5/0/0');
+        map.setCenter([2.0, 1.0]);
+        expect(window.location.hash).toBe('#5/1/2');
+        expect(window.location.href).toBe('http://localhost/#5/1/2');
+    });
+
+    test('initialize http://localhost', () => {
+        window.location.href = 'http://localhost';
+        createHash().addTo(map);
+        map.setZoom(4);
+        expect(window.location.hash).toBe('#4/0/0');
+        expect(window.location.href).toBe('http://localhost/#4/0/0');
+        map.setCenter([2.0, 1.0]);
+        expect(window.location.hash).toBe('#4/1/2');
+        expect(window.location.href).toBe('http://localhost/#4/1/2');
     });
 
     test('map#remove', () => {

--- a/src/ui/hash.test.ts
+++ b/src/ui/hash.test.ts
@@ -327,7 +327,7 @@ describe('hash', () => {
         expect(window.location.hash).toBe('#baz&foo=bar');
     });
 
-    test('url ending with hash', ()=>{
+    test('url ending with hash', () => {
         window.location.href = 'http://localhost/#';
         createHash().addTo(map);
         map.setZoom(3);

--- a/src/ui/hash.ts
+++ b/src/ui/hash.ts
@@ -118,7 +118,7 @@ export class Hash {
 
     _updateHashUnthrottled = () => {
         // Replace if already present, else append the updated hash string
-        const location = window.location.href.replace(/(#.+)?$/, this.getHashString());
+        const location = window.location.href.replace(/(#.*)?$/, this.getHashString());
         window.history.replaceState(window.history.state, null, location);
     };
 


### PR DESCRIPTION
Closes #4732 
- #4732 

I've added a test for this, and a fix which is to modify the regex that recognize the hash. The section following the hashtag should be zero/one/more chars (.*), instead of one/more chars (.+).

Result before this PR:
`http://localhost:9966/test/examples/cluster.html##3/40.67/-103.59`

Result after this PR:
`http://localhost:9966/test/examples/cluster.html#3/40.67/-103.59`

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
