### PR TITLE
Camera Roll

### DIFF
--- a/src/geo/projection/camera_helper.ts
+++ b/src/geo/projection/camera_helper.ts
@@ -23,6 +23,7 @@ export type CameraForBoxAndBearingHandlerResult = {
 export type EaseToHandlerOptions = {
     bearing: number;
     pitch: number;
+    roll: number;
     padding: PaddingOptions;
     offsetAsPoint: Point;
     around?: LngLat;
@@ -41,6 +42,7 @@ export type EaseToHandlerResult = {
 export type FlyToHandlerOptions = {
     bearing: number;
     pitch: number;
+    roll: number;
     padding: PaddingOptions;
     offsetAsPoint: Point;
     center?: LngLatLike;

--- a/src/geo/projection/globe_camera_helper.ts
+++ b/src/geo/projection/globe_camera_helper.ts
@@ -191,6 +191,7 @@ export class GlobeCameraHelper implements ICameraHelper {
         clonedTr.setCenter(result.center);
         clonedTr.setBearing(result.bearing);
         clonedTr.setPitch(0);
+        clonedTr.setRoll(0);
         clonedTr.setZoom(result.zoom);
         const matrix = clonedTr.modelViewProjectionMatrix;
 
@@ -261,6 +262,7 @@ export class GlobeCameraHelper implements ICameraHelper {
         const startZoom = tr.zoom;
         const startBearing = tr.bearing;
         const startPitch = tr.pitch;
+        const startRoll = tr.roll;
         const startCenter = tr.center;
 
         const optionsZoom = typeof options.zoom !== 'undefined';
@@ -317,6 +319,9 @@ export class GlobeCameraHelper implements ICameraHelper {
             }
             if (startPitch !== options.pitch) {
                 tr.setPitch(interpolates.number(startPitch, options.pitch, k));
+            }
+            if (startRoll !== options.roll) {
+                tr.setRoll(interpolates.number(startRoll, options.roll, k));
             }
 
             if (options.around) {

--- a/src/geo/projection/globe_transform.ts
+++ b/src/geo/projection/globe_transform.ts
@@ -93,6 +93,9 @@ export class GlobeTransform implements ITransform {
     setPitch(pitch: number): void {
         this._helper.setPitch(pitch);
     }
+    setRoll(roll: number): void {
+        this._helper.setRoll(roll);
+    }
     setFov(fov: number): void {
         this._helper.setFov(fov);
     }
@@ -180,6 +183,9 @@ export class GlobeTransform implements ITransform {
     }
     get pitch(): number {
         return this._helper.pitch;
+    }
+    get roll(): number {
+        return this._helper.roll;
     }
     get bearing(): number {
         return this._helper.bearing;
@@ -628,6 +634,7 @@ export class GlobeTransform implements ITransform {
         this._globeProjMatrixInverted = createMat4f64();
         mat4.invert(this._globeProjMatrixInverted, globeMatrix);
         mat4.translate(globeMatrix, globeMatrix, [0, 0, -this.cameraToCenterDistance]);
+        mat4.rotateZ(globeMatrix, globeMatrix, -this.roll * Math.PI / 180);
         mat4.rotateX(globeMatrix, globeMatrix, -this.pitch * Math.PI / 180);
         mat4.rotateZ(globeMatrix, globeMatrix, -this.angle);
         mat4.translate(globeMatrix, globeMatrix, [0.0, 0, -globeRadiusPixels]);
@@ -655,6 +662,7 @@ export class GlobeTransform implements ITransform {
         const zero = createVec3f64();
         this._cameraPosition = createVec3f64();
         this._cameraPosition[2] = this.cameraToCenterDistance / globeRadiusPixels;
+        vec3.rotateZ(this._cameraPosition, this._cameraPosition, zero, this.roll * Math.PI / 180);
         vec3.rotateX(this._cameraPosition, this._cameraPosition, zero, this.pitch * Math.PI / 180);
         vec3.rotateZ(this._cameraPosition, this._cameraPosition, zero, this.angle);
         vec3.add(this._cameraPosition, this._cameraPosition, [0, 0, 1]);

--- a/src/geo/projection/globe_transform.ts
+++ b/src/geo/projection/globe_transform.ts
@@ -634,7 +634,7 @@ export class GlobeTransform implements ITransform {
         this._globeProjMatrixInverted = createMat4f64();
         mat4.invert(this._globeProjMatrixInverted, globeMatrix);
         mat4.translate(globeMatrix, globeMatrix, [0, 0, -this.cameraToCenterDistance]);
-        mat4.rotateZ(globeMatrix, globeMatrix, -this.roll * Math.PI / 180);
+        mat4.rotateZ(globeMatrix, globeMatrix, this.roll * Math.PI / 180);
         mat4.rotateX(globeMatrix, globeMatrix, -this.pitch * Math.PI / 180);
         mat4.rotateZ(globeMatrix, globeMatrix, -this.angle);
         mat4.translate(globeMatrix, globeMatrix, [0.0, 0, -globeRadiusPixels]);
@@ -662,7 +662,7 @@ export class GlobeTransform implements ITransform {
         const zero = createVec3f64();
         this._cameraPosition = createVec3f64();
         this._cameraPosition[2] = this.cameraToCenterDistance / globeRadiusPixels;
-        vec3.rotateZ(this._cameraPosition, this._cameraPosition, zero, this.roll * Math.PI / 180);
+        vec3.rotateZ(this._cameraPosition, this._cameraPosition, zero, -this.roll * Math.PI / 180);
         vec3.rotateX(this._cameraPosition, this._cameraPosition, zero, this.pitch * Math.PI / 180);
         vec3.rotateZ(this._cameraPosition, this._cameraPosition, zero, this.angle);
         vec3.add(this._cameraPosition, this._cameraPosition, [0, 0, 1]);

--- a/src/geo/projection/mercator_camera_helper.ts
+++ b/src/geo/projection/mercator_camera_helper.ts
@@ -126,10 +126,10 @@ export class MercatorCameraHelper implements ICameraHelper {
         const startPitch = tr.pitch;
         const startRoll = tr.roll;
         const startPadding = tr.padding;
-        let startRotation: quat = new Float64Array(4) as any;
+        const startRotation: quat = new Float64Array(4) as any;
         quat.fromEuler(startRotation, tr.roll, tr.pitch - 90.0, tr.bearing);
-        let endRotation: quat = new Float64Array(4) as any;
-        quat.fromEuler(endRotation, 
+        const endRotation: quat = new Float64Array(4) as any;
+        quat.fromEuler(endRotation,
             options.roll === undefined ? tr.roll : options.roll,
             options.pitch === undefined ? tr.pitch - 90.0 : options.pitch - 90.0,
             options.bearing === undefined ? tr.bearing : options.bearing);
@@ -162,7 +162,7 @@ export class MercatorCameraHelper implements ICameraHelper {
             }
             if (this.useSlerp) {
                 if (!quat.equals(startRotation, endRotation)) {
-                    let rotation: quat = new Float64Array(4) as any;
+                    const rotation: quat = new Float64Array(4) as any;
                     quat.slerp(rotation, startRotation, endRotation, k);
                     const eulerAngles = getRollPitchBearing(rotation);
                     tr.setRoll(eulerAngles.roll);

--- a/src/geo/projection/mercator_camera_helper.ts
+++ b/src/geo/projection/mercator_camera_helper.ts
@@ -121,6 +121,7 @@ export class MercatorCameraHelper implements ICameraHelper {
         const startZoom = tr.zoom;
         const startBearing = tr.bearing;
         const startPitch = tr.pitch;
+        const startRoll = tr.roll;
         const startPadding = tr.padding;
 
         const optionsZoom = typeof options.zoom !== 'undefined';
@@ -154,6 +155,9 @@ export class MercatorCameraHelper implements ICameraHelper {
             }
             if (startPitch !== options.pitch) {
                 tr.setPitch(interpolates.number(startPitch, options.pitch, k));
+            }
+            if (startRoll !== options.roll) {
+                tr.setRoll(interpolates.number(startRoll, options.roll, k));
             }
             if (doPadding) {
                 tr.interpolatePadding(startPadding, options.padding, k);

--- a/src/geo/projection/mercator_transform.ts
+++ b/src/geo/projection/mercator_transform.ts
@@ -68,6 +68,9 @@ export class MercatorTransform implements ITransform {
     setPitch(pitch: number): void {
         this._helper.setPitch(pitch);
     }
+    setRoll(roll: number): void {
+        this._helper.setRoll(roll);
+    }
     setFov(fov: number): void {
         this._helper.setFov(fov);
     }
@@ -155,6 +158,9 @@ export class MercatorTransform implements ITransform {
     }
     get pitch(): number {
         return this._helper.pitch;
+    }
+    get roll(): number {
+        return this._helper.roll;
     }
     get bearing(): number {
         return this._helper.bearing;
@@ -531,7 +537,8 @@ export class MercatorTransform implements ITransform {
         // 1 Z unit is equivalent to 1 horizontal px at the center of the map
         // (the distance between[width/2, height/2] and [width/2 + 1, height/2])
         const groundAngle = Math.PI / 2 + this._helper._pitch;
-        const fovAboveCenter = this._helper._fov * (0.5 + offset.y / this._helper._height);
+        const zfov = this._helper._fov * (Math.abs(Math.cos(this._helper._roll))*this._helper._height + Math.abs(Math.sin(this._helper._roll))*this._helper._width) / this._helper._height;
+        const fovAboveCenter = zfov * (0.5 + offset.y / this._helper._height);
         const topHalfSurfaceDistance = Math.sin(fovAboveCenter) * lowestPlane / Math.sin(clamp(Math.PI - groundAngle - fovAboveCenter, 0.01, Math.PI - 0.01));
 
         // Find the distance from the center point to the horizon
@@ -568,6 +575,7 @@ export class MercatorTransform implements ITransform {
 
         mat4.scale(m, m, [1, -1, 1]);
         mat4.translate(m, m, [0, 0, -this._cameraToCenterDistance]);
+        mat4.rotateZ(m, m, this._helper._roll);
         mat4.rotateX(m, m, this._helper._pitch);
         mat4.rotateZ(m, m, this._helper._angle);
         mat4.translate(m, m, [-x, -y, 0]);
@@ -603,6 +611,7 @@ export class MercatorTransform implements ITransform {
         this._fogMatrix[9] = offset.y * 2 / this.height;
         mat4.scale(this._fogMatrix, this._fogMatrix, [1, -1, 1]);
         mat4.translate(this._fogMatrix, this._fogMatrix, [0, 0, -this.cameraToCenterDistance]);
+        mat4.rotateZ(this._fogMatrix, this._fogMatrix, this._helper._roll);
         mat4.rotateX(this._fogMatrix, this._fogMatrix, this._helper._pitch);
         mat4.rotateZ(this._fogMatrix, this._fogMatrix, this.angle);
         mat4.translate(this._fogMatrix, this._fogMatrix, [-x, -y, 0]);

--- a/src/geo/projection/mercator_transform.ts
+++ b/src/geo/projection/mercator_transform.ts
@@ -537,7 +537,7 @@ export class MercatorTransform implements ITransform {
         // 1 Z unit is equivalent to 1 horizontal px at the center of the map
         // (the distance between[width/2, height/2] and [width/2 + 1, height/2])
         const groundAngle = Math.PI / 2 + this._helper._pitch;
-        const zfov = this._helper._fov * (Math.abs(Math.cos(this._helper._roll))*this._helper._height + Math.abs(Math.sin(this._helper._roll))*this._helper._width) / this._helper._height;
+        const zfov = this._helper._fov * (Math.abs(Math.cos(this._helper._roll)) * this._helper._height + Math.abs(Math.sin(this._helper._roll)) * this._helper._width) / this._helper._height;
         const fovAboveCenter = zfov * (0.5 + offset.y / this._helper._height);
         const topHalfSurfaceDistance = Math.sin(fovAboveCenter) * lowestPlane / Math.sin(clamp(Math.PI - groundAngle - fovAboveCenter, 0.01, Math.PI - 0.01));
 

--- a/src/geo/projection/mercator_transform.ts
+++ b/src/geo/projection/mercator_transform.ts
@@ -575,7 +575,7 @@ export class MercatorTransform implements ITransform {
 
         mat4.scale(m, m, [1, -1, 1]);
         mat4.translate(m, m, [0, 0, -this._cameraToCenterDistance]);
-        mat4.rotateZ(m, m, this._helper._roll);
+        mat4.rotateZ(m, m, -this._helper._roll);
         mat4.rotateX(m, m, this._helper._pitch);
         mat4.rotateZ(m, m, this._helper._angle);
         mat4.translate(m, m, [-x, -y, 0]);
@@ -611,7 +611,7 @@ export class MercatorTransform implements ITransform {
         this._fogMatrix[9] = offset.y * 2 / this.height;
         mat4.scale(this._fogMatrix, this._fogMatrix, [1, -1, 1]);
         mat4.translate(this._fogMatrix, this._fogMatrix, [0, 0, -this.cameraToCenterDistance]);
-        mat4.rotateZ(this._fogMatrix, this._fogMatrix, this._helper._roll);
+        mat4.rotateZ(this._fogMatrix, this._fogMatrix, -this._helper._roll);
         mat4.rotateX(this._fogMatrix, this._fogMatrix, this._helper._pitch);
         mat4.rotateZ(this._fogMatrix, this._fogMatrix, this.angle);
         mat4.translate(this._fogMatrix, this._fogMatrix, [-x, -y, 0]);

--- a/src/geo/transform_helper.ts
+++ b/src/geo/transform_helper.ts
@@ -103,6 +103,10 @@ export class TransformHelper implements ITransformGetters {
      * Pitch in radians.
      */
     _pitch: number;
+    /**
+     * Roll in radians.
+     */
+    _roll: number;
     _zoom: number;
     _renderWorldCopies: boolean;
     _minZoom: number;
@@ -145,6 +149,7 @@ export class TransformHelper implements ITransformGetters {
         this._angle = 0;
         this._fov = 0.6435011087932844;
         this._pitch = 0;
+        this._roll = 0;
         this._unmodified = true;
         this._edgeInsets = new EdgeInsets();
         this._minElevationForCurrentTile = 0;
@@ -164,6 +169,7 @@ export class TransformHelper implements ITransformGetters {
         this._angle = -thatI.bearing * Math.PI / 180;
         this._fov = thatI.fov * Math.PI / 180;
         this._pitch = thatI.pitch * Math.PI / 180;
+        this._roll = thatI.roll * Math.PI / 180;
         this._unmodified = thatI.unmodified;
         this._edgeInsets = new EdgeInsets(thatI.padding.top, thatI.padding.bottom, thatI.padding.left, thatI.padding.right);
         this._minZoom = thatI.minZoom;
@@ -288,6 +294,17 @@ export class TransformHelper implements ITransformGetters {
         if (this._pitch === p) return;
         this._unmodified = false;
         this._pitch = p;
+        this._calcMatrices();
+    }
+
+    get roll(): number {
+        return this._roll / Math.PI * 180;
+    }
+    setRoll(roll: number) {
+        const r = roll / 180 * Math.PI;
+        if (this._roll === r) return;
+        this._unmodified = false;
+        this._roll = r;
         this._calcMatrices();
     }
 

--- a/src/geo/transform_interface.ts
+++ b/src/geo/transform_interface.ts
@@ -91,6 +91,10 @@ export interface ITransformGetters {
     get minPitch(): number;
     get maxPitch(): number;
     /**
+     * Roll in degrees.
+     */
+    get roll(): number;
+    /**
      * Pitch in degrees.
      */
     get pitch(): number;
@@ -152,6 +156,11 @@ interface ITransformMutators {
      * Recomputes internal matrices if needed.
      */
     setPitch(pitch: number): void;
+    /**
+     * Sets the transform's roll, in degrees.
+     * Recomputes internal matrices if needed.
+     */
+    setRoll(roll: number): void;
     /**
      * Sets the transform's vertical field of view, in degrees.
      * Recomputes internal matrices if needed.

--- a/src/render/draw_sky.ts
+++ b/src/render/draw_sky.ts
@@ -64,7 +64,7 @@ function getSunPos(light: Light, transform: IReadonlyTransform): vec3 {
     const lightMat = mat4.identity(new Float64Array(16) as any);
 
     if (light.properties.get('anchor') === 'map') {
-        mat4.rotateZ(lightMat, lightMat, -transform.roll * Math.PI / 180);
+        mat4.rotateZ(lightMat, lightMat, transform.roll * Math.PI / 180);
         mat4.rotateX(lightMat, lightMat, -transform.pitch * Math.PI / 180);
         mat4.rotateZ(lightMat, lightMat, -transform.angle);
         mat4.rotateX(lightMat, lightMat, transform.center.lat * Math.PI / 180.0);

--- a/src/render/draw_sky.ts
+++ b/src/render/draw_sky.ts
@@ -64,6 +64,7 @@ function getSunPos(light: Light, transform: IReadonlyTransform): vec3 {
     const lightMat = mat4.identity(new Float64Array(16) as any);
 
     if (light.properties.get('anchor') === 'map') {
+        mat4.rotateZ(lightMat, lightMat, -transform.roll * Math.PI / 180);
         mat4.rotateX(lightMat, lightMat, -transform.pitch * Math.PI / 180);
         mat4.rotateZ(lightMat, lightMat, -transform.angle);
         mat4.rotateX(lightMat, lightMat, transform.center.lat * Math.PI / 180.0);

--- a/src/render/program/sky_program.ts
+++ b/src/render/program/sky_program.ts
@@ -22,15 +22,15 @@ const skyUniforms = (context: Context, locations: UniformLocations): SkyUniforms
 });
 
 const skyUniformValues = (sky: Sky, transform: IReadonlyTransform, pixelRatio: number): UniformValues<SkyUniformsType> => {
-    const cos_roll = Math.cos(transform.roll * Math.PI / 180.0);
-    const sin_roll = Math.sin(transform.roll * Math.PI / 180.0);
-    const mercator_horizon  = getMercatorHorizon(transform);
+    const cosRoll = Math.cos(transform.roll * Math.PI / 180.0);
+    const sinRoll = Math.sin(transform.roll * Math.PI / 180.0);
+    const mercatorHorizon  = getMercatorHorizon(transform);
     return {
         'u_sky_color': sky.properties.get('sky-color'),
         'u_horizon_color': sky.properties.get('horizon-color'),
-        'u_horizon': [(transform.width / 2 - mercator_horizon * sin_roll)  * pixelRatio,
-            (transform.height / 2 + mercator_horizon * cos_roll) * pixelRatio],
-        'u_horizon_normal' : [-sin_roll, cos_roll],
+        'u_horizon': [(transform.width / 2 - mercatorHorizon * sinRoll)  * pixelRatio,
+            (transform.height / 2 + mercatorHorizon * cosRoll) * pixelRatio],
+        'u_horizon_normal' : [-sinRoll, cosRoll],
         'u_sky_horizon_blend': (sky.properties.get('sky-horizon-blend') * transform.height / 2) * pixelRatio,
     };
 };

--- a/src/render/program/sky_program.ts
+++ b/src/render/program/sky_program.ts
@@ -30,7 +30,7 @@ const skyUniformValues = (sky: Sky, transform: IReadonlyTransform, pixelRatio: n
         'u_horizon_color': sky.properties.get('horizon-color'),
         'u_horizon': [(transform.width / 2 - mercatorHorizon * sinRoll)  * pixelRatio,
             (transform.height / 2 + mercatorHorizon * cosRoll) * pixelRatio],
-        'u_horizon_normal' : [-sinRoll, cosRoll],
+        'u_horizon_normal': [-sinRoll, cosRoll],
         'u_sky_horizon_blend': (sky.properties.get('sky-horizon-blend') * transform.height / 2) * pixelRatio,
     };
 };

--- a/src/render/program/sky_program.ts
+++ b/src/render/program/sky_program.ts
@@ -24,7 +24,8 @@ const skyUniforms = (context: Context, locations: UniformLocations): SkyUniforms
 const skyUniformValues = (sky: Sky, transform: IReadonlyTransform, pixelRatio: number): UniformValues<SkyUniformsType> => ({
     'u_sky_color': sky.properties.get('sky-color'),
     'u_horizon_color': sky.properties.get('horizon-color'),
-    'u_horizon': [transform.width / 2, (transform.height / 2 + getMercatorHorizon(transform)) * pixelRatio],
+    'u_horizon': [(transform.width / 2 + getMercatorHorizon(transform) * Math.sin(transform.roll * Math.PI / 180.0))  * pixelRatio,
+        (transform.height / 2 + getMercatorHorizon(transform) * Math.cos(transform.roll * Math.PI / 180.0)) * pixelRatio],
     'u_horizon_normal' : [Math.sin(transform.roll * Math.PI / 180.0), Math.cos(transform.roll * Math.PI / 180.0)],
     'u_sky_horizon_blend': (sky.properties.get('sky-horizon-blend') * transform.height / 2) * pixelRatio,
 });

--- a/src/render/program/sky_program.ts
+++ b/src/render/program/sky_program.ts
@@ -28,9 +28,9 @@ const skyUniformValues = (sky: Sky, transform: IReadonlyTransform, pixelRatio: n
     return {
         'u_sky_color': sky.properties.get('sky-color'),
         'u_horizon_color': sky.properties.get('horizon-color'),
-        'u_horizon': [(transform.width / 2 + mercator_horizon * sin_roll)  * pixelRatio,
+        'u_horizon': [(transform.width / 2 - mercator_horizon * sin_roll)  * pixelRatio,
             (transform.height / 2 + mercator_horizon * cos_roll) * pixelRatio],
-        'u_horizon_normal' : [sin_roll, cos_roll],
+        'u_horizon_normal' : [-sin_roll, cos_roll],
         'u_sky_horizon_blend': (sky.properties.get('sky-horizon-blend') * transform.height / 2) * pixelRatio,
     };
 };

--- a/src/render/program/sky_program.ts
+++ b/src/render/program/sky_program.ts
@@ -21,13 +21,18 @@ const skyUniforms = (context: Context, locations: UniformLocations): SkyUniforms
     'u_sky_horizon_blend': new Uniform1f(context, locations.u_sky_horizon_blend),
 });
 
-const skyUniformValues = (sky: Sky, transform: IReadonlyTransform, pixelRatio: number): UniformValues<SkyUniformsType> => ({
-    'u_sky_color': sky.properties.get('sky-color'),
-    'u_horizon_color': sky.properties.get('horizon-color'),
-    'u_horizon': [(transform.width / 2 + getMercatorHorizon(transform) * Math.sin(transform.roll * Math.PI / 180.0))  * pixelRatio,
-        (transform.height / 2 + getMercatorHorizon(transform) * Math.cos(transform.roll * Math.PI / 180.0)) * pixelRatio],
-    'u_horizon_normal' : [Math.sin(transform.roll * Math.PI / 180.0), Math.cos(transform.roll * Math.PI / 180.0)],
-    'u_sky_horizon_blend': (sky.properties.get('sky-horizon-blend') * transform.height / 2) * pixelRatio,
-});
+const skyUniformValues = (sky: Sky, transform: IReadonlyTransform, pixelRatio: number): UniformValues<SkyUniformsType> => {
+    const cos_roll = Math.cos(transform.roll * Math.PI / 180.0);
+    const sin_roll = Math.sin(transform.roll * Math.PI / 180.0);
+    const mercator_horizon  = getMercatorHorizon(transform);
+    return {
+        'u_sky_color': sky.properties.get('sky-color'),
+        'u_horizon_color': sky.properties.get('horizon-color'),
+        'u_horizon': [(transform.width / 2 + mercator_horizon * sin_roll)  * pixelRatio,
+            (transform.height / 2 + mercator_horizon * cos_roll) * pixelRatio],
+        'u_horizon_normal' : [sin_roll, cos_roll],
+        'u_sky_horizon_blend': (sky.properties.get('sky-horizon-blend') * transform.height / 2) * pixelRatio,
+    };
+};
 
 export {skyUniforms, skyUniformValues};

--- a/src/render/program/sky_program.ts
+++ b/src/render/program/sky_program.ts
@@ -1,4 +1,4 @@
-import {UniformColor, Uniform1f} from '../uniform_binding';
+import {UniformColor, Uniform1f, Uniform2f} from '../uniform_binding';
 import type {Context} from '../../gl/context';
 import type {UniformValues, UniformLocations} from '../uniform_binding';
 import {IReadonlyTransform} from '../../geo/transform_interface';
@@ -8,21 +8,24 @@ import {getMercatorHorizon} from '../../geo/projection/mercator_utils';
 export type SkyUniformsType = {
     'u_sky_color': UniformColor;
     'u_horizon_color': UniformColor;
-    'u_horizon': Uniform1f;
+    'u_horizon': Uniform2f;
+    'u_horizon_normal': Uniform2f;
     'u_sky_horizon_blend': Uniform1f;
 };
 
 const skyUniforms = (context: Context, locations: UniformLocations): SkyUniformsType => ({
     'u_sky_color': new UniformColor(context, locations.u_sky_color),
     'u_horizon_color': new UniformColor(context, locations.u_horizon_color),
-    'u_horizon': new Uniform1f(context, locations.u_horizon),
+    'u_horizon': new Uniform2f(context, locations.u_horizon),
+    'u_horizon_normal': new Uniform2f(context, locations.u_horizon_normal),
     'u_sky_horizon_blend': new Uniform1f(context, locations.u_sky_horizon_blend),
 });
 
 const skyUniformValues = (sky: Sky, transform: IReadonlyTransform, pixelRatio: number): UniformValues<SkyUniformsType> => ({
     'u_sky_color': sky.properties.get('sky-color'),
     'u_horizon_color': sky.properties.get('horizon-color'),
-    'u_horizon': (transform.height / 2 + getMercatorHorizon(transform)) * pixelRatio,
+    'u_horizon': [transform.width / 2, (transform.height / 2 + getMercatorHorizon(transform)) * pixelRatio],
+    'u_horizon_normal' : [Math.sin(transform.roll * Math.PI / 180.0), Math.cos(transform.roll * Math.PI / 180.0)],
     'u_sky_horizon_blend': (sky.properties.get('sky-horizon-blend') * transform.height / 2) * pixelRatio,
 });
 

--- a/src/shaders/sky.fragment.glsl
+++ b/src/shaders/sky.fragment.glsl
@@ -1,13 +1,15 @@
 uniform vec4 u_sky_color;
 uniform vec4 u_horizon_color;
 
-uniform float u_horizon;
+uniform vec2 u_horizon;
+uniform vec2 u_horizon_normal;
 uniform float u_sky_horizon_blend;
 
 void main() {
+    float x = gl_FragCoord.x;
     float y = gl_FragCoord.y;
-    if (y > u_horizon) {
-        float blend = y - u_horizon;
+    float blend = (y - u_horizon.y) * u_horizon_normal.y + (x - u_horizon.x) * u_horizon_normal.x;
+    if (blend > 0.0) {
         if (blend < u_sky_horizon_blend) {
             gl_FragColor = mix(u_sky_color, u_horizon_color, pow(1.0 - blend / u_sky_horizon_blend, 2.0));
         } else {

--- a/src/ui/camera.ts
+++ b/src/ui/camera.ts
@@ -635,7 +635,6 @@ export abstract class Camera extends Evented {
         return this;
     }
 
-
     /**
      * Returns the map's current roll angle.
      *

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -904,21 +904,21 @@ export type RollPitchBearing = {
  * @returns roll, pitch, and bearing angles in degrees
  */
 export function getRollPitchBearing(rotation: quat): RollPitchBearing {
-    let m: mat3 = new Float64Array(9) as any;
+    const m: mat3 = new Float64Array(9) as any;
     mat3.fromQuat(m, rotation);
-    
-    const x_angle = radiansToDegrees(-Math.asin(clamp(m[2], -1, 1)));
-    let roll: number
+
+    const xAngle = radiansToDegrees(-Math.asin(clamp(m[2], -1, 1)));
+    let roll: number;
     let bearing: number;
     if (Math.hypot(m[5], m[8]) < 1.0e-3) {
         roll = 0.0;
         bearing = radiansToDegrees(Math.atan2(m[3], m[4]));
     } else {
-        roll = radiansToDegrees((m[5] == 0.0 && m[8] == 0.0) ? 0.0 :  Math.atan2(m[5], m[8]));
-        bearing = radiansToDegrees((m[1] == 0.0 && m[0] == 0.0) ? 0.0 : Math.atan2(m[1], m[0]));
+        roll = radiansToDegrees((m[5] === 0.0 && m[8] === 0.0) ? 0.0 :  Math.atan2(m[5], m[8]));
+        bearing = radiansToDegrees((m[1] === 0.0 && m[0] === 0.0) ? 0.0 : Math.atan2(m[1], m[0]));
     }
 
-    return {roll, pitch: x_angle + 90.0, bearing}
+    return {roll, pitch: xAngle + 90.0, bearing};
 }
 
 /**

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -3,7 +3,7 @@ import UnitBezier from '@mapbox/unitbezier';
 import {isOffscreenCanvasDistorted} from './offscreen_canvas_distorted';
 import type {Size} from './image';
 import type {WorkerGlobalScopeInterface} from './web_worker';
-import {mat4, vec3, vec4} from 'gl-matrix';
+import {mat3, mat4, quat, vec3, vec4} from 'gl-matrix';
 import {pixelsToTileUnits} from '../source/pixels_to_tile_units';
 import {OverscaledTileID} from '../source/tile_id';
 
@@ -880,6 +880,38 @@ export function subscribe(target: Subscriber, message: keyof WindowEventMap, lis
  */
 export function degreesToRadians(degrees: number): number {
     return degrees * Math.PI / 180;
+}
+
+/**
+ * This method converts radians to degrees.
+ * The return value is the degrees value.
+ * @param degrees - The number of radians
+ * @returns degrees
+ */
+export function radiansToDegrees(degrees: number): number {
+    return degrees / Math.PI * 180;
+}
+
+export type RollPitchBearing = {
+    roll: number;
+    pitch: number;
+    bearing: number;
+};
+
+/**
+ * This method converts a rotation quaternion to roll, pitch, and bearing angles in degrees.
+ * @param rotation - The rotation quaternion
+ * @returns roll, pitch, and bearing angles in degrees
+ */
+export function getRollPitchBearing(rotation: quat): RollPitchBearing {
+    let m: mat3 = new Float64Array(9) as any;
+    mat3.fromQuat(m, rotation);
+    
+    const roll = radiansToDegrees((m[5] == 0.0 && m[8] == 0.0) ? 0.0 :  Math.atan2(m[5], m[8]));
+    const x_angle = radiansToDegrees(-Math.asin(m[2]));
+    const bearing = radiansToDegrees((m[1] == 0.0 && m[0] == 0.0) ? 0.0 : Math.atan2(m[1], m[0]));
+
+    return {roll, pitch: x_angle + 90.0, bearing}
 }
 
 /**

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -907,9 +907,16 @@ export function getRollPitchBearing(rotation: quat): RollPitchBearing {
     let m: mat3 = new Float64Array(9) as any;
     mat3.fromQuat(m, rotation);
     
-    const roll = radiansToDegrees((m[5] == 0.0 && m[8] == 0.0) ? 0.0 :  Math.atan2(m[5], m[8]));
-    const x_angle = radiansToDegrees(-Math.asin(m[2]));
-    const bearing = radiansToDegrees((m[1] == 0.0 && m[0] == 0.0) ? 0.0 : Math.atan2(m[1], m[0]));
+    const x_angle = radiansToDegrees(-Math.asin(clamp(m[2], -1, 1)));
+    let roll: number
+    let bearing: number;
+    if (Math.hypot(m[5], m[8]) < 1.0e-3) {
+        roll = 0.0;
+        bearing = radiansToDegrees(Math.atan2(m[3], m[4]));
+    } else {
+        roll = radiansToDegrees((m[5] == 0.0 && m[8] == 0.0) ? 0.0 :  Math.atan2(m[5], m[8]));
+        bearing = radiansToDegrees((m[1] == 0.0 && m[0] == 0.0) ? 0.0 : Math.atan2(m[1], m[0]));
+    }
 
     return {roll, pitch: x_angle + 90.0, bearing}
 }


### PR DESCRIPTION
@ssokol @Samarth1696

This is the first part of https://github.com/maplibre/maplibre-gl-js/issues/4717: adding camera roll.

In this PR, `roll` is defined as rotation about the camera boresight. Rotation order is `bearing`, `pitch`, `roll`. `easeTo()` and `flyTo()` are implemented using linear interpolation of Euler angles.

You can play with this feature here, using the controls in the top right corner: https://nathanmolson.github.io/camera_roll

There is some weirdness near +/- 90 degrees roll, but I'd like to get https://github.com/maplibre/maplibre-gl-js/pull/4750 merged before attempting to address it.