### PR TITLE
Fix ScaleControl for Globe projection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes
+- Fixes scale control for globe on zoom out ([#4897](https://github.com/maplibre/maplibre-gl-js/pull/4897))
 - _...Add new stuff here..._
 
 ## 5.0.0-pre.5
@@ -20,7 +21,6 @@
 
 - Fix line-placed map-pitch-aligned texts being too large when viewed from some latitudes on a globe ([#4786](https://github.com/maplibre/maplibre-gl-js/issues/4786))
 - Disabled unsupported Fog rendering, for Terrain3D on Globe ([#4963](https://github.com/maplibre/maplibre-gl-js/pull/4963))
-- Fixes scale control for globe on zoom out ([#4897](https://github.com/maplibre/maplibre-gl-js/pull/4897))
 - _...Add new stuff here..._
 
 ## 5.0.0-pre.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@
 
 - Fix line-placed map-pitch-aligned texts being too large when viewed from some latitudes on a globe ([#4786](https://github.com/maplibre/maplibre-gl-js/issues/4786))
 - Disabled unsupported Fog rendering, for Terrain3D on Globe ([#4963](https://github.com/maplibre/maplibre-gl-js/pull/4963))
+- Fixes scale control for globe on zoom out ([#4897](https://github.com/maplibre/maplibre-gl-js/pull/4897))
+- _...Add new stuff here..._
 
 ## 5.0.0-pre.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,6 @@
 
 - Fix line-placed map-pitch-aligned texts being too large when viewed from some latitudes on a globe ([#4786](https://github.com/maplibre/maplibre-gl-js/issues/4786))
 - Disabled unsupported Fog rendering, for Terrain3D on Globe ([#4963](https://github.com/maplibre/maplibre-gl-js/pull/4963))
-- _...Add new stuff here..._
 
 ## 5.0.0-pre.4
 

--- a/src/ui/control/scale_control.ts
+++ b/src/ui/control/scale_control.ts
@@ -101,7 +101,6 @@ function updateScale(map, container, options) {
     // found between the two coordinates.
     // Minimum maxWidth is calculated for the scale box.
 
-
     const optWidth = options && options.maxWidth || 100;
     const y = map._container.clientHeight / 2;
     const x = map._container.clientWidth / 2;

--- a/src/ui/control/scale_control.ts
+++ b/src/ui/control/scale_control.ts
@@ -99,11 +99,18 @@ function updateScale(map, container, options) {
     // container with maximum length (Default) as 100px.
     // Using spherical law of cosines approximation, the real distance is
     // found between the two coordinates.
-    const maxWidth = options && options.maxWidth || 100;
+    // Minimum maxWidth is calculated for the scale box.
 
+
+    const optWidth = options && options.maxWidth || 100;
     const y = map._container.clientHeight / 2;
-    const left = map.unproject([0, y]);
-    const right = map.unproject([maxWidth, y]);
+    const x = map._container.clientWidth / 2;
+    const left = map.unproject([x - optWidth / 2, y]);
+    const right = map.unproject([x + optWidth / 2, y]);
+
+    const globeWidth = Math.round(map.project(right).x - map.project(left).x);
+    const maxWidth = Math.min(optWidth, globeWidth, map._container.clientWidth);
+
     const maxMeters = left.distanceTo(right);
     // The real distance corresponding to 100px scale length is rounded off to
     // near pretty number and the scale length for the same is found out.


### PR DESCRIPTION
Supersedes this pr, due to git issues:
- #4897 

Closes #4804 , closes #4897

Thanks @pcardinal!

It appear to work as expected now - Functionality can be checked by adding to the simple-map.html the:

```
map.addControl(new maplibregl.ScaleControl())
map.addControl(new maplibregl.GlobeControl())
```


Before

https://github.com/user-attachments/assets/83f1a399-1d3e-4dd8-92f8-10f2f5071b87


After

https://github.com/user-attachments/assets/0d5f5dee-b48b-41b3-b688-f76785b6c616




## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!