### PR TITLE
add retry for flaky test

### DIFF
--- a/src/util/actor.test.ts
+++ b/src/util/actor.test.ts
@@ -95,7 +95,7 @@ describe('Actor', () => {
         expect(gotAbortSignal).toBeTruthy();
     });
 
-    test('cancel a request that must be queued will not call the method at all', async () => {
+    test('cancel a request that must be queued will not call the method at all', {retry: 3}, async () => {
         const worker = workerFactory() as any as WorkerGlobalScopeInterface & ActorTarget;
         const actor = new Actor(worker, '1');
 


### PR DESCRIPTION
I believe the CI is breaking, because we have a flaky test.

This adds a few retries - I think it'll do.



 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!