### PR TITLE
remove @types/cssnano

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,6 @@
         "@rollup/plugin-typescript": "^12.1.1",
         "@stylistic/eslint-plugin-ts": "^2.11.0",
         "@types/benchmark": "^2.1.5",
-        "@types/cssnano": "^5.1.3",
         "@types/d3": "^7.4.3",
         "@types/diff": "^6.0.0",
         "@types/earcut": "^2.1.4",
@@ -2911,16 +2910,6 @@
       "version": "0.12.2",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/cssnano": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@types/cssnano/-/cssnano-5.1.3.tgz",
-      "integrity": "sha512-BahAZSSvuFXyhgJiwQgsfsNlStE9K/ULGL+YEzK4mmL2Vf02Pjl2yZs+KmbkAg3MxkC9WwMuFwuwnwvrg7CqvQ==",
-      "deprecated": "This is a stub types definition. cssnano provides its own type definitions, so you do not need this installed.",
-      "dev": true,
-      "dependencies": {
-        "cssnano": "*"
-      }
     },
     "node_modules/@types/d3": {
       "version": "7.4.3",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
     "@rollup/plugin-typescript": "^12.1.1",
     "@stylistic/eslint-plugin-ts": "^2.11.0",
     "@types/benchmark": "^2.1.5",
-    "@types/cssnano": "^5.1.3",
     "@types/d3": "^7.4.3",
     "@types/diff": "^6.0.0",
     "@types/earcut": "^2.1.4",


### PR DESCRIPTION
on `npm ci` i get

```sh
npm warn deprecated @types/cssnano@5.1.3: This is a stub types definition. cssnano provides its own type definitions, so you do not need this installed.
```

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [X] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [ ] Briefly describe the changes in this PR.
 - [ ] Link to related issues.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [ ] Add an entry to `CHANGELOG.md` under the `## main` section.
