### PR TITLE
Fix memory leak by removing listener

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - Improve performance of `queryRenderedFeatures` by using JavaScript `Set`s to assess layer membership internally.
 
 ### 🐞 Bug fixes
-- Fix a memory leak due to missing unregistration of event listener ([#4824](https://github.com/maplibre/maplibre-gl-js/pull/4824))
+- Fix a memory leak due to missing removal of event listener registration ([#4824](https://github.com/maplibre/maplibre-gl-js/pull/4824))
 - _...Add new stuff here..._
 
 ## 5.0.0-pre.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Improve performance of `queryRenderedFeatures` by using JavaScript `Set`s to assess layer membership internally.
 
 ### 🐞 Bug fixes
+- Fix a memory leak due to missing unregistration of event listener ([#4824](https://github.com/maplibre/maplibre-gl-js/pull/4824))
 - _...Add new stuff here..._
 
 ## 5.0.0-pre.1

--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -3300,6 +3300,7 @@ export class Map extends Camera {
         this._canvas.removeEventListener('webglcontextlost', this._contextLost, false);
         DOM.remove(this._canvasContainer);
         DOM.remove(this._controlContainer);
+        this._container.removeEventListener('scroll', this._onMapScroll, false);
         this._container.classList.remove('maplibregl-map');
 
         PerformanceUtils.clearMetrics();


### PR DESCRIPTION
## Launch Checklist

When using a profiler it was evident that the memory leak was coming from a unregistered event when removing the map.

- #4811
- #4650

Fixes #4811
Fixes #4650



 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [x] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Add an entry to `CHANGELOG.md` under the `## main` section.


After - using 10 map remove.
![image](https://github.com/user-attachments/assets/a233590a-54aa-4fbf-b4ca-f54b48267f22)
