### PR TITLE
Transform specific `projectPoint`

### DIFF
--- a/src/geo/projection/globe_transform.ts
+++ b/src/geo/projection/globe_transform.ts
@@ -317,6 +317,10 @@ export class GlobeTransform implements ITransform {
         return this.currentTransform.projectTileCoordinates(x, y, unwrappedTileID, getElevation);
     }
 
+    public projectPoint(p: Point, pixelPosMatrix: mat4): Point {
+        return this.currentTransform.projectPoint(p, pixelPosMatrix);
+    }
+
     private _calcMatrices(): void {
         if (!this._helper._width || !this._helper._height) {
             return;

--- a/src/geo/projection/mercator_transform.ts
+++ b/src/geo/projection/mercator_transform.ts
@@ -779,6 +779,11 @@ export class MercatorTransform implements ITransform {
         };
     }
 
+    projectPoint(p: Point, pixelPosMatrix: mat4) {
+        const point = vec4.transformMat4([] as any, [p.x, p.y, 0, 1], pixelPosMatrix);
+        return new Point(point[0] / point[3], point[1] / point[3]);
+    }
+
     populateCache(coords: Array<OverscaledTileID>): void {
         for (const coord of coords) {
             // Return value is thrown away, but this function will still

--- a/src/geo/projection/vertical_perspective_transform.ts
+++ b/src/geo/projection/vertical_perspective_transform.ts
@@ -437,6 +437,11 @@ export class VerticalPerspectiveTransform implements ITransform {
         };
     }
 
+    public projectPoint(p: Point) {
+        const point = vec4.transformMat4([] as any, [p.x, p.y, 0, 1], this._globeViewProjMatrix32f);
+        return new Point(point[0] / point[3], point[1] / point[3]);
+    }
+
     private _calcMatrices(): void {
         if (!this._helper._width || !this._helper._height) {
             return;

--- a/src/geo/transform_interface.ts
+++ b/src/geo/transform_interface.ts
@@ -463,6 +463,11 @@ export interface IReadonlyTransform extends ITransformGetters {
     projectTileCoordinates(x: number, y: number, unwrappedTileID: UnwrappedTileID, getElevation: (x: number, y: number) => number): PointProjection;
 
     /**
+     * Projects a point in screen coordinates to tile coordinates
+     */
+    projectPoint(p: Point, pixelPosMatrix: mat4): Point;
+
+    /**
      * Returns a matrix that will place, rotate and scale a model to display at the given location and altitude
      * while also being projected by the custom layer matrix.
      * This function is intended to be called from custom layers.

--- a/src/style/style_layer/circle_style_layer.ts
+++ b/src/style/style_layer/circle_style_layer.ts
@@ -64,13 +64,13 @@ export class CircleStyleLayer extends StyleLayer {
         // // A circle with fixed scaling relative to the viewport gets larger in tile space as it moves into the distance
         // // A circle with fixed scaling relative to the map gets smaller in viewport space as it moves into the distance
         const alignWithMap = this.paint.get('circle-pitch-alignment') === 'map';
-        const transformedPolygon = alignWithMap ? translatedPolygon : projectQueryGeometry(translatedPolygon, pixelPosMatrix);
+        const transformedPolygon = alignWithMap ? translatedPolygon : projectQueryGeometry(translatedPolygon, pixelPosMatrix, transform);
         const transformedSize = alignWithMap ? size * pixelsToTileUnits : size;
 
         for (const ring of geometry) {
             for (const point of ring) {
 
-                const transformedPoint = alignWithMap ? point : projectPoint(point, pixelPosMatrix);
+                const transformedPoint = alignWithMap ? point : transform.projectPoint(point, pixelPosMatrix);
 
                 let adjustedSize = transformedSize;
                 const projectedCenter = vec4.transformMat4([] as any, [point.x, point.y, 0, 1], pixelPosMatrix);
@@ -88,13 +88,9 @@ export class CircleStyleLayer extends StyleLayer {
     }
 }
 
-function projectPoint(p: Point, pixelPosMatrix: mat4) {
-    const point = vec4.transformMat4([] as any, [p.x, p.y, 0, 1], pixelPosMatrix);
-    return new Point(point[0] / point[3], point[1] / point[3]);
-}
-
-function projectQueryGeometry(queryGeometry: Array<Point>, pixelPosMatrix: mat4) {
+function projectQueryGeometry(queryGeometry: Array<Point>, pixelPosMatrix: mat4, transform: IReadonlyTransform) {
     return queryGeometry.map((p) => {
-        return projectPoint(p, pixelPosMatrix);
+        const projected = transform.projectPoint(p, pixelPosMatrix);
+        return new Point(projected.x, projected.y);
     });
 }


### PR DESCRIPTION
This PR is my first take on fixing https://github.com/maplibre/maplibre-gl-js/issues/5255
It moves circle-layer specific projection code to each transform to make it transform-aware. 
Globe projection is implemented using the view projection matrix, which works as a simple approximation 

Before (Notice how the cursor changes to a hand when the underlying feature is detected)

https://github.com/user-attachments/assets/3b93b415-ab2a-4f6a-9361-69142c1c3369

After

https://github.com/user-attachments/assets/21fb77af-b291-4c05-bbc5-76e48ce8500f

@kubapelc I'd love if you could take this PR and follow along with a more exact implementation if you have time

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [x] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [ ] Add an entry to `CHANGELOG.md` under the `## main` section.
