### PR TITLE
Use ESM and latest three.js 0.169.0

### DIFF
--- a/test/examples/add-3d-model-threejs-with-shadow.html
+++ b/test/examples/add-3d-model-threejs-with-shadow.html
@@ -38,7 +38,7 @@
         import * as THREE from 'three';
         import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
 
-        const map = (window.map = new maplibregl.Map({
+        const map = new maplibregl.Map({
             container: 'map',
             style:
                 'https://api.maptiler.com/maps/basic/style.json?key=get_your_own_OpIi9ZULNHzrESv6T2vL',
@@ -46,7 +46,7 @@
             center: [148.9819, -35.3981],
             pitch: 60,
             antialias: true
-        }));
+        });
 
         const modelOrigin = [148.9819, -35.39847];
         const modelAltitude = 0;

--- a/test/examples/add-3d-model-threejs-with-shadow.html
+++ b/test/examples/add-3d-model-threejs-with-shadow.html
@@ -4,7 +4,7 @@
 <head>
     <title>Add a 3D model with shadow using three.js</title>
     <meta property="og:description"
-        content="Use a custom style layer using three.js to add a 3D model with shadow to the map." />
+        content="Use a custom style layer with three.js to add a 3D model with shadow to the map." />
     <meta charset='utf-8'>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel='stylesheet' href='../../dist/maplibre-gl.css' />

--- a/test/examples/add-3d-model-threejs-with-shadow.html
+++ b/test/examples/add-3d-model-threejs-with-shadow.html
@@ -2,8 +2,9 @@
 <html lang="en">
 
 <head>
-    <title>Add a 3D model with shadow with three.js</title>
-    <meta property="og:description" content="Use a custom style layer with three.js to add a 3D model with Shadow to the map." />
+    <title>Add a 3D model with shadow using three.js</title>
+    <meta property="og:description"
+        content="Use a custom style layer using three.js to add a 3D model with shadow to the map." />
     <meta charset='utf-8'>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel='stylesheet' href='../../dist/maplibre-gl.css' />
@@ -20,13 +21,23 @@
             height: 100%;
         }
     </style>
+    <script type="importmap">
+        {
+            "imports": {
+            "three": "https://cdn.jsdelivr.net/npm/three@0.169.0/build/three.module.js",
+            "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.169.0/examples/jsm/"
+            }
+        }
+    </script>
 </head>
 
 <body>
-    <script src="https://unpkg.com/three@0.147.0/build/three.min.js"></script>
-    <script src="https://unpkg.com/three@0.147.0/examples/js/loaders/GLTFLoader.js"></script>
     <div id="map"></div>
