### PR TITLE
Add Vertical Perspective projection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## main
 
 ### ✨ Features and improvements
+- Support Vertical Perspective projection ([#5023](https://github.com/maplibre/maplibre-gl-js/pull/5023))
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@mapbox/unitbezier": "^0.0.1",
         "@mapbox/vector-tile": "^1.3.1",
         "@mapbox/whoots-js": "^3.1.0",
-        "@maplibre/maplibre-gl-style-spec": "^21.1.0",
+        "@maplibre/maplibre-gl-style-spec": "^21.2.0",
         "@types/geojson": "^7946.0.14",
         "@types/geojson-vt": "3.2.5",
         "@types/mapbox__point-geometry": "^0.1.4",
@@ -2122,9 +2122,10 @@
       }
     },
     "node_modules/@maplibre/maplibre-gl-style-spec": {
-      "version": "21.1.0",
-      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-21.1.0.tgz",
-      "integrity": "sha512-4w6RMRWzsbR3AymdYIzQcOyot6hPbysEFs3gVsTkj1B7Au8HxHtHfTqY2mXs+WrBV9Ua2oezrRkz9phF5txXVQ==",
+      "version": "21.2.0",
+      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-21.2.0.tgz",
+      "integrity": "sha512-jd+YjJEhR2bg9EhF2UPEIpoK6imPEw0SzWhfUmaVgSWfxw92jKrkBVb3OP29CtDVPY17RYMkZj+kz7CP75kAHw==",
+      "license": "ISC",
       "dependencies": {
         "@mapbox/jsonlint-lines-primitives": "~2.0.2",
         "@mapbox/unitbezier": "^0.0.1",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@mapbox/unitbezier": "^0.0.1",
     "@mapbox/vector-tile": "^1.3.1",
     "@mapbox/whoots-js": "^3.1.0",
-    "@maplibre/maplibre-gl-style-spec": "^21.1.0",
+    "@maplibre/maplibre-gl-style-spec": "^21.2.0",
     "@types/geojson": "^7946.0.14",
     "@types/geojson-vt": "3.2.5",
     "@types/mapbox__point-geometry": "^0.1.4",

--- a/src/geo/projection/globe_transform.ts
+++ b/src/geo/projection/globe_transform.ts
@@ -282,8 +282,11 @@ export class GlobeTransform implements ITransform {
     private _farZ: number;
 
     private _coveringTilesDetailsProvider: GlobeCoveringTilesDetailsProvider;
+    private _adaptive: boolean; false;
 
-    public constructor(globeProjection: GlobeProjection, globeProjectionEnabled: boolean = true) {
+    public constructor(globeProjection: GlobeProjection, globeProjectionEnabled: boolean = true, adaptive:boolean = false) {
+        this._adaptive = adaptive;
+
         this._helper = new TransformHelper({
             calcMatrices: () => { this._calcMatrices(); },
             getConstrained: (center, zoom) => { return this.getConstrained(center, zoom); }
@@ -372,7 +375,8 @@ export class GlobeTransform implements ITransform {
     newFrameUpdate(): TransformUpdateResult {
         this._lastUpdateTimeSeconds = browser.now() / 1000.0;
         const oldGlobeRendering = this.isGlobeRendering;
-        this._globeness = this._computeGlobenessAnimation();
+
+        this._globeness = (!this._adaptive && this._globeProjectionAllowed) ? 1 : this._computeGlobenessAnimation();
         // Everything below this comment must happen AFTER globeness update
         this._updateErrorCorrectionValue();
         this._calcMatrices();

--- a/src/geo/projection/globe_transform.ts
+++ b/src/geo/projection/globe_transform.ts
@@ -282,9 +282,9 @@ export class GlobeTransform implements ITransform {
     private _farZ: number;
 
     private _coveringTilesDetailsProvider: GlobeCoveringTilesDetailsProvider;
-    private _adaptive: boolean; false;
+    private _adaptive: boolean; true;
 
-    public constructor(globeProjection: GlobeProjection, globeProjectionEnabled: boolean = true, adaptive:boolean = false) {
+    public constructor(globeProjection: GlobeProjection, globeProjectionEnabled: boolean = true, adaptive:boolean = true) {
         this._adaptive = adaptive;
 
         this._helper = new TransformHelper({

--- a/src/geo/projection/globe_transform.ts
+++ b/src/geo/projection/globe_transform.ts
@@ -282,7 +282,7 @@ export class GlobeTransform implements ITransform {
     private _farZ: number;
 
     private _coveringTilesDetailsProvider: GlobeCoveringTilesDetailsProvider;
-    private _adaptive: boolean; true;
+    private _adaptive: boolean;
 
     public constructor(globeProjection: GlobeProjection, globeProjectionEnabled: boolean = true, adaptive:boolean = true) {
         this._adaptive = adaptive;

--- a/src/geo/projection/projection_factory.ts
+++ b/src/geo/projection/projection_factory.ts
@@ -29,7 +29,7 @@ export function createProjectionFromName(name: ProjectionSpecification['type']):
             const proj = new GlobeProjection();
             return {
                 projection: proj,
-                transform: new GlobeTransform(proj, true, true),
+                transform: new GlobeTransform(proj, true),
                 cameraHelper: new GlobeCameraHelper(proj),
             };
         }

--- a/src/geo/projection/projection_factory.ts
+++ b/src/geo/projection/projection_factory.ts
@@ -29,7 +29,16 @@ export function createProjectionFromName(name: ProjectionSpecification['type']):
             const proj = new GlobeProjection();
             return {
                 projection: proj,
-                transform: new GlobeTransform(proj),
+                transform: new GlobeTransform(proj, true, true),
+                cameraHelper: new GlobeCameraHelper(proj),
+            };
+        }
+        case 'vertical-perspective':
+        {
+            const proj = new GlobeProjection();
+            return {
+                projection: proj,
+                transform: new GlobeTransform(proj, true, false),
                 cameraHelper: new GlobeCameraHelper(proj),
             };
         }


### PR DESCRIPTION
Allow using projection `{ "type": "vertical-perspective" }` at all zoom levels.

See [Style Spec docs](https://maplibre.org/maplibre-style-spec/projection/), for all projection options.

Implemented by passing an adaptive flag to the GlobeTransform.


https://github.com/user-attachments/assets/e384c650-63ea-4a8d-a42e-34955d12e1ee




## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [ ] Briefly describe the changes in this PR.
 - [ ] Link to related issues.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [ ] Add an entry to `CHANGELOG.md` under the `## main` section.
