### PR TITLE
Don't suppress useful errors

### DIFF
--- a/src/render/program.ts
+++ b/src/render/program.ts
@@ -94,7 +94,7 @@ export class Program<Us extends UniformBindings> {
         gl.compileShader(fragmentShader);
 
         if (!gl.getShaderParameter(fragmentShader, gl.COMPILE_STATUS)) {
-            throw new Error(`WebGL: Could not compile fragment shader: ${gl.getShaderInfoLog(fragmentShader)}`);
+            throw new Error(`Could not compile fragment shader: ${gl.getShaderInfoLog(fragmentShader)}`);
         }
 
         gl.attachShader(this.program, fragmentShader);
@@ -108,7 +108,7 @@ export class Program<Us extends UniformBindings> {
         gl.compileShader(vertexShader);
 
         if (!gl.getShaderParameter(vertexShader, gl.COMPILE_STATUS)) {
-            throw new Error(`WebGL: Could not compile vertex shader: ${gl.getShaderInfoLog(vertexShader)}`);
+            throw new Error(`Could not compile vertex shader: ${gl.getShaderInfoLog(vertexShader)}`);
         }
 
         gl.attachShader(this.program, vertexShader);
@@ -128,7 +128,7 @@ export class Program<Us extends UniformBindings> {
         gl.linkProgram(this.program);
 
         if (!gl.getProgramParameter(this.program, gl.LINK_STATUS)) {
-            throw new Error(`WebGL: Program failed to link: ${gl.getProgramInfoLog(this.program)}`);
+            throw new Error(`Program failed to link: ${gl.getProgramInfoLog(this.program)}`);
         }
 
         gl.deleteShader(vertexShader);

--- a/src/render/program.ts
+++ b/src/render/program.ts
@@ -94,7 +94,7 @@ export class Program<Us extends UniformBindings> {
         gl.compileShader(fragmentShader);
 
         if (!gl.getShaderParameter(fragmentShader, gl.COMPILE_STATUS)) {
-            throw new Error(`Could not compile fragment shader: ${gl.getShaderInfoLog(fragmentShader)}`);
+            throw new Error(`WebGL: Could not compile fragment shader: ${gl.getShaderInfoLog(fragmentShader)}`);
         }
 
         gl.attachShader(this.program, fragmentShader);
@@ -108,7 +108,7 @@ export class Program<Us extends UniformBindings> {
         gl.compileShader(vertexShader);
 
         if (!gl.getShaderParameter(vertexShader, gl.COMPILE_STATUS)) {
-            throw new Error(`Could not compile vertex shader: ${gl.getShaderInfoLog(vertexShader)}`);
+            throw new Error(`WebGL: Could not compile vertex shader: ${gl.getShaderInfoLog(vertexShader)}`);
         }
 
         gl.attachShader(this.program, vertexShader);
@@ -128,7 +128,7 @@ export class Program<Us extends UniformBindings> {
         gl.linkProgram(this.program);
 
         if (!gl.getProgramParameter(this.program, gl.LINK_STATUS)) {
-            throw new Error(`Program failed to link: ${gl.getProgramInfoLog(this.program)}`);
+            throw new Error(`WebGL: Program failed to link: ${gl.getProgramInfoLog(this.program)}`);
         }
 
         gl.deleteShader(vertexShader);

--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -3341,7 +3341,11 @@ export class Map extends Camera {
                 PerformanceUtils.frame(paintStartTimeStamp);
                 this._frameRequest = null;
                 this._render(paintStartTimeStamp);
-            }).catch(() => {}); // ignore abort error
+            }).catch((error: Error) => {
+                if (error.message.startsWith('WebGL:')) {
+                    throw error;
+                }
+            }); // ignore abort error
         }
     }
 

--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -64,6 +64,7 @@ import {MercatorTransform} from '../geo/projection/mercator_transform';
 import {ITransform} from '../geo/transform_interface';
 import {ICameraHelper} from '../geo/projection/camera_helper';
 import {MercatorCameraHelper} from '../geo/projection/mercator_camera_helper';
+import {isAbortError} from '../util/abort_error';
 
 const version = packageJSON.version;
 
@@ -3342,7 +3343,7 @@ export class Map extends Camera {
                 this._frameRequest = null;
                 this._render(paintStartTimeStamp);
             }).catch((error: Error) => {
-                if (error.message.startsWith('WebGL:')) {
+                if (!isAbortError(error)) {
                     throw error;
                 }
             }); // ignore abort error


### PR DESCRIPTION
This PR avoids suppressing any error that's not an abort error.
We were swallowing all of them and I found difficult to debug GLSL shaders with that happening.
Fixes #4532


## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [ ] Link to related issues.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [ ] Add an entry to `CHANGELOG.md` under the `## main` section.
