### PR TITLE
Changes query terrain elevation to return elevation above mean sea level

### DIFF
--- a/src/geo/projection/mercator_transform.ts
+++ b/src/geo/projection/mercator_transform.ts
@@ -778,15 +778,12 @@ export class MercatorTransform implements ITransform {
         // both matrices by EXTENT. We also need to rescale Z.
 
         const scale: vec3 = [EXTENT, EXTENT, this.worldSize / this._helper.pixelsPerMeter];
-        const translate: vec3 = [0, 0, this.elevation];
 
         const fallbackMatrixScaled = createMat4f64();
-        mat4.translate(fallbackMatrixScaled, tileMatrix, translate);
-        mat4.scale(fallbackMatrixScaled, fallbackMatrixScaled, scale);
+        mat4.scale(fallbackMatrixScaled, tileMatrix, scale);
 
         const projectionMatrixScaled = createMat4f64();
-        mat4.translate(projectionMatrixScaled, tileMatrix, translate);
-        mat4.scale(projectionMatrixScaled, projectionMatrixScaled, scale);
+        mat4.scale(projectionMatrixScaled, tileMatrix, scale);
 
         projectionData.fallbackMatrix = fallbackMatrixScaled;
         projectionData.mainMatrix = projectionMatrixScaled;

--- a/src/ui/camera.test.ts
+++ b/src/ui/camera.test.ts
@@ -5,7 +5,7 @@ import {fixedLngLat, fixedNum} from '../../test/unit/lib/fixed';
 import {setMatchMedia} from '../util/test/util';
 import {mercatorZfromAltitude} from '../geo/mercator_coordinate';
 import {Terrain} from '../render/terrain';
-import {LngLat, LngLatLike} from '../geo/lng_lat';
+import {LngLat} from '../geo/lng_lat';
 import {Event} from '../util/evented';
 import {LngLatBounds} from '../geo/lng_lat_bounds';
 import {MercatorTransform} from '../geo/projection/mercator_transform';
@@ -2334,34 +2334,17 @@ describe('queryTerrainElevation', () => {
         expect(result).toBeNull();
     });
 
-    test('should return the correct elevation', () => {
-        // Set up mock transform and terrain objects
-        const transform = new MercatorTransform(0, 22, 0, 60, true);
-        transform.setElevation(50);
-        const terrain = {
-            getElevationForLngLatZoom: jest.fn().mockReturnValue(200)
-        } as any as Terrain;
+    test('Calls getElevationForLngLatZoom with correct arguments', () => {
+        const getElevationForLngLatZoom = jest.fn();
+        camera.terrain = {getElevationForLngLatZoom} as any as Terrain;
+        camera.transform = new MercatorTransform(0, 22, 0, 60, true);
 
-        // Set up camera with mock transform and terrain
-        camera.transform = transform;
-        camera.terrain = terrain;
+        camera.queryTerrainElevation([1, 2]);
 
-        // Call queryTerrainElevation with mock lngLat
-        const lngLatLike: LngLatLike = [1, 2];
-        const expectedElevation = 150; // 200 - 50 = 150
-        const result = camera.queryTerrainElevation(lngLatLike);
-
-        // Check that transform.getElevation was called with the correct arguments
-        expect(terrain.getElevationForLngLatZoom).toHaveBeenCalledWith(
-            expect.objectContaining({
-                lng: lngLatLike[0],
-                lat: lngLatLike[1],
-            }),
-            transform.tileZoom
+        expect(camera.terrain.getElevationForLngLatZoom).toHaveBeenCalledWith(
+            expect.objectContaining({lng: 1, lat: 2,}),
+            camera.transform.tileZoom
         );
-
-        // Check that the correct elevation value was returned
-        expect(result).toEqual(expectedElevation);
     });
 });
 

--- a/src/ui/camera.ts
+++ b/src/ui/camera.ts
@@ -1480,19 +1480,15 @@ export abstract class Camera extends Evented {
     }
 
     /**
-     * Get the elevation difference between a given point
-     * and a point that is currently in the middle of the screen.
-     * This method should be used for proper positioning of custom 3d objects, as explained [here](https://maplibre.org/maplibre-gl-js/docs/examples/add-3d-model-with-terrain/)
+     * Get the elevation of a point above mean sea level in meters.
      * Returns null if terrain is not enabled.
-     * This method is subject to change in Maplibre GL JS v5.
-     * @param lngLatLike - [x,y] or LngLat coordinates of the location
-     * @returns elevation offset in meters
+     * @param lngLatLike - the coordinates of the location
+     * @returns elevation in meters
      */
-    queryTerrainElevation(lngLatLike: LngLatLike): number | null {
+    queryTerrainElevation(lngLatLike: LngLatLike): number {
         if (!this.terrain) {
             return null;
         }
-        const elevation = this.terrain.getElevationForLngLatZoom(LngLat.convert(lngLatLike), this.transform.tileZoom);
-        return elevation - this.transform.elevation;
+        return this.terrain.getElevationForLngLatZoom(LngLat.convert(lngLatLike), this.transform.tileZoom);
     }
 }

--- a/src/ui/camera.ts
+++ b/src/ui/camera.ts
@@ -1485,7 +1485,7 @@ export abstract class Camera extends Evented {
      * @param lngLatLike - the coordinates of the location
      * @returns elevation in meters
      */
-    queryTerrainElevation(lngLatLike: LngLatLike): number {
+    queryTerrainElevation(lngLatLike: LngLatLike): number | null {
         if (!this.terrain) {
             return null;
         }

--- a/test/examples/add-3d-model-with-terrain.html
+++ b/test/examples/add-3d-model-with-terrain.html
@@ -140,7 +140,7 @@
                     const axesHelper = new THREE.AxesHelper(60);
                     this.scene.add(axesHelper);
 
-                    // Getting model elevations (in meters) relative to scene origin from maplibre's terrain.
+                    // Getting model elevations in meters above sea level
                     const sceneElevation = map.queryTerrainElevation(sceneOrigin) || 0;
                     const model1Elevation = map.queryTerrainElevation(model1Location) || 0;
                     const model2Elevation = map.queryTerrainElevation(model2Location) || 0;


### PR DESCRIPTION
## Launch Checklist

This is a replacement of 
- #3854
Which fixes:
- #3736

It changes the `queryTerrainElevation` to return the elevation above mean sea level if the terrain is loaded.
This caused confusion in the past.
Fixes #3736

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [x] Write tests for all new functionality.
 - [x] Document any changes to public APIs.
 - [ ] Add an entry to `CHANGELOG.md` under the `## main` section.
