### PR TITLE
Make sure overscaledZ is at least as big as tile Z

### DIFF
--- a/src/geo/projection/covering_tiles.ts
+++ b/src/geo/projection/covering_tiles.ts
@@ -240,7 +240,7 @@ export function coveringTiles(transform: IReadonlyTransform, options: CoveringTi
             const dz = nominalZ - it.zoom;
             const dx = cameraPoint[0] - 0.5 - (x << dz);
             const dy = cameraPoint[1] - 0.5 - (y << dz);
-            const overscaledZ = options.reparseOverscaled ? thisTileDesiredZ : it.zoom;
+            const overscaledZ = options.reparseOverscaled ? Math.max(it.zoom, thisTileDesiredZ) : it.zoom;
             result.push({
                 tileID: new OverscaledTileID(it.zoom === maxZoom ? overscaledZ : it.zoom, it.wrap, it.zoom, x, y),
                 distanceSq: vec2.sqrLen([centerPoint[0] - 0.5 - x, centerPoint[1] - 0.5 - y]),

--- a/src/geo/projection/mercator_transform.test.ts
+++ b/src/geo/projection/mercator_transform.test.ts
@@ -374,6 +374,28 @@ describe('transform', () => {
 
     });
 
+    test('coveringTiles: overscaledZ', () => {
+        const options = {
+            minzoom: 1,
+            maxzoom: 10,
+            tileSize: 256,
+            reparseOverscaled: true
+        };
+
+        const transform = new MercatorTransform(0, 10, 0, 85, true);
+        transform.resize(10, 400);
+        // make slightly off center so that sort order is not subject to precision issues
+        transform.setCenter(new LngLat(-0.01, 0.01));
+        transform.setPitch(85);
+        transform.setFov(10);
+
+        transform.setZoom(10);
+        const tiles = coveringTiles(transform, options);
+        for (const tile of tiles) {
+            expect(tile.canonical.z <= tile.overscaledZ);
+        }
+    });
+
     test('maxzoom-0', () => {
         const options = {
             minzoom: 0,

--- a/src/geo/projection/mercator_transform.test.ts
+++ b/src/geo/projection/mercator_transform.test.ts
@@ -392,7 +392,7 @@ describe('transform', () => {
         transform.setZoom(10);
         const tiles = coveringTiles(transform, options);
         for (const tile of tiles) {
-            expect(tile.canonical.z <= tile.overscaledZ);
+            expect(tile.overscaledZ).toBeGreaterThanOrEqual(tile.canonical.z);
         }
     });
 


### PR DESCRIPTION
This fixes an issue I found when testing `main` after #4779 was merged. `overscaledZ` was sometimes smaller than `z`, causing a silent exception in `map._render()`

 - [X] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [X] Briefly describe the changes in this PR.
 - [X] Link to related issues.
