### PR TITLE
Refactor usage of implicit parameter to an explicit one when rendering

### DIFF
--- a/src/geo/projection/globe_transform.test.ts
+++ b/src/geo/projection/globe_transform.test.ts
@@ -27,7 +27,7 @@ function planeDistance(point: Array<number>, plane: Array<number>) {
 }
 
 function createGlobeTransform(globeProjection: GlobeProjection) {
-    const globeTransform = new GlobeTransform(globeProjection);
+    const globeTransform = new GlobeTransform(globeProjection, true);
     globeTransform.resize(640, 480);
     globeTransform.setFov(45);
     return globeTransform;
@@ -46,14 +46,14 @@ describe('GlobeTransform', () => {
             expectToBeCloseToArray(projectionData.tileMercatorCoords, [0.5, 0, 0.5 / EXTENT, 0.5 / EXTENT]);
         });
 
-        test('Globe transition is not 0 when not ignoring the globe matrix', () => {
+        test('Globe transition is 0 when not applying the globe matrix', () => {
             const projectionData = globeTransform.getProjectionData({overscaledTileID: new OverscaledTileID(1, 0, 1, 1, 0)});
-            expect(projectionData.projectionTransition).not.toBe(0);
+            expect(projectionData.projectionTransition).toBe(0);
         });
 
-        test('Ignoring the globe matrix sets transition to 0', () => {
-            const projectionData = globeTransform.getProjectionData({overscaledTileID: new OverscaledTileID(1, 0, 1, 1, 0), ignoreGlobeMatrix: true});
-            expect(projectionData.projectionTransition).toBe(0);
+        test('Applying the globe matrix sets transition to something different than 0', () => {
+            const projectionData = globeTransform.getProjectionData({overscaledTileID: new OverscaledTileID(1, 0, 1, 1, 0), applyGlobeMatrix: true});
+            expect(projectionData.projectionTransition).not.toBe(0);
         });
     });
 

--- a/src/geo/projection/globe_transform.ts
+++ b/src/geo/projection/globe_transform.ts
@@ -454,8 +454,8 @@ export class GlobeTransform implements ITransform {
     }
 
     getProjectionData(params: ProjectionDataParams): ProjectionData {
-        const {overscaledTileID, aligned, ignoreTerrainMatrix, ignoreGlobeMatrix} = params;
-        const data = this._mercatorTransform.getProjectionData({overscaledTileID, aligned, ignoreTerrainMatrix});
+        const {overscaledTileID, aligned, applyTerrainMatrix, applyGlobeMatrix} = params;
+        const data = this._mercatorTransform.getProjectionData({overscaledTileID, aligned, applyTerrainMatrix});
 
         // Set 'projectionMatrix' to actual globe transform
         if (this.isGlobeRendering) {
@@ -463,7 +463,7 @@ export class GlobeTransform implements ITransform {
         }
 
         data.clippingPlane = this._cachedClippingPlane as [number, number, number, number];
-        data.projectionTransition = ignoreGlobeMatrix ? 0 : this._globeness;
+        data.projectionTransition = applyGlobeMatrix ? this._globeness : 0;
 
         return data;
     }
@@ -1184,8 +1184,8 @@ export class GlobeTransform implements ITransform {
         return m;
     }
 
-    getProjectionDataForCustomLayer(ignoreGlobeMatrix: boolean = false): ProjectionData {
-        const projectionData = this.getProjectionData({overscaledTileID: new OverscaledTileID(0, 0, 0, 0, 0), ignoreGlobeMatrix});
+    getProjectionDataForCustomLayer(applyGlobeMatrix: boolean = true): ProjectionData {
+        const projectionData = this.getProjectionData({overscaledTileID: new OverscaledTileID(0, 0, 0, 0, 0), applyGlobeMatrix});
         projectionData.tileMercatorCoords = [0, 0, 1, 1];
 
         // Even though we requested projection data for the mercator base tile which covers the entire mercator range,

--- a/src/geo/projection/globe_transform.ts
+++ b/src/geo/projection/globe_transform.ts
@@ -1184,8 +1184,8 @@ export class GlobeTransform implements ITransform {
         return m;
     }
 
-    getProjectionDataForCustomLayer(): ProjectionData {
-        const projectionData = this.getProjectionData({overscaledTileID: new OverscaledTileID(0, 0, 0, 0, 0)});
+    getProjectionDataForCustomLayer(ignoreGlobeMatrix: boolean = false): ProjectionData {
+        const projectionData = this.getProjectionData({overscaledTileID: new OverscaledTileID(0, 0, 0, 0, 0), ignoreGlobeMatrix});
         projectionData.tileMercatorCoords = [0, 0, 1, 1];
 
         // Even though we requested projection data for the mercator base tile which covers the entire mercator range,

--- a/src/geo/projection/mercator_transform.test.ts
+++ b/src/geo/projection/mercator_transform.test.ts
@@ -506,7 +506,7 @@ describe('transform', () => {
         transform.setPitch(67.25);
         transform.setCenter(new LngLat(0.0, 0.0));
 
-        const customLayerMatrix = transform.getProjectionDataForCustomLayer().mainMatrix;
+        const customLayerMatrix = transform.getProjectionDataForCustomLayer(false).mainMatrix;
         expect(customLayerMatrix[0].toString().length).toBeGreaterThan(9);
         expect(transform.pixelsToClipSpaceMatrix[0].toString().length).toBeGreaterThan(9);
         expect(transform.maxPitchScaleFactor()).toBeCloseTo(2.366025418080343, 5);

--- a/src/geo/projection/mercator_transform.test.ts
+++ b/src/geo/projection/mercator_transform.test.ts
@@ -506,7 +506,7 @@ describe('transform', () => {
         transform.setPitch(67.25);
         transform.setCenter(new LngLat(0.0, 0.0));
 
-        const customLayerMatrix = transform.getProjectionDataForCustomLayer(false).mainMatrix;
+        const customLayerMatrix = transform.getProjectionDataForCustomLayer().mainMatrix;
         expect(customLayerMatrix[0].toString().length).toBeGreaterThan(9);
         expect(transform.pixelsToClipSpaceMatrix[0].toString().length).toBeGreaterThan(9);
         expect(transform.maxPitchScaleFactor()).toBeCloseTo(2.366025418080343, 5);

--- a/src/geo/projection/mercator_transform.ts
+++ b/src/geo/projection/mercator_transform.ts
@@ -759,9 +759,9 @@ export class MercatorTransform implements ITransform {
     }
 
     getProjectionData(params: ProjectionDataParams): ProjectionData {
-        const {overscaledTileID, aligned, ignoreTerrainMatrix} = params;
+        const {overscaledTileID, aligned, applyTerrainMatrix} = params;
         const matrix = overscaledTileID ? this.calculatePosMatrix(overscaledTileID, aligned) : null;
-        return getBasicProjectionData(overscaledTileID, matrix, ignoreTerrainMatrix);
+        return getBasicProjectionData(overscaledTileID, matrix, applyTerrainMatrix);
     }
 
     isLocationOccluded(_: LngLat): boolean {
@@ -833,9 +833,9 @@ export class MercatorTransform implements ITransform {
         return m;
     }
 
-    getProjectionDataForCustomLayer(ignoreGlobeMatrix: boolean = false): ProjectionData {
+    getProjectionDataForCustomLayer(applyGlobeMatrix: boolean = true): ProjectionData {
         const tileID = new OverscaledTileID(0, 0, 0, 0, 0);
-        const projectionData = this.getProjectionData({overscaledTileID: tileID, ignoreTerrainMatrix: true, ignoreGlobeMatrix});
+        const projectionData = this.getProjectionData({overscaledTileID: tileID, applyGlobeMatrix});
 
         const tileMatrix = calculateTileMatrix(tileID, this.worldSize);
         mat4.multiply(tileMatrix, this._viewProjMatrix, tileMatrix);

--- a/src/geo/projection/mercator_transform.ts
+++ b/src/geo/projection/mercator_transform.ts
@@ -833,9 +833,9 @@ export class MercatorTransform implements ITransform {
         return m;
     }
 
-    getProjectionDataForCustomLayer(): ProjectionData {
+    getProjectionDataForCustomLayer(ignoreGlobeMatrix: boolean = false): ProjectionData {
         const tileID = new OverscaledTileID(0, 0, 0, 0, 0);
-        const projectionData = this.getProjectionData({overscaledTileID: tileID, ignoreTerrainMatrix: true});
+        const projectionData = this.getProjectionData({overscaledTileID: tileID, ignoreTerrainMatrix: true, ignoreGlobeMatrix});
 
         const tileMatrix = calculateTileMatrix(tileID, this.worldSize);
         mat4.multiply(tileMatrix, this._viewProjMatrix, tileMatrix);

--- a/src/geo/projection/mercator_utils.ts
+++ b/src/geo/projection/mercator_utils.ts
@@ -94,7 +94,7 @@ export function getMercatorHorizon(transform: {pitch: number; cameraToCenterDist
         Math.tan(degreesToRadians(maxMercatorHorizonAngle - transform.pitch)));
 }
 
-export function getBasicProjectionData(overscaledTileID: OverscaledTileID, tilePosMatrix?: mat4, ignoreTerrainMatrix?: boolean): ProjectionData {
+export function getBasicProjectionData(overscaledTileID: OverscaledTileID, tilePosMatrix?: mat4, applyTerrainMatrix: boolean = true): ProjectionData {
     let tileOffsetSize: [number, number, number, number];
 
     if (overscaledTileID) {
@@ -110,7 +110,7 @@ export function getBasicProjectionData(overscaledTileID: OverscaledTileID, tileP
     }
 
     let mainMatrix: mat4;
-    if (overscaledTileID && overscaledTileID.terrainRttPosMatrix && !ignoreTerrainMatrix) {
+    if (overscaledTileID && overscaledTileID.terrainRttPosMatrix && applyTerrainMatrix) {
         mainMatrix = overscaledTileID.terrainRttPosMatrix;
     } else if (tilePosMatrix) {
         mainMatrix = tilePosMatrix;

--- a/src/geo/projection/projection_data.ts
+++ b/src/geo/projection/projection_data.ts
@@ -56,11 +56,11 @@ export type ProjectionDataParams = {
      */
     aligned?: boolean;
     /**
-     * Set to true if the terrain matrix should be ignored
+     * Set to true if the terrain matrix should be applied (i.e. when rendering terrain)
      */
-    ignoreTerrainMatrix?: boolean;
+    applyTerrainMatrix?: boolean;
     /**
-     * Set to true if the globe matrix should be ignored (i.e. when rendering to texture for terrain)
+     * Set to true if the globe matrix should be applied (i.e. when rendering globe)
      */
-    ignoreGlobeMatrix?: boolean;
+    applyGlobeMatrix?: boolean;
 }

--- a/src/geo/transform_interface.ts
+++ b/src/geo/transform_interface.ts
@@ -471,7 +471,7 @@ export interface IReadonlyTransform extends ITransformGetters {
     /**
      * Return projection data such that coordinates in mercator projection in range 0..1 will get projected to the map correctly.
      */
-    getProjectionDataForCustomLayer(): ProjectionData;
+    getProjectionDataForCustomLayer(ignoreGlobeMatrix: boolean): ProjectionData;
 
     /**
      * Returns a tile-specific projection matrix. Used for symbol placement fast-path for mercator transform.

--- a/src/geo/transform_interface.ts
+++ b/src/geo/transform_interface.ts
@@ -471,7 +471,7 @@ export interface IReadonlyTransform extends ITransformGetters {
     /**
      * Return projection data such that coordinates in mercator projection in range 0..1 will get projected to the map correctly.
      */
-    getProjectionDataForCustomLayer(ignoreGlobeMatrix: boolean): ProjectionData;
+    getProjectionDataForCustomLayer(applyGlobeMatrix: boolean): ProjectionData;
 
     /**
      * Returns a tile-specific projection matrix. Used for symbol placement fast-path for mercator transform.

--- a/src/render/draw_background.ts
+++ b/src/render/draw_background.ts
@@ -12,13 +12,13 @@ import type {BackgroundStyleLayer} from '../style/style_layer/background_style_l
 import {OverscaledTileID} from '../source/tile_id';
 import {coveringTiles} from '../geo/projection/covering_tiles';
 
-export function drawBackground(painter: Painter, sourceCache: SourceCache, layer: BackgroundStyleLayer, coords: Array<OverscaledTileID>, renderFlags: RenderOptions) {
+export function drawBackground(painter: Painter, sourceCache: SourceCache, layer: BackgroundStyleLayer, coords: Array<OverscaledTileID>, renderOptions: RenderOptions) {
     const color = layer.paint.get('background-color');
     const opacity = layer.paint.get('background-opacity');
 
     if (opacity === 0) return;
 
-    const {isRenderingToTexture} = renderFlags;
+    const {isRenderingToTexture} = renderOptions;
     const context = painter.context;
     const gl = context.gl;
     const projection = painter.style.projection;

--- a/src/render/draw_background.ts
+++ b/src/render/draw_background.ts
@@ -6,13 +6,13 @@ import {
     backgroundPatternUniformValues
 } from './program/background_program';
 
-import type {Painter, RenderFlags} from './painter';
+import type {Painter, RenderOptions} from './painter';
 import type {SourceCache} from '../source/source_cache';
 import type {BackgroundStyleLayer} from '../style/style_layer/background_style_layer';
 import {OverscaledTileID} from '../source/tile_id';
 import {coveringTiles} from '../geo/projection/covering_tiles';
 
-export function drawBackground(painter: Painter, sourceCache: SourceCache, layer: BackgroundStyleLayer, coords: Array<OverscaledTileID>, renderFlags: RenderFlags) {
+export function drawBackground(painter: Painter, sourceCache: SourceCache, layer: BackgroundStyleLayer, coords: Array<OverscaledTileID>, renderFlags: RenderOptions) {
     const color = layer.paint.get('background-color');
     const opacity = layer.paint.get('background-opacity');
 

--- a/src/render/draw_background.ts
+++ b/src/render/draw_background.ts
@@ -12,7 +12,7 @@ import type {BackgroundStyleLayer} from '../style/style_layer/background_style_l
 import {OverscaledTileID} from '../source/tile_id';
 import {coveringTiles} from '../geo/projection/covering_tiles';
 
-export function drawBackground(painter: Painter, sourceCache: SourceCache, layer: BackgroundStyleLayer, coords?: Array<OverscaledTileID>) {
+export function drawBackground(painter: Painter, sourceCache: SourceCache, layer: BackgroundStyleLayer, coords?: Array<OverscaledTileID>, isRenderingToTexture: boolean = false) {
     const color = layer.paint.get('background-color');
     const opacity = layer.paint.get('background-opacity');
 
@@ -24,7 +24,6 @@ export function drawBackground(painter: Painter, sourceCache: SourceCache, layer
     const transform = painter.transform;
     const tileSize = transform.tileSize;
     const image = layer.paint.get('background-pattern');
-    const globeWithTerrain = painter.style.map.terrain && painter.style.projection.name === 'globe';
 
     if (painter.isPatternMissing(image)) return;
 
@@ -47,7 +46,7 @@ export function drawBackground(painter: Painter, sourceCache: SourceCache, layer
     for (const tileID of tileIDs) {
         const projectionData = transform.getProjectionData({
             overscaledTileID: tileID,
-            ignoreGlobeMatrix: globeWithTerrain
+            ignoreGlobeMatrix: isRenderingToTexture
         });
 
         const uniformValues = image ?

--- a/src/render/draw_background.ts
+++ b/src/render/draw_background.ts
@@ -6,18 +6,19 @@ import {
     backgroundPatternUniformValues
 } from './program/background_program';
 
-import type {Painter} from './painter';
+import type {Painter, RenderFlags} from './painter';
 import type {SourceCache} from '../source/source_cache';
 import type {BackgroundStyleLayer} from '../style/style_layer/background_style_layer';
 import {OverscaledTileID} from '../source/tile_id';
 import {coveringTiles} from '../geo/projection/covering_tiles';
 
-export function drawBackground(painter: Painter, sourceCache: SourceCache, layer: BackgroundStyleLayer, coords?: Array<OverscaledTileID>, isRenderingToTexture: boolean = false) {
+export function drawBackground(painter: Painter, sourceCache: SourceCache, layer: BackgroundStyleLayer, coords: Array<OverscaledTileID>, renderFlags: RenderFlags) {
     const color = layer.paint.get('background-color');
     const opacity = layer.paint.get('background-opacity');
 
     if (opacity === 0) return;
 
+    const {isRenderingToTexture} = renderFlags;
     const context = painter.context;
     const gl = context.gl;
     const projection = painter.style.projection;

--- a/src/render/draw_background.ts
+++ b/src/render/draw_background.ts
@@ -46,7 +46,7 @@ export function drawBackground(painter: Painter, sourceCache: SourceCache, layer
     for (const tileID of tileIDs) {
         const projectionData = transform.getProjectionData({
             overscaledTileID: tileID,
-            ignoreGlobeMatrix: isRenderingToTexture
+            applyGlobeMatrix: !isRenderingToTexture
         });
 
         const uniformValues = image ?

--- a/src/render/draw_background.ts
+++ b/src/render/draw_background.ts
@@ -47,7 +47,8 @@ export function drawBackground(painter: Painter, sourceCache: SourceCache, layer
     for (const tileID of tileIDs) {
         const projectionData = transform.getProjectionData({
             overscaledTileID: tileID,
-            applyGlobeMatrix: !isRenderingToTexture
+            applyGlobeMatrix: !isRenderingToTexture,
+            applyTerrainMatrix: true
         });
 
         const uniformValues = image ?

--- a/src/render/draw_circle.ts
+++ b/src/render/draw_circle.ts
@@ -6,7 +6,7 @@ import {circleUniformValues} from './program/circle_program';
 import {SegmentVector} from '../data/segment';
 import {OverscaledTileID} from '../source/tile_id';
 
-import type {Painter, RenderFlags} from './painter';
+import type {Painter, RenderOptions} from './painter';
 import type {SourceCache} from '../source/source_cache';
 import type {CircleStyleLayer} from '../style/style_layer/circle_style_layer';
 import type {CircleBucket} from '../data/bucket/circle_bucket';
@@ -35,7 +35,7 @@ type SegmentsTileRenderState = {
     state: TileRenderState;
 };
 
-export function drawCircles(painter: Painter, sourceCache: SourceCache, layer: CircleStyleLayer, coords: Array<OverscaledTileID>, renderFlags: RenderFlags) {
+export function drawCircles(painter: Painter, sourceCache: SourceCache, layer: CircleStyleLayer, coords: Array<OverscaledTileID>, renderFlags: RenderOptions) {
     if (painter.renderPass !== 'translucent') return;
 
     const {isRenderingToTexture} = renderFlags;

--- a/src/render/draw_circle.ts
+++ b/src/render/draw_circle.ts
@@ -81,7 +81,7 @@ export function drawCircles(painter: Painter, sourceCache: SourceCache, layer: C
         const terrainData = painter.style.map.terrain && painter.style.map.terrain.getTerrainData(coord);
         const uniformValues = circleUniformValues(painter, tile, layer, translateForUniforms, radiusCorrectionFactor);
 
-        const projectionData = transform.getProjectionData({overscaledTileID: coord, applyGlobeMatrix: !isRenderingToTexture});
+        const projectionData = transform.getProjectionData({overscaledTileID: coord, applyGlobeMatrix: !isRenderingToTexture, applyTerrainMatrix: true});
 
         const state: TileRenderState = {
             programConfiguration,

--- a/src/render/draw_circle.ts
+++ b/src/render/draw_circle.ts
@@ -80,7 +80,7 @@ export function drawCircles(painter: Painter, sourceCache: SourceCache, layer: C
         const terrainData = painter.style.map.terrain && painter.style.map.terrain.getTerrainData(coord);
         const uniformValues = circleUniformValues(painter, tile, layer, translateForUniforms, radiusCorrectionFactor);
 
-        const projectionData = transform.getProjectionData({overscaledTileID: coord, ignoreGlobeMatrix: isRenderingToTexture});
+        const projectionData = transform.getProjectionData({overscaledTileID: coord, applyGlobeMatrix: !isRenderingToTexture});
 
         const state: TileRenderState = {
             programConfiguration,

--- a/src/render/draw_circle.ts
+++ b/src/render/draw_circle.ts
@@ -35,10 +35,10 @@ type SegmentsTileRenderState = {
     state: TileRenderState;
 };
 
-export function drawCircles(painter: Painter, sourceCache: SourceCache, layer: CircleStyleLayer, coords: Array<OverscaledTileID>, renderFlags: RenderOptions) {
+export function drawCircles(painter: Painter, sourceCache: SourceCache, layer: CircleStyleLayer, coords: Array<OverscaledTileID>, renderOptions: RenderOptions) {
     if (painter.renderPass !== 'translucent') return;
 
-    const {isRenderingToTexture} = renderFlags;
+    const {isRenderingToTexture} = renderOptions;
     const opacity = layer.paint.get('circle-opacity');
     const strokeWidth = layer.paint.get('circle-stroke-width');
     const strokeOpacity = layer.paint.get('circle-stroke-opacity');

--- a/src/render/draw_circle.ts
+++ b/src/render/draw_circle.ts
@@ -6,7 +6,7 @@ import {circleUniformValues} from './program/circle_program';
 import {SegmentVector} from '../data/segment';
 import {OverscaledTileID} from '../source/tile_id';
 
-import type {Painter} from './painter';
+import type {Painter, RenderFlags} from './painter';
 import type {SourceCache} from '../source/source_cache';
 import type {CircleStyleLayer} from '../style/style_layer/circle_style_layer';
 import type {CircleBucket} from '../data/bucket/circle_bucket';
@@ -35,9 +35,10 @@ type SegmentsTileRenderState = {
     state: TileRenderState;
 };
 
-export function drawCircles(painter: Painter, sourceCache: SourceCache, layer: CircleStyleLayer, coords: Array<OverscaledTileID>, isRenderingToTexture: boolean = false) {
+export function drawCircles(painter: Painter, sourceCache: SourceCache, layer: CircleStyleLayer, coords: Array<OverscaledTileID>, renderFlags: RenderFlags) {
     if (painter.renderPass !== 'translucent') return;
 
+    const {isRenderingToTexture} = renderFlags;
     const opacity = layer.paint.get('circle-opacity');
     const strokeWidth = layer.paint.get('circle-stroke-width');
     const strokeOpacity = layer.paint.get('circle-stroke-opacity');

--- a/src/render/draw_circle.ts
+++ b/src/render/draw_circle.ts
@@ -35,7 +35,7 @@ type SegmentsTileRenderState = {
     state: TileRenderState;
 };
 
-export function drawCircles(painter: Painter, sourceCache: SourceCache, layer: CircleStyleLayer, coords: Array<OverscaledTileID>) {
+export function drawCircles(painter: Painter, sourceCache: SourceCache, layer: CircleStyleLayer, coords: Array<OverscaledTileID>, isRenderingToTexture: boolean = false) {
     if (painter.renderPass !== 'translucent') return;
 
     const opacity = layer.paint.get('circle-opacity');
@@ -80,7 +80,7 @@ export function drawCircles(painter: Painter, sourceCache: SourceCache, layer: C
         const terrainData = painter.style.map.terrain && painter.style.map.terrain.getTerrainData(coord);
         const uniformValues = circleUniformValues(painter, tile, layer, translateForUniforms, radiusCorrectionFactor);
 
-        const projectionData = transform.getProjectionData({overscaledTileID: coord});
+        const projectionData = transform.getProjectionData({overscaledTileID: coord, ignoreGlobeMatrix: isRenderingToTexture});
 
         const state: TileRenderState = {
             programConfiguration,

--- a/src/render/draw_collision_debug.ts
+++ b/src/render/draw_collision_debug.ts
@@ -62,7 +62,7 @@ export function drawCollisionDebug(painter: Painter, sourceCache: SourceCache, l
             CullFaceMode.disabled,
             collisionUniformValues(painter.transform),
             painter.style.map.terrain && painter.style.map.terrain.getTerrainData(coord),
-            transform.getProjectionData({overscaledTileID: coord}),
+            transform.getProjectionData({overscaledTileID: coord, applyGlobeMatrix: true, applyTerrainMatrix: true}),
             layer.id, buffers.layoutVertexBuffer, buffers.indexBuffer,
             buffers.segments, null, painter.transform.zoom, null, null,
             buffers.collisionVertexBuffer);

--- a/src/render/draw_custom.test.ts
+++ b/src/render/draw_custom.test.ts
@@ -60,8 +60,8 @@ describe('drawCustom', () => {
                 };
             },
         });
-        const renderFlags: RenderOptions = {isRenderingToTexture: false, isRenderingGlobe: false};
-        drawCustom(mockPainter, sourceCacheMock, mockLayer, renderFlags);
+        const renderOptions: RenderOptions = {isRenderingToTexture: false, isRenderingGlobe: false};
+        drawCustom(mockPainter, sourceCacheMock, mockLayer, renderOptions);
         expect(result.gl).toBeDefined();
         expect(result.args.farZ).toBeCloseTo(804.8028169246645, 6);
         expect(result.args.farZ).toBe(mockPainter.transform.farZ);

--- a/src/render/draw_custom.test.ts
+++ b/src/render/draw_custom.test.ts
@@ -1,7 +1,7 @@
 import {OverscaledTileID} from '../source/tile_id';
 import {SourceCache} from '../source/source_cache';
 import {Tile} from '../source/tile';
-import {Painter} from './painter';
+import {Painter, RenderFlags} from './painter';
 import type {Map} from '../ui/map';
 import {drawCustom} from './draw_custom';
 import {CustomStyleLayer} from '../style/style_layer/custom_style_layer';
@@ -60,7 +60,8 @@ describe('drawCustom', () => {
                 };
             },
         });
-        drawCustom(mockPainter, sourceCacheMock, mockLayer);
+        const renderFlags: RenderFlags = {isRenderingToTexture: false, isRenderingGlobe: false};
+        drawCustom(mockPainter, sourceCacheMock, mockLayer, renderFlags);
         expect(result.gl).toBeDefined();
         expect(result.args.farZ).toBeCloseTo(804.8028169246645, 6);
         expect(result.args.farZ).toBe(mockPainter.transform.farZ);

--- a/src/render/draw_custom.test.ts
+++ b/src/render/draw_custom.test.ts
@@ -1,7 +1,7 @@
 import {OverscaledTileID} from '../source/tile_id';
 import {SourceCache} from '../source/source_cache';
 import {Tile} from '../source/tile';
-import {Painter, RenderFlags} from './painter';
+import {Painter, RenderOptions} from './painter';
 import type {Map} from '../ui/map';
 import {drawCustom} from './draw_custom';
 import {CustomStyleLayer} from '../style/style_layer/custom_style_layer';
@@ -60,7 +60,7 @@ describe('drawCustom', () => {
                 };
             },
         });
-        const renderFlags: RenderFlags = {isRenderingToTexture: false, isRenderingGlobe: false};
+        const renderFlags: RenderOptions = {isRenderingToTexture: false, isRenderingGlobe: false};
         drawCustom(mockPainter, sourceCacheMock, mockLayer, renderFlags);
         expect(result.gl).toBeDefined();
         expect(result.args.farZ).toBeCloseTo(804.8028169246645, 6);

--- a/src/render/draw_custom.ts
+++ b/src/render/draw_custom.ts
@@ -5,14 +5,14 @@ import type {Painter} from './painter';
 import type {SourceCache} from '../source/source_cache';
 import type {CustomRenderMethodInput, CustomStyleLayer} from '../style/style_layer/custom_style_layer';
 
-export function drawCustom(painter: Painter, sourceCache: SourceCache, layer: CustomStyleLayer) {
+export function drawCustom(painter: Painter, sourceCache: SourceCache, layer: CustomStyleLayer, isRenderingToTexture: boolean = false) {
 
     const context = painter.context;
     const implementation = layer.implementation;
     const projection = painter.style.projection;
     const transform = painter.transform;
 
-    const projectionData = transform.getProjectionDataForCustomLayer();
+    const projectionData = transform.getProjectionDataForCustomLayer(isRenderingToTexture);
 
     const customLayerArgs: CustomRenderMethodInput = {
         farZ: transform.farZ,

--- a/src/render/draw_custom.ts
+++ b/src/render/draw_custom.ts
@@ -5,9 +5,9 @@ import type {Painter, RenderOptions} from './painter';
 import type {SourceCache} from '../source/source_cache';
 import type {CustomRenderMethodInput, CustomStyleLayer} from '../style/style_layer/custom_style_layer';
 
-export function drawCustom(painter: Painter, sourceCache: SourceCache, layer: CustomStyleLayer, renderFlags: RenderOptions) {
+export function drawCustom(painter: Painter, sourceCache: SourceCache, layer: CustomStyleLayer, renderOptions: RenderOptions) {
 
-    const {isRenderingToTexture} = renderFlags;
+    const {isRenderingToTexture} = renderOptions;
     const context = painter.context;
     const implementation = layer.implementation;
     const projection = painter.style.projection;

--- a/src/render/draw_custom.ts
+++ b/src/render/draw_custom.ts
@@ -1,11 +1,11 @@
 import {DepthMode} from '../gl/depth_mode';
 import {StencilMode} from '../gl/stencil_mode';
 
-import type {Painter, RenderFlags} from './painter';
+import type {Painter, RenderOptions} from './painter';
 import type {SourceCache} from '../source/source_cache';
 import type {CustomRenderMethodInput, CustomStyleLayer} from '../style/style_layer/custom_style_layer';
 
-export function drawCustom(painter: Painter, sourceCache: SourceCache, layer: CustomStyleLayer, renderFlags: RenderFlags) {
+export function drawCustom(painter: Painter, sourceCache: SourceCache, layer: CustomStyleLayer, renderFlags: RenderOptions) {
 
     const {isRenderingToTexture} = renderFlags;
     const context = painter.context;

--- a/src/render/draw_custom.ts
+++ b/src/render/draw_custom.ts
@@ -7,13 +7,13 @@ import type {CustomRenderMethodInput, CustomStyleLayer} from '../style/style_lay
 
 export function drawCustom(painter: Painter, sourceCache: SourceCache, layer: CustomStyleLayer, renderOptions: RenderOptions) {
 
-    const {isRenderingToTexture} = renderOptions;
+    const {isRenderingGlobe} = renderOptions;
     const context = painter.context;
     const implementation = layer.implementation;
     const projection = painter.style.projection;
     const transform = painter.transform;
 
-    const projectionData = transform.getProjectionDataForCustomLayer(isRenderingToTexture);
+    const projectionData = transform.getProjectionDataForCustomLayer(isRenderingGlobe);
 
     const customLayerArgs: CustomRenderMethodInput = {
         farZ: transform.farZ,

--- a/src/render/draw_custom.ts
+++ b/src/render/draw_custom.ts
@@ -1,12 +1,13 @@
 import {DepthMode} from '../gl/depth_mode';
 import {StencilMode} from '../gl/stencil_mode';
 
-import type {Painter} from './painter';
+import type {Painter, RenderFlags} from './painter';
 import type {SourceCache} from '../source/source_cache';
 import type {CustomRenderMethodInput, CustomStyleLayer} from '../style/style_layer/custom_style_layer';
 
-export function drawCustom(painter: Painter, sourceCache: SourceCache, layer: CustomStyleLayer, isRenderingToTexture: boolean = false) {
+export function drawCustom(painter: Painter, sourceCache: SourceCache, layer: CustomStyleLayer, renderFlags: RenderFlags) {
 
+    const {isRenderingToTexture} = renderFlags;
     const context = painter.context;
     const implementation = layer.implementation;
     const projection = painter.style.projection;

--- a/src/render/draw_debug.ts
+++ b/src/render/draw_debug.ts
@@ -91,7 +91,7 @@ function drawDebugTile(painter: Painter, sourceCache: SourceCache, coord: Oversc
     const tileLabel = `${tileIdText} ${tileSizeKb}kB`;
     drawTextToOverlay(painter, tileLabel);
 
-    const projectionData = painter.transform.getProjectionData({overscaledTileID: coord});
+    const projectionData = painter.transform.getProjectionData({overscaledTileID: coord, applyGlobeMatrix: true, applyTerrainMatrix: true});
 
     program.draw(context, gl.TRIANGLES, depthMode, stencilMode, ColorMode.alphaBlended, CullFaceMode.disabled,
         debugUniformValues(Color.transparent, scaleRatio), null, projectionData, id,

--- a/src/render/draw_fill.test.ts
+++ b/src/render/draw_fill.test.ts
@@ -2,7 +2,7 @@ import {mat4} from 'gl-matrix';
 import {OverscaledTileID} from '../source/tile_id';
 import {SourceCache} from '../source/source_cache';
 import {Tile} from '../source/tile';
-import {Painter, RenderFlags} from './painter';
+import {Painter, RenderOptions} from './painter';
 import {Program} from './program';
 import type {ZoomHistory} from '../style/zoom_history';
 import type {Map} from '../ui/map';
@@ -38,7 +38,7 @@ describe('drawFill', () => {
         (sourceCacheMock.getTile as jest.Mock).mockReturnValue(mockTile);
         sourceCacheMock.map = {showCollisionBoxes: false} as any as Map;
 
-        const renderFlags: RenderFlags = {isRenderingToTexture: false, isRenderingGlobe: false};
+        const renderFlags: RenderOptions = {isRenderingToTexture: false, isRenderingGlobe: false};
         drawFill(painterMock, sourceCacheMock, layer, [mockTile.tileID], renderFlags);
 
         // twice: first for fill, second for stroke

--- a/src/render/draw_fill.test.ts
+++ b/src/render/draw_fill.test.ts
@@ -2,7 +2,7 @@ import {mat4} from 'gl-matrix';
 import {OverscaledTileID} from '../source/tile_id';
 import {SourceCache} from '../source/source_cache';
 import {Tile} from '../source/tile';
-import {Painter} from './painter';
+import {Painter, RenderFlags} from './painter';
 import {Program} from './program';
 import type {ZoomHistory} from '../style/zoom_history';
 import type {Map} from '../ui/map';
@@ -38,7 +38,8 @@ describe('drawFill', () => {
         (sourceCacheMock.getTile as jest.Mock).mockReturnValue(mockTile);
         sourceCacheMock.map = {showCollisionBoxes: false} as any as Map;
 
-        drawFill(painterMock, sourceCacheMock, layer, [mockTile.tileID]);
+        const renderFlags: RenderFlags = {isRenderingToTexture: false, isRenderingGlobe: false};
+        drawFill(painterMock, sourceCacheMock, layer, [mockTile.tileID], renderFlags);
 
         // twice: first for fill, second for stroke
         expect(programMock.draw).toHaveBeenCalledTimes(2);

--- a/src/render/draw_fill.test.ts
+++ b/src/render/draw_fill.test.ts
@@ -38,8 +38,8 @@ describe('drawFill', () => {
         (sourceCacheMock.getTile as jest.Mock).mockReturnValue(mockTile);
         sourceCacheMock.map = {showCollisionBoxes: false} as any as Map;
 
-        const renderFlags: RenderOptions = {isRenderingToTexture: false, isRenderingGlobe: false};
-        drawFill(painterMock, sourceCacheMock, layer, [mockTile.tileID], renderFlags);
+        const renderOptions: RenderOptions = {isRenderingToTexture: false, isRenderingGlobe: false};
+        drawFill(painterMock, sourceCacheMock, layer, [mockTile.tileID], renderOptions);
 
         // twice: first for fill, second for stroke
         expect(programMock.draw).toHaveBeenCalledTimes(2);

--- a/src/render/draw_fill.ts
+++ b/src/render/draw_fill.ts
@@ -18,7 +18,7 @@ import {updatePatternPositionsInProgram} from './update_pattern_positions_in_pro
 import {StencilMode} from '../gl/stencil_mode';
 import {translatePosition} from '../util/util';
 
-export function drawFill(painter: Painter, sourceCache: SourceCache, layer: FillStyleLayer, coords: Array<OverscaledTileID>, renderFlags: RenderOptions) {
+export function drawFill(painter: Painter, sourceCache: SourceCache, layer: FillStyleLayer, coords: Array<OverscaledTileID>, renderOptions: RenderOptions) {
     const color = layer.paint.get('fill-color');
     const opacity = layer.paint.get('fill-opacity');
 
@@ -26,7 +26,7 @@ export function drawFill(painter: Painter, sourceCache: SourceCache, layer: Fill
         return;
     }
 
-    const {isRenderingToTexture} = renderFlags;
+    const {isRenderingToTexture} = renderOptions;
     const colorMode = painter.colorModeForRenderPass();
     const pattern = layer.paint.get('fill-pattern');
     const pass = painter.opaquePassEnabledForLayer() &&

--- a/src/render/draw_fill.ts
+++ b/src/render/draw_fill.ts
@@ -9,7 +9,7 @@ import {
     fillOutlinePatternUniformValues
 } from './program/fill_program';
 
-import type {Painter} from './painter';
+import type {Painter, RenderFlags} from './painter';
 import type {SourceCache} from '../source/source_cache';
 import type {FillStyleLayer} from '../style/style_layer/fill_style_layer';
 import type {FillBucket} from '../data/bucket/fill_bucket';
@@ -18,7 +18,7 @@ import {updatePatternPositionsInProgram} from './update_pattern_positions_in_pro
 import {StencilMode} from '../gl/stencil_mode';
 import {translatePosition} from '../util/util';
 
-export function drawFill(painter: Painter, sourceCache: SourceCache, layer: FillStyleLayer, coords: Array<OverscaledTileID>, isRenderingToTexture: boolean = false) {
+export function drawFill(painter: Painter, sourceCache: SourceCache, layer: FillStyleLayer, coords: Array<OverscaledTileID>, renderFlags: RenderFlags) {
     const color = layer.paint.get('fill-color');
     const opacity = layer.paint.get('fill-opacity');
 
@@ -26,6 +26,7 @@ export function drawFill(painter: Painter, sourceCache: SourceCache, layer: Fill
         return;
     }
 
+    const {isRenderingToTexture} = renderFlags;
     const colorMode = painter.colorModeForRenderPass();
     const pattern = layer.paint.get('fill-pattern');
     const pass = painter.opaquePassEnabledForLayer() &&

--- a/src/render/draw_fill.ts
+++ b/src/render/draw_fill.ts
@@ -9,7 +9,7 @@ import {
     fillOutlinePatternUniformValues
 } from './program/fill_program';
 
-import type {Painter, RenderFlags} from './painter';
+import type {Painter, RenderOptions} from './painter';
 import type {SourceCache} from '../source/source_cache';
 import type {FillStyleLayer} from '../style/style_layer/fill_style_layer';
 import type {FillBucket} from '../data/bucket/fill_bucket';
@@ -18,7 +18,7 @@ import {updatePatternPositionsInProgram} from './update_pattern_positions_in_pro
 import {StencilMode} from '../gl/stencil_mode';
 import {translatePosition} from '../util/util';
 
-export function drawFill(painter: Painter, sourceCache: SourceCache, layer: FillStyleLayer, coords: Array<OverscaledTileID>, renderFlags: RenderFlags) {
+export function drawFill(painter: Painter, sourceCache: SourceCache, layer: FillStyleLayer, coords: Array<OverscaledTileID>, renderFlags: RenderOptions) {
     const color = layer.paint.get('fill-color');
     const opacity = layer.paint.get('fill-opacity');
 

--- a/src/render/draw_fill.ts
+++ b/src/render/draw_fill.ts
@@ -110,7 +110,8 @@ function drawFillTiles(
 
         const projectionData = transform.getProjectionData({
             overscaledTileID: coord,
-            applyGlobeMatrix: !isRenderingToTexture
+            applyGlobeMatrix: !isRenderingToTexture,
+            applyTerrainMatrix: true
         });
 
         const translateForUniforms = translatePosition(transform, tile, propertyFillTranslate, propertyFillTranslateAnchor);

--- a/src/render/draw_fill.ts
+++ b/src/render/draw_fill.ts
@@ -109,7 +109,7 @@ function drawFillTiles(
 
         const projectionData = transform.getProjectionData({
             overscaledTileID: coord,
-            ignoreGlobeMatrix: isRenderingToTexture
+            applyGlobeMatrix: !isRenderingToTexture
         });
 
         const translateForUniforms = translatePosition(transform, tile, propertyFillTranslate, propertyFillTranslateAnchor);

--- a/src/render/draw_fill_extrusion.ts
+++ b/src/render/draw_fill_extrusion.ts
@@ -7,7 +7,7 @@ import {
     fillExtrusionPatternUniformValues,
 } from './program/fill_extrusion_program';
 
-import type {Painter} from './painter';
+import type {Painter, RenderFlags} from './painter';
 import type {SourceCache} from '../source/source_cache';
 import type {FillExtrusionStyleLayer} from '../style/style_layer/fill_extrusion_style_layer';
 import type {FillExtrusionBucket} from '../data/bucket/fill_extrusion_bucket';
@@ -16,12 +16,13 @@ import type {OverscaledTileID} from '../source/tile_id';
 import {updatePatternPositionsInProgram} from './update_pattern_positions_in_program';
 import {translatePosition} from '../util/util';
 
-export function drawFillExtrusion(painter: Painter, source: SourceCache, layer: FillExtrusionStyleLayer, coords: Array<OverscaledTileID>, isRenderingToTexture: boolean = false) {
+export function drawFillExtrusion(painter: Painter, source: SourceCache, layer: FillExtrusionStyleLayer, coords: Array<OverscaledTileID>, renderFlags: RenderFlags) {
     const opacity = layer.paint.get('fill-extrusion-opacity');
     if (opacity === 0) {
         return;
     }
 
+    const {isRenderingToTexture} = renderFlags;
     if (painter.renderPass === 'translucent') {
         const depthMode = new DepthMode(painter.context.gl.LEQUAL, DepthMode.ReadWrite, painter.depthRangeFor3D);
 

--- a/src/render/draw_fill_extrusion.ts
+++ b/src/render/draw_fill_extrusion.ts
@@ -16,13 +16,13 @@ import type {OverscaledTileID} from '../source/tile_id';
 import {updatePatternPositionsInProgram} from './update_pattern_positions_in_program';
 import {translatePosition} from '../util/util';
 
-export function drawFillExtrusion(painter: Painter, source: SourceCache, layer: FillExtrusionStyleLayer, coords: Array<OverscaledTileID>, renderFlags: RenderOptions) {
+export function drawFillExtrusion(painter: Painter, source: SourceCache, layer: FillExtrusionStyleLayer, coords: Array<OverscaledTileID>, renderOptions: RenderOptions) {
     const opacity = layer.paint.get('fill-extrusion-opacity');
     if (opacity === 0) {
         return;
     }
 
-    const {isRenderingToTexture} = renderFlags;
+    const {isRenderingToTexture} = renderOptions;
     if (painter.renderPass === 'translucent') {
         const depthMode = new DepthMode(painter.context.gl.LEQUAL, DepthMode.ReadWrite, painter.depthRangeFor3D);
 

--- a/src/render/draw_fill_extrusion.ts
+++ b/src/render/draw_fill_extrusion.ts
@@ -80,7 +80,7 @@ function drawExtrusionTiles(
             programConfiguration.updatePaintBuffers(crossfade);
         }
 
-        const projectionData = transform.getProjectionData({overscaledTileID: coord, ignoreGlobeMatrix: isRenderingToTexture});
+        const projectionData = transform.getProjectionData({overscaledTileID: coord, applyGlobeMatrix: !isRenderingToTexture});
         updatePatternPositionsInProgram(programConfiguration, fillPropertyName, constantPattern, tile, layer);
 
         const translate = translatePosition(

--- a/src/render/draw_fill_extrusion.ts
+++ b/src/render/draw_fill_extrusion.ts
@@ -7,7 +7,7 @@ import {
     fillExtrusionPatternUniformValues,
 } from './program/fill_extrusion_program';
 
-import type {Painter, RenderFlags} from './painter';
+import type {Painter, RenderOptions} from './painter';
 import type {SourceCache} from '../source/source_cache';
 import type {FillExtrusionStyleLayer} from '../style/style_layer/fill_extrusion_style_layer';
 import type {FillExtrusionBucket} from '../data/bucket/fill_extrusion_bucket';
@@ -16,7 +16,7 @@ import type {OverscaledTileID} from '../source/tile_id';
 import {updatePatternPositionsInProgram} from './update_pattern_positions_in_program';
 import {translatePosition} from '../util/util';
 
-export function drawFillExtrusion(painter: Painter, source: SourceCache, layer: FillExtrusionStyleLayer, coords: Array<OverscaledTileID>, renderFlags: RenderFlags) {
+export function drawFillExtrusion(painter: Painter, source: SourceCache, layer: FillExtrusionStyleLayer, coords: Array<OverscaledTileID>, renderFlags: RenderOptions) {
     const opacity = layer.paint.get('fill-extrusion-opacity');
     if (opacity === 0) {
         return;

--- a/src/render/draw_fill_extrusion.ts
+++ b/src/render/draw_fill_extrusion.ts
@@ -81,7 +81,7 @@ function drawExtrusionTiles(
             programConfiguration.updatePaintBuffers(crossfade);
         }
 
-        const projectionData = transform.getProjectionData({overscaledTileID: coord, applyGlobeMatrix: !isRenderingToTexture});
+        const projectionData = transform.getProjectionData({overscaledTileID: coord, applyGlobeMatrix: !isRenderingToTexture, applyTerrainMatrix: true});
         updatePatternPositionsInProgram(programConfiguration, fillPropertyName, constantPattern, tile, layer);
 
         const translate = translatePosition(

--- a/src/render/draw_heatmap.ts
+++ b/src/render/draw_heatmap.ts
@@ -19,12 +19,12 @@ import type {HeatmapStyleLayer} from '../style/style_layer/heatmap_style_layer';
 import type {HeatmapBucket} from '../data/bucket/heatmap_bucket';
 import type {OverscaledTileID} from '../source/tile_id';
 
-export function drawHeatmap(painter: Painter, sourceCache: SourceCache, layer: HeatmapStyleLayer, tileIDs: Array<OverscaledTileID>, renderFlags: RenderOptions) {
+export function drawHeatmap(painter: Painter, sourceCache: SourceCache, layer: HeatmapStyleLayer, tileIDs: Array<OverscaledTileID>, renderOptions: RenderOptions) {
     if (layer.paint.get('heatmap-opacity') === 0) {
         return;
     }
     const context = painter.context;
-    const {isRenderingToTexture, isRenderingGlobe} = renderFlags;
+    const {isRenderingToTexture, isRenderingGlobe} = renderOptions;
 
     if (painter.style.map.terrain) {
         for (const coord of tileIDs) {

--- a/src/render/draw_heatmap.ts
+++ b/src/render/draw_heatmap.ts
@@ -25,7 +25,7 @@ export function drawHeatmap(painter: Painter, sourceCache: SourceCache, layer: H
     }
     const context = painter.context;
 
-    if (isRenderingToTexture) {
+    if (painter.style.map.terrain) {
         for (const coord of tileIDs) {
             const tile = sourceCache.getTile(coord);
             // Skip tiles that have uncovered parents to avoid flickering; we don't need
@@ -35,7 +35,7 @@ export function drawHeatmap(painter: Painter, sourceCache: SourceCache, layer: H
             if (painter.renderPass === 'offscreen') {
                 prepareHeatmapTerrain(painter, tile, layer, coord);
             } else if (painter.renderPass === 'translucent') {
-                renderHeatmapTerrain(painter, layer, coord);
+                renderHeatmapTerrain(painter, layer, coord, isRenderingToTexture);
             }
         }
         context.viewport.set([0, 0, painter.width, painter.height]);
@@ -156,7 +156,7 @@ function prepareHeatmapTerrain(painter: Painter, tile: Tile, layer: HeatmapStyle
         programConfiguration);
 }
 
-function renderHeatmapTerrain(painter: Painter, layer: HeatmapStyleLayer, coord: OverscaledTileID) {
+function renderHeatmapTerrain(painter: Painter, layer: HeatmapStyleLayer, coord: OverscaledTileID, isRenderingToTexture: boolean) {
     const isGlobe = painter.style.projection.name === 'globe';
     const context = painter.context;
     const gl = context.gl;
@@ -179,7 +179,7 @@ function renderHeatmapTerrain(painter: Painter, layer: HeatmapStyleLayer, coord:
     context.activeTexture.set(gl.TEXTURE1);
     colorRampTexture.bind(gl.LINEAR, gl.CLAMP_TO_EDGE);
 
-    const projectionData = transform.getProjectionData({overscaledTileID: coord, ignoreTerrainMatrix: !isGlobe});
+    const projectionData = transform.getProjectionData({overscaledTileID: coord, ignoreTerrainMatrix: !isGlobe, ignoreGlobeMatrix: isRenderingToTexture});
 
     painter.useProgram('heatmapTexture').draw(context, gl.TRIANGLES,
         DepthMode.disabled, StencilMode.disabled, painter.colorModeForRenderPass(), CullFaceMode.disabled,

--- a/src/render/draw_heatmap.ts
+++ b/src/render/draw_heatmap.ts
@@ -179,7 +179,7 @@ function renderHeatmapTerrain(painter: Painter, layer: HeatmapStyleLayer, coord:
     context.activeTexture.set(gl.TEXTURE1);
     colorRampTexture.bind(gl.LINEAR, gl.CLAMP_TO_EDGE);
 
-    const projectionData = transform.getProjectionData({overscaledTileID: coord, ignoreTerrainMatrix: !isGlobe, ignoreGlobeMatrix: isRenderingToTexture});
+    const projectionData = transform.getProjectionData({overscaledTileID: coord, applyTerrainMatrix: isGlobe, applyGlobeMatrix: !isRenderingToTexture});
 
     painter.useProgram('heatmapTexture').draw(context, gl.TRIANGLES,
         DepthMode.disabled, StencilMode.disabled, painter.colorModeForRenderPass(), CullFaceMode.disabled,

--- a/src/render/draw_heatmap.ts
+++ b/src/render/draw_heatmap.ts
@@ -80,7 +80,7 @@ function prepareHeatmapFlat(painter: Painter, sourceCache: SourceCache, layer: H
         const programConfiguration = bucket.programConfigurations.get(layer.id);
         const program = painter.useProgram('heatmap', programConfiguration);
 
-        const projectionData = transform.getProjectionData({overscaledTileID: coord});
+        const projectionData = transform.getProjectionData({overscaledTileID: coord, applyGlobeMatrix: true, applyTerrainMatrix: false});
 
         const radiusCorrectionFactor = transform.getCircleRadiusCorrection();
 
@@ -146,7 +146,7 @@ function prepareHeatmapTerrain(painter: Painter, tile: Tile, layer: HeatmapStyle
     const programConfiguration = bucket.programConfigurations.get(layer.id);
     const program = painter.useProgram('heatmap', programConfiguration, !isRenderingGlobe);
 
-    const projectionData = painter.transform.getProjectionData({overscaledTileID: tile.tileID});
+    const projectionData = painter.transform.getProjectionData({overscaledTileID: tile.tileID, applyGlobeMatrix: true, applyTerrainMatrix: true});
 
     const terrainData = painter.style.map.terrain.getTerrainData(coord);
     program.draw(context, gl.TRIANGLES, DepthMode.disabled, stencilMode, colorMode, CullFaceMode.disabled,

--- a/src/render/draw_heatmap.ts
+++ b/src/render/draw_heatmap.ts
@@ -13,13 +13,13 @@ import {
 } from './program/heatmap_program';
 import {HEATMAP_FULL_RENDER_FBO_KEY} from '../style/style_layer/heatmap_style_layer';
 
-import type {Painter, RenderFlags} from './painter';
+import type {Painter, RenderOptions} from './painter';
 import type {SourceCache} from '../source/source_cache';
 import type {HeatmapStyleLayer} from '../style/style_layer/heatmap_style_layer';
 import type {HeatmapBucket} from '../data/bucket/heatmap_bucket';
 import type {OverscaledTileID} from '../source/tile_id';
 
-export function drawHeatmap(painter: Painter, sourceCache: SourceCache, layer: HeatmapStyleLayer, tileIDs: Array<OverscaledTileID>, renderFlags: RenderFlags) {
+export function drawHeatmap(painter: Painter, sourceCache: SourceCache, layer: HeatmapStyleLayer, tileIDs: Array<OverscaledTileID>, renderFlags: RenderOptions) {
     if (layer.paint.get('heatmap-opacity') === 0) {
         return;
     }

--- a/src/render/draw_heatmap.ts
+++ b/src/render/draw_heatmap.ts
@@ -19,13 +19,13 @@ import type {HeatmapStyleLayer} from '../style/style_layer/heatmap_style_layer';
 import type {HeatmapBucket} from '../data/bucket/heatmap_bucket';
 import type {OverscaledTileID} from '../source/tile_id';
 
-export function drawHeatmap(painter: Painter, sourceCache: SourceCache, layer: HeatmapStyleLayer, tileIDs: Array<OverscaledTileID>) {
+export function drawHeatmap(painter: Painter, sourceCache: SourceCache, layer: HeatmapStyleLayer, tileIDs: Array<OverscaledTileID>, isRenderingToTexture: boolean = false) {
     if (layer.paint.get('heatmap-opacity') === 0) {
         return;
     }
     const context = painter.context;
 
-    if (painter.style.map.terrain) {
+    if (isRenderingToTexture) {
         for (const coord of tileIDs) {
             const tile = sourceCache.getTile(coord);
             // Skip tiles that have uncovered parents to avoid flickering; we don't need

--- a/src/render/draw_hillshade.ts
+++ b/src/render/draw_hillshade.ts
@@ -78,7 +78,8 @@ function renderHillshade(
         const projectionData = transform.getProjectionData({
             overscaledTileID: coord,
             aligned: align,
-            applyGlobeMatrix: !isRenderingToTexture
+            applyGlobeMatrix: !isRenderingToTexture,
+            applyTerrainMatrix: true
         });
 
         program.draw(context, gl.TRIANGLES, depthMode, stencilModes[coord.overscaledZ], colorMode, CullFaceMode.backCCW,

--- a/src/render/draw_hillshade.ts
+++ b/src/render/draw_hillshade.ts
@@ -8,14 +8,15 @@ import {
     hillshadeUniformPrepareValues
 } from './program/hillshade_program';
 
-import type {Painter} from './painter';
+import type {Painter, RenderFlags} from './painter';
 import type {SourceCache} from '../source/source_cache';
 import type {HillshadeStyleLayer} from '../style/style_layer/hillshade_style_layer';
 import type {OverscaledTileID} from '../source/tile_id';
 
-export function drawHillshade(painter: Painter, sourceCache: SourceCache, layer: HillshadeStyleLayer, tileIDs: Array<OverscaledTileID>, isRenderingToTexture: boolean = false) {
+export function drawHillshade(painter: Painter, sourceCache: SourceCache, layer: HillshadeStyleLayer, tileIDs: Array<OverscaledTileID>, renderFlags: RenderFlags) {
     if (painter.renderPass !== 'offscreen' && painter.renderPass !== 'translucent') return;
 
+    const {isRenderingToTexture} = renderFlags;
     const context = painter.context;
     const projection = painter.style.projection;
     const useSubdivision = projection.useSubdivision;

--- a/src/render/draw_hillshade.ts
+++ b/src/render/draw_hillshade.ts
@@ -8,12 +8,12 @@ import {
     hillshadeUniformPrepareValues
 } from './program/hillshade_program';
 
-import type {Painter, RenderFlags} from './painter';
+import type {Painter, RenderOptions} from './painter';
 import type {SourceCache} from '../source/source_cache';
 import type {HillshadeStyleLayer} from '../style/style_layer/hillshade_style_layer';
 import type {OverscaledTileID} from '../source/tile_id';
 
-export function drawHillshade(painter: Painter, sourceCache: SourceCache, layer: HillshadeStyleLayer, tileIDs: Array<OverscaledTileID>, renderFlags: RenderFlags) {
+export function drawHillshade(painter: Painter, sourceCache: SourceCache, layer: HillshadeStyleLayer, tileIDs: Array<OverscaledTileID>, renderFlags: RenderOptions) {
     if (painter.renderPass !== 'offscreen' && painter.renderPass !== 'translucent') return;
 
     const {isRenderingToTexture} = renderFlags;

--- a/src/render/draw_hillshade.ts
+++ b/src/render/draw_hillshade.ts
@@ -13,7 +13,7 @@ import type {SourceCache} from '../source/source_cache';
 import type {HillshadeStyleLayer} from '../style/style_layer/hillshade_style_layer';
 import type {OverscaledTileID} from '../source/tile_id';
 
-export function drawHillshade(painter: Painter, sourceCache: SourceCache, layer: HillshadeStyleLayer, tileIDs: Array<OverscaledTileID>) {
+export function drawHillshade(painter: Painter, sourceCache: SourceCache, layer: HillshadeStyleLayer, tileIDs: Array<OverscaledTileID>, isRenderingToTexture: boolean = false) {
     if (painter.renderPass !== 'offscreen' && painter.renderPass !== 'translucent') return;
 
     const context = painter.context;
@@ -33,12 +33,12 @@ export function drawHillshade(painter: Painter, sourceCache: SourceCache, layer:
         if (useSubdivision) {
             // Two-pass rendering
             const [stencilBorderless, stencilBorders, coords] = painter.stencilConfigForOverlapTwoPass(tileIDs);
-            renderHillshade(painter, sourceCache, layer, coords, stencilBorderless, depthMode, colorMode, false); // draw without borders
-            renderHillshade(painter, sourceCache, layer, coords, stencilBorders, depthMode, colorMode, true); // draw with borders
+            renderHillshade(painter, sourceCache, layer, coords, stencilBorderless, depthMode, colorMode, false, isRenderingToTexture); // draw without borders
+            renderHillshade(painter, sourceCache, layer, coords, stencilBorders, depthMode, colorMode, true, isRenderingToTexture); // draw with borders
         } else {
             // Simple rendering
             const [stencil, coords] = painter.stencilConfigForOverlap(tileIDs);
-            renderHillshade(painter, sourceCache, layer, coords, stencil, depthMode, colorMode, false);
+            renderHillshade(painter, sourceCache, layer, coords, stencil, depthMode, colorMode, false, isRenderingToTexture);
         }
     }
 }
@@ -51,7 +51,8 @@ function renderHillshade(
     stencilModes: {[_: number]: Readonly<StencilMode>},
     depthMode: Readonly<DepthMode>,
     colorMode: Readonly<ColorMode>,
-    useBorder: boolean
+    useBorder: boolean,
+    isRenderingToTexture: boolean
 ) {
     const projection = painter.style.projection;
     const context = painter.context;
@@ -73,12 +74,10 @@ function renderHillshade(
         context.activeTexture.set(gl.TEXTURE0);
         gl.bindTexture(gl.TEXTURE_2D, fbo.colorAttachment.get());
 
-        const globeWithTerrain = painter.style.map.terrain && painter.style.projection.name === 'globe';
-
         const projectionData = transform.getProjectionData({
             overscaledTileID: coord,
             aligned: align,
-            ignoreGlobeMatrix: globeWithTerrain
+            ignoreGlobeMatrix: isRenderingToTexture
         });
 
         program.draw(context, gl.TRIANGLES, depthMode, stencilModes[coord.overscaledZ], colorMode, CullFaceMode.backCCW,

--- a/src/render/draw_hillshade.ts
+++ b/src/render/draw_hillshade.ts
@@ -77,7 +77,7 @@ function renderHillshade(
         const projectionData = transform.getProjectionData({
             overscaledTileID: coord,
             aligned: align,
-            ignoreGlobeMatrix: isRenderingToTexture
+            applyGlobeMatrix: !isRenderingToTexture
         });
 
         program.draw(context, gl.TRIANGLES, depthMode, stencilModes[coord.overscaledZ], colorMode, CullFaceMode.backCCW,

--- a/src/render/draw_hillshade.ts
+++ b/src/render/draw_hillshade.ts
@@ -13,10 +13,10 @@ import type {SourceCache} from '../source/source_cache';
 import type {HillshadeStyleLayer} from '../style/style_layer/hillshade_style_layer';
 import type {OverscaledTileID} from '../source/tile_id';
 
-export function drawHillshade(painter: Painter, sourceCache: SourceCache, layer: HillshadeStyleLayer, tileIDs: Array<OverscaledTileID>, renderFlags: RenderOptions) {
+export function drawHillshade(painter: Painter, sourceCache: SourceCache, layer: HillshadeStyleLayer, tileIDs: Array<OverscaledTileID>, renderOptions: RenderOptions) {
     if (painter.renderPass !== 'offscreen' && painter.renderPass !== 'translucent') return;
 
-    const {isRenderingToTexture} = renderFlags;
+    const {isRenderingToTexture} = renderOptions;
     const context = painter.context;
     const projection = painter.style.projection;
     const useSubdivision = projection.useSubdivision;

--- a/src/render/draw_line.ts
+++ b/src/render/draw_line.ts
@@ -71,7 +71,8 @@ export function drawLine(painter: Painter, sourceCache: SourceCache, layer: Line
 
         const projectionData = transform.getProjectionData({
             overscaledTileID: coord,
-            applyGlobeMatrix: !isRenderingToTexture
+            applyGlobeMatrix: !isRenderingToTexture,
+            applyTerrainMatrix: true
         });
 
         const pixelRatio = transform.getPixelScale();

--- a/src/render/draw_line.ts
+++ b/src/render/draw_line.ts
@@ -69,7 +69,7 @@ export function drawLine(painter: Painter, sourceCache: SourceCache, layer: Line
 
         const projectionData = transform.getProjectionData({
             overscaledTileID: coord,
-            ignoreGlobeMatrix: isRenderingToTexture
+            applyGlobeMatrix: !isRenderingToTexture
         });
 
         const pixelRatio = transform.getPixelScale();

--- a/src/render/draw_line.ts
+++ b/src/render/draw_line.ts
@@ -17,10 +17,10 @@ import {clamp, nextPowerOfTwo} from '../util/util';
 import {renderColorRamp} from '../util/color_ramp';
 import {EXTENT} from '../data/extent';
 
-export function drawLine(painter: Painter, sourceCache: SourceCache, layer: LineStyleLayer, coords: Array<OverscaledTileID>, renderFlags: RenderOptions) {
+export function drawLine(painter: Painter, sourceCache: SourceCache, layer: LineStyleLayer, coords: Array<OverscaledTileID>, renderOptions: RenderOptions) {
     if (painter.renderPass !== 'translucent') return;
 
-    const {isRenderingToTexture} = renderFlags;
+    const {isRenderingToTexture} = renderOptions;
 
     const opacity = layer.paint.get('line-opacity');
     const width = layer.paint.get('line-width');

--- a/src/render/draw_line.ts
+++ b/src/render/draw_line.ts
@@ -8,7 +8,7 @@ import {
     lineGradientUniformValues
 } from './program/line_program';
 
-import type {Painter, RenderFlags} from './painter';
+import type {Painter, RenderOptions} from './painter';
 import type {SourceCache} from '../source/source_cache';
 import type {LineStyleLayer} from '../style/style_layer/line_style_layer';
 import type {LineBucket} from '../data/bucket/line_bucket';
@@ -17,7 +17,7 @@ import {clamp, nextPowerOfTwo} from '../util/util';
 import {renderColorRamp} from '../util/color_ramp';
 import {EXTENT} from '../data/extent';
 
-export function drawLine(painter: Painter, sourceCache: SourceCache, layer: LineStyleLayer, coords: Array<OverscaledTileID>, renderFlags: RenderFlags) {
+export function drawLine(painter: Painter, sourceCache: SourceCache, layer: LineStyleLayer, coords: Array<OverscaledTileID>, renderFlags: RenderOptions) {
     if (painter.renderPass !== 'translucent') return;
 
     const {isRenderingToTexture} = renderFlags;

--- a/src/render/draw_line.ts
+++ b/src/render/draw_line.ts
@@ -17,7 +17,7 @@ import {clamp, nextPowerOfTwo} from '../util/util';
 import {renderColorRamp} from '../util/color_ramp';
 import {EXTENT} from '../data/extent';
 
-export function drawLine(painter: Painter, sourceCache: SourceCache, layer: LineStyleLayer, coords: Array<OverscaledTileID>) {
+export function drawLine(painter: Painter, sourceCache: SourceCache, layer: LineStyleLayer, coords: Array<OverscaledTileID>, isRenderingToTexture: boolean = false) {
     if (painter.renderPass !== 'translucent') return;
 
     const opacity = layer.paint.get('line-opacity');
@@ -26,7 +26,6 @@ export function drawLine(painter: Painter, sourceCache: SourceCache, layer: Line
 
     const depthMode = painter.getDepthModeForSublayer(0, DepthMode.ReadOnly);
     const colorMode = painter.colorModeForRenderPass();
-    const globeWithTerrain = !!painter.style.map.terrain && painter.style.projection.name === 'globe';
     
     const dasharray = layer.paint.get('line-dasharray');
     const patternProperty = layer.paint.get('line-pattern');
@@ -70,7 +69,7 @@ export function drawLine(painter: Painter, sourceCache: SourceCache, layer: Line
 
         const projectionData = transform.getProjectionData({
             overscaledTileID: coord,
-            ignoreGlobeMatrix: globeWithTerrain
+            ignoreGlobeMatrix: isRenderingToTexture
         });
 
         const pixelRatio = transform.getPixelScale();
@@ -123,7 +122,7 @@ export function drawLine(painter: Painter, sourceCache: SourceCache, layer: Line
         }
 
         const [stencilModes] = painter.stencilConfigForOverlap(coords);
-        const stencil = globeWithTerrain ? stencilModes[coord.overscaledZ] : painter.stencilModeForClipping(coord);
+        const stencil = isRenderingToTexture ? stencilModes[coord.overscaledZ] : painter.stencilModeForClipping(coord);
 
         program.draw(context, gl.TRIANGLES, depthMode,
             stencil, colorMode, CullFaceMode.disabled, uniformValues, terrainData, projectionData,

--- a/src/render/draw_line.ts
+++ b/src/render/draw_line.ts
@@ -8,7 +8,7 @@ import {
     lineGradientUniformValues
 } from './program/line_program';
 
-import type {Painter} from './painter';
+import type {Painter, RenderFlags} from './painter';
 import type {SourceCache} from '../source/source_cache';
 import type {LineStyleLayer} from '../style/style_layer/line_style_layer';
 import type {LineBucket} from '../data/bucket/line_bucket';
@@ -17,8 +17,10 @@ import {clamp, nextPowerOfTwo} from '../util/util';
 import {renderColorRamp} from '../util/color_ramp';
 import {EXTENT} from '../data/extent';
 
-export function drawLine(painter: Painter, sourceCache: SourceCache, layer: LineStyleLayer, coords: Array<OverscaledTileID>, isRenderingToTexture: boolean = false) {
+export function drawLine(painter: Painter, sourceCache: SourceCache, layer: LineStyleLayer, coords: Array<OverscaledTileID>, renderFlags: RenderFlags) {
     if (painter.renderPass !== 'translucent') return;
+
+    const {isRenderingToTexture} = renderFlags;
 
     const opacity = layer.paint.get('line-opacity');
     const width = layer.paint.get('line-width');

--- a/src/render/draw_raster.ts
+++ b/src/render/draw_raster.ts
@@ -126,7 +126,7 @@ function drawTiles(
         }
 
         const terrainData = painter.style.map.terrain && painter.style.map.terrain.getTerrainData(coord);
-        const projectionData = transform.getProjectionData({overscaledTileID: coord, aligned: align, applyGlobeMatrix: !isRenderingToTexture});
+        const projectionData = transform.getProjectionData({overscaledTileID: coord, aligned: align, applyGlobeMatrix: !isRenderingToTexture, applyTerrainMatrix: true});
         const uniformValues = rasterUniformValues(parentTL || [0, 0], parentScaleBy || 1, fade, layer, corners);
 
         const mesh = projection.getMeshFromTileID(context, coord.canonical, useBorder, allowPoles, 'raster');

--- a/src/render/draw_raster.ts
+++ b/src/render/draw_raster.ts
@@ -10,7 +10,7 @@ import {EXTENT} from '../data/extent';
 import {coveringZoomLevel} from '../geo/projection/covering_tiles';
 import Point from '@mapbox/point-geometry';
 
-import type {Painter, RenderFlags} from './painter';
+import type {Painter, RenderOptions} from './painter';
 import type {SourceCache} from '../source/source_cache';
 import type {RasterStyleLayer} from '../style/style_layer/raster_style_layer';
 import type {OverscaledTileID} from '../source/tile_id';
@@ -25,7 +25,7 @@ const cornerCoords = [
     new Point(0, EXTENT),
 ];
 
-export function drawRaster(painter: Painter, sourceCache: SourceCache, layer: RasterStyleLayer, tileIDs: Array<OverscaledTileID>, renderFlags: RenderFlags) {
+export function drawRaster(painter: Painter, sourceCache: SourceCache, layer: RasterStyleLayer, tileIDs: Array<OverscaledTileID>, renderFlags: RenderOptions) {
     if (painter.renderPass !== 'translucent') return;
     if (layer.paint.get('raster-opacity') === 0) return;
     if (!tileIDs.length) return;

--- a/src/render/draw_raster.ts
+++ b/src/render/draw_raster.ts
@@ -25,12 +25,12 @@ const cornerCoords = [
     new Point(0, EXTENT),
 ];
 
-export function drawRaster(painter: Painter, sourceCache: SourceCache, layer: RasterStyleLayer, tileIDs: Array<OverscaledTileID>, renderFlags: RenderOptions) {
+export function drawRaster(painter: Painter, sourceCache: SourceCache, layer: RasterStyleLayer, tileIDs: Array<OverscaledTileID>, renderOptions: RenderOptions) {
     if (painter.renderPass !== 'translucent') return;
     if (layer.paint.get('raster-opacity') === 0) return;
     if (!tileIDs.length) return;
 
-    const {isRenderingToTexture} = renderFlags;
+    const {isRenderingToTexture} = renderOptions;
     const source = sourceCache.getSource();
 
     const projection = painter.style.projection;

--- a/src/render/draw_raster.ts
+++ b/src/render/draw_raster.ts
@@ -10,7 +10,7 @@ import {EXTENT} from '../data/extent';
 import {coveringZoomLevel} from '../geo/projection/covering_tiles';
 import Point from '@mapbox/point-geometry';
 
-import type {Painter} from './painter';
+import type {Painter, RenderFlags} from './painter';
 import type {SourceCache} from '../source/source_cache';
 import type {RasterStyleLayer} from '../style/style_layer/raster_style_layer';
 import type {OverscaledTileID} from '../source/tile_id';
@@ -25,11 +25,12 @@ const cornerCoords = [
     new Point(0, EXTENT),
 ];
 
-export function drawRaster(painter: Painter, sourceCache: SourceCache, layer: RasterStyleLayer, tileIDs: Array<OverscaledTileID>, isRenderingToTexture: boolean = false) {
+export function drawRaster(painter: Painter, sourceCache: SourceCache, layer: RasterStyleLayer, tileIDs: Array<OverscaledTileID>, renderFlags: RenderFlags) {
     if (painter.renderPass !== 'translucent') return;
     if (layer.paint.get('raster-opacity') === 0) return;
     if (!tileIDs.length) return;
 
+    const {isRenderingToTexture} = renderFlags;
     const source = sourceCache.getSource();
 
     const projection = painter.style.projection;

--- a/src/render/draw_raster.ts
+++ b/src/render/draw_raster.ts
@@ -125,7 +125,7 @@ function drawTiles(
         }
 
         const terrainData = painter.style.map.terrain && painter.style.map.terrain.getTerrainData(coord);
-        const projectionData = transform.getProjectionData({overscaledTileID: coord, aligned: align, ignoreGlobeMatrix: isRenderingToTexture});
+        const projectionData = transform.getProjectionData({overscaledTileID: coord, aligned: align, applyGlobeMatrix: !isRenderingToTexture});
         const uniformValues = rasterUniformValues(parentTL || [0, 0], parentScaleBy || 1, fade, layer, corners);
 
         const mesh = projection.getMeshFromTileID(context, coord.canonical, useBorder, allowPoles, 'raster');

--- a/src/render/draw_sky.ts
+++ b/src/render/draw_sky.ts
@@ -85,7 +85,7 @@ export function drawAtmosphere(painter: Painter, sky: Sky, light: Light) {
 
     const sunPos = getSunPos(light, painter.transform);
 
-    const projectionData = transform.getProjectionData({overscaledTileID: null});
+    const projectionData = transform.getProjectionData({overscaledTileID: null, applyGlobeMatrix: true, applyTerrainMatrix: true});
     const atmosphereBlend = sky.properties.get('atmosphere-blend') * projectionData.projectionTransition;
 
     if (atmosphereBlend === 0) {

--- a/src/render/draw_symbol.test.ts
+++ b/src/render/draw_symbol.test.ts
@@ -4,7 +4,7 @@ import {SymbolBucket} from '../data/bucket/symbol_bucket';
 import {SourceCache} from '../source/source_cache';
 import {Tile} from '../source/tile';
 import {SymbolStyleLayer} from '../style/style_layer/symbol_style_layer';
-import {Painter, RenderFlags} from './painter';
+import {Painter, RenderOptions} from './painter';
 import {Program} from './program';
 import {drawSymbols} from './draw_symbol';
 import * as symbolProjection from '../symbol/projection';
@@ -49,7 +49,7 @@ describe('drawSymbol', () => {
         const mockPainter = new Painter(null, null);
         mockPainter.renderPass = 'opaque';
 
-        const renderFlags: RenderFlags = {isRenderingToTexture: false, isRenderingGlobe: false};
+        const renderFlags: RenderOptions = {isRenderingToTexture: false, isRenderingGlobe: false};
         drawSymbols(mockPainter, null, null, null, null, renderFlags);
 
         expect(mockPainter.colorModeForRenderPass).not.toHaveBeenCalled();
@@ -111,7 +111,7 @@ describe('drawSymbol', () => {
         sourceCacheMock.map = {showCollisionBoxes: false} as any as Map;
         sourceCacheMock.getTile = (_a) => tile;
 
-        const renderFlags: RenderFlags = {isRenderingToTexture: false, isRenderingGlobe: false};
+        const renderFlags: RenderOptions = {isRenderingToTexture: false, isRenderingGlobe: false};
         drawSymbols(painterMock, sourceCacheMock, layer, [tileId], null, renderFlags);
 
         expect(programMock.draw).toHaveBeenCalledTimes(1);
@@ -179,7 +179,7 @@ describe('drawSymbol', () => {
         } as any as Style;
 
         const spy = jest.spyOn(symbolProjection, 'updateLineLabels');
-        const renderFlags: RenderFlags = {isRenderingToTexture: false, isRenderingGlobe: false};
+        const renderFlags: RenderOptions = {isRenderingToTexture: false, isRenderingGlobe: false};
         drawSymbols(painterMock, sourceCacheMock, layer, [tileId], null, renderFlags);
 
         expect(spy.mock.calls[0][7]).toBeFalsy(); // rotateToLine === false
@@ -241,7 +241,7 @@ describe('drawSymbol', () => {
         (sourceCacheMock.getTile as jest.Mock).mockReturnValue(tile);
         sourceCacheMock.map = {showCollisionBoxes: false} as any as Map;
 
-        const renderFlags: RenderFlags = {isRenderingToTexture: false, isRenderingGlobe: false};
+        const renderFlags: RenderOptions = {isRenderingToTexture: false, isRenderingGlobe: false};
         drawSymbols(painterMock, sourceCacheMock, layer, [tileId], null, renderFlags);
 
         expect(programMock.draw).toHaveBeenCalledTimes(0);

--- a/src/render/draw_symbol.test.ts
+++ b/src/render/draw_symbol.test.ts
@@ -4,7 +4,7 @@ import {SymbolBucket} from '../data/bucket/symbol_bucket';
 import {SourceCache} from '../source/source_cache';
 import {Tile} from '../source/tile';
 import {SymbolStyleLayer} from '../style/style_layer/symbol_style_layer';
-import {Painter} from './painter';
+import {Painter, RenderFlags} from './painter';
 import {Program} from './program';
 import {drawSymbols} from './draw_symbol';
 import * as symbolProjection from '../symbol/projection';
@@ -49,7 +49,8 @@ describe('drawSymbol', () => {
         const mockPainter = new Painter(null, null);
         mockPainter.renderPass = 'opaque';
 
-        drawSymbols(mockPainter, null, null, null, null);
+        const renderFlags: RenderFlags = {isRenderingToTexture: false, isRenderingGlobe: false};
+        drawSymbols(mockPainter, null, null, null, null, renderFlags);
 
         expect(mockPainter.colorModeForRenderPass).not.toHaveBeenCalled();
     });
@@ -110,7 +111,8 @@ describe('drawSymbol', () => {
         sourceCacheMock.map = {showCollisionBoxes: false} as any as Map;
         sourceCacheMock.getTile = (_a) => tile;
 
-        drawSymbols(painterMock, sourceCacheMock, layer, [tileId], null);
+        const renderFlags: RenderFlags = {isRenderingToTexture: false, isRenderingGlobe: false};
+        drawSymbols(painterMock, sourceCacheMock, layer, [tileId], null, renderFlags);
 
         expect(programMock.draw).toHaveBeenCalledTimes(1);
     });
@@ -177,7 +179,8 @@ describe('drawSymbol', () => {
         } as any as Style;
 
         const spy = jest.spyOn(symbolProjection, 'updateLineLabels');
-        drawSymbols(painterMock, sourceCacheMock, layer, [tileId], null);
+        const renderFlags: RenderFlags = {isRenderingToTexture: false, isRenderingGlobe: false};
+        drawSymbols(painterMock, sourceCacheMock, layer, [tileId], null, renderFlags);
 
         expect(spy.mock.calls[0][7]).toBeFalsy(); // rotateToLine === false
     });
@@ -238,7 +241,8 @@ describe('drawSymbol', () => {
         (sourceCacheMock.getTile as jest.Mock).mockReturnValue(tile);
         sourceCacheMock.map = {showCollisionBoxes: false} as any as Map;
 
-        drawSymbols(painterMock, sourceCacheMock, layer, [tileId], null);
+        const renderFlags: RenderFlags = {isRenderingToTexture: false, isRenderingGlobe: false};
+        drawSymbols(painterMock, sourceCacheMock, layer, [tileId], null, renderFlags);
 
         expect(programMock.draw).toHaveBeenCalledTimes(0);
     });

--- a/src/render/draw_symbol.test.ts
+++ b/src/render/draw_symbol.test.ts
@@ -49,8 +49,8 @@ describe('drawSymbol', () => {
         const mockPainter = new Painter(null, null);
         mockPainter.renderPass = 'opaque';
 
-        const renderFlags: RenderOptions = {isRenderingToTexture: false, isRenderingGlobe: false};
-        drawSymbols(mockPainter, null, null, null, null, renderFlags);
+        const renderOptions: RenderOptions = {isRenderingToTexture: false, isRenderingGlobe: false};
+        drawSymbols(mockPainter, null, null, null, null, renderOptions);
 
         expect(mockPainter.colorModeForRenderPass).not.toHaveBeenCalled();
     });
@@ -111,8 +111,8 @@ describe('drawSymbol', () => {
         sourceCacheMock.map = {showCollisionBoxes: false} as any as Map;
         sourceCacheMock.getTile = (_a) => tile;
 
-        const renderFlags: RenderOptions = {isRenderingToTexture: false, isRenderingGlobe: false};
-        drawSymbols(painterMock, sourceCacheMock, layer, [tileId], null, renderFlags);
+        const renderOptions: RenderOptions = {isRenderingToTexture: false, isRenderingGlobe: false};
+        drawSymbols(painterMock, sourceCacheMock, layer, [tileId], null, renderOptions);
 
         expect(programMock.draw).toHaveBeenCalledTimes(1);
     });
@@ -179,8 +179,8 @@ describe('drawSymbol', () => {
         } as any as Style;
 
         const spy = jest.spyOn(symbolProjection, 'updateLineLabels');
-        const renderFlags: RenderOptions = {isRenderingToTexture: false, isRenderingGlobe: false};
-        drawSymbols(painterMock, sourceCacheMock, layer, [tileId], null, renderFlags);
+        const renderOptions: RenderOptions = {isRenderingToTexture: false, isRenderingGlobe: false};
+        drawSymbols(painterMock, sourceCacheMock, layer, [tileId], null, renderOptions);
 
         expect(spy.mock.calls[0][7]).toBeFalsy(); // rotateToLine === false
     });
@@ -241,8 +241,8 @@ describe('drawSymbol', () => {
         (sourceCacheMock.getTile as jest.Mock).mockReturnValue(tile);
         sourceCacheMock.map = {showCollisionBoxes: false} as any as Map;
 
-        const renderFlags: RenderOptions = {isRenderingToTexture: false, isRenderingGlobe: false};
-        drawSymbols(painterMock, sourceCacheMock, layer, [tileId], null, renderFlags);
+        const renderOptions: RenderOptions = {isRenderingToTexture: false, isRenderingGlobe: false};
+        drawSymbols(painterMock, sourceCacheMock, layer, [tileId], null, renderOptions);
 
         expect(programMock.draw).toHaveBeenCalledTimes(0);
     });

--- a/src/render/draw_symbol.ts
+++ b/src/render/draw_symbol.ts
@@ -62,7 +62,7 @@ const identityMat4 = mat4.identity(new Float32Array(16));
 
 export function drawSymbols(painter: Painter, sourceCache: SourceCache, layer: SymbolStyleLayer, coords: Array<OverscaledTileID>, variableOffsets: {
     [_ in CrossTileID]: VariableOffset;
-}) {
+}, isRenderingToTexture: boolean = false) {
     if (painter.renderPass !== 'translucent') return;
 
     // Disable the stencil test so that labels aren't clipped to tile boundaries.
@@ -89,7 +89,7 @@ export function drawSymbols(painter: Painter, sourceCache: SourceCache, layer: S
             layer.layout.get('icon-rotation-alignment'),
             layer.layout.get('icon-pitch-alignment'),
             layer.layout.get('icon-keep-upright'),
-            stencilMode, colorMode
+            stencilMode, colorMode, isRenderingToTexture
         );
     }
 
@@ -100,7 +100,7 @@ export function drawSymbols(painter: Painter, sourceCache: SourceCache, layer: S
             layer.layout.get('text-rotation-alignment'),
             layer.layout.get('text-pitch-alignment'),
             layer.layout.get('text-keep-upright'),
-            stencilMode, colorMode
+            stencilMode, colorMode, isRenderingToTexture
         );
     }
 
@@ -303,7 +303,8 @@ function drawLayerSymbols(
     pitchAlignment: SymbolLayerSpecification['layout']['text-pitch-alignment'],
     keepUpright: boolean,
     stencilMode: StencilMode,
-    colorMode: Readonly<ColorMode>) {
+    colorMode: Readonly<ColorMode>, 
+    isRenderingToTexture: boolean) {
 
     const context = painter.context;
     const gl = context.gl;
@@ -379,7 +380,7 @@ function drawLayerSymbols(
         const glCoordMatrixForShader = getGlCoordMatrix(pitchWithMap, rotateWithMap, painter.transform, s);
 
         const translation = translatePosition(transform, tile, translate, translateAnchor);
-        const projectionData = transform.getProjectionData({overscaledTileID: coord});
+        const projectionData = transform.getProjectionData({overscaledTileID: coord, ignoreGlobeMatrix: isRenderingToTexture});
 
         const hasVariableAnchors = hasVariablePlacement && bucket.hasTextData();
         const updateTextFitIcon = layer.layout.get('icon-text-fit') !== 'none' &&

--- a/src/render/draw_symbol.ts
+++ b/src/render/draw_symbol.ts
@@ -380,7 +380,7 @@ function drawLayerSymbols(
         const glCoordMatrixForShader = getGlCoordMatrix(pitchWithMap, rotateWithMap, painter.transform, s);
 
         const translation = translatePosition(transform, tile, translate, translateAnchor);
-        const projectionData = transform.getProjectionData({overscaledTileID: coord, ignoreGlobeMatrix: isRenderingToTexture});
+        const projectionData = transform.getProjectionData({overscaledTileID: coord, applyGlobeMatrix: !isRenderingToTexture});
 
         const hasVariableAnchors = hasVariablePlacement && bucket.hasTextData();
         const updateTextFitIcon = layer.layout.get('icon-text-fit') !== 'none' &&

--- a/src/render/draw_symbol.ts
+++ b/src/render/draw_symbol.ts
@@ -20,7 +20,7 @@ import {
     symbolTextAndIconUniformValues
 } from './program/symbol_program';
 
-import type {Painter} from './painter';
+import type {Painter, RenderFlags} from './painter';
 import type {SourceCache} from '../source/source_cache';
 import type {SymbolStyleLayer} from '../style/style_layer/symbol_style_layer';
 
@@ -62,9 +62,10 @@ const identityMat4 = mat4.identity(new Float32Array(16));
 
 export function drawSymbols(painter: Painter, sourceCache: SourceCache, layer: SymbolStyleLayer, coords: Array<OverscaledTileID>, variableOffsets: {
     [_ in CrossTileID]: VariableOffset;
-}, isRenderingToTexture: boolean = false) {
+}, renderFlags: RenderFlags) {
     if (painter.renderPass !== 'translucent') return;
 
+    const {isRenderingToTexture} = renderFlags;
     // Disable the stencil test so that labels aren't clipped to tile boundaries.
     const stencilMode = StencilMode.disabled;
     const colorMode = painter.colorModeForRenderPass();

--- a/src/render/draw_symbol.ts
+++ b/src/render/draw_symbol.ts
@@ -20,7 +20,7 @@ import {
     symbolTextAndIconUniformValues
 } from './program/symbol_program';
 
-import type {Painter, RenderFlags} from './painter';
+import type {Painter, RenderOptions} from './painter';
 import type {SourceCache} from '../source/source_cache';
 import type {SymbolStyleLayer} from '../style/style_layer/symbol_style_layer';
 
@@ -62,7 +62,7 @@ const identityMat4 = mat4.identity(new Float32Array(16));
 
 export function drawSymbols(painter: Painter, sourceCache: SourceCache, layer: SymbolStyleLayer, coords: Array<OverscaledTileID>, variableOffsets: {
     [_ in CrossTileID]: VariableOffset;
-}, renderFlags: RenderFlags) {
+}, renderFlags: RenderOptions) {
     if (painter.renderPass !== 'translucent') return;
 
     const {isRenderingToTexture} = renderFlags;

--- a/src/render/draw_symbol.ts
+++ b/src/render/draw_symbol.ts
@@ -381,7 +381,7 @@ function drawLayerSymbols(
         const glCoordMatrixForShader = getGlCoordMatrix(pitchWithMap, rotateWithMap, painter.transform, s);
 
         const translation = translatePosition(transform, tile, translate, translateAnchor);
-        const projectionData = transform.getProjectionData({overscaledTileID: coord, applyGlobeMatrix: !isRenderingToTexture});
+        const projectionData = transform.getProjectionData({overscaledTileID: coord, applyGlobeMatrix: !isRenderingToTexture, applyTerrainMatrix: true});
 
         const hasVariableAnchors = hasVariablePlacement && bucket.hasTextData();
         const updateTextFitIcon = layer.layout.get('icon-text-fit') !== 'none' &&

--- a/src/render/draw_symbol.ts
+++ b/src/render/draw_symbol.ts
@@ -62,10 +62,10 @@ const identityMat4 = mat4.identity(new Float32Array(16));
 
 export function drawSymbols(painter: Painter, sourceCache: SourceCache, layer: SymbolStyleLayer, coords: Array<OverscaledTileID>, variableOffsets: {
     [_ in CrossTileID]: VariableOffset;
-}, renderFlags: RenderOptions) {
+}, renderOptions: RenderOptions) {
     if (painter.renderPass !== 'translucent') return;
 
-    const {isRenderingToTexture} = renderFlags;
+    const {isRenderingToTexture} = renderOptions;
     // Disable the stencil test so that labels aren't clipped to tile boundaries.
     const stencilMode = StencilMode.disabled;
     const colorMode = painter.colorModeForRenderPass();

--- a/src/render/draw_terrain.ts
+++ b/src/render/draw_terrain.ts
@@ -1,7 +1,7 @@
 import {StencilMode} from '../gl/stencil_mode';
 import {DepthMode} from '../gl/depth_mode';
 import {terrainUniformValues, terrainDepthUniformValues, terrainCoordsUniformValues} from './program/terrain_program';
-import type {Painter} from './painter';
+import type {Painter, RenderFlags} from './painter';
 import type {Tile} from '../source/tile';
 import {CullFaceMode} from '../gl/cull_face_mode';
 import {Color} from '@maplibre/maplibre-gl-style-spec';
@@ -69,7 +69,8 @@ function drawCoords(painter: Painter, terrain: Terrain) {
     context.viewport.set([0, 0, painter.width, painter.height]);
 }
 
-function drawTerrain(painter: Painter, terrain: Terrain, tiles: Array<Tile>) {
+function drawTerrain(painter: Painter, terrain: Terrain, tiles: Array<Tile>, renderFlags: RenderFlags) {
+    const {isRenderingGlobe} = renderFlags;
     const context = painter.context;
     const gl = context.gl;
     const tr = painter.transform;
@@ -88,7 +89,7 @@ function drawTerrain(painter: Painter, terrain: Terrain, tiles: Array<Tile>) {
         gl.bindTexture(gl.TEXTURE_2D, texture.texture);
         const eleDelta = terrain.getMeshFrameDelta(tr.zoom);
         const fogMatrix = tr.calculateFogMatrix(tile.tileID.toUnwrapped());
-        const uniformValues = terrainUniformValues(eleDelta, fogMatrix, painter.style.sky, tr.pitch, painter.style.projection?.name === 'globe');
+        const uniformValues = terrainUniformValues(eleDelta, fogMatrix, painter.style.sky, tr.pitch, isRenderingGlobe);
         const projectionData = tr.getProjectionData({overscaledTileID: tile.tileID, applyTerrainMatrix: false});
         program.draw(context, gl.TRIANGLES, depthMode, StencilMode.disabled, colorMode, CullFaceMode.backCCW, uniformValues, terrainData, projectionData, 'terrain', mesh.vertexBuffer, mesh.indexBuffer, mesh.segments);
     }

--- a/src/render/draw_terrain.ts
+++ b/src/render/draw_terrain.ts
@@ -69,8 +69,8 @@ function drawCoords(painter: Painter, terrain: Terrain) {
     context.viewport.set([0, 0, painter.width, painter.height]);
 }
 
-function drawTerrain(painter: Painter, terrain: Terrain, tiles: Array<Tile>, renderFlags: RenderOptions) {
-    const {isRenderingGlobe} = renderFlags;
+function drawTerrain(painter: Painter, terrain: Terrain, tiles: Array<Tile>, renderOptions: RenderOptions) {
+    const {isRenderingGlobe} = renderOptions;
     const context = painter.context;
     const gl = context.gl;
     const tr = painter.transform;

--- a/src/render/draw_terrain.ts
+++ b/src/render/draw_terrain.ts
@@ -1,7 +1,7 @@
 import {StencilMode} from '../gl/stencil_mode';
 import {DepthMode} from '../gl/depth_mode';
 import {terrainUniformValues, terrainDepthUniformValues, terrainCoordsUniformValues} from './program/terrain_program';
-import type {Painter, RenderFlags} from './painter';
+import type {Painter, RenderOptions} from './painter';
 import type {Tile} from '../source/tile';
 import {CullFaceMode} from '../gl/cull_face_mode';
 import {Color} from '@maplibre/maplibre-gl-style-spec';
@@ -69,7 +69,7 @@ function drawCoords(painter: Painter, terrain: Terrain) {
     context.viewport.set([0, 0, painter.width, painter.height]);
 }
 
-function drawTerrain(painter: Painter, terrain: Terrain, tiles: Array<Tile>, renderFlags: RenderFlags) {
+function drawTerrain(painter: Painter, terrain: Terrain, tiles: Array<Tile>, renderFlags: RenderOptions) {
     const {isRenderingGlobe} = renderFlags;
     const context = painter.context;
     const gl = context.gl;

--- a/src/render/draw_terrain.ts
+++ b/src/render/draw_terrain.ts
@@ -27,7 +27,7 @@ function drawDepth(painter: Painter, terrain: Terrain) {
     context.clear({color: Color.transparent, depth: 1});
     for (const tile of tiles) {
         const terrainData = terrain.getTerrainData(tile.tileID);
-        const projectionData = tr.getProjectionData({overscaledTileID: tile.tileID, applyTerrainMatrix: false});
+        const projectionData = tr.getProjectionData({overscaledTileID: tile.tileID, applyTerrainMatrix: false, applyGlobeMatrix: true});
         const uniformValues = terrainDepthUniformValues(terrain.getMeshFrameDelta(tr.zoom));
         program.draw(context, gl.TRIANGLES, depthMode, StencilMode.disabled, colorMode, CullFaceMode.backCCW, uniformValues, terrainData, projectionData, 'terrain', mesh.vertexBuffer, mesh.indexBuffer, mesh.segments);
     }
@@ -61,7 +61,7 @@ function drawCoords(painter: Painter, terrain: Terrain) {
         context.activeTexture.set(gl.TEXTURE0);
         gl.bindTexture(gl.TEXTURE_2D, coords.texture);
         const uniformValues = terrainCoordsUniformValues(255 - terrain.coordsIndex.length, terrain.getMeshFrameDelta(tr.zoom));
-        const projectionData = tr.getProjectionData({overscaledTileID: tile.tileID, applyTerrainMatrix: false});
+        const projectionData = tr.getProjectionData({overscaledTileID: tile.tileID, applyTerrainMatrix: false, applyGlobeMatrix: true});
         program.draw(context, gl.TRIANGLES, depthMode, StencilMode.disabled, colorMode, CullFaceMode.backCCW, uniformValues, terrainData, projectionData, 'terrain', mesh.vertexBuffer, mesh.indexBuffer, mesh.segments);
         terrain.coordsIndex.push(tile.tileID.key);
     }
@@ -90,7 +90,7 @@ function drawTerrain(painter: Painter, terrain: Terrain, tiles: Array<Tile>, ren
         const eleDelta = terrain.getMeshFrameDelta(tr.zoom);
         const fogMatrix = tr.calculateFogMatrix(tile.tileID.toUnwrapped());
         const uniformValues = terrainUniformValues(eleDelta, fogMatrix, painter.style.sky, tr.pitch, isRenderingGlobe);
-        const projectionData = tr.getProjectionData({overscaledTileID: tile.tileID, applyTerrainMatrix: false});
+        const projectionData = tr.getProjectionData({overscaledTileID: tile.tileID, applyTerrainMatrix: false, applyGlobeMatrix: true});
         program.draw(context, gl.TRIANGLES, depthMode, StencilMode.disabled, colorMode, CullFaceMode.backCCW, uniformValues, terrainData, projectionData, 'terrain', mesh.vertexBuffer, mesh.indexBuffer, mesh.segments);
     }
 }

--- a/src/render/draw_terrain.ts
+++ b/src/render/draw_terrain.ts
@@ -27,7 +27,7 @@ function drawDepth(painter: Painter, terrain: Terrain) {
     context.clear({color: Color.transparent, depth: 1});
     for (const tile of tiles) {
         const terrainData = terrain.getTerrainData(tile.tileID);
-        const projectionData = tr.getProjectionData({overscaledTileID: tile.tileID, ignoreTerrainMatrix: true});
+        const projectionData = tr.getProjectionData({overscaledTileID: tile.tileID, applyTerrainMatrix: false});
         const uniformValues = terrainDepthUniformValues(terrain.getMeshFrameDelta(tr.zoom));
         program.draw(context, gl.TRIANGLES, depthMode, StencilMode.disabled, colorMode, CullFaceMode.backCCW, uniformValues, terrainData, projectionData, 'terrain', mesh.vertexBuffer, mesh.indexBuffer, mesh.segments);
     }
@@ -61,7 +61,7 @@ function drawCoords(painter: Painter, terrain: Terrain) {
         context.activeTexture.set(gl.TEXTURE0);
         gl.bindTexture(gl.TEXTURE_2D, coords.texture);
         const uniformValues = terrainCoordsUniformValues(255 - terrain.coordsIndex.length, terrain.getMeshFrameDelta(tr.zoom));
-        const projectionData = tr.getProjectionData({overscaledTileID: tile.tileID, ignoreTerrainMatrix: true});
+        const projectionData = tr.getProjectionData({overscaledTileID: tile.tileID, applyTerrainMatrix: false});
         program.draw(context, gl.TRIANGLES, depthMode, StencilMode.disabled, colorMode, CullFaceMode.backCCW, uniformValues, terrainData, projectionData, 'terrain', mesh.vertexBuffer, mesh.indexBuffer, mesh.segments);
         terrain.coordsIndex.push(tile.tileID.key);
     }
@@ -89,7 +89,7 @@ function drawTerrain(painter: Painter, terrain: Terrain, tiles: Array<Tile>) {
         const eleDelta = terrain.getMeshFrameDelta(tr.zoom);
         const fogMatrix = tr.calculateFogMatrix(tile.tileID.toUnwrapped());
         const uniformValues = terrainUniformValues(eleDelta, fogMatrix, painter.style.sky, tr.pitch, painter.style.projection?.name === 'globe');
-        const projectionData = tr.getProjectionData({overscaledTileID: tile.tileID, ignoreTerrainMatrix: true});
+        const projectionData = tr.getProjectionData({overscaledTileID: tile.tileID, applyTerrainMatrix: false});
         program.draw(context, gl.TRIANGLES, depthMode, StencilMode.disabled, colorMode, CullFaceMode.backCCW, uniformValues, terrainData, projectionData, 'terrain', mesh.vertexBuffer, mesh.indexBuffer, mesh.segments);
     }
 }

--- a/src/render/painter.ts
+++ b/src/render/painter.ts
@@ -49,6 +49,16 @@ import type {ResolvedImage} from '@maplibre/maplibre-gl-style-spec';
 import type {RenderToTexture} from './render_to_texture';
 import type {ProjectionData} from '../geo/projection/projection_data';
 import {coveringTiles} from '../geo/projection/covering_tiles';
+import {isSymbolStyleLayer} from '../style/style_layer/symbol_style_layer';
+import {isCircleStyleLayer} from '../style/style_layer/circle_style_layer';
+import {isHeatmapStyleLayer} from '../style/style_layer/heatmap_style_layer';
+import {isLineStyleLayer} from '../style/style_layer/line_style_layer';
+import {isFillStyleLayer} from '../style/style_layer/fill_style_layer';
+import {isFillExtrusionStyleLayer} from '../style/style_layer/fill_extrusion_style_layer';
+import {isHillshadeStyleLayer} from '../style/style_layer/hillshade_style_layer';
+import {isRasterStyleLayer} from '../style/style_layer/raster_style_layer';
+import {isBackgroundStyleLayer} from '../style/style_layer/background_style_layer';
+import {isCustomStyleLayer} from '../style/style_layer/custom_style_layer';
 
 export type RenderPass = 'offscreen' | 'opaque' | 'translucent';
 
@@ -638,36 +648,36 @@ export class Painter {
         if (layer.type !== 'background' && layer.type !== 'custom' && !(coords || []).length) return;
         this.id = layer.id;
 
-        switch (layer.type) {
-            case 'symbol':
-                drawSymbols(painter, sourceCache, layer as any, coords, this.style.placement.variableOffsets, isRenderingToTexture);
+        switch (true) {
+            case isSymbolStyleLayer(layer):
+                drawSymbols(painter, sourceCache, layer, coords, this.style.placement.variableOffsets, isRenderingToTexture);
                 break;
-            case 'circle':
-                drawCircles(painter, sourceCache, layer as any, coords, isRenderingToTexture);
+            case isCircleStyleLayer(layer):
+                drawCircles(painter, sourceCache, layer, coords, isRenderingToTexture);
                 break;
-            case 'heatmap':
-                drawHeatmap(painter, sourceCache, layer as any, coords, isRenderingToTexture);
+            case isHeatmapStyleLayer(layer):
+                drawHeatmap(painter, sourceCache, layer, coords, isRenderingToTexture);
                 break;
-            case 'line':
-                drawLine(painter, sourceCache, layer as any, coords, isRenderingToTexture);
+            case isLineStyleLayer(layer):
+                drawLine(painter, sourceCache, layer, coords, isRenderingToTexture);
                 break;
-            case 'fill':
-                drawFill(painter, sourceCache, layer as any, coords, isRenderingToTexture);
+            case isFillStyleLayer(layer):
+                drawFill(painter, sourceCache, layer, coords, isRenderingToTexture);
                 break;
-            case 'fill-extrusion':
-                drawFillExtrusion(painter, sourceCache, layer as any, coords, isRenderingToTexture);
+            case isFillExtrusionStyleLayer(layer):
+                drawFillExtrusion(painter, sourceCache, layer, coords, isRenderingToTexture);
                 break;
-            case 'hillshade':
-                drawHillshade(painter, sourceCache, layer as any, coords, isRenderingToTexture);
+            case isHillshadeStyleLayer(layer):
+                drawHillshade(painter, sourceCache, layer, coords, isRenderingToTexture);
                 break;
-            case 'raster':
-                drawRaster(painter, sourceCache, layer as any, coords, isRenderingToTexture);
+            case isRasterStyleLayer(layer):
+                drawRaster(painter, sourceCache, layer, coords, isRenderingToTexture);
                 break;
-            case 'background':
-                drawBackground(painter, sourceCache, layer as any, coords, isRenderingToTexture);
+            case isBackgroundStyleLayer(layer):
+                drawBackground(painter, sourceCache, layer, coords, isRenderingToTexture);
                 break;
-            case 'custom':
-                drawCustom(painter, sourceCache, layer as any, isRenderingToTexture);
+            case isCustomStyleLayer(layer):
+                drawCustom(painter, sourceCache, layer, isRenderingToTexture);
                 break;
         }
     }

--- a/src/render/painter.ts
+++ b/src/render/painter.ts
@@ -72,7 +72,7 @@ type PainterOptions = {
     fadeDuration: number;
 };
 
-export type RenderFlags = {
+export type RenderOptions = {
     isRenderingToTexture: boolean;
     isRenderingGlobe: boolean;
 }
@@ -489,7 +489,7 @@ export class Painter {
         const coordsAscending: {[_: string]: Array<OverscaledTileID>} = {};
         const coordsDescending: {[_: string]: Array<OverscaledTileID>} = {};
         const coordsDescendingSymbol: {[_: string]: Array<OverscaledTileID>} = {};
-        const renderFlags: RenderFlags = {isRenderingToTexture: false, isRenderingGlobe: style.projection.name === 'globe'};
+        const renderFlags: RenderOptions = {isRenderingToTexture: false, isRenderingGlobe: style.projection.name === 'globe'};
 
         for (const id in sourceCaches) {
             const sourceCache = sourceCaches[id];
@@ -649,7 +649,7 @@ export class Painter {
         drawCoords(this, this.style.map.terrain);
     }
 
-    renderLayer(painter: Painter, sourceCache: SourceCache, layer: StyleLayer, coords: Array<OverscaledTileID>, renderFlags: RenderFlags) {
+    renderLayer(painter: Painter, sourceCache: SourceCache, layer: StyleLayer, coords: Array<OverscaledTileID>, renderFlags: RenderOptions) {
         if (layer.isHidden(this.transform.zoom)) return;
         if (layer.type !== 'background' && layer.type !== 'custom' && !(coords || []).length) return;
         this.id = layer.id;

--- a/src/render/painter.ts
+++ b/src/render/painter.ts
@@ -643,28 +643,28 @@ export class Painter {
                 drawSymbols(painter, sourceCache, layer as any, coords, this.style.placement.variableOffsets);
                 break;
             case 'circle':
-                drawCircles(painter, sourceCache, layer as any, coords);
+                drawCircles(painter, sourceCache, layer as any, coords, isRenderingToTexture);
                 break;
             case 'heatmap':
-                drawHeatmap(painter, sourceCache, layer as any, coords);
+                drawHeatmap(painter, sourceCache, layer as any, coords, isRenderingToTexture);
                 break;
             case 'line':
-                drawLine(painter, sourceCache, layer as any, coords);
+                drawLine(painter, sourceCache, layer as any, coords, isRenderingToTexture);
                 break;
             case 'fill':
-                drawFill(painter, sourceCache, layer as any, coords);
+                drawFill(painter, sourceCache, layer as any, coords, isRenderingToTexture);
                 break;
             case 'fill-extrusion':
-                drawFillExtrusion(painter, sourceCache, layer as any, coords);
+                drawFillExtrusion(painter, sourceCache, layer as any, coords, isRenderingToTexture);
                 break;
             case 'hillshade':
-                drawHillshade(painter, sourceCache, layer as any, coords);
+                drawHillshade(painter, sourceCache, layer as any, coords, isRenderingToTexture);
                 break;
             case 'raster':
                 drawRaster(painter, sourceCache, layer as any, coords, isRenderingToTexture);
                 break;
             case 'background':
-                drawBackground(painter, sourceCache, layer as any, coords);
+                drawBackground(painter, sourceCache, layer as any, coords, isRenderingToTexture);
                 break;
             case 'custom':
                 drawCustom(painter, sourceCache, layer as any);

--- a/src/render/painter.ts
+++ b/src/render/painter.ts
@@ -313,7 +313,7 @@ export class Painter {
 
             const mesh = projection.getMeshFromTileID(this.context, tileID.canonical, useBorders, true, 'stencil');
 
-            const projectionData = transform.getProjectionData({overscaledTileID: tileID});
+            const projectionData = transform.getProjectionData({overscaledTileID: tileID, applyGlobeMatrix: true, applyTerrainMatrix: true});
 
             program.draw(context, gl.TRIANGLES, DepthMode.disabled,
                 // Tests will always pass, and ref value will be written to stencil buffer.
@@ -343,7 +343,7 @@ export class Painter {
             const terrainData = this.style.map.terrain && this.style.map.terrain.getTerrainData(tileID);
             const mesh = projection.getMeshFromTileID(this.context, tileID.canonical, true, true, 'raster');
 
-            const projectionData = transform.getProjectionData({overscaledTileID: tileID});
+            const projectionData = transform.getProjectionData({overscaledTileID: tileID, applyGlobeMatrix: true, applyTerrainMatrix: true});
 
             program.draw(context, gl.TRIANGLES, depthMode, StencilMode.disabled,
                 ColorMode.disabled, CullFaceMode.backCCW, null,

--- a/src/render/painter.ts
+++ b/src/render/painter.ts
@@ -640,7 +640,7 @@ export class Painter {
 
         switch (layer.type) {
             case 'symbol':
-                drawSymbols(painter, sourceCache, layer as any, coords, this.style.placement.variableOffsets);
+                drawSymbols(painter, sourceCache, layer as any, coords, this.style.placement.variableOffsets, isRenderingToTexture);
                 break;
             case 'circle':
                 drawCircles(painter, sourceCache, layer as any, coords, isRenderingToTexture);
@@ -667,7 +667,7 @@ export class Painter {
                 drawBackground(painter, sourceCache, layer as any, coords, isRenderingToTexture);
                 break;
             case 'custom':
-                drawCustom(painter, sourceCache, layer as any);
+                drawCustom(painter, sourceCache, layer as any, isRenderingToTexture);
                 break;
         }
     }

--- a/src/render/program/sky_program.ts
+++ b/src/render/program/sky_program.ts
@@ -27,7 +27,7 @@ const skyUniformValues = (sky: Sky, transform: IReadonlyTransform, pixelRatio: n
     const cosRoll = Math.cos(transform.rollInRadians);
     const sinRoll = Math.sin(transform.rollInRadians);
     const mercatorHorizon  = getMercatorHorizon(transform);
-    const projectionData = transform.getProjectionData({overscaledTileID: null});
+    const projectionData = transform.getProjectionData({overscaledTileID: null, applyGlobeMatrix: true, applyTerrainMatrix: true});
     const skyBlend = projectionData.projectionTransition;
     return {
         'u_sky_color': sky.properties.get('sky-color'),

--- a/src/render/render_to_texture.test.ts
+++ b/src/render/render_to_texture.test.ts
@@ -133,9 +133,10 @@ describe('render to texture', () => {
         style._order = ['maine-fill', 'maine-symbol'];
         rtt.prepareForRender(style, 0);
         layersDrawn = 0;
+        const renderOptions = {isRenderingToTexture: false, isRenderingGlobe: false};
         expect(rtt._renderableLayerIds).toStrictEqual(['maine-fill', 'maine-symbol']);
-        expect(rtt.renderLayer(fillLayer)).toBeTruthy();
-        expect(rtt.renderLayer(symbolLayer)).toBeFalsy();
+        expect(rtt.renderLayer(fillLayer, renderOptions)).toBeTruthy();
+        expect(rtt.renderLayer(symbolLayer, renderOptions)).toBeFalsy();
         expect(layersDrawn).toBe(1);
     });
 
@@ -143,14 +144,15 @@ describe('render to texture', () => {
         style._order = ['maine-background', 'maine-fill', 'maine-raster', 'maine-hillshade', 'maine-symbol', 'maine-line', 'maine-symbol'];
         rtt.prepareForRender(style, 0);
         layersDrawn = 0;
+        const renderOptions = {isRenderingToTexture: false, isRenderingGlobe: false};
         expect(rtt._renderableLayerIds).toStrictEqual(['maine-background', 'maine-fill', 'maine-raster', 'maine-hillshade', 'maine-symbol', 'maine-line', 'maine-symbol']);
-        expect(rtt.renderLayer(backgroundLayer)).toBeTruthy();
-        expect(rtt.renderLayer(fillLayer)).toBeTruthy();
-        expect(rtt.renderLayer(rasterLayer)).toBeTruthy();
-        expect(rtt.renderLayer(hillshadeLayer)).toBeTruthy();
-        expect(rtt.renderLayer(symbolLayer)).toBeFalsy();
-        expect(rtt.renderLayer(lineLayer)).toBeTruthy();
-        expect(rtt.renderLayer(symbolLayer)).toBeFalsy();
+        expect(rtt.renderLayer(backgroundLayer, renderOptions)).toBeTruthy();
+        expect(rtt.renderLayer(fillLayer, renderOptions)).toBeTruthy();
+        expect(rtt.renderLayer(rasterLayer, renderOptions)).toBeTruthy();
+        expect(rtt.renderLayer(hillshadeLayer, renderOptions)).toBeTruthy();
+        expect(rtt.renderLayer(symbolLayer, renderOptions)).toBeFalsy();
+        expect(rtt.renderLayer(lineLayer, renderOptions)).toBeTruthy();
+        expect(rtt.renderLayer(symbolLayer, renderOptions)).toBeFalsy();
         expect(layersDrawn).toBe(2);
     });
 
@@ -158,13 +160,14 @@ describe('render to texture', () => {
         style._order = ['maine-background', 'maine-symbol', 'maine-hillshade', 'maine-symbol', 'maine-line', 'maine-symbol'];
         rtt.prepareForRender(style, 0);
         layersDrawn = 0;
+        const renderOptions = {isRenderingToTexture: false, isRenderingGlobe: false};
         expect(rtt._renderableLayerIds).toStrictEqual(['maine-background', 'maine-symbol', 'maine-hillshade', 'maine-symbol', 'maine-line', 'maine-symbol']);
-        expect(rtt.renderLayer(backgroundLayer)).toBeTruthy();
-        expect(rtt.renderLayer(symbolLayer)).toBeFalsy();
-        expect(rtt.renderLayer(hillshadeLayer)).toBeTruthy();
-        expect(rtt.renderLayer(symbolLayer)).toBeFalsy();
-        expect(rtt.renderLayer(lineLayer)).toBeTruthy();
-        expect(rtt.renderLayer(symbolLayer)).toBeFalsy();
+        expect(rtt.renderLayer(backgroundLayer, renderOptions)).toBeTruthy();
+        expect(rtt.renderLayer(symbolLayer, renderOptions)).toBeFalsy();
+        expect(rtt.renderLayer(hillshadeLayer, renderOptions)).toBeTruthy();
+        expect(rtt.renderLayer(symbolLayer, renderOptions)).toBeFalsy();
+        expect(rtt.renderLayer(lineLayer, renderOptions)).toBeTruthy();
+        expect(rtt.renderLayer(symbolLayer, renderOptions)).toBeFalsy();
         expect(layersDrawn).toBe(3);
     });
 });

--- a/src/render/render_to_texture.ts
+++ b/src/render/render_to_texture.ts
@@ -1,4 +1,4 @@
-import {Painter} from './painter';
+import {Painter, RenderFlags} from './painter';
 import {Tile} from '../source/tile';
 import {Color} from '@maplibre/maplibre-gl-style-spec';
 import {OverscaledTileID} from '../source/tile_id';
@@ -126,11 +126,13 @@ export class RenderToTexture {
      * and 'live'-layers (f.e. symbols) it is necessary to create more stacks. For example
      * a symbol-layer is in between of fill-layers.
      * @param layer - the layer to render
+     * @param renderFlags - flags describing how to render the layer
      * @returns if true layer is rendered to texture, otherwise false
      */
-    renderLayer(layer: StyleLayer): boolean {
+    renderLayer(layer: StyleLayer, renderFlags: RenderFlags): boolean {
         if (layer.isHidden(this.painter.transform.zoom)) return false;
 
+        const flags: RenderFlags = {...renderFlags, isRenderingToTexture: true};
         const type = layer.type;
         const painter = this.painter;
         const isLastLayer = this._renderableLayerIds[this._renderableLayerIds.length - 1] === layer.id;
@@ -153,7 +155,7 @@ export class RenderToTexture {
             for (const tile of this._renderableTiles) {
                 // if render pool is full draw current tiles to screen and free pool
                 if (this.pool.isFull()) {
-                    drawTerrain(this.painter, this.terrain, this._rttTiles);
+                    drawTerrain(this.painter, this.terrain, this._rttTiles, flags);
                     this._rttTiles = [];
                     this.pool.freeAllObjects();
                 }
@@ -180,11 +182,11 @@ export class RenderToTexture {
                     const coords = layer.source ? this._coordsAscending[layer.source][tile.tileID.key] : [tile.tileID];
                     painter.context.viewport.set([0, 0, obj.fbo.width, obj.fbo.height]);
                     painter._renderTileClippingMasks(layer, coords, true);
-                    painter.renderLayer(painter, painter.style.sourceCaches[layer.source], layer, coords, true);
+                    painter.renderLayer(painter, painter.style.sourceCaches[layer.source], layer, coords, flags);
                     if (layer.source) tile.rttCoords[layer.source] = this._coordsAscendingStr[layer.source][tile.tileID.key];
                 }
             }
-            drawTerrain(this.painter, this.terrain, this._rttTiles);
+            drawTerrain(this.painter, this.terrain, this._rttTiles, flags);
             this._rttTiles = [];
             this.pool.freeAllObjects();
 

--- a/src/render/render_to_texture.ts
+++ b/src/render/render_to_texture.ts
@@ -1,4 +1,4 @@
-import {Painter, RenderFlags} from './painter';
+import {Painter, RenderOptions} from './painter';
 import {Tile} from '../source/tile';
 import {Color} from '@maplibre/maplibre-gl-style-spec';
 import {OverscaledTileID} from '../source/tile_id';
@@ -129,10 +129,10 @@ export class RenderToTexture {
      * @param renderFlags - flags describing how to render the layer
      * @returns if true layer is rendered to texture, otherwise false
      */
-    renderLayer(layer: StyleLayer, renderFlags: RenderFlags): boolean {
+    renderLayer(layer: StyleLayer, renderFlags: RenderOptions): boolean {
         if (layer.isHidden(this.painter.transform.zoom)) return false;
 
-        const flags: RenderFlags = {...renderFlags, isRenderingToTexture: true};
+        const flags: RenderOptions = {...renderFlags, isRenderingToTexture: true};
         const type = layer.type;
         const painter = this.painter;
         const isLastLayer = this._renderableLayerIds[this._renderableLayerIds.length - 1] === layer.id;

--- a/src/render/render_to_texture.ts
+++ b/src/render/render_to_texture.ts
@@ -132,7 +132,7 @@ export class RenderToTexture {
     renderLayer(layer: StyleLayer, renderOptions: RenderOptions): boolean {
         if (layer.isHidden(this.painter.transform.zoom)) return false;
 
-        const flags: RenderOptions = {...renderOptions, isRenderingToTexture: true};
+        const options: RenderOptions = {...renderOptions, isRenderingToTexture: true};
         const type = layer.type;
         const painter = this.painter;
         const isLastLayer = this._renderableLayerIds[this._renderableLayerIds.length - 1] === layer.id;
@@ -155,7 +155,7 @@ export class RenderToTexture {
             for (const tile of this._renderableTiles) {
                 // if render pool is full draw current tiles to screen and free pool
                 if (this.pool.isFull()) {
-                    drawTerrain(this.painter, this.terrain, this._rttTiles, flags);
+                    drawTerrain(this.painter, this.terrain, this._rttTiles, options);
                     this._rttTiles = [];
                     this.pool.freeAllObjects();
                 }
@@ -182,11 +182,11 @@ export class RenderToTexture {
                     const coords = layer.source ? this._coordsAscending[layer.source][tile.tileID.key] : [tile.tileID];
                     painter.context.viewport.set([0, 0, obj.fbo.width, obj.fbo.height]);
                     painter._renderTileClippingMasks(layer, coords, true);
-                    painter.renderLayer(painter, painter.style.sourceCaches[layer.source], layer, coords, flags);
+                    painter.renderLayer(painter, painter.style.sourceCaches[layer.source], layer, coords, options);
                     if (layer.source) tile.rttCoords[layer.source] = this._coordsAscendingStr[layer.source][tile.tileID.key];
                 }
             }
-            drawTerrain(this.painter, this.terrain, this._rttTiles, flags);
+            drawTerrain(this.painter, this.terrain, this._rttTiles, options);
             this._rttTiles = [];
             this.pool.freeAllObjects();
 

--- a/src/render/render_to_texture.ts
+++ b/src/render/render_to_texture.ts
@@ -126,13 +126,13 @@ export class RenderToTexture {
      * and 'live'-layers (f.e. symbols) it is necessary to create more stacks. For example
      * a symbol-layer is in between of fill-layers.
      * @param layer - the layer to render
-     * @param renderFlags - flags describing how to render the layer
+     * @param renderOptions - flags describing how to render the layer
      * @returns if true layer is rendered to texture, otherwise false
      */
-    renderLayer(layer: StyleLayer, renderFlags: RenderOptions): boolean {
+    renderLayer(layer: StyleLayer, renderOptions: RenderOptions): boolean {
         if (layer.isHidden(this.painter.transform.zoom)) return false;
 
-        const flags: RenderOptions = {...renderFlags, isRenderingToTexture: true};
+        const flags: RenderOptions = {...renderOptions, isRenderingToTexture: true};
         const type = layer.type;
         const painter = this.painter;
         const isLastLayer = this._renderableLayerIds[this._renderableLayerIds.length - 1] === layer.id;

--- a/src/style/style_layer/background_style_layer.ts
+++ b/src/style/style_layer/background_style_layer.ts
@@ -6,6 +6,8 @@ import {Transitionable, Transitioning, PossiblyEvaluated} from '../properties';
 import type {BackgroundPaintProps} from './background_style_layer_properties.g';
 import type {LayerSpecification} from '@maplibre/maplibre-gl-style-spec';
 
+export const isBackgroundStyleLayer = (layer: StyleLayer): layer is BackgroundStyleLayer => layer.type === 'background';
+
 export class BackgroundStyleLayer extends StyleLayer {
     _transitionablePaint: Transitionable<BackgroundPaintProps>;
     _transitioningPaint: Transitioning<BackgroundPaintProps>;

--- a/src/style/style_layer/circle_style_layer.ts
+++ b/src/style/style_layer/circle_style_layer.ts
@@ -13,6 +13,8 @@ import type {Bucket, BucketParameters} from '../../data/bucket';
 import type {CircleLayoutProps, CirclePaintProps} from './circle_style_layer_properties.g';
 import type {VectorTileFeature} from '@mapbox/vector-tile';
 
+export const isCircleStyleLayer = (layer: StyleLayer): layer is CircleStyleLayer => layer.type === 'circle';
+
 /**
  * A style layer that defines a circle
  */

--- a/src/style/style_layer/custom_style_layer.ts
+++ b/src/style/style_layer/custom_style_layer.ts
@@ -260,6 +260,8 @@ export function validateCustomStyleLayer(layerObject: CustomLayerInterface) {
     return errors;
 }
 
+export const isCustomStyleLayer = (layer: StyleLayer): layer is CustomStyleLayer => layer.type === 'custom';
+
 export class CustomStyleLayer extends StyleLayer {
 
     implementation: CustomLayerInterface;

--- a/src/style/style_layer/fill_extrusion_style_layer.ts
+++ b/src/style/style_layer/fill_extrusion_style_layer.ts
@@ -17,6 +17,8 @@ export class Point3D extends Point {
     z: number;
 }
 
+export const isFillExtrusionStyleLayer = (layer: StyleLayer): layer is FillExtrusionStyleLayer => layer.type === 'fill-extrusion';
+
 export class FillExtrusionStyleLayer extends StyleLayer {
     _transitionablePaint: Transitionable<FillExtrusionPaintProps>;
     _transitioningPaint: Transitioning<FillExtrusionPaintProps>;

--- a/src/style/style_layer/fill_style_layer.ts
+++ b/src/style/style_layer/fill_style_layer.ts
@@ -14,6 +14,8 @@ import type {EvaluationParameters} from '../evaluation_parameters';
 import type {IReadonlyTransform} from '../../geo/transform_interface';
 import type {VectorTileFeature} from '@mapbox/vector-tile';
 
+export const isFillStyleLayer = (layer: StyleLayer): layer is FillStyleLayer => layer.type === 'fill';
+
 export class FillStyleLayer extends StyleLayer {
     _unevaluatedLayout: Layout<FillLayoutProps>;
     layout: PossiblyEvaluated<FillLayoutProps, FillLayoutPropsPossiblyEvaluated>;

--- a/src/style/style_layer/heatmap_style_layer.ts
+++ b/src/style/style_layer/heatmap_style_layer.ts
@@ -13,7 +13,6 @@ import type {LayerSpecification} from '@maplibre/maplibre-gl-style-spec';
 
 export const HEATMAP_FULL_RENDER_FBO_KEY = 'big-fb';
 
-
 export const isHeatmapStyleLayer = (layer: StyleLayer): layer is HeatmapStyleLayer => layer.type === 'heatmap';
 
 /**

--- a/src/style/style_layer/heatmap_style_layer.ts
+++ b/src/style/style_layer/heatmap_style_layer.ts
@@ -13,6 +13,9 @@ import type {LayerSpecification} from '@maplibre/maplibre-gl-style-spec';
 
 export const HEATMAP_FULL_RENDER_FBO_KEY = 'big-fb';
 
+
+export const isHeatmapStyleLayer = (layer: StyleLayer): layer is HeatmapStyleLayer => layer.type === 'heatmap';
+
 /**
  * A style layer that defines a heatmap
  */

--- a/src/style/style_layer/hillshade_style_layer.ts
+++ b/src/style/style_layer/hillshade_style_layer.ts
@@ -6,6 +6,8 @@ import {Transitionable, Transitioning, PossiblyEvaluated} from '../properties';
 import type {HillshadePaintProps} from './hillshade_style_layer_properties.g';
 import type {LayerSpecification} from '@maplibre/maplibre-gl-style-spec';
 
+export const isHillshadeStyleLayer = (layer: StyleLayer): layer is HillshadeStyleLayer => layer.type === 'hillshade';
+
 export class HillshadeStyleLayer extends StyleLayer {
     _transitionablePaint: Transitionable<HillshadePaintProps>;
     _transitioningPaint: Transitioning<HillshadePaintProps>;

--- a/src/style/style_layer/line_style_layer.ts
+++ b/src/style/style_layer/line_style_layer.ts
@@ -37,6 +37,8 @@ export class LineFloorwidthProperty extends DataDrivenProperty<number> {
 
 let lineFloorwidthProperty: LineFloorwidthProperty;
 
+export const isLineStyleLayer = (layer: StyleLayer): layer is LineStyleLayer => layer.type === 'line';
+
 export class LineStyleLayer extends StyleLayer {
     _unevaluatedLayout: Layout<LineLayoutProps>;
     layout: PossiblyEvaluated<LineLayoutProps, LineLayoutPropsPossiblyEvaluated>;

--- a/src/style/style_layer/raster_style_layer.ts
+++ b/src/style/style_layer/raster_style_layer.ts
@@ -6,6 +6,8 @@ import {Transitionable, Transitioning, PossiblyEvaluated} from '../properties';
 import type {RasterPaintProps} from './raster_style_layer_properties.g';
 import type {LayerSpecification} from '@maplibre/maplibre-gl-style-spec';
 
+export const isRasterStyleLayer = (layer: StyleLayer): layer is RasterStyleLayer => layer.type === 'raster';
+
 export class RasterStyleLayer extends StyleLayer {
     _transitionablePaint: Transitionable<RasterPaintProps>;
     _transitioningPaint: Transitioning<RasterPaintProps>;

--- a/src/style/style_layer/symbol_style_layer.ts
+++ b/src/style/style_layer/symbol_style_layer.ts
@@ -31,6 +31,8 @@ import type {Expression, Feature, SourceExpression, LayerSpecification} from '@m
 import type {CanonicalTileID} from '../../source/tile_id';
 import {FormatSectionOverride} from '../format_section_override';
 
+export const isSymbolStyleLayer = (layer: StyleLayer): layer is SymbolStyleLayer => layer.type === 'symbol';
+
 export class SymbolStyleLayer extends StyleLayer {
     _unevaluatedLayout: Layout<SymbolLayoutProps>;
     layout: PossiblyEvaluated<SymbolLayoutProps, SymbolLayoutPropsPossiblyEvaluated>;

--- a/test/build/min.test.ts
+++ b/test/build/min.test.ts
@@ -37,7 +37,7 @@ describe('test min build', () => {
         const decreaseQuota = 4096;
 
         // feel free to update this value after you've checked that it has changed on purpose :-)
-        const expectedBytes = 893706;
+        const expectedBytes = 894730;
 
         expect(actualBytes).toBeLessThan(expectedBytes + increaseQuota);
         expect(actualBytes).toBeGreaterThan(expectedBytes - decreaseQuota);


### PR DESCRIPTION
This PR aims to refactor our codebase a little bit in order to move away of what, IMHO, are code smells.

First, some context. 
The [Painter](https://github.com/maplibre/maplibre-gl-js/blob/main/src/render/painter.ts#L69) object mostly contains properties that describe how things are going to be rendered via the underlying rendering API (i.e. vertex and index buffers, stencil buffer definitions, depth range, etc.) but it also contains the `Style` object which in itself describes how things should look like. 
`draw_*` functions (i.e. [draw_background](https://github.com/maplibre/maplibre-gl-js/blob/b6e3b551e85b4fe42211226f75c0991cba698418/src/render/draw_background.ts#L15)) get both the `Painter` object and `StyleLayer` object, which is basically the subset of the `Style` that we need to render a given layer.

There are various places in the `draw_*` functions where we use `painter.style` to get information about the current rendering mode:
- We use `painter.style.map.terrain` to know if we are rendering with terrain
- We use `painter.style.projection.name` to know if we are rendering using `globe` or `mercator` projections

and change the drawing behaviour according to that. Since those properties are deep into the `Painter` object, you might get two similar-looking `draw_*` calls with very different results. 

This PR replaces checks for terrain rendering via the `painter.style` property with an extra `renderLayer` parameter that tells a given `draw_*` function if it's being rendered to a texture.

A follow-up idea would be to remove `style` entirely from the `Painter` object and add all the properties that are needed for the various `draw_*` functions into the `Painter` object itself.

Cc @birkskyum since we talked about this.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [ ] Link to related issues.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [ ] Add an entry to `CHANGELOG.md` under the `## main` section.
