### PR TITLE
Publish pre-release to github

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,8 +102,6 @@ jobs:
           echo "release_notes=${RELEASE_NOTES_PATH}" >> $GITHUB_OUTPUT
 
       - name: Create GitHub Release
-        id: create_regular_release
-        if: ${{ steps.prepare_release.outputs.release_type == 'regular' }}
         uses: ncipollo/release-action@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Launch Checklist

This fixes a bug I introduced in last CI change where pre-release message was not added and a github version was not created:

- #5085

For version 5.0.0-pre.8 I did this manually to workaround this bug.
