### PR TITLE
Fix NavigationControl compass regression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### 🐞 Bug fixes
 - Fix globe custom layers being supplied incorrect matrices after projection transition to mercator ([#5150](https://github.com/maplibre/maplibre-gl-js/pull/5150))
 - Fix custom 3D models disappearing during projection transition ([#5150](https://github.com/maplibre/maplibre-gl-js/pull/5150))
+- Fix regression in NavigationControl compass on Firefox and Safari browsers ([#5205](https://github.com/maplibre/maplibre-gl-js/pull/5205))
 - _...Add new stuff here..._
 
 ## 5.0.0-pre.9

--- a/src/ui/handler/drag_move_state_manager.ts
+++ b/src/ui/handler/drag_move_state_manager.ts
@@ -122,7 +122,7 @@ export class MouseOrTouchMoveStateManager implements DragMoveStateManager<MouseE
 
     _onMouseEventOrTouchEvent(e: MouseEvent | TouchEvent, onMouseEvent: (MouseEvent) => any, onTouchEvent: (TouchEvent) => any) {
         if (e instanceof MouseEvent) return onMouseEvent(e as MouseEvent);
-        if ('TouchEvent' in window && e instanceof TouchEvent) return onTouchEvent(e as TouchEvent);
+        if (window.TouchEvent && e instanceof TouchEvent) return onTouchEvent(e as TouchEvent);
     }
 
     startMove(e: MouseEvent | TouchEvent) {

--- a/src/ui/handler/drag_move_state_manager.ts
+++ b/src/ui/handler/drag_move_state_manager.ts
@@ -120,24 +120,38 @@ export class MouseOrTouchMoveStateManager implements DragMoveStateManager<MouseE
         private oneFingerTouchMoveStateManager = new OneFingerTouchMoveStateManager()
     ) {}
 
+    _onMouseEventOrTouchEvent(e: MouseEvent | TouchEvent, onMouseEvent: (MouseEvent) => any, onTouchEvent: (TouchEvent) => any) {
+        if (e instanceof MouseEvent) return onMouseEvent(e as MouseEvent);
+        if ("TouchEvent" in window && e instanceof TouchEvent) return onTouchEvent(e as TouchEvent);
+    }
+
     startMove(e: MouseEvent | TouchEvent) {
-        if (e instanceof MouseEvent) this.mouseMoveStateManager.startMove(e);
-        if (e instanceof TouchEvent) this.oneFingerTouchMoveStateManager.startMove(e);
+        this._onMouseEventOrTouchEvent(e,
+            e => this.mouseMoveStateManager.startMove(e),
+            e => this.oneFingerTouchMoveStateManager.startMove(e));
     }
+
     endMove(e?: MouseEvent | TouchEvent) {
-        if (e instanceof MouseEvent) this.mouseMoveStateManager.endMove(e);
-        if (e instanceof TouchEvent) this.oneFingerTouchMoveStateManager.endMove(e);
+        this._onMouseEventOrTouchEvent(e,
+            e => this.mouseMoveStateManager.endMove(e),
+            e => this.oneFingerTouchMoveStateManager.endMove(e));
     }
+
     isValidStartEvent(e: MouseEvent | TouchEvent) {
-        if (e instanceof MouseEvent) return this.mouseMoveStateManager.isValidStartEvent(e);
-        if (e instanceof TouchEvent) return this.oneFingerTouchMoveStateManager.isValidStartEvent(e);
+        return this._onMouseEventOrTouchEvent(e,
+            e => this.mouseMoveStateManager.isValidStartEvent(e),
+            e => this.oneFingerTouchMoveStateManager.isValidStartEvent(e));
     }
+
     isValidMoveEvent(e: MouseEvent | TouchEvent) {
-        if (e instanceof MouseEvent) return this.mouseMoveStateManager.isValidMoveEvent(e);
-        if (e instanceof TouchEvent) return this.oneFingerTouchMoveStateManager.isValidMoveEvent(e);
+        return this._onMouseEventOrTouchEvent(e,
+            e => this.mouseMoveStateManager.isValidMoveEvent(e),
+            e => this.oneFingerTouchMoveStateManager.isValidMoveEvent(e));
     }
+
     isValidEndEvent(e?: MouseEvent | TouchEvent) {
-        if (e instanceof MouseEvent) return this.mouseMoveStateManager.isValidEndEvent(e);
-        if (e instanceof TouchEvent) return this.oneFingerTouchMoveStateManager.isValidEndEvent(e);
+        return this._onMouseEventOrTouchEvent(e,
+            e => this.mouseMoveStateManager.isValidEndEvent(e),
+            e => this.oneFingerTouchMoveStateManager.isValidEndEvent(e));
     }
 }

--- a/src/ui/handler/drag_move_state_manager.ts
+++ b/src/ui/handler/drag_move_state_manager.ts
@@ -122,7 +122,7 @@ export class MouseOrTouchMoveStateManager implements DragMoveStateManager<MouseE
 
     _onMouseEventOrTouchEvent(e: MouseEvent | TouchEvent, onMouseEvent: (MouseEvent) => any, onTouchEvent: (TouchEvent) => any) {
         if (e instanceof MouseEvent) return onMouseEvent(e as MouseEvent);
-        if (window.TouchEvent && e instanceof TouchEvent) return onTouchEvent(e as TouchEvent);
+        if (typeof TouchEvent !== 'undefined' && e instanceof TouchEvent) return onTouchEvent(e as TouchEvent);
     }
 
     startMove(e: MouseEvent | TouchEvent) {

--- a/src/ui/handler/drag_move_state_manager.ts
+++ b/src/ui/handler/drag_move_state_manager.ts
@@ -122,7 +122,7 @@ export class MouseOrTouchMoveStateManager implements DragMoveStateManager<MouseE
 
     _onMouseEventOrTouchEvent(e: MouseEvent | TouchEvent, onMouseEvent: (MouseEvent) => any, onTouchEvent: (TouchEvent) => any) {
         if (e instanceof MouseEvent) return onMouseEvent(e as MouseEvent);
-        if ("TouchEvent" in window && e instanceof TouchEvent) return onTouchEvent(e as TouchEvent);
+        if ('TouchEvent' in window && e instanceof TouchEvent) return onTouchEvent(e as TouchEvent);
     }
 
     startMove(e: MouseEvent | TouchEvent) {

--- a/src/ui/handler/drag_move_state_manager.ts
+++ b/src/ui/handler/drag_move_state_manager.ts
@@ -120,37 +120,37 @@ export class MouseOrTouchMoveStateManager implements DragMoveStateManager<MouseE
         private oneFingerTouchMoveStateManager = new OneFingerTouchMoveStateManager()
     ) {}
 
-    _onMouseEventOrTouchEvent(e: MouseEvent | TouchEvent, onMouseEvent: (MouseEvent) => any, onTouchEvent: (TouchEvent) => any) {
-        if (e instanceof MouseEvent) return onMouseEvent(e as MouseEvent);
-        if (typeof TouchEvent !== 'undefined' && e instanceof TouchEvent) return onTouchEvent(e as TouchEvent);
+    _executeRelevantHandler(e: MouseEvent | TouchEvent, onMouseEvent: (MouseEvent) => any, onTouchEvent: (TouchEvent) => any) {
+        if (e instanceof MouseEvent) return onMouseEvent(e);
+        if (typeof TouchEvent !== 'undefined' && e instanceof TouchEvent) return onTouchEvent(e);
     }
 
     startMove(e: MouseEvent | TouchEvent) {
-        this._onMouseEventOrTouchEvent(e,
+        this._executeRelevantHandler(e,
             e => this.mouseMoveStateManager.startMove(e),
             e => this.oneFingerTouchMoveStateManager.startMove(e));
     }
 
     endMove(e?: MouseEvent | TouchEvent) {
-        this._onMouseEventOrTouchEvent(e,
+        this._executeRelevantHandler(e,
             e => this.mouseMoveStateManager.endMove(e),
             e => this.oneFingerTouchMoveStateManager.endMove(e));
     }
 
     isValidStartEvent(e: MouseEvent | TouchEvent) {
-        return this._onMouseEventOrTouchEvent(e,
+        return this._executeRelevantHandler(e,
             e => this.mouseMoveStateManager.isValidStartEvent(e),
             e => this.oneFingerTouchMoveStateManager.isValidStartEvent(e));
     }
 
     isValidMoveEvent(e: MouseEvent | TouchEvent) {
-        return this._onMouseEventOrTouchEvent(e,
+        return this._executeRelevantHandler(e,
             e => this.mouseMoveStateManager.isValidMoveEvent(e),
             e => this.oneFingerTouchMoveStateManager.isValidMoveEvent(e));
     }
 
     isValidEndEvent(e?: MouseEvent | TouchEvent) {
-        return this._onMouseEventOrTouchEvent(e,
+        return this._executeRelevantHandler(e,
             e => this.mouseMoveStateManager.isValidEndEvent(e),
             e => this.oneFingerTouchMoveStateManager.isValidEndEvent(e));
     }


### PR DESCRIPTION
## Launch Checklist

See https://github.com/maplibre/maplibre-gl-js/discussions/5195 for discussion.

I think the regression was caused by "TouchEvent" only being defined on Chromium-derived and/or touchscreen-equipped browsers, such that the drag handler would fail on Firefox and Safari on my Mac laptop.

This PR does two things:
* Adds a `typeof TouchEvent !== 'undefined'` check to prevent a runtime error when it's undefined.
* Consolidates the type checks into an `_onMouseEventOrTouchEvent` method to reduce duplication, possibly at the cost of clarity.

 - [X] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [X] Briefly describe the changes in this PR.
 - [X] Link to related issues.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [ ] Add an entry to `CHANGELOG.md` under the `## main` section.
