### PR TITLE
Avoid constraining with Mercator transform when Globe is used

### DIFF
--- a/src/geo/projection/globe_transform.ts
+++ b/src/geo/projection/globe_transform.ts
@@ -121,8 +121,8 @@ export class GlobeTransform implements ITransform {
     isPaddingEqual(padding: PaddingOptions): boolean {
         return this._helper.isPaddingEqual(padding);
     }
-    resize(width: number, height: number): void {
-        this._helper.resize(width, height);
+    resize(width: number, height: number, constrainTransform: boolean = true): void {
+        this._helper.resize(width, height, constrainTransform);
     }
     getMaxBounds(): LngLatBounds {
         return this._helper.getMaxBounds();

--- a/src/geo/projection/mercator_transform.ts
+++ b/src/geo/projection/mercator_transform.ts
@@ -97,8 +97,8 @@ export class MercatorTransform implements ITransform {
     isPaddingEqual(padding: PaddingOptions): boolean {
         return this._helper.isPaddingEqual(padding);
     }
-    resize(width: number, height: number): void {
-        this._helper.resize(width, height);
+    resize(width: number, height: number, constrain: boolean = true): void {
+        this._helper.resize(width, height, constrain);
     }
     getMaxBounds(): LngLatBounds {
         return this._helper.getMaxBounds();

--- a/src/geo/transform_helper.ts
+++ b/src/geo/transform_helper.ts
@@ -407,10 +407,10 @@ export class TransformHelper implements ITransformGetters {
         this._calcMatrices();
     }
 
-    resize(width: number, height: number) {
+    resize(width: number, height: number, constrain: boolean): void {
         this._width = width;
         this._height = height;
-        this._constrain();
+        if (constrain) this._constrain();
         this._calcMatrices();
     }
 

--- a/src/geo/transform_interface.ts
+++ b/src/geo/transform_interface.ts
@@ -151,7 +151,7 @@ interface ITransformMutators {
     /**
      * Sets the transform's width and height and recomputes internal matrices.
      */
-    resize(width: number, height: number): void;
+    resize(width: number, height: number, constrainTransform: boolean): void;
     /**
      * Helper method to update edge-insets in place
      *

--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -725,7 +725,11 @@ export class Map extends Camera {
             }
         }
 
-        this.resize();
+        // When no style is set or it's using the default mercator projection, we can constrain the camera.
+        // When a style is set with other projections though, we can't constrain the camera until the style is loaded
+        // and the correct transform is used. Otherwise, valid points in the desired projection could be rejected
+        const shouldConstrainUsingMercatorTransform = typeof resolvedOptions.style === 'string' || !resolvedOptions.style || !resolvedOptions.style?.projection || resolvedOptions.style?.projection?.type === 'mercator';
+        this.resize(null, shouldConstrainUsingMercatorTransform);
 
         this._localIdeographFontFamily = resolvedOptions.localIdeographFontFamily;
         this._validateStyle = resolvedOptions.validateStyle;
@@ -739,6 +743,8 @@ export class Map extends Camera {
             this.addControl(new LogoControl(), resolvedOptions.logoPosition);
 
         this.on('style.load', () => {
+            // If we didn't constrain the camera before, we do it now
+            if (!shouldConstrainUsingMercatorTransform) this._resizeTransform();
             if (this.transform.unmodified) {
                 const coercedOptions = pick(this.style.stylesheet, ['center', 'zoom', 'bearing', 'pitch', 'roll']) as CameraOptions;
                 this.jumpTo(coercedOptions);
@@ -878,7 +884,7 @@ export class Map extends Camera {
      * if (mapDiv.style.visibility === true) map.resize();
      * ```
      */
-    resize(eventData?: any): Map {
+    resize(eventData?: any, constrainTransform = true): Map {
         const dimensions = this._containerDimensions();
         const width = dimensions[0];
         const height = dimensions[1];
@@ -897,8 +903,8 @@ export class Map extends Camera {
             this.painter.resize(width, height, clampedPixelRatio);
         }
 
-        this.transform.resize(width, height);
-        this._requestedCameraState?.resize(width, height);
+        this.transform.resize(width, height, constrainTransform);
+        this._requestedCameraState?.resize(width, height, constrainTransform);
 
         const fireMoving = !this._moving;
         if (fireMoving) {
@@ -912,6 +918,15 @@ export class Map extends Camera {
         if (fireMoving) this.fire(new Event('moveend', eventData));
 
         return this;
+    }
+
+    _resizeTransform() {
+        const dimensions = this._containerDimensions();
+        const width = dimensions[0];
+        const height = dimensions[1];
+
+        this.transform.resize(width, height, true);
+        this._requestedCameraState?.resize(width, height, true);
     }
 
     /**

--- a/src/ui/map_tests/map_style.test.ts
+++ b/src/ui/map_tests/map_style.test.ts
@@ -116,7 +116,7 @@ describe('#setStyle', () => {
     test('style transform overrides unmodified map transform', () => new Promise<void>(done => {
         const map = new Map({container: window.document.createElement('div')} as any as MapOptions);
         map.transform.setMaxBounds(new LngLatBounds([-120, -60], [140, 80]));
-        map.transform.resize(600, 400);
+        map.transform.resize(600, 400, true);
         expect(map.transform.zoom).toBe(0.6983039737971013);
         expect(map.transform.unmodified).toBeTruthy();
         map.setStyle(createStyle());

--- a/src/ui/map_tests/map_transform_constrains.test.ts
+++ b/src/ui/map_tests/map_transform_constrains.test.ts
@@ -1,0 +1,85 @@
+import {beforeEach, test, expect} from 'vitest';
+import {createMap, beforeMapTest} from '../../util/test/util';
+import {fixedLngLat, fixedNum} from '../../../test/unit/lib/fixed';
+
+beforeEach(() => {
+    beforeMapTest();
+    global.fetch = null;
+});
+
+test('Creating a map without style constrains invalid hash values to valid Mercator transform values', () => {
+    const container = window.document.createElement('div');
+    Object.defineProperty(container, 'offsetWidth', {value: 512});
+    Object.defineProperty(container, 'offsetHeight', {value: 512});
+
+    const map = createMap({container, center: [-180, -90], zoom: -2});
+
+    expect(fixedLngLat(map.getCenter(), 4)).toEqual({lng: 180, lat: 0});
+    expect(fixedNum(map.getZoom(), 3)).toBe(-0.771);
+});
+
+test('Creating a map without style keeps valid hash values as Mercator transform values', () => {
+  const container = window.document.createElement('div');
+  Object.defineProperty(container, 'offsetWidth', {value: 512});
+  Object.defineProperty(container, 'offsetHeight', {value: 512});
+
+  const map = createMap({container, center: [15, 30], zoom: 3});
+
+  expect(fixedLngLat(map.getCenter(), 4)).toEqual({lng: 15, lat: 30});
+  expect(fixedNum(map.getZoom(), 3)).toBe(3);
+});
+
+test('Creating a map with style but no projection uses Mercator transform constrains', () => {
+  const container = window.document.createElement('div');
+  Object.defineProperty(container, 'offsetWidth', {value: 512});
+  Object.defineProperty(container, 'offsetHeight', {value: 512});
+
+  const map = createMap({container, center: [-180, -90], zoom: -2, style: {version: 8, sources: {}, layers: []}});
+
+  expect(fixedLngLat(map.getCenter(), 4)).toEqual({lng: 180, lat: 0});
+  expect(fixedNum(map.getZoom(), 3)).toBe(-0.771);
+});
+
+test('Creating a map with style but no projection does not constrain valid values', () => {
+  const container = window.document.createElement('div');
+  Object.defineProperty(container, 'offsetWidth', {value: 512});
+  Object.defineProperty(container, 'offsetHeight', {value: 512});
+
+  const map = createMap({container, center: [15, 30], zoom: 3, style: {version: 8, sources: {}, layers: []}});
+
+  expect(fixedLngLat(map.getCenter(), 4)).toEqual({lng: 15, lat: 30});
+  expect(fixedNum(map.getZoom(), 3)).toBe(3);
+});
+
+test('Creating a map with style defining mercator projection uses Mercator transform constrains', () => {
+  const container = window.document.createElement('div');
+  Object.defineProperty(container, 'offsetWidth', {value: 512});
+  Object.defineProperty(container, 'offsetHeight', {value: 512});
+
+  const map = createMap({container, center: [-180, -90], zoom: -2, style: {version: 8, sources: {}, layers: [], projection: { type: 'mercator' }}});
+
+  expect(fixedLngLat(map.getCenter(), 4)).toEqual({lng: 180, lat: 0});
+  expect(fixedNum(map.getZoom(), 3)).toBe(-0.771);
+});
+
+test('Creating a map with style defining mercator projection does not constrain valid values', () => {
+  const container = window.document.createElement('div');
+  Object.defineProperty(container, 'offsetWidth', {value: 512});
+  Object.defineProperty(container, 'offsetHeight', {value: 512});
+
+  const map = createMap({container, center: [15, 30], zoom: 3, style: {version: 8, sources: {}, layers: [], projection: { type: 'mercator' }}});
+
+  expect(fixedLngLat(map.getCenter(), 4)).toEqual({lng: 15, lat: 30});
+  expect(fixedNum(map.getZoom(), 3)).toBe(3);
+});
+
+test('Creating a map with style defining globe projection uses Globe transform constrains', () => {
+  const container = window.document.createElement('div');
+  Object.defineProperty(container, 'offsetWidth', {value: 512});
+  Object.defineProperty(container, 'offsetHeight', {value: 512});
+
+  const map = createMap({container, center: [65.7, -38.2], zoom: -2, style: {version: 8, sources: {}, layers: [], projection: { type: 'globe' }}});
+
+  expect(fixedLngLat(map.getCenter(), 4)).toEqual({lng: 65.7, lat: -38.2});
+  expect(fixedNum(map.getZoom(), 3)).toBe(-2);
+});


### PR DESCRIPTION
This fixes a subtle bug I found while trying to create a test for another issue.
When a Map is created and before the style is loaded, a Mercator transform is created as a default. When a style that uses globe is loaded, a new transform is created. This is not a problem in general but it is when setting center and zoom values that are valid when using globe and not when using Mercator.

What this PR does is avoid constraining the center and zoom values when a style is defined until the style is loaded and we can be sure we are constraining them with the correct transform.

TLDR:
Before: Notice how both the hash and the camera position change after a reload when using invalid Mercator values

https://github.com/user-attachments/assets/3ec31e6e-1e7c-4609-9574-cecadc51fbda


After: Notice how the hash and the camera are in the same position after a reload

https://github.com/user-attachments/assets/e513cfc9-d3fc-4758-add7-8ae67b4cec9e




## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [ ] Link to related issues.
 - [x] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [x] Add an entry to `CHANGELOG.md` under the `## main` section.
