### PR TITLE
Refactor globe transfrom

### DIFF
--- a/src/geo/projection/covering_tiles.ts
+++ b/src/geo/projection/covering_tiles.ts
@@ -1,12 +1,12 @@
 import {OverscaledTileID} from '../../source/tile_id';
 import {vec2, type vec4} from 'gl-matrix';
-import {type IReadonlyTransform} from '../transform_interface';
 import {MercatorCoordinate} from '../mercator_coordinate';
-import {scaleZoom} from '../transform_helper';
-import {clamp, degreesToRadians} from '../../util/util';
-import {type Terrain} from '../../render/terrain';
-import {type Frustum} from '../../util/primitives/frustum';
+import {clamp, degreesToRadians, scaleZoom} from '../../util/util';
 import {type Aabb, IntersectionResult} from '../../util/primitives/aabb';
+
+import type {IReadonlyTransform} from '../transform_interface';
+import type {Terrain} from '../../render/terrain';
+import type {Frustum} from '../../util/primitives/frustum';
 
 type CoveringTilesResult = {
     tileID: OverscaledTileID;

--- a/src/geo/projection/globe_camera_helper.ts
+++ b/src/geo/projection/globe_camera_helper.ts
@@ -3,9 +3,9 @@ import {cameraBoundsWarning, type CameraForBoxAndBearingHandlerResult, type Ease
 import {LngLat, type LngLatLike} from '../lng_lat';
 import {MercatorCameraHelper} from './mercator_camera_helper';
 import {angularCoordinatesToSurfaceVector, computeGlobePanCenter, getGlobeRadiusPixels, getZoomAdjustment, globeDistanceOfLocationsPixels, interpolateLngLatForGlobe} from './globe_utils';
-import {clamp, createVec3f64, differenceOfAnglesDegrees, remapSaturate, rollPitchBearingEqual, scaleZoom, warnOnce, zoomScale} from '../../util/util';
+import {clamp, createVec3f64, differenceOfAnglesDegrees, MAX_VALID_LATITUDE, remapSaturate, rollPitchBearingEqual, scaleZoom, warnOnce, zoomScale} from '../../util/util';
 import {type mat4, vec3} from 'gl-matrix';
-import {MAX_VALID_LATITUDE, normalizeCenter} from '../transform_helper';
+import {normalizeCenter} from '../transform_helper';
 import {interpolates} from '@maplibre/maplibre-gl-style-spec';
 
 import type {IReadonlyTransform, ITransform} from '../transform_interface';

--- a/src/geo/projection/globe_camera_helper.ts
+++ b/src/geo/projection/globe_camera_helper.ts
@@ -1,17 +1,18 @@
 import Point from '@mapbox/point-geometry';
-import {type IReadonlyTransform, type ITransform} from '../transform_interface';
 import {cameraBoundsWarning, type CameraForBoxAndBearingHandlerResult, type EaseToHandlerResult, type EaseToHandlerOptions, type FlyToHandlerResult, type FlyToHandlerOptions, type ICameraHelper, type MapControlsDeltas, updateRotation, type UpdateRotationArgs} from './camera_helper';
-import {type GlobeProjection} from './globe';
 import {LngLat, type LngLatLike} from '../lng_lat';
 import {MercatorCameraHelper} from './mercator_camera_helper';
 import {angularCoordinatesToSurfaceVector, computeGlobePanCenter, getGlobeRadiusPixels, getZoomAdjustment, globeDistanceOfLocationsPixels, interpolateLngLatForGlobe} from './globe_utils';
-import {clamp, createVec3f64, differenceOfAnglesDegrees, remapSaturate, rollPitchBearingEqual, warnOnce} from '../../util/util';
+import {clamp, createVec3f64, differenceOfAnglesDegrees, remapSaturate, rollPitchBearingEqual, scaleZoom, warnOnce, zoomScale} from '../../util/util';
 import {type mat4, vec3} from 'gl-matrix';
-import {MAX_VALID_LATITUDE, normalizeCenter, scaleZoom, zoomScale} from '../transform_helper';
-import {type CameraForBoundsOptions} from '../../ui/camera';
-import {type LngLatBounds} from '../lng_lat_bounds';
-import {type PaddingOptions} from '../edge_insets';
+import {MAX_VALID_LATITUDE, normalizeCenter} from '../transform_helper';
 import {interpolates} from '@maplibre/maplibre-gl-style-spec';
+
+import type {IReadonlyTransform, ITransform} from '../transform_interface';
+import type {GlobeProjection} from './globe';
+import type {CameraForBoundsOptions} from '../../ui/camera';
+import type {LngLatBounds} from '../lng_lat_bounds';
+import type {PaddingOptions} from '../edge_insets';
 
 /**
  * @internal

--- a/src/geo/projection/globe_transform.ts
+++ b/src/geo/projection/globe_transform.ts
@@ -1126,7 +1126,6 @@ export class GlobeTransform implements ITransform {
     //
     // Vertical perspective area for refactoring... //
     //
-
     
     private vp_getMatrixForModel(location: LngLatLike, altitude?: number): mat4 {
         const lnglat = LngLat.convert(location);
@@ -1141,7 +1140,7 @@ export class GlobeTransform implements ITransform {
         return m;
     }
 
-    vp_isPointOnMapSurface(p: Point, terrain?: Terrain): boolean {
+    vp_isPointOnMapSurface(p: Point, _terrain?: Terrain): boolean {
         const rayOrigin = this._cameraPosition;
         const rayDirection = this.getRayDirectionFromPixel(p);
 

--- a/src/geo/projection/globe_transform.ts
+++ b/src/geo/projection/globe_transform.ts
@@ -715,15 +715,15 @@ export class GlobeTransform implements ITransform {
     }
 
     getCameraPoint(): Point {
-        return this._mercatorTransform.getCameraPoint();
+        return this._helper.getCameraPoint();
     }
 
     getCameraAltitude(): number {
-        return this._mercatorTransform.getCameraAltitude();
+        return this._helper.getCameraAltitude();
     }
 
     getCameraLngLat(): LngLat {
-        return this._mercatorTransform.getCameraLngLat();
+        return this._helper.getCameraLngLat();
     }
 
     lngLatToCameraDepth(lngLat: LngLat, elevation: number): number {

--- a/src/geo/projection/globe_transform.ts
+++ b/src/geo/projection/globe_transform.ts
@@ -835,7 +835,7 @@ export class GlobeTransform implements ITransform {
     }
 
     calculateCenterFromCameraLngLatAlt(lngLat: LngLatLike, alt: number, bearing?: number, pitch?: number): {center: LngLat; elevation: number; zoom: number} {
-        return this._mercatorTransform.calculateCenterFromCameraLngLatAlt(lngLat, alt, bearing, pitch);
+        return this._helper.calculateCenterFromCameraLngLatAlt(lngLat, alt, bearing, pitch);
     }
 
     /**

--- a/src/geo/projection/globe_transform.ts
+++ b/src/geo/projection/globe_transform.ts
@@ -1,8 +1,8 @@
 import {type mat2, mat4, vec3, vec4} from 'gl-matrix';
-import {MAX_VALID_LATITUDE, TransformHelper} from '../transform_helper';
+import {TransformHelper} from '../transform_helper';
 import {MercatorTransform} from './mercator_transform';
 import {LngLat, type LngLatLike, earthRadius} from '../lng_lat';
-import {angleToRotateBetweenVectors2D, clamp, createIdentityMat4f32, createIdentityMat4f64, createMat4f32, createMat4f64, createVec3f64, createVec4f64, differenceOfAnglesDegrees, distanceOfAnglesRadians, easeCubicInOut, lerp, pointPlaneSignedDistance, warnOnce} from '../../util/util';
+import {angleToRotateBetweenVectors2D, clamp, createIdentityMat4f32, createIdentityMat4f64, createMat4f32, createMat4f64, createVec3f64, createVec4f64, differenceOfAnglesDegrees, distanceOfAnglesRadians, easeCubicInOut, lerp, MAX_VALID_LATITUDE, pointPlaneSignedDistance, warnOnce} from '../../util/util';
 import {UnwrappedTileID, OverscaledTileID, type CanonicalTileID} from '../../source/tile_id';
 import Point from '@mapbox/point-geometry';
 import {browser} from '../../util/browser';

--- a/src/geo/projection/globe_transform.ts
+++ b/src/geo/projection/globe_transform.ts
@@ -449,18 +449,16 @@ export class GlobeTransform implements ITransform {
     }
 
     getProjectionData(params: ProjectionDataParams): ProjectionData {
-        const {overscaledTileID, aligned, applyTerrainMatrix, applyGlobeMatrix} = params;
-        const data = this._mercatorTransform.getProjectionData({overscaledTileID, aligned, applyTerrainMatrix});
+        const {overscaledTileID, applyGlobeMatrix} = params;
+        const mercatorProjectionData = this._mercatorTransform.getProjectionData(params)
 
-        // Set 'projectionMatrix' to actual globe transform
-        if (this.isGlobeRendering) {
-            data.mainMatrix = this._globeViewProjMatrix32f;
-        }
-
-        data.clippingPlane = this._cachedClippingPlane as [number, number, number, number];
-        data.projectionTransition = applyGlobeMatrix ? this._globeness : 0;
-
-        return data;
+        return {
+            mainMatrix: this.isGlobeRendering ? this._globeViewProjMatrix32f : mercatorProjectionData.mainMatrix,
+            tileMercatorCoords: this._helper.getTileMercatorCoordinates(overscaledTileID),
+            clippingPlane: this._cachedClippingPlane as [number, number, number, number],
+            projectionTransition: applyGlobeMatrix ? this._globeness : 0,
+            fallbackMatrix: mercatorProjectionData.mainMatrix
+        };
     }
 
     private _computeClippingPlane(globeRadiusPixels: number): vec4 {

--- a/src/geo/projection/globe_transform.ts
+++ b/src/geo/projection/globe_transform.ts
@@ -304,7 +304,8 @@ export class GlobeTransform implements ITransform {
 
     clone(): ITransform {
         const clone = new GlobeTransform(null, this._globeProjectionAllowed);
-        clone._applyGlobeTransform(this);
+        clone._globeness = this._globeness;
+        clone._globeLatitudeErrorCorrectionRadians = this._globeLatitudeErrorCorrectionRadians;
         clone.apply(this);
         return clone;
     }
@@ -312,11 +313,6 @@ export class GlobeTransform implements ITransform {
     public apply(that: IReadonlyTransform): void {
         this._helper.apply(that);
         this._mercatorTransform.apply(this);
-    }
-
-    private _applyGlobeTransform(that: GlobeTransform): void {
-        this._globeness = that._globeness;
-        this._globeLatitudeErrorCorrectionRadians = that._globeLatitudeErrorCorrectionRadians;
     }
 
     public get projectionMatrix(): mat4 { return this.isGlobeRendering ? this._projectionMatrix : this._mercatorTransform.projectionMatrix; }

--- a/src/geo/projection/globe_transform.ts
+++ b/src/geo/projection/globe_transform.ts
@@ -215,7 +215,10 @@ export class GlobeTransform implements ITransform {
     get renderWorldCopies(): boolean {
         return this._helper.renderWorldCopies;
     }
-
+    get cameraToCenterDistance(): number {
+        // Globe uses the same cameraToCenterDistance as mercator.
+        return this._helper.cameraToCenterDistance;
+    }
     //
     // Implementation of globe transform
     //
@@ -329,11 +332,6 @@ export class GlobeTransform implements ITransform {
         copy[1] = this._cameraPosition[1];
         copy[2] = this._cameraPosition[2];
         return copy;
-    }
-
-    get cameraToCenterDistance(): number {
-        // Globe uses the same cameraToCenterDistance as mercator.
-        return this._mercatorTransform.cameraToCenterDistance;
     }
 
     public get nearZ(): number { return this._nearZ; }

--- a/src/geo/projection/globe_utils.ts
+++ b/src/geo/projection/globe_utils.ts
@@ -1,9 +1,9 @@
 import {vec3} from 'gl-matrix';
-import {clamp, lerp, mod, remapSaturate, wrap} from '../../util/util';
+import {clamp, lerp, mod, remapSaturate, scaleZoom, wrap} from '../../util/util';
 import {LngLat} from '../lng_lat';
-import {MAX_VALID_LATITUDE, scaleZoom} from '../transform_helper';
-import type Point from '@mapbox/point-geometry';
+import {MAX_VALID_LATITUDE} from '../transform_helper';
 import {EXTENT} from '../../data/extent';
+import type Point from '@mapbox/point-geometry';
 
 export function getGlobeCircumferencePixels(transform: {worldSize: number; center: {lat: number}}): number {
     const radius = getGlobeRadiusPixels(transform.worldSize, transform.center.lat);

--- a/src/geo/projection/globe_utils.ts
+++ b/src/geo/projection/globe_utils.ts
@@ -1,7 +1,6 @@
 import {vec3} from 'gl-matrix';
-import {clamp, lerp, mod, remapSaturate, scaleZoom, wrap} from '../../util/util';
+import {clamp, lerp, MAX_VALID_LATITUDE, mod, remapSaturate, scaleZoom, wrap} from '../../util/util';
 import {LngLat} from '../lng_lat';
-import {MAX_VALID_LATITUDE} from '../transform_helper';
 import {EXTENT} from '../../data/extent';
 import type Point from '@mapbox/point-geometry';
 

--- a/src/geo/projection/mercator_camera_helper.ts
+++ b/src/geo/projection/mercator_camera_helper.ts
@@ -1,14 +1,15 @@
 import Point from '@mapbox/point-geometry';
 import {LngLat, type LngLatLike} from '../lng_lat';
-import {type IReadonlyTransform, type ITransform} from '../transform_interface';
 import {cameraBoundsWarning, type CameraForBoxAndBearingHandlerResult, type EaseToHandlerResult, type EaseToHandlerOptions, type FlyToHandlerResult, type FlyToHandlerOptions, type ICameraHelper, type MapControlsDeltas, updateRotation, type UpdateRotationArgs} from './camera_helper';
-import {type CameraForBoundsOptions} from '../../ui/camera';
-import {type PaddingOptions} from '../edge_insets';
-import {type LngLatBounds} from '../lng_lat_bounds';
-import {normalizeCenter, scaleZoom, zoomScale} from '../transform_helper';
-import {degreesToRadians, rollPitchBearingEqual} from '../../util/util';
+import {normalizeCenter} from '../transform_helper';
+import {degreesToRadians, rollPitchBearingEqual, scaleZoom, zoomScale} from '../../util/util';
 import {projectToWorldCoordinates, unprojectFromWorldCoordinates} from './mercator_utils';
 import {interpolates} from '@maplibre/maplibre-gl-style-spec';
+
+import type {IReadonlyTransform, ITransform} from '../transform_interface';
+import type {CameraForBoundsOptions} from '../../ui/camera';
+import type {PaddingOptions} from '../edge_insets';
+import type {LngLatBounds} from '../lng_lat_bounds';
 
 /**
  * @internal

--- a/src/geo/projection/mercator_transform.test.ts
+++ b/src/geo/projection/mercator_transform.test.ts
@@ -3,12 +3,14 @@ import Point from '@mapbox/point-geometry';
 import {LngLat} from '../lng_lat';
 import {CanonicalTileID, UnwrappedTileID} from '../../source/tile_id';
 import {fixedLngLat, fixedCoord} from '../../../test/unit/lib/fixed';
-import type {Terrain} from '../../render/terrain';
 import {MercatorTransform} from './mercator_transform';
 import {LngLatBounds} from '../lng_lat_bounds';
 import {getMercatorHorizon} from './mercator_utils';
 import {mat4} from 'gl-matrix';
 import {expectToBeCloseToArray} from '../../util/test/util';
+import {createIdentityMat4f32} from '../../util/util';
+
+import type {Terrain} from '../../render/terrain';
 
 describe('transform', () => {
     test('creates a transform', () => {
@@ -594,5 +596,15 @@ describe('transform', () => {
         expect(transform.getCameraAltitude()).toBeCloseTo(camAlt, 10);
         expect(transform.getCameraLngLat().lng).toBeCloseTo(camLngLat.lng, 10);
         expect(transform.getCameraLngLat().lat).toBeCloseTo(camLngLat.lat, 10);
+    });
+
+    describe('getProjectionData', () => {
+        test('fallbackMatrix is identity when overscaledTileID is not set', () => {
+            const transform = new MercatorTransform(0, 22, 0, 180, true);
+            const mat = mat4.create();
+            mat[0] = 1234;
+            const projectionData = transform.getProjectionData({overscaledTileID: null});
+            expect(projectionData.fallbackMatrix).toEqual(createIdentityMat4f32());
+        });
     });
 });

--- a/src/geo/projection/mercator_utils.test.ts
+++ b/src/geo/projection/mercator_utils.test.ts
@@ -1,7 +1,7 @@
 import {describe, expect, test} from 'vitest';
 import Point from '@mapbox/point-geometry';
 import {LngLat} from '../lng_lat';
-import {getBasicProjectionData, getMercatorHorizon, locationToMercatorCoordinate, projectToWorldCoordinates, tileCoordinatesToLocation, tileCoordinatesToMercatorCoordinates} from './mercator_utils';
+import {getBasicProjectionData, getMercatorHorizon, projectToWorldCoordinates, tileCoordinatesToLocation, tileCoordinatesToMercatorCoordinates} from './mercator_utils';
 import {MercatorTransform} from './mercator_transform';
 import {mat4} from 'gl-matrix';
 import {CanonicalTileID, OverscaledTileID} from '../../source/tile_id';
@@ -23,10 +23,6 @@ describe('mercator utils', () => {
 
         expect(projectToWorldCoordinates(transform.worldSize, new LngLat(0, -90))).toEqual(projectToWorldCoordinates(transform.worldSize, new LngLat(0, -MAX_VALID_LATITUDE)));
         expect(projectToWorldCoordinates(transform.worldSize, new LngLat(0, 90))).toEqual(projectToWorldCoordinates(transform.worldSize, new LngLat(0, MAX_VALID_LATITUDE)));
-    });
-
-    test('locationCoordinate', () => {
-        expect(locationToMercatorCoordinate(new LngLat(0, 0))).toEqual({x: 0.5, y: 0.5, z: 0});
     });
 
     test('getMercatorHorizon', () => {

--- a/src/geo/projection/mercator_utils.test.ts
+++ b/src/geo/projection/mercator_utils.test.ts
@@ -3,11 +3,12 @@ import Point from '@mapbox/point-geometry';
 import {LngLat} from '../lng_lat';
 import {getBasicProjectionData, getMercatorHorizon, locationToMercatorCoordinate, projectToWorldCoordinates, tileCoordinatesToLocation, tileCoordinatesToMercatorCoordinates} from './mercator_utils';
 import {MercatorTransform} from './mercator_transform';
-import {MAX_VALID_LATITUDE} from '../transform_helper';
 import {mat4} from 'gl-matrix';
 import {CanonicalTileID, OverscaledTileID} from '../../source/tile_id';
 import {EXTENT} from '../../data/extent';
 import {expectToBeCloseToArray} from '../../util/test/util';
+import {MAX_VALID_LATITUDE} from '../../util/util';
+
 import type {ProjectionData} from './projection_data';
 
 describe('mercator utils', () => {

--- a/src/geo/projection/mercator_utils.test.ts
+++ b/src/geo/projection/mercator_utils.test.ts
@@ -1,15 +1,11 @@
 import {describe, expect, test} from 'vitest';
 import Point from '@mapbox/point-geometry';
 import {LngLat} from '../lng_lat';
-import {getBasicProjectionData, getMercatorHorizon, projectToWorldCoordinates, tileCoordinatesToLocation, tileCoordinatesToMercatorCoordinates} from './mercator_utils';
+import {getMercatorHorizon, projectToWorldCoordinates, tileCoordinatesToLocation, tileCoordinatesToMercatorCoordinates} from './mercator_utils';
 import {MercatorTransform} from './mercator_transform';
-import {mat4} from 'gl-matrix';
-import {CanonicalTileID, OverscaledTileID} from '../../source/tile_id';
+import {CanonicalTileID} from '../../source/tile_id';
 import {EXTENT} from '../../data/extent';
-import {expectToBeCloseToArray} from '../../util/test/util';
 import {MAX_VALID_LATITUDE} from '../../util/util';
-
-import type {ProjectionData} from './projection_data';
 
 describe('mercator utils', () => {
     test('projectToWorldCoordinates basic', () => {
@@ -50,28 +46,6 @@ describe('mercator utils', () => {
         const horizon = getMercatorHorizon(transform);
 
         expect(horizon).toBeCloseTo(-75.52102888757743, 10);
-    });
-
-    describe('getBasicProjectionData', () => {
-        test('posMatrix is set', () => {
-            const mat = mat4.create();
-            mat[0] = 1234;
-            const projectionData = getBasicProjectionData(new OverscaledTileID(0, 0, 0, 0, 0), mat);
-            expect(projectionData.fallbackMatrix).toEqual(mat);
-        });
-
-        test('mercator tile extents are set', () => {
-            let projectionData: ProjectionData;
-
-            projectionData = getBasicProjectionData(new OverscaledTileID(0, 0, 0, 0, 0));
-            expectToBeCloseToArray(projectionData.tileMercatorCoords, [0, 0, 1 / EXTENT, 1 / EXTENT]);
-
-            projectionData = getBasicProjectionData(new OverscaledTileID(1, 0, 1, 0, 0));
-            expectToBeCloseToArray(projectionData.tileMercatorCoords, [0, 0, 0.5 / EXTENT, 0.5 / EXTENT]);
-
-            projectionData = getBasicProjectionData(new OverscaledTileID(1, 0, 1, 1, 0));
-            expectToBeCloseToArray(projectionData.tileMercatorCoords, [0.5, 0, 0.5 / EXTENT, 0.5 / EXTENT]);
-        });
     });
 
     describe('tileCoordinatesToMercatorCoordinates', () => {

--- a/src/geo/projection/mercator_utils.ts
+++ b/src/geo/projection/mercator_utils.ts
@@ -1,10 +1,10 @@
 import {mat4} from 'gl-matrix';
 import {EXTENT} from '../../data/extent';
-import {clamp, createIdentityMat4f32, degreesToRadians, zoomScale} from '../../util/util';
-import {MAX_VALID_LATITUDE, type UnwrappedTileIDType} from '../transform_helper';
+import {clamp, createIdentityMat4f32, degreesToRadians, MAX_VALID_LATITUDE, zoomScale} from '../../util/util';
 import {MercatorCoordinate, mercatorXfromLng, mercatorYfromLat, mercatorZfromAltitude} from '../mercator_coordinate';
 import Point from '@mapbox/point-geometry';
 
+import type {UnwrappedTileIDType} from '../transform_helper';
 import type {OverscaledTileID} from '../../source/tile_id';
 import type {LngLat} from '../lng_lat';
 import type {ProjectionData} from './projection_data';

--- a/src/geo/projection/mercator_utils.ts
+++ b/src/geo/projection/mercator_utils.ts
@@ -1,13 +1,11 @@
 import {mat4} from 'gl-matrix';
 import {EXTENT} from '../../data/extent';
-import {clamp, createIdentityMat4f32, degreesToRadians, MAX_VALID_LATITUDE, zoomScale} from '../../util/util';
+import {clamp, degreesToRadians, MAX_VALID_LATITUDE, zoomScale} from '../../util/util';
 import {MercatorCoordinate, mercatorXfromLng, mercatorYfromLat, mercatorZfromAltitude} from '../mercator_coordinate';
 import Point from '@mapbox/point-geometry';
 
 import type {UnwrappedTileIDType} from '../transform_helper';
-import type {OverscaledTileID} from '../../source/tile_id';
 import type {LngLat} from '../lng_lat';
-import type {ProjectionData} from './projection_data';
 
 /*
 * The maximum angle to use for the Mercator horizon. This must be less than 90
@@ -74,41 +72,6 @@ export function unprojectFromWorldCoordinates(worldSize: number, point: Point): 
 export function getMercatorHorizon(transform: {pitch: number; cameraToCenterDistance: number}): number {
     return transform.cameraToCenterDistance * Math.min(Math.tan(degreesToRadians(90 - transform.pitch)) * 0.85,
         Math.tan(degreesToRadians(maxMercatorHorizonAngle - transform.pitch)));
-}
-
-export function getBasicProjectionData(overscaledTileID: OverscaledTileID, tilePosMatrix?: mat4, applyTerrainMatrix: boolean = true): ProjectionData {
-    let tileOffsetSize: [number, number, number, number];
-
-    if (overscaledTileID) {
-        const scale = (overscaledTileID.canonical.z >= 0) ? (1 << overscaledTileID.canonical.z) : Math.pow(2.0, overscaledTileID.canonical.z);
-        tileOffsetSize = [
-            overscaledTileID.canonical.x / scale,
-            overscaledTileID.canonical.y / scale,
-            1.0 / scale / EXTENT,
-            1.0 / scale / EXTENT
-        ];
-    } else {
-        tileOffsetSize = [0, 0, 1, 1];
-    }
-
-    let mainMatrix: mat4;
-    if (overscaledTileID && overscaledTileID.terrainRttPosMatrix32f && applyTerrainMatrix) {
-        mainMatrix = overscaledTileID.terrainRttPosMatrix32f;
-    } else if (tilePosMatrix) {
-        mainMatrix = tilePosMatrix; // This matrix should be float32
-    } else {
-        mainMatrix = createIdentityMat4f32();
-    }
-
-    const data: ProjectionData = {
-        mainMatrix, // Might be set to a custom matrix by different projections.
-        tileMercatorCoords: tileOffsetSize,
-        clippingPlane: [0, 0, 0, 0],
-        projectionTransition: 0.0, // Range 0..1, where 0 is mercator, 1 is another projection, mostly globe.
-        fallbackMatrix: mainMatrix,
-    };
-
-    return data;
 }
 
 export function calculateTileMatrix(unwrappedTileID: UnwrappedTileIDType, worldSize: number): mat4 {

--- a/src/geo/projection/mercator_utils.ts
+++ b/src/geo/projection/mercator_utils.ts
@@ -43,25 +43,6 @@ export function tileCoordinatesToLocation(inTileX: number, inTileY: number, cano
 }
 
 /**
- * Given a geographical lnglat, return an unrounded
- * coordinate that represents it at low zoom level.
- * @param lnglat - the location
- * @returns The mercator coordinate
- */
-export function locationToMercatorCoordinate(lnglat: LngLat): MercatorCoordinate {
-    return MercatorCoordinate.fromLngLat(lnglat);
-}
-
-/**
- * Given a Coordinate, return its geographical position.
- * @param coord - mercator coordinates
- * @returns lng and lat
- */
-export function mercatorCoordinateToLocation(coord: MercatorCoordinate): LngLat {
-    return coord && coord.toLngLat();
-}
-
-/**
  * Convert from LngLat to world coordinates (Mercator coordinates scaled by world size).
  * @param worldSize - Mercator world size computed from zoom level and tile size.
  * @param lnglat - The location to convert.

--- a/src/geo/projection/mercator_utils.ts
+++ b/src/geo/projection/mercator_utils.ts
@@ -1,11 +1,12 @@
 import {mat4} from 'gl-matrix';
 import {EXTENT} from '../../data/extent';
-import {type OverscaledTileID} from '../../source/tile_id';
-import {clamp, createIdentityMat4f32, degreesToRadians} from '../../util/util';
-import {MAX_VALID_LATITUDE, type UnwrappedTileIDType, zoomScale} from '../transform_helper';
-import {type LngLat} from '../lng_lat';
+import {clamp, createIdentityMat4f32, degreesToRadians, zoomScale} from '../../util/util';
+import {MAX_VALID_LATITUDE, type UnwrappedTileIDType} from '../transform_helper';
 import {MercatorCoordinate, mercatorXfromLng, mercatorYfromLat, mercatorZfromAltitude} from '../mercator_coordinate';
 import Point from '@mapbox/point-geometry';
+
+import type {OverscaledTileID} from '../../source/tile_id';
+import type {LngLat} from '../lng_lat';
 import type {ProjectionData} from './projection_data';
 
 /*

--- a/src/geo/transform_helper.test.ts
+++ b/src/geo/transform_helper.test.ts
@@ -2,14 +2,17 @@ import {describe, expect, test} from 'vitest';
 import {LngLat} from './lng_lat';
 import {LngLatBounds} from './lng_lat_bounds';
 import {TransformHelper} from './transform_helper';
+import {OverscaledTileID} from '../source/tile_id';
+import {EXTENT} from '../data/extent';
+import {expectToBeCloseToArray} from '../util/test/util';
+
+const emptyCallbacks = {
+    calcMatrices: () => {},
+    getConstrained: (center, zoom) => { return {center, zoom}; },
+};
 
 describe('TransformHelper', () => {
     test('apply', () => {
-        const emptyCallbacks = {
-            calcMatrices: () => {},
-            getConstrained: (center, zoom) => { return {center, zoom}; },
-        };
-
         const original = new TransformHelper(emptyCallbacks);
         original.setBearing(12);
         original.setCenter(new LngLat(3, 4));
@@ -60,5 +63,22 @@ describe('TransformHelper', () => {
         expect(cloned.padding).toEqual(original.padding);
         expect(cloned.unmodified).toEqual(original.unmodified);
         expect(cloned.renderWorldCopies).toEqual(original.renderWorldCopies);
+    });
+
+    describe('getTileMercatorCoordinates', () => {
+
+        test('mercator tile extents are set', () => {
+            const helper = new TransformHelper(emptyCallbacks);
+            helper.getTileMercatorCoordinates
+
+            let coords = helper.getTileMercatorCoordinates(new OverscaledTileID(0, 0, 0, 0, 0));
+            expectToBeCloseToArray(coords, [0, 0, 1 / EXTENT, 1 / EXTENT]);
+
+            coords = helper.getTileMercatorCoordinates(new OverscaledTileID(1, 0, 1, 0, 0));
+            expectToBeCloseToArray(coords, [0, 0, 0.5 / EXTENT, 0.5 / EXTENT]);
+
+            coords = helper.getTileMercatorCoordinates(new OverscaledTileID(1, 0, 1, 1, 0));
+            expectToBeCloseToArray(coords, [0.5, 0, 0.5 / EXTENT, 0.5 / EXTENT]);
+        });
     });
 });

--- a/src/geo/transform_helper.test.ts
+++ b/src/geo/transform_helper.test.ts
@@ -1,7 +1,7 @@
 import {describe, expect, test} from 'vitest';
 import {LngLat} from './lng_lat';
 import {LngLatBounds} from './lng_lat_bounds';
-import {scaleZoom, TransformHelper, zoomScale} from './transform_helper';
+import {TransformHelper} from './transform_helper';
 
 describe('TransformHelper', () => {
     test('apply', () => {
@@ -60,12 +60,5 @@ describe('TransformHelper', () => {
         expect(cloned.padding).toEqual(original.padding);
         expect(cloned.unmodified).toEqual(original.unmodified);
         expect(cloned.renderWorldCopies).toEqual(original.renderWorldCopies);
-    });
-
-    test('scaleZoom+zoomScale', () => {
-        expect(scaleZoom(0)).toBe(-Infinity);
-        expect(scaleZoom(10)).toBe(3.3219280948873626);
-        expect(zoomScale(3.3219280948873626)).toBeCloseTo(10, 10);
-        expect(scaleZoom(zoomScale(5))).toBe(5);
     });
 });

--- a/src/geo/transform_helper.ts
+++ b/src/geo/transform_helper.ts
@@ -124,6 +124,7 @@ export class TransformHelper implements ITransformGetters {
     _pixelsToGLUnits: [number, number];
     _pixelsToClipSpaceMatrix: mat4;
     _clipSpaceToPixelsMatrix: mat4;
+    _cameraToCenterDistance: number;
 
     constructor(callbacks: TransformHelperCallbacks, minZoom?: number, maxZoom?: number, minPitch?: number, maxPitch?: number, renderWorldCopies?: boolean) {
         this._callbacks = callbacks;
@@ -176,6 +177,7 @@ export class TransformHelper implements ITransformGetters {
         this._minPitch = thatI.minPitch;
         this._maxPitch = thatI.maxPitch;
         this._renderWorldCopies = thatI.renderWorldCopies;
+        this._cameraToCenterDistance = thatI.cameraToCenterDistance;
         if (constrain) {
             this._constrain();
         }
@@ -383,6 +385,8 @@ export class TransformHelper implements ITransformGetters {
 
     get unmodified(): boolean { return this._unmodified; }
 
+    get cameraToCenterDistance(): number { return this._cameraToCenterDistance; }
+
     /**
      * Returns if the padding params match
      *
@@ -512,6 +516,8 @@ export class TransformHelper implements ITransformGetters {
             mat4.translate(m, m, [-1, -1, 0]);
             mat4.scale(m, m, [2 / this._width, 2 / this._height, 1]);
             this._pixelsToClipSpaceMatrix = m;
+            const halfFov = this.fovInRadians / 2;
+            this._cameraToCenterDistance = 0.5 / Math.tan(halfFov) * this._height;
         }
         this._callbacks.calcMatrices();
     }

--- a/src/geo/transform_helper.ts
+++ b/src/geo/transform_helper.ts
@@ -1,7 +1,7 @@
 import {LngLat} from './lng_lat';
 import {LngLatBounds} from './lng_lat_bounds';
 import Point from '@mapbox/point-geometry';
-import {wrap, clamp, degreesToRadians, radiansToDegrees, zoomScale} from '../util/util';
+import {wrap, clamp, degreesToRadians, radiansToDegrees, zoomScale, MAX_VALID_LATITUDE} from '../util/util';
 import {mat4, mat2} from 'gl-matrix';
 import {EdgeInsets} from './edge_insets';
 import {mercatorZfromAltitude} from './mercator_coordinate';
@@ -9,8 +9,6 @@ import {cameraMercatorCoordinateFromCenterAndRotation} from './projection/mercat
 
 import type {PaddingOptions} from './edge_insets';
 import type {IReadonlyTransform, ITransformGetters} from './transform_interface';
-
-export const MAX_VALID_LATITUDE = 85.051129;
 
 /**
  * If a path crossing the antimeridian would be shorter, extend the final coordinate so that

--- a/src/geo/transform_helper.ts
+++ b/src/geo/transform_helper.ts
@@ -1,10 +1,10 @@
-import {LngLat} from './lng_lat';
+import {LngLat, type LngLatLike} from './lng_lat';
 import {LngLatBounds} from './lng_lat_bounds';
 import Point from '@mapbox/point-geometry';
-import {wrap, clamp, degreesToRadians, radiansToDegrees, zoomScale, MAX_VALID_LATITUDE} from '../util/util';
+import {wrap, clamp, degreesToRadians, radiansToDegrees, zoomScale, MAX_VALID_LATITUDE, scaleZoom} from '../util/util';
 import {mat4, mat2} from 'gl-matrix';
 import {EdgeInsets} from './edge_insets';
-import {mercatorZfromAltitude} from './mercator_coordinate';
+import {altitudeFromMercatorZ, MercatorCoordinate, mercatorZfromAltitude} from './mercator_coordinate';
 import {cameraMercatorCoordinateFromCenterAndRotation} from './projection/mercator_utils';
 
 import type {PaddingOptions} from './edge_insets';
@@ -528,5 +528,53 @@ export class TransformHelper implements ITransformGetters {
         const cameraToCenterDistanceMeters = this._cameraToCenterDistance / pixelPerMeter;
         const camMercator = cameraMercatorCoordinateFromCenterAndRotation(this.center, this.elevation, this.pitch, this.bearing, cameraToCenterDistanceMeters);
         return camMercator.toLngLat();
+    }
+
+    calculateCenterFromCameraLngLatAlt(lnglat: LngLatLike, alt: number, bearing?: number, pitch?: number): {center: LngLat; elevation: number; zoom: number} {
+        const cameraBearing = bearing !== undefined ? bearing : this.bearing;
+        const cameraPitch = pitch = pitch !== undefined ? pitch : this.pitch;
+
+        const camMercator = MercatorCoordinate.fromLngLat(lnglat, alt);
+        const dzNormalized = -Math.cos(degreesToRadians(cameraPitch));
+        const dhNormalized = Math.sin(degreesToRadians(cameraPitch));
+        const dxNormalized = dhNormalized * Math.sin(degreesToRadians(cameraBearing));
+        const dyNormalized = -dhNormalized * Math.cos(degreesToRadians(cameraBearing));
+
+        let elevation = this.elevation;
+        const altitudeAGL = alt - elevation;
+        let distanceToCenterMeters;
+        if (dzNormalized * altitudeAGL >= 0.0 || Math.abs(dzNormalized) < 0.1) {
+            distanceToCenterMeters = 10000;
+            elevation = alt + distanceToCenterMeters * dzNormalized;
+        } else {
+            distanceToCenterMeters = -altitudeAGL / dzNormalized;
+        }
+
+        // The mercator transform scale changes with latitude. At high latitudes, there are more "Merc units" per meter
+        // than at the equator. We treat the center point as our fundamental quantity. This means we want to convert
+        // elevation to Mercator Z using the scale factor at the center point (not the camera point). Since the center point is
+        // initially unknown, we compute it using the scale factor at the camera point. This gives us a better estimate of the
+        // center point scale factor, which we use to recompute the center point. We repeat until the error is very small.
+        // This typically takes about 5 iterations.
+        let metersPerMercUnit = altitudeFromMercatorZ(1, camMercator.y);
+        let centerMercator: MercatorCoordinate;
+        let dMercator: number;
+        let iter = 0;
+        const maxIter = 10;
+        do {
+            iter += 1;
+            if (iter > maxIter) {
+                break;
+            }
+            dMercator = distanceToCenterMeters / metersPerMercUnit;
+            const dx = dxNormalized * dMercator;
+            const dy = dyNormalized * dMercator;
+            centerMercator = new MercatorCoordinate(camMercator.x + dx, camMercator.y + dy);
+            metersPerMercUnit = 1 / centerMercator.meterInMercatorCoordinateUnits();
+        } while (Math.abs(distanceToCenterMeters - dMercator * metersPerMercUnit) > 1.0e-12);
+
+        const center = centerMercator.toLngLat();
+        const zoom = scaleZoom(this.height / 2 / Math.tan(this.fovInRadians / 2) / dMercator / this.tileSize);
+        return {center, elevation, zoom};
     }
 }

--- a/src/geo/transform_helper.ts
+++ b/src/geo/transform_helper.ts
@@ -6,9 +6,11 @@ import {mat4, mat2} from 'gl-matrix';
 import {EdgeInsets} from './edge_insets';
 import {altitudeFromMercatorZ, MercatorCoordinate, mercatorZfromAltitude} from './mercator_coordinate';
 import {cameraMercatorCoordinateFromCenterAndRotation} from './projection/mercator_utils';
+import {EXTENT} from '../data/extent';
 
 import type {PaddingOptions} from './edge_insets';
 import type {IReadonlyTransform, ITransformGetters} from './transform_interface';
+import type {OverscaledTileID} from '../source/tile_id';
 
 /**
  * If a path crossing the antimeridian would be shorter, extend the final coordinate so that
@@ -576,5 +578,18 @@ export class TransformHelper implements ITransformGetters {
         const center = centerMercator.toLngLat();
         const zoom = scaleZoom(this.height / 2 / Math.tan(this.fovInRadians / 2) / dMercator / this.tileSize);
         return {center, elevation, zoom};
+    }
+
+    getTileMercatorCoordinates(overscaledTileID: OverscaledTileID): [number, number, number, number] {
+        if (!overscaledTileID) {
+            return [0, 0, 1, 1];
+        }
+        const scale = (overscaledTileID.canonical.z >= 0) ? (1 << overscaledTileID.canonical.z) : Math.pow(2.0, overscaledTileID.canonical.z);
+        return [
+            overscaledTileID.canonical.x / scale,
+            overscaledTileID.canonical.y / scale,
+            1.0 / scale / EXTENT,
+            1.0 / scale / EXTENT
+        ];
     }
 }

--- a/src/geo/transform_interface.ts
+++ b/src/geo/transform_interface.ts
@@ -82,6 +82,8 @@ export interface ITransformGetters {
     get unmodified(): boolean;
 
     get renderWorldCopies(): boolean;
+
+    get cameraToCenterDistance(): number;
 }
 
 /**

--- a/src/ui/camera.ts
+++ b/src/ui/camera.ts
@@ -1,4 +1,4 @@
-import {extend, wrap, defaultEasing, pick} from '../util/util';
+import {extend, wrap, defaultEasing, pick, scaleZoom} from '../util/util';
 import {interpolates} from '@maplibre/maplibre-gl-style-spec';
 import {browser} from '../util/browser';
 import {LngLat} from '../geo/lng_lat';
@@ -14,8 +14,7 @@ import type {LngLatBoundsLike} from '../geo/lng_lat_bounds';
 import type {TaskID} from '../util/task_queue';
 import type {PaddingOptions} from '../geo/edge_insets';
 import type {HandlerManager} from './handler_manager';
-import {scaleZoom} from '../geo/transform_helper';
-import {type ICameraHelper} from '../geo/projection/camera_helper';
+import type {ICameraHelper} from '../geo/projection/camera_helper';
 
 /**
  * A [Point](https://github.com/mapbox/point-geometry) or an array of two numbers representing `x` and `y` screen coordinates in pixels.

--- a/src/ui/handler/scroll_zoom.ts
+++ b/src/ui/handler/scroll_zoom.ts
@@ -1,6 +1,6 @@
 import {DOM} from '../../util/dom';
 
-import {defaultEasing, bezier} from '../../util/util';
+import {defaultEasing, bezier, zoomScale, scaleZoom} from '../../util/util';
 import {browser} from '../../util/browser';
 import {interpolates} from '@maplibre/maplibre-gl-style-spec';
 import {LngLat} from '../../geo/lng_lat';
@@ -10,7 +10,6 @@ import type {Map} from '../map';
 import type Point from '@mapbox/point-geometry';
 import type {AroundCenterOptions} from './two_fingers_touch';
 import {type Handler} from '../handler_manager';
-import {scaleZoom, zoomScale} from '../../geo/transform_helper';
 
 // deltaY value for mouse scroll wheel identification
 const wheelZoomDelta = 4.000244140625;

--- a/src/util/util.test.ts
+++ b/src/util/util.test.ts
@@ -1,6 +1,6 @@
 import {describe, beforeEach, test, expect, vi} from 'vitest';
 import Point from '@mapbox/point-geometry';
-import {arraysIntersect, bezier, clamp, clone, deepEqual, easeCubicInOut, extend, filterObject, findLineIntersection, isCounterClockwise, isPowerOfTwo, keysDifference, mapObject, nextPowerOfTwo, parseCacheControl, pick, readImageDataUsingOffscreenCanvas, readImageUsingVideoFrame, uniqueId, wrap, mod, distanceOfAnglesRadians, distanceOfAnglesDegrees, differenceOfAnglesRadians, differenceOfAnglesDegrees, solveQuadratic, remapSaturate, radiansToDegrees, degreesToRadians, rollPitchBearingToQuat, getRollPitchBearing, getAngleDelta} from './util';
+import {arraysIntersect, bezier, clamp, clone, deepEqual, easeCubicInOut, extend, filterObject, findLineIntersection, isCounterClockwise, isPowerOfTwo, keysDifference, mapObject, nextPowerOfTwo, parseCacheControl, pick, readImageDataUsingOffscreenCanvas, readImageUsingVideoFrame, uniqueId, wrap, mod, distanceOfAnglesRadians, distanceOfAnglesDegrees, differenceOfAnglesRadians, differenceOfAnglesDegrees, solveQuadratic, remapSaturate, radiansToDegrees, degreesToRadians, rollPitchBearingToQuat, getRollPitchBearing, getAngleDelta, scaleZoom, zoomScale} from './util';
 import {Canvas} from 'canvas';
 
 describe('util', () => {
@@ -517,5 +517,14 @@ describe('util getAngleDelta', () => {
         const center = new Point(0, 0);
 
         expect(getAngleDelta(lastPoint, currentPoint, center)).toBe(-90);
+    });
+});
+
+describe('zoom and scale', () => {
+    test('scaleZoom+zoomScale', () => {
+        expect(scaleZoom(0)).toBe(-Infinity);
+        expect(scaleZoom(10)).toBe(3.3219280948873626);
+        expect(zoomScale(3.3219280948873626)).toBeCloseTo(10, 10);
+        expect(scaleZoom(zoomScale(5))).toBe(5);
     });
 });

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -966,6 +966,16 @@ export function rollPitchBearingToQuat(roll: number, pitch: number, bearing: num
 }
 
 /**
+ * Computes scaling from zoom level.
+ */
+export function zoomScale(zoom: number) { return Math.pow(2, zoom); }
+
+/**
+ * Computes zoom level from scaling.
+ */
+export function scaleZoom(scale: number) { return Math.log(scale) / Math.LN2; }
+
+/**
  * Makes optional keys required and add the the undefined type.
  *
  * ```

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -1033,3 +1033,8 @@ export const MAX_TILE_ZOOM = 25;
  * In other words, the lower bound supported for tile zoom.
  */
 export const MIN_TILE_ZOOM = 0;
+
+/**
+ * The maximum valid latitude.
+ */
+export const MAX_VALID_LATITUDE = 85.051129;

--- a/test/build/min.test.ts
+++ b/test/build/min.test.ts
@@ -38,7 +38,7 @@ describe('test min build', () => {
         const decreaseQuota = 4096;
 
         // feel free to update this value after you've checked that it has changed on purpose :-)
-        const expectedBytes = 898930;
+        const expectedBytes = 899999;
 
         expect(actualBytes).toBeLessThan(expectedBytes + increaseQuota);
         expect(actualBytes).toBeGreaterThan(expectedBytes - decreaseQuota);


### PR DESCRIPTION
## Launch Checklist

See here: 
- #5139

This is a WIP to refactor globe transform to move all the logic that is related to globe to a different transform keeping only the transition logic in the globe class and creating a new class for virtual perspective.


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [ ] Briefly describe the changes in this PR.
 - [ ] Link to related issues.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [ ] Add an entry to `CHANGELOG.md` under the `## main` section.
