### PR TITLE
Allow choosing webgl version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## main
 
 ### ✨ Features and improvements
+- Allows setting the desired WebGL version to use ([#5236](https://github.com/maplibre/maplibre-gl-js/pull/5236)). You can now use `contextType` inside `canvasContextAttributes` to choose which WebGL version to use
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes

--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -68,7 +68,7 @@ import {MercatorCameraHelper} from '../geo/projection/mercator_camera_helper';
 const version = packageJSON.version;
 
 type WebGLSupportedVersions = 'webgl2' | 'webgl' | undefined
-type WebGLContextAttributesWithType = WebGLContextAttributes & {contextType: WebGLSupportedVersions};
+type WebGLContextAttributesWithType = WebGLContextAttributes & {contextType?: WebGLSupportedVersions};
 
 /**
  * The {@link Map} options object.
@@ -3061,10 +3061,7 @@ export class Map extends Camera {
         if (this._canvasContextAttributes.contextType) {
             gl = this._canvas.getContext(this._canvasContextAttributes.contextType, attributes) as WebGL2RenderingContext | WebGLRenderingContext;
         } else {
-            gl = this._canvas.getContext('webgl2', attributes) as WebGL2RenderingContext;
-            if (!gl) {
-                gl = this._canvas.getContext('webgl', attributes) as WebGLRenderingContext;
-            }
+            gl = this._canvas.getContext('webgl2', attributes) as WebGL2RenderingContext || this._canvas.getContext('webgl', attributes) as WebGLRenderingContext;
         }
 
         if (!gl) {

--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -117,7 +117,7 @@ export type MapOptions = {
     /**
      * Set of WebGLContextAttributes that are applied to the WebGL context of the map.
      * See https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/getContext for more details.
-     * `contextType` can be set to `webgl2` or `webgl1` to force a WebGL version. `webgl2withfallback` can be used to use of WebGL 2.0 if available with a fallback to WebGL 1.0 in case it's not.
+     * `contextType` can be set to `webgl2` or `webgl` to force a WebGL version. `webgl2withfallback` can be used to use of WebGL 2.0 if available with a fallback to WebGL 1.0 in case it's not.
      * @defaultValue antialias: false, powerPreference: 'high-performance', preserveDrawingBuffer: false, failIfMajorPerformanceCaveat: false, desynchronized: false, contextType: 'webgl2withfallback'
      */
     canvasContextAttributes?: WebGLContextAttributes & {contextType?: WebGLSupportedVersions};

--- a/src/ui/map_tests/map_webgl.test.ts
+++ b/src/ui/map_tests/map_webgl.test.ts
@@ -1,9 +1,15 @@
-import {beforeEach, test, expect, vi} from 'vitest';
+import {beforeEach, afterEach, test, expect, vi} from 'vitest';
 import {createMap, beforeMapTest} from '../../util/test/util';
 
+let originalGetContext: typeof HTMLCanvasElement.prototype.getContext;
 beforeEach(() => {
     beforeMapTest();
     global.fetch = null;
+    originalGetContext = HTMLCanvasElement.prototype.getContext;
+});
+
+afterEach(() => {
+    HTMLCanvasElement.prototype.getContext = originalGetContext;
 });
 
 test('does not fire "webglcontextlost" after #remove has been called', () => new Promise<void>((done) => {
@@ -34,7 +40,6 @@ test('does not fire "webglcontextrestored" after #remove has been called', () =>
 }));
 
 test('WebGL error while creating map', () => {
-    const original = HTMLCanvasElement.prototype.getContext;
     HTMLCanvasElement.prototype.getContext = function (type: string) {
         if (type === 'webgl2' || type === 'webgl') {
             const errorEvent = new Event('webglcontextcreationerror');
@@ -53,21 +58,16 @@ test('WebGL error while creating map', () => {
 
         // this is from test mock
         expect(errorMessageObject.statusMessage).toBe('mocked webglcontextcreationerror message');
-    } finally {
-        HTMLCanvasElement.prototype.getContext = original;
     }
 });
 
-test('Check Map is being created with desired WebGL version', ({onTestFinished}) => {
-    const original = HTMLCanvasElement.prototype.getContext;
+test('Check Map is being created with desired WebGL version', () => {
     HTMLCanvasElement.prototype.getContext = function (type: string) {
         const errorEvent = new Event('webglcontextcreationerror');
         (errorEvent as any).statusMessage = `${type} is not supported`;
         (this as HTMLCanvasElement).dispatchEvent(errorEvent);
         return null;
     };
-
-    onTestFinished(() => {HTMLCanvasElement.prototype.getContext = original});
 
     try {
         createMap({canvasContextAttributes: {contextType: 'webgl2'}});
@@ -85,17 +85,17 @@ test('Check Map is being created with desired WebGL version', ({onTestFinished})
 
 });
 
-test('Check Map falls back to WebGL if WebGL 2 is not supported', ({onTestFinished}) => {
-    const original = HTMLCanvasElement.prototype.getContext;
+test('Check Map falls back to WebGL if WebGL 2 is not supported', () => {
     const mockGetContext = vi.fn().mockImplementation((type: string) => {
         if (type === 'webgl2') {return null;}
-        return original.apply(this, [type]);
+        return originalGetContext.apply(this, [type]);
     });
     HTMLCanvasElement.prototype.getContext = mockGetContext
-
-    onTestFinished(() => {HTMLCanvasElement.prototype.getContext = original});
   
-    createMap();
+    try {
+        createMap();
+    } catch(_) { // eslint-disable-line @typescript-eslint/no-unused-vars
+    }
     expect(mockGetContext).toHaveBeenCalledTimes(2);
     expect(mockGetContext.mock.calls[0][0]).toBe('webgl2');
     expect(mockGetContext.mock.calls[1][0]).toBe('webgl');

--- a/src/ui/map_tests/map_webgl.test.ts
+++ b/src/ui/map_tests/map_webgl.test.ts
@@ -1,4 +1,4 @@
-import {beforeEach, test, expect, vi, onTestFinished, onTestFailed} from 'vitest';
+import {beforeEach, test, expect, vi} from 'vitest';
 import {createMap, beforeMapTest} from '../../util/test/util';
 
 beforeEach(() => {
@@ -59,46 +59,46 @@ test('WebGL error while creating map', () => {
 });
 
 test('Check Map is being created with desired WebGL version', ({onTestFinished}) => {
-  const original = HTMLCanvasElement.prototype.getContext;
-  HTMLCanvasElement.prototype.getContext = function (type: string) {
-      const errorEvent = new Event('webglcontextcreationerror');
-      (errorEvent as any).statusMessage = `${type} is not supported`;
-      (this as HTMLCanvasElement).dispatchEvent(errorEvent);
-      return null;
-  };
+    const original = HTMLCanvasElement.prototype.getContext;
+    HTMLCanvasElement.prototype.getContext = function (type: string) {
+        const errorEvent = new Event('webglcontextcreationerror');
+        (errorEvent as any).statusMessage = `${type} is not supported`;
+        (this as HTMLCanvasElement).dispatchEvent(errorEvent);
+        return null;
+    };
 
-  onTestFinished(() => {HTMLCanvasElement.prototype.getContext = original});
+    onTestFinished(() => {HTMLCanvasElement.prototype.getContext = original});
 
-  try {
-      createMap({canvasContextAttributes:{contextType: 'webgl2'}});
-  } catch (e) {
-      const errorMessageObject = JSON.parse(e.message);
-      expect(errorMessageObject.statusMessage).toBe('webgl2 is not supported');
-  }
+    try {
+        createMap({canvasContextAttributes: {contextType: 'webgl2'}});
+    } catch (e) {
+        const errorMessageObject = JSON.parse(e.message);
+        expect(errorMessageObject.statusMessage).toBe('webgl2 is not supported');
+    }
   
-  try {
-      createMap({canvasContextAttributes:{contextType: 'webgl'}});
-  } catch (e) {
-      const errorMessageObject = JSON.parse(e.message);
-      expect(errorMessageObject.statusMessage).toBe('webgl is not supported');
-  }
+    try {
+        createMap({canvasContextAttributes: {contextType: 'webgl'}});
+    } catch (e) {
+        const errorMessageObject = JSON.parse(e.message);
+        expect(errorMessageObject.statusMessage).toBe('webgl is not supported');
+    }
 
 });
 
 test('Check Map falls back to WebGL if WebGL 2 is not supported', ({onTestFinished}) => {
-  const original = HTMLCanvasElement.prototype.getContext;
-  const mockGetContext = vi.fn().mockImplementation((type: string) => {
-    if (type === 'webgl2') {return null;}
-    return original.apply(this, [type]);
-});
-  HTMLCanvasElement.prototype.getContext = mockGetContext
+    const original = HTMLCanvasElement.prototype.getContext;
+    const mockGetContext = vi.fn().mockImplementation((type: string) => {
+        if (type === 'webgl2') {return null;}
+        return original.apply(this, [type]);
+    });
+    HTMLCanvasElement.prototype.getContext = mockGetContext
 
-  onTestFinished(() => {HTMLCanvasElement.prototype.getContext = original});
+    onTestFinished(() => {HTMLCanvasElement.prototype.getContext = original});
   
-  createMap();
-  expect(mockGetContext).toHaveBeenCalledTimes(2);
-  expect(mockGetContext.mock.calls[0][0]).toBe('webgl2');
-  expect(mockGetContext.mock.calls[1][0]).toBe('webgl');
+    createMap();
+    expect(mockGetContext).toHaveBeenCalledTimes(2);
+    expect(mockGetContext.mock.calls[0][0]).toBe('webgl2');
+    expect(mockGetContext.mock.calls[1][0]).toBe('webgl');
   
 });
 


### PR DESCRIPTION
Following https://github.com/maplibre/maplibre-gl-js/pull/5198, this PR allows to use a desired WebGL version by setting `contextType` inside the `canvasContextAttributes` option on Map creation.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [ ] Link to related issues.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [x] Add an entry to `CHANGELOG.md` under the `## main` section.
