### PR TITLE
Fix globe-custom-tiles example

### DIFF
--- a/test/examples/globe-custom-tiles.html
+++ b/test/examples/globe-custom-tiles.html
@@ -262,7 +262,7 @@
                     }
                 };
 
-                const projectionData = map.transform.getProjectionData({overscaledTileId: tileID});
+                const projectionData = map.transform.getProjectionData({overscaledTileID: tileID});
 
                 gl.uniform4f(
                     locations['u_projection_clipping_plane'],


### PR DESCRIPTION
## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->
Fixes a typo in the globe-custom-tiles example that causes the tile mesh not to be rendered. Should be overscaledTileID

https://github.com/maplibre/maplibre-gl-js/blob/9ba25c6d6cf2a15c542be6c919338928bab8b194/test/examples/globe-custom-tiles.html#L265

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [ ] Link to related issues.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [ ] Add an entry to `CHANGELOG.md` under the `## main` section.
