### PR TITLE
interpolate atmosphere in hybrid-terrain example

### DIFF
--- a/test/examples/hybrid-terrain.html
+++ b/test/examples/hybrid-terrain.html
@@ -23,8 +23,7 @@
         maxPitch: 95
     });
 
-    map.setStyle('https://tiles.openfreemap.org/styles/liberty', {
-            transformStyle: (previousStyle, nextStyle) => {
+    map.setStyle('https://api.maptiler.com/maps/hybrid/style.json?key=get_your_own_OpIi9ZULNHzrESv6T2vL', {            transformStyle: (previousStyle, nextStyle) => {
                 nextStyle.projection = {type: 'globe'};
                 nextStyle.sources = {
                     ...nextStyle.sources, terrainSource: {

--- a/test/examples/hybrid-terrain.html
+++ b/test/examples/hybrid-terrain.html
@@ -23,7 +23,8 @@
         maxPitch: 95
     });
 
-    map.setStyle('https://api.maptiler.com/maps/hybrid/style.json?key=get_your_own_OpIi9ZULNHzrESv6T2vL', {            transformStyle: (previousStyle, nextStyle) => {
+    map.setStyle('https://api.maptiler.com/maps/hybrid/style.json?key=get_your_own_OpIi9ZULNHzrESv6T2vL', {
+            transformStyle: (previousStyle, nextStyle) => {
                 nextStyle.projection = {type: 'globe'};
                 nextStyle.sources = {
                     ...nextStyle.sources, terrainSource: {

--- a/test/examples/hybrid-terrain.html
+++ b/test/examples/hybrid-terrain.html
@@ -53,7 +53,6 @@
                     ],
                 }
 
-
                 nextStyle.layers.push({
                     id: 'hills',
                     type: 'hillshade',

--- a/test/examples/hybrid-terrain.html
+++ b/test/examples/hybrid-terrain.html
@@ -25,6 +25,7 @@
 
     map.setStyle('https://tiles.openfreemap.org/styles/liberty', {
             transformStyle: (previousStyle, nextStyle) => {
+                nextStyle.projection = {type: 'globe'};
                 nextStyle.sources = {
                     ...nextStyle.sources, terrainSource: {
                         type: 'raster-dem',

--- a/test/examples/hybrid-terrain.html
+++ b/test/examples/hybrid-terrain.html
@@ -23,7 +23,7 @@
         maxPitch: 95
     });
 
-    map.setStyle('https://api.maptiler.com/maps/hybrid/style.json?key=get_your_own_OpIi9ZULNHzrESv6T2vL', {
+    map.setStyle('https://tiles.openfreemap.org/styles/liberty', {
             transformStyle: (previousStyle, nextStyle) => {
                 nextStyle.sources = {
                     ...nextStyle.sources, terrainSource: {
@@ -42,7 +42,16 @@
                     exaggeration: 1
                 }
 
-                nextStyle.sky = {}
+                nextStyle.sky = {
+                    'atmosphere-blend': [
+                        'interpolate',
+                        ['linear'],
+                        ['zoom'],
+                        0, 1,
+                        2, 0
+                    ],
+                }
+
 
                 nextStyle.layers.push({
                     id: 'hills',
@@ -63,6 +72,7 @@
             showCompass: true
         })
     );
+
 
     map.addControl(
         new maplibregl.GlobeControl()


### PR DESCRIPTION
The globe atmosphere looks really bad in this example.

I realized the style spec has a [recommendation to interpolate](https://maplibre.org/maplibre-style-spec/sky/#atmosphere-blend) which looks much better:
> interpolate this expression when using globe projection.

Maybe we should even change the default value to a good looking interpolation, instead of 0.8.

I changed the projection to globe too (it has toggle), because we can finally render that correctly when this
- #4977 

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->
 - [X] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!