### PR TITLE
Add contextAttributes map option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### ✨ Features and improvements
 - Add support for projection type expression as part of a refactoring of the transfrom and projection classes ([#5139](https://github.com/maplibre/maplibre-gl-js/pull/5139))
+- ⚠️ Support setting WebGL context options on map creation ([#5196](https://github.com/maplibre/maplibre-gl-js/pull/5196))
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### ✨ Features and improvements
 - Add support for projection type expression as part of a refactoring of the transfrom and projection classes ([#5139](https://github.com/maplibre/maplibre-gl-js/pull/5139))
-- ⚠️ Support setting WebGL context options on map creation ([#5196](https://github.com/maplibre/maplibre-gl-js/pull/5196))
+- ⚠️ Support setting WebGL context options on map creation ([#5196](https://github.com/maplibre/maplibre-gl-js/pull/5196)). Previously supported WebGL context options like `antialias`, `preserveDrawingBuffer` and `failIfMajorPerformanceCaveat` must now be defined inside the `canvasContextAttributes` object on `MapOptions`.
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes

--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -113,21 +113,14 @@ export type MapOptions = {
      */
     logoPosition?: ControlPosition;
     /**
-     * If `true`, map creation will fail if the performance of MapLibre GL JS would be dramatically worse than expected
-     * (i.e. a software renderer would be used).
-     * @defaultValue false
+     * Set of WebGLContextAttributes that are applied to the WebGL context of the map.
+     * Setting antialias to `true`, the gl context will be created with MSAA antialiasing, which can be useful for antialiasing custom layers. It's disabled by default as a performance optimization.
+     * Setting powerPreference to `high-performance`, the map's canvas will use a dedicated GPU if available. If set to `default`, the browser will decide which GPU to use.
+     * Setting preserveDrawingBuffer to `true`, the map's canvas can be exported to a PNG using `map.getCanvas().toDataURL()`. It's disabled by default as a performance optimization.
+     * Setting failIfMajorPerformanceCaveat to `true`, the map creation will fail if the performance of MapLibre GL JS would be dramatically worse than expected (i.e. a software renderer would be used).
+     * @defaultValue antialias: false, powerPreference: 'high-performance', preserveDrawingBuffer: false, failIfMajorPerformanceCaveat: false, desynchronized: false
      */
-    failIfMajorPerformanceCaveat?: boolean;
-    /**
-     * If `true`, the map's canvas can be exported to a PNG using `map.getCanvas().toDataURL()`. This is `false` by default as a performance optimization.
-     * @defaultValue false
-     */
-    preserveDrawingBuffer?: boolean;
-    /**
-     * If `true`, the gl context will be created with MSAA antialiasing, which can be useful for antialiasing custom layers.
-     * Disabled by default as a performance optimization.
-     */
-    antialias?: boolean;
+    contextAttributes?: WebGLContextAttributes;
     /**
      * If `false`, the map won't attempt to re-request tiles once they expire per their HTTP `cacheControl`/`expires` headers.
      * @defaultValue true
@@ -391,9 +384,15 @@ const defaultOptions: Readonly<Partial<MapOptions>> = {
     bearingSnap: 7,
     attributionControl: defaultAttributionControlOptions,
     maplibreLogo: false,
-    failIfMajorPerformanceCaveat: false,
-    preserveDrawingBuffer: false,
     refreshExpiredTiles: true,
+
+    contextAttributes: {
+        antialias: false,
+        preserveDrawingBuffer: false,
+        powerPreference: 'high-performance',
+        failIfMajorPerformanceCaveat: false,
+        desynchronized: false
+    },
 
     scrollZoom: true,
     minZoom: defaultMinZoom,
@@ -498,9 +497,7 @@ export class Map extends Camera {
     _fullyLoaded: boolean;
     _trackResize: boolean;
     _resizeObserver: ResizeObserver;
-    _preserveDrawingBuffer: boolean;
-    _failIfMajorPerformanceCaveat: boolean;
-    _antialias: boolean;
+    _contextAttributes: WebGLContextAttributes;
     _refreshExpiredTiles: boolean;
     _hash: Hash;
     _delegatedListeners: Record<string, DelegatedListener[]>;
@@ -593,7 +590,10 @@ export class Map extends Camera {
     constructor(options: MapOptions) {
         PerformanceUtils.mark(PerformanceMarkers.create);
 
-        const resolvedOptions = {...defaultOptions, ...options} as CompleteMapOptions;
+        const resolvedOptions = {...defaultOptions, ...options, contextAttributes: {
+            ...defaultOptions.contextAttributes,
+            ...options.contextAttributes
+        }} as CompleteMapOptions;
 
         if (resolvedOptions.minZoom != null && resolvedOptions.maxZoom != null && resolvedOptions.minZoom > resolvedOptions.maxZoom) {
             throw new Error('maxZoom must be greater than or equal to minZoom');
@@ -637,9 +637,7 @@ export class Map extends Camera {
         this._interactive = resolvedOptions.interactive;
         this._maxTileCacheSize = resolvedOptions.maxTileCacheSize;
         this._maxTileCacheZoomLevels = resolvedOptions.maxTileCacheZoomLevels;
-        this._failIfMajorPerformanceCaveat = resolvedOptions.failIfMajorPerformanceCaveat === true;
-        this._preserveDrawingBuffer = resolvedOptions.preserveDrawingBuffer === true;
-        this._antialias = resolvedOptions.antialias === true;
+        this._contextAttributes = {...resolvedOptions.contextAttributes};
         this._trackResize = resolvedOptions.trackResize === true;
         this._bearingSnap = resolvedOptions.bearingSnap;
         this._centerClampedToGround = resolvedOptions.centerClampedToGround;
@@ -3038,13 +3036,14 @@ export class Map extends Camera {
 
     _setupPainter() {
 
+        // Maplibre WebGL context requires alpha, depth and stencil buffers. It also forces premultipliedAlpha: true.
+        // We use the values provided in the map constructor for the rest of context attributes
         const attributes = {
+            ...this._contextAttributes,
             alpha: true,
-            stencil: true,
             depth: true,
-            failIfMajorPerformanceCaveat: this._failIfMajorPerformanceCaveat,
-            preserveDrawingBuffer: this._preserveDrawingBuffer,
-            antialias: this._antialias || false
+            stencil: true,
+            premultipliedAlpha: true
         };
 
         let webglcontextcreationerrorDetailObject: any = null;

--- a/src/ui/map_tests/map_canvas.test.ts
+++ b/src/ui/map_tests/map_canvas.test.ts
@@ -62,7 +62,7 @@ describe('Max Canvas Size option', () => {
 describe('WebGLContextAttributes options', () => {
     test('Optional values can be set correctly', () => {
         const container = window.document.createElement('div');
-        const contextAttributes = {
+        const canvasContextAttributes = {
             antialias: true,
             preserveDrawingBuffer: true,
             powerPreference: 'default',
@@ -71,19 +71,19 @@ describe('WebGLContextAttributes options', () => {
         }
         Object.defineProperty(container, 'clientWidth', {value: 2048});
         Object.defineProperty(container, 'clientHeight', {value: 2048});
-        const map = createMap({container, contextAttributes});
+        const map = createMap({container, canvasContextAttributes});
         const gl = map.painter.context.gl;
         const mapContextAttributes = gl.getContextAttributes();
-        expect(mapContextAttributes.antialias).toBe(contextAttributes.antialias);
-        expect(mapContextAttributes.preserveDrawingBuffer).toBe(contextAttributes.preserveDrawingBuffer);
-        expect(mapContextAttributes.powerPreference).toBe(contextAttributes.powerPreference);
-        expect(mapContextAttributes.failIfMajorPerformanceCaveat).toBe(contextAttributes.failIfMajorPerformanceCaveat);
-        expect(mapContextAttributes.desynchronized).toBe(contextAttributes.desynchronized);
+        expect(mapContextAttributes.antialias).toBe(canvasContextAttributes.antialias);
+        expect(mapContextAttributes.preserveDrawingBuffer).toBe(canvasContextAttributes.preserveDrawingBuffer);
+        expect(mapContextAttributes.powerPreference).toBe(canvasContextAttributes.powerPreference);
+        expect(mapContextAttributes.failIfMajorPerformanceCaveat).toBe(canvasContextAttributes.failIfMajorPerformanceCaveat);
+        expect(mapContextAttributes.desynchronized).toBe(canvasContextAttributes.desynchronized);
     });
 
     test('Required values cannot be set', () => {
         const container = window.document.createElement('div');
-        const contextAttributes = {
+        const canvasContextAttributes = {
             alpha: false,
             depth: false,
             stencil: false,
@@ -91,7 +91,7 @@ describe('WebGLContextAttributes options', () => {
         }
         Object.defineProperty(container, 'clientWidth', {value: 2048});
         Object.defineProperty(container, 'clientHeight', {value: 2048});
-        const map = createMap({container, contextAttributes});
+        const map = createMap({container, canvasContextAttributes});
         const mapContextAttributes = map.painter.context.gl.getContextAttributes();
         console.log(mapContextAttributes);
         expect(mapContextAttributes.alpha).toBe(true);

--- a/src/ui/map_tests/map_canvas.test.ts
+++ b/src/ui/map_tests/map_canvas.test.ts
@@ -58,3 +58,46 @@ describe('Max Canvas Size option', () => {
         expect(map.getCanvas().height).toBe(3072);
     });
 });
+
+describe('WebGLContextAttributes options', () => {
+    test('Optional values can be set correctly', () => {
+        const container = window.document.createElement('div');
+        const contextAttributes = {
+            antialias: true,
+            preserveDrawingBuffer: true,
+            powerPreference: 'default',
+            failIfMajorPerformanceCaveat: true,
+            desynchronized: true,
+        }
+        Object.defineProperty(container, 'clientWidth', {value: 2048});
+        Object.defineProperty(container, 'clientHeight', {value: 2048});
+        const map = createMap({container, contextAttributes});
+        const gl = map.painter.context.gl;
+        const mapContextAttributes = gl.getContextAttributes();
+        expect(mapContextAttributes.antialias).toBe(contextAttributes.antialias);
+        expect(mapContextAttributes.preserveDrawingBuffer).toBe(contextAttributes.preserveDrawingBuffer);
+        expect(mapContextAttributes.powerPreference).toBe(contextAttributes.powerPreference);
+        expect(mapContextAttributes.failIfMajorPerformanceCaveat).toBe(contextAttributes.failIfMajorPerformanceCaveat);
+        expect(mapContextAttributes.desynchronized).toBe(contextAttributes.desynchronized);
+    });
+
+    test('Required values cannot be set', () => {
+        const container = window.document.createElement('div');
+        const contextAttributes = {
+            alpha: false,
+            depth: false,
+            stencil: false,
+            premultipliedAlpha: false,
+        }
+        Object.defineProperty(container, 'clientWidth', {value: 2048});
+        Object.defineProperty(container, 'clientHeight', {value: 2048});
+        const map = createMap({container, contextAttributes});
+        const mapContextAttributes = map.painter.context.gl.getContextAttributes();
+        console.log(mapContextAttributes);
+        expect(mapContextAttributes.alpha).toBe(true);
+        expect(mapContextAttributes.depth).toBe(true);
+        expect(mapContextAttributes.stencil).toBe(true);
+        expect(mapContextAttributes.premultipliedAlpha).toBe(true);
+    });
+
+});

--- a/test/integration/query/query.test.ts
+++ b/test/integration/query/query.test.ts
@@ -87,7 +87,7 @@ function performQueryOnFixture(fixture)  {
             interactive: false,
             attributionControl: false,
             pixelRatio: options.pixelRatio,
-            contextAttributes: {preserveDrawingBuffer: true},
+            contextAttributes: {preserveDrawingBuffer: true, powerPreference: 'default'},
             fadeDuration: options.fadeDuration || 0,
             localIdeographFontFamily: options.localIdeographFontFamily || false,
             crossSourceCollisions: typeof options.crossSourceCollisions === 'undefined' ? true : options.crossSourceCollisions

--- a/test/integration/query/query.test.ts
+++ b/test/integration/query/query.test.ts
@@ -87,7 +87,7 @@ function performQueryOnFixture(fixture)  {
             interactive: false,
             attributionControl: false,
             pixelRatio: options.pixelRatio,
-            contextAttributes: {preserveDrawingBuffer: true, powerPreference: 'default'},
+            canvasContextAttributes: {preserveDrawingBuffer: true, powerPreference: 'default'},
             fadeDuration: options.fadeDuration || 0,
             localIdeographFontFamily: options.localIdeographFontFamily || false,
             crossSourceCollisions: typeof options.crossSourceCollisions === 'undefined' ? true : options.crossSourceCollisions

--- a/test/integration/query/query.test.ts
+++ b/test/integration/query/query.test.ts
@@ -87,7 +87,7 @@ function performQueryOnFixture(fixture)  {
             interactive: false,
             attributionControl: false,
             pixelRatio: options.pixelRatio,
-            preserveDrawingBuffer: true,
+            contextAttributes: {preserveDrawingBuffer: true},
             fadeDuration: options.fadeDuration || 0,
             localIdeographFontFamily: options.localIdeographFontFamily || false,
             crossSourceCollisions: typeof options.crossSourceCollisions === 'undefined' ? true : options.crossSourceCollisions

--- a/test/integration/render/run_render_tests.ts
+++ b/test/integration/render/run_render_tests.ts
@@ -732,7 +732,7 @@ async function getImageFromStyle(styleForTest: StyleWithTestData, page: Page): P
                 attributionControl: false,
                 maxPitch: options.maxPitch,
                 pixelRatio: options.pixelRatio,
-                contextAttributes: {preserveDrawingBuffer: true},
+                contextAttributes: {preserveDrawingBuffer: true, powerPreference: 'default'},
                 fadeDuration: options.fadeDuration || 0,
                 localIdeographFontFamily: options.localIdeographFontFamily || false as any,
                 crossSourceCollisions: typeof options.crossSourceCollisions === 'undefined' ? true : options.crossSourceCollisions,

--- a/test/integration/render/run_render_tests.ts
+++ b/test/integration/render/run_render_tests.ts
@@ -732,7 +732,7 @@ async function getImageFromStyle(styleForTest: StyleWithTestData, page: Page): P
                 attributionControl: false,
                 maxPitch: options.maxPitch,
                 pixelRatio: options.pixelRatio,
-                preserveDrawingBuffer: true,
+                contextAttributes: {preserveDrawingBuffer: true},
                 fadeDuration: options.fadeDuration || 0,
                 localIdeographFontFamily: options.localIdeographFontFamily || false as any,
                 crossSourceCollisions: typeof options.crossSourceCollisions === 'undefined' ? true : options.crossSourceCollisions,

--- a/test/integration/render/run_render_tests.ts
+++ b/test/integration/render/run_render_tests.ts
@@ -732,7 +732,7 @@ async function getImageFromStyle(styleForTest: StyleWithTestData, page: Page): P
                 attributionControl: false,
                 maxPitch: options.maxPitch,
                 pixelRatio: options.pixelRatio,
-                contextAttributes: {preserveDrawingBuffer: true, powerPreference: 'default'},
+                canvasContextAttributes: {preserveDrawingBuffer: true, powerPreference: 'default'},
                 fadeDuration: options.fadeDuration || 0,
                 localIdeographFontFamily: options.localIdeographFontFamily || false as any,
                 crossSourceCollisions: typeof options.crossSourceCollisions === 'undefined' ? true : options.crossSourceCollisions,


### PR DESCRIPTION
This PR fixes https://github.com/maplibre/maplibre-gl-js/issues/5135 by adding a `contextAttributes` property to the map constructor that supports all [WebGLContextAttributes](https://registry.khronos.org/webgl/specs/latest/1.0/#5.2), so now you can do something like:


```js
const map = new maplibregl.Map({
  container: 'map',
  style: 'https://demotiles.maplibre.org/style.json',
  center: [0, 0],
  zoom: 2,
  contextAttributes: {
    powerPreference: 'default',
    antialias: true
});
```

Note that some `WebGLContextAttributes` can't be overwritten because Maplibre relies on it. These are `alpha`, `depth`, `stencil` and `premultipliedAlpha` which are always set to `true`.

This PR also sets the default WebGL `powerPreference` to `high-performance` instead of `default`, which defaults to using dedicated GPUs on multi-GPU systems.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [x] Add an entry to `CHANGELOG.md` under the `## main` section.
