### PR TITLE
Test codecov 5 after explicit repo addition

### DIFF
--- a/src/gl/vertex_buffer.ts
+++ b/src/gl/vertex_buffer.ts
@@ -89,7 +89,7 @@ export class VertexBuffer {
                 gl.vertexAttribPointer(
                     attribIndex,
                     member.components,
-                    (gl as any)[AttributeType[member.type]],
+                    gl[AttributeType[member.type]],
                     false,
                     this.itemSize,
                     member.offset + (this.itemSize * (vertexOffset || 0))


### PR DESCRIPTION
Dummy PR to test [codecov version upgrade](https://github.com/maplibre/maplibre-gl-js/pull/5050/files). The one [attempted earlier](https://github.com/maplibre/maplibre-gl-js/pull/5051) did not have the comment from codecov as expected. Creating a new PR after updating the codecov configuration at the organisation level.

