### PR TITLE
Dev bundle should not minify

### DIFF
--- a/build/rollup_plugins.ts
+++ b/build/rollup_plugins.ts
@@ -31,7 +31,7 @@ export const plugins = (production: boolean): Plugin[] => [
         sourceMap: true,
         functions: ['PerformanceUtils.*']
     }),
-    terser({
+    production && terser({
         compress: {
             pure_getters: true,
             passes: 3


### PR DESCRIPTION
Pointed out [here](https://github.com/maplibre/maplibre-gl-js/pull/4906#issuecomment-2455656279), we're missing a flag that makes only the prod build minified.

https://github.com/maplibre/maplibre-gl-js/commit/a3f67eb29448c1fd2abec0e6845a368f369b5170#diff-1925b6790595de2a8e9305249f59ea6cc5eb109c15c6013ae09de2f30132cc7aL34

Currently, we minify the dev build as well.

https://github.com/maplibre/maplibre-gl-js/blob/6eeafe9c5ebd625d511e7f5e540b19924a99d5a4/build/rollup_plugins.ts#L34-L40

cc @NathanMOlson 

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [X] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
