### PR TITLE
Add `vitest` script to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -176,7 +176,8 @@
     "gl-stats": "node --no-warnings --loader ts-node/esm test/bench/gl-stats.ts",
     "prepare": "npm run codegen",
     "typecheck": "tsc --noEmit && tsc --project tsconfig.dist.json",
-    "tsnode": "node --experimental-loader=ts-node/esm --no-warnings"
+    "tsnode": "node --experimental-loader=ts-node/esm --no-warnings",
+    "vitest": "vitest"
   },
   "files": [
     "build/",

--- a/package.json
+++ b/package.json
@@ -162,7 +162,7 @@
     "start-bench": "run-p watch-css watch-benchmarks start-server",
     "lint": "eslint",
     "lint-css": "stylelint **/*.css --fix -f verbose",
-    "test": "run-p lint lint-css test-render vitest",
+    "test": "run-p lint lint-css test-render test-unit test-integration test-build",
     "test-unit": "vitest run --config vitest.config.unit.ts",
     "test-unit-ci": "vitest run --config vitest.config.unit.ts --coverage",
     "test-integration": "vitest run --config vitest.config.integration.ts",
@@ -176,8 +176,7 @@
     "gl-stats": "node --no-warnings --loader ts-node/esm test/bench/gl-stats.ts",
     "prepare": "npm run codegen",
     "typecheck": "tsc --noEmit && tsc --project tsconfig.dist.json",
-    "tsnode": "node --experimental-loader=ts-node/esm --no-warnings",
-    "vitest": "vitest"
+    "tsnode": "node --experimental-loader=ts-node/esm --no-warnings"
   },
   "files": [
     "build/",


### PR DESCRIPTION
In https://github.com/maplibre/maplibre-gl-js/pull/4728 `jest` was replaced with `vitest` but the `jest` script was removed instead of updated. That made `npm run test` to fail.
This PR fixes it by adding a new entry to `package.json` called `vitest`.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [ ] Link to related issues.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [ ] Add an entry to `CHANGELOG.md` under the `## main` section.
