### PR TITLE
doc: updated maplibre-gl-terradraw version to 0.6.4

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -94,6 +94,6 @@ Note too that if the CSS isn't available by the first render, as soon as the CSS
 MapLibre GL JS is also distributed via UNPKG. Our latest version can installed by adding below tags this in the html `<head>`. Further instructions on how to select specific versions and semver ranges can be found on at [unpkg.com](https://unpkg.com).
 
 ```html
-<script src="https://unpkg.com/maplibre-gl@^5.0.0-pre.9/dist/maplibre-gl.js"></script>
-<link href="https://unpkg.com/maplibre-gl@^5.0.0-pre.9/dist/maplibre-gl.css" rel="stylesheet" />
+<script src="https://unpkg.com/maplibre-gl@^4.7.0/dist/maplibre-gl.js"></script>
+<link href="https://unpkg.com/maplibre-gl@^4.7.0/dist/maplibre-gl.css" rel="stylesheet" />
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -94,6 +94,6 @@ Note too that if the CSS isn't available by the first render, as soon as the CSS
 MapLibre GL JS is also distributed via UNPKG. Our latest version can installed by adding below tags this in the html `<head>`. Further instructions on how to select specific versions and semver ranges can be found on at [unpkg.com](https://unpkg.com).
 
 ```html
-<script src="https://unpkg.com/maplibre-gl@^4.7.0/dist/maplibre-gl.js"></script>
-<link href="https://unpkg.com/maplibre-gl@^4.7.0/dist/maplibre-gl.css" rel="stylesheet" />
+<script src="https://unpkg.com/maplibre-gl@^5.0.0-pre.9/dist/maplibre-gl.js"></script>
+<link href="https://unpkg.com/maplibre-gl@^5.0.0-pre.9/dist/maplibre-gl.css" rel="stylesheet" />
 ```

--- a/test/examples/maplibre-gl-terradraw.html
+++ b/test/examples/maplibre-gl-terradraw.html
@@ -14,10 +14,10 @@
 </head>
 <body>
 
-<script src="https://cdn.jsdelivr.net/npm/@watergis/maplibre-gl-terradraw@0.1.1/dist/maplibre-gl-terradraw.umd.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/@watergis/maplibre-gl-terradraw@0.6.4/dist/maplibre-gl-terradraw.umd.js"></script>
 <link
     rel="stylesheet"
-    href="https://cdn.jsdelivr.net/npm/@watergis/maplibre-gl-terradraw@0.1.1/dist/maplibre-gl-terradraw.css"
+    href="https://cdn.jsdelivr.net/npm/@watergis/maplibre-gl-terradraw@0.6.4/dist/maplibre-gl-terradraw.css"
 />
 <div id="map"></div>
 
@@ -32,16 +32,21 @@
 
     // By default, all terra-draw drawing modes are enabled.
     // you can disable some of modes in the constructor options if you want.
-    const draw = new MaplibreTerradrawControl({
+    const draw = new MaplibreTerradrawControl.MaplibreTerradrawControl({
         modes: [
+            'render',
             'point',
             'linestring',
             'polygon',
             'rectangle',
-            'angled-rectangle',
             'circle',
             'freehand',
-            'select'
+            'angled-rectangle',
+            'sensor',
+            'sector',
+            'select',
+            'delete-selection',
+            'delete'
         ],
         open: true,
     });


### PR DESCRIPTION
I updated maplibre-gl-terradraw version from v0.1.1 to the latest version (v0.6.4) since it has quite a lot of changes on plugin interface.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [ ] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [ ] Link to related issues.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [ ] Add an entry to `CHANGELOG.md` under the `## main` section.