-    <script>
+
+    <script type="module">
+        import * as THREE from 'three';
+        import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
+
         const map = (window.map = new maplibregl.Map({
             container: 'map',
             style:
@@ -55,8 +66,6 @@
             rotateZ: modelRotate[2],
             scale: modelAsMercatorCoordinate.meterInMercatorCoordinateUnits()
         };
-
-        const THREE = window.THREE;
 
         const customLayer = {
             id: '3d-model',
@@ -89,7 +98,7 @@
                 ground.receiveShadow = true;
                 this.scene.add(ground);
 
-                const loader = new THREE.GLTFLoader();
+                const loader = new GLTFLoader();
                 loader.load(
                     'https://maplibre.org/maplibre-gl-js/docs/assets/34M_17/34M_17.gltf',
                     (gltf) => {

--- a/test/examples/add-3d-model-with-terrain.html
+++ b/test/examples/add-3d-model-with-terrain.html
@@ -3,7 +3,7 @@
 
 <head>
     <title>Adding 3D models using three.js on terrain</title>
-    <meta property="og:description" content="Use a custom style layer using three.js to add 3D models to a map with 3d terrain." />
+    <meta property="og:description" content="Use a custom style layer with three.js to add 3D models to a map with 3d terrain." />
     <meta charset='utf-8'>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel='stylesheet' href='../../dist/maplibre-gl.css' />

--- a/test/examples/add-3d-model-with-terrain.html
+++ b/test/examples/add-3d-model-with-terrain.html
@@ -2,8 +2,8 @@
 <html lang="en">
 
 <head>
-    <title>Adding 3D models with three.js on terrain</title>
-    <meta property="og:description" content="Use a custom style layer with three.js to add 3D models to a map with 3d terrain." />
+    <title>Adding 3D models using three.js on terrain</title>
+    <meta property="og:description" content="Use a custom style layer using three.js to add 3D models to a map with 3d terrain." />
     <meta charset='utf-8'>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel='stylesheet' href='../../dist/maplibre-gl.css' />
@@ -20,13 +20,22 @@
             height: 100%;
         }
     </style>
+    <script type="importmap">
+        {
+            "imports": {
+            "three": "https://cdn.jsdelivr.net/npm/three@0.169.0/build/three.module.js",
+            "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.169.0/examples/jsm/"
+            }
+        }
+    </script>
 </head>
-
 <body>
-    <script src="https://unpkg.com/three@0.147.0/build/three.min.js"></script>
-    <script src="https://unpkg.com/three@0.147.0/examples/js/loaders/GLTFLoader.js"></script>
-    <div id="map"></div>
-    <script>
+<div id="map"></div>
+
+<script type="module">
+    import * as THREE from 'three';
+    import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
+
         /**
          * Objective:
          * Given two known world-locations `model1Location` and `model2Location`,
@@ -35,8 +44,6 @@
          */
 
         async function main() {
-
-            const THREE = window.THREE;
 
             const map = new maplibregl.Map({
                 container: 'map',
@@ -100,7 +107,7 @@
             }
 
             async function loadModel() {
-                const loader = new THREE.GLTFLoader();
+                const loader = new GLTFLoader();
                 const gltf = await loader.loadAsync('https://maplibre.org/maplibre-gl-js/docs/assets/34M_17/34M_17.gltf');
                 const model = gltf.scene;
                 return model;

--- a/test/examples/add-3d-model.html
+++ b/test/examples/add-3d-model.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <title>Add a 3D model with three.js</title>
-    <meta property="og:description" content="Use a custom style layer with three.js to add a 3D model to the map." />
+    <title>Add a 3D model using three.js</title>
+    <meta property="og:description" content="Use a custom style layer using three.js to add a 3D model to the map." />
     <meta charset='utf-8'>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel='stylesheet' href='../../dist/maplibre-gl.css' />
@@ -13,10 +13,20 @@
     </style>
 </head>
 <body>
-<script src="https://unpkg.com/three@0.147.0/build/three.min.js"></script>
-<script src="https://unpkg.com/three@0.147.0/examples/js/loaders/GLTFLoader.js"></script>
+<script type="importmap">
+    {
+        "imports": {
+        "three": "https://cdn.jsdelivr.net/npm/three@0.169.0/build/three.module.js",
+        "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.169.0/examples/jsm/"
+        }
+    }
+</script>
 <div id="map"></div>
-<script>
+
+<script type="module">
+    import * as THREE from 'three';
+    import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
+
     const map = (window.map = new maplibregl.Map({
         container: 'map',
         style:
@@ -51,7 +61,6 @@
         scale: modelAsMercatorCoordinate.meterInMercatorCoordinateUnits()
     };
 
-    const THREE = window.THREE;
 
     // configuration of the custom layer for a 3D model per the CustomLayerInterface
     const customLayer = {
@@ -72,7 +81,7 @@
             this.scene.add(directionalLight2);
 
             // use the three.js GLTF loader to add the 3D model to the three.js scene
-            const loader = new THREE.GLTFLoader();
+            const loader = new GLTFLoader();
             loader.load(
                 'https://maplibre.org/maplibre-gl-js/docs/assets/34M_17/34M_17.gltf',
                 (gltf) => {

--- a/test/examples/add-3d-model.html
+++ b/test/examples/add-3d-model.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <title>Add a 3D model using three.js</title>
-    <meta property="og:description" content="Use a custom style layer using three.js to add a 3D model to the map." />
+    <meta property="og:description" content="Use a custom style layer with three.js to add a 3D model to the map." />
     <meta charset='utf-8'>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel='stylesheet' href='../../dist/maplibre-gl.css' />

--- a/test/examples/add-3d-model.html
+++ b/test/examples/add-3d-model.html
@@ -27,7 +27,7 @@
     import * as THREE from 'three';
     import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
 
-    const map = (window.map = new maplibregl.Map({
+    const map = new maplibregl.Map({
         container: 'map',
         style:
             'https://api.maptiler.com/maps/basic/style.json?key=get_your_own_OpIi9ZULNHzrESv6T2vL',
@@ -35,7 +35,7 @@
         center: [148.9819, -35.3981],
         pitch: 60,
         antialias: true // create the gl context with MSAA antialiasing, so custom layers are antialiased
-    }));
+    });
 
     // parameters to ensure the model is georeferenced correctly on the map
     const modelOrigin = [148.9819, -35.39847];

--- a/test/examples/globe-3d-model.html
+++ b/test/examples/globe-3d-model.html
@@ -56,7 +56,7 @@
         import * as THREE from 'three';
         import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
 
-        const map = (window.map = new maplibregl.Map({
+        const map = new maplibregl.Map({
             container: 'map',
             style: 'https://api.maptiler.com/maps/basic/style.json?key=get_your_own_OpIi9ZULNHzrESv6T2vL',
             zoom: 5.5,
@@ -64,7 +64,7 @@
             maxPitch: 80,
             pitch: 70,
             antialias: true, // create the gl context with MSAA antialiasing, so custom layers are antialiased
-        }));
+        });
 
         map.on('style.load', () => {
             map.setProjection({

--- a/test/examples/globe-3d-model.html
+++ b/test/examples/globe-3d-model.html
@@ -3,7 +3,7 @@
 
 <head>
     <title>Add a 3D model to globe using three.js</title>
-    <meta property="og:description" content="Use a custom style layer using three.js to add a 3D model to a globe." />
+    <meta property="og:description" content="Use a custom style layer with three.js to add a 3D model to a globe." />
     <meta charset='utf-8'>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel='stylesheet' href='../../dist/maplibre-gl.css' />

--- a/test/examples/globe-3d-model.html
+++ b/test/examples/globe-3d-model.html
@@ -2,8 +2,8 @@
 <html lang="en">
 
 <head>
-    <title>Add a 3D model to globe with three.js</title>
-    <meta property="og:description" content="Use a custom style layer with three.js to add a 3D model to a globe." />
+    <title>Add a 3D model to globe using three.js</title>
+    <meta property="og:description" content="Use a custom style layer using three.js to add a 3D model to a globe." />
     <meta charset='utf-8'>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel='stylesheet' href='../../dist/maplibre-gl.css' />
@@ -39,12 +39,23 @@
 </head>
 
 <body>
-    <script src="https://unpkg.com/three@0.147.0/build/three.min.js"></script>
-    <script src="https://unpkg.com/three@0.147.0/examples/js/loaders/GLTFLoader.js"></script>
+    <script type="importmap">
+        {
+            "imports": {
+            "three": "https://cdn.jsdelivr.net/npm/three@0.169.0/build/three.module.js",
+            "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.169.0/examples/jsm/"
+            }
+        }
+    </script>
+
     <div id="map"></div>
     <br />
     <button id="project">Toggle projection</button>
-    <script>
+    <script type="module">
+
+        import * as THREE from 'three';
+        import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
+
         const map = (window.map = new maplibregl.Map({
             container: 'map',
             style: 'https://api.maptiler.com/maps/basic/style.json?key=get_your_own_OpIi9ZULNHzrESv6T2vL',
@@ -71,8 +82,6 @@
             });
         });
 
-        const THREE = window.THREE;
-
         // configuration of the custom layer for a 3D model per the CustomLayerInterface
         const customLayer = {
             id: '3d-model',
@@ -92,7 +101,7 @@
                 this.scene.add(directionalLight2);
 
                 // use the three.js GLTF loader to add the 3D model to the three.js scene
-                const loader = new THREE.GLTFLoader();
+                const loader = new GLTFLoader();
                 loader.load(
                     'https://maplibre.org/maplibre-gl-js/docs/assets/34M_17/34M_17.gltf',
                     (gltf) => {


### PR DESCRIPTION
This updates all the Three.js examples to the latest version 0.169.0

This requires the examples to be updated to ESM / importmap, which is the only distribution of Three.js since 0.160.0.

Resolves the issues mentioned in #4885 :
- remove `map = window.map`
- write "using three.js" instead of "with three.js"
- latest three.js version 0.169.0 instead of 2y old 0.147.0

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->
 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!