### PR TITLE
Fix children not retained when wrapped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Fix parsing wrong hash location ([#5131](https://github.com/maplibre/maplibre-gl-js/pull/5131))
 - Fix swallowing of errors ([#4532](https://github.com/maplibre/maplibre-gl-js/issues/4532))
 - Fix erroring requests not reported on `error` handler ([#4613](https://github.com/maplibre/maplibre-gl-js/issues/4613))
+- Fix children not retained when using globe ([#5271](https://github.com/maplibre/maplibre-gl-js/pull/5271))
 - _...Add new stuff here..._
 
 ## 5.0.0-pre.10

--- a/src/source/source_cache.test.ts
+++ b/src/source/source_cache.test.ts
@@ -14,6 +14,7 @@ import {TileBounds} from './tile_bounds';
 import {sleep} from '../util/test/util';
 import {type TileCache} from './tile_cache';
 import {MercatorTransform} from '../geo/projection/mercator_transform';
+import {GlobeTransform} from '../geo/projection/globe_transform';
 
 class SourceMock extends Evented implements Source {
     id: string;
@@ -848,6 +849,43 @@ describe('SourceCache#update', () => {
             }
         });
 
+        sourceCache.onAdd(undefined);
+    }));
+
+    test('retains children tiles for pending parents', () => new Promise<void>(done => {
+        const transform = new GlobeTransform();
+        transform.resize(511, 511);
+        transform.setZoom(1);
+        transform.setCenter(new LngLat(360, 0));
+
+        const sourceCache = createSourceCache();
+        sourceCache._source.loadTile = async (tile) => {
+            tile.state = (tile.tileID.key === new OverscaledTileID(0, 1, 0, 0, 0).key) ? 'loading' : 'loaded';
+        };
+
+        sourceCache.on('data', (e) => {
+            if (e.sourceDataType === 'metadata') {
+                sourceCache.update(transform);
+                expect(sourceCache.getIds()).toEqual([
+                    new OverscaledTileID(1, 1, 1, 1, 1).key,
+                    new OverscaledTileID(1, 1, 1, 0, 1).key,
+                    new OverscaledTileID(1, 1, 1, 1, 0).key,
+                    new OverscaledTileID(1, 1, 1, 0, 0).key
+                ]);
+
+                transform.setZoom(0);
+                sourceCache.update(transform);
+
+                expect(sourceCache.getIds()).toEqual([
+                    new OverscaledTileID(0, 1, 0, 0, 0).key,
+                    new OverscaledTileID(1, 1, 1, 1, 1).key,
+                    new OverscaledTileID(1, 1, 1, 0, 1).key,
+                    new OverscaledTileID(1, 1, 1, 1, 0).key,
+                    new OverscaledTileID(1, 1, 1, 0, 0).key
+                ]);
+                done();
+            }
+        });
         sourceCache.onAdd(undefined);
     }));
 

--- a/src/source/source_cache.test.ts
+++ b/src/source/source_cache.test.ts
@@ -852,7 +852,7 @@ describe('SourceCache#update', () => {
         sourceCache.onAdd(undefined);
     }));
 
-    test('retains children tiles for pending parents', () => new Promise<void>(done => {
+    test('retains children tiles for pending parents', () => {
         const transform = new GlobeTransform();
         transform.resize(511, 511);
         transform.setZoom(1);
@@ -883,11 +883,10 @@ describe('SourceCache#update', () => {
                     new OverscaledTileID(1, 1, 1, 1, 0).key,
                     new OverscaledTileID(1, 1, 1, 0, 0).key
                 ]);
-                done();
             }
         });
         sourceCache.onAdd(undefined);
-    }));
+    });
 
     test('retains overscaled loaded children', () => new Promise<void>(done => {
         const transform = new MercatorTransform();

--- a/src/source/source_cache.ts
+++ b/src/source/source_cache.ts
@@ -394,7 +394,7 @@ export class SourceCache extends Evented {
             while (tileID.overscaledZ > zoom) {
                 tileID = tileID.scaledTo(tileID.overscaledZ - 1);
 
-                if (idealTiles[tileID.key]) {
+                if (idealTiles[tileID.key] || (idealTiles[tileID.canonical.key])) {
                     // found a parent that needed a loaded child; retain that child
                     retain[topmostLoadedID.key] = topmostLoadedID;
                     break;


### PR DESCRIPTION
This PR fixes https://github.com/maplibre/maplibre-gl-js/issues/5248

Looking at it, when globe is being used, some tileIDs coordinates are wrapped and we were only using unwrapped tile ids to check if a parent tile had loaded children. The fix here is just to add a check for the canonical key, in addition to the existing one.


Before

https://github.com/user-attachments/assets/fabfc02b-ae6f-410e-840c-f5f052efa242


After

https://github.com/user-attachments/assets/9d2769c3-eb47-4b57-9cbf-fb33df747cb7



## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [ ] Briefly describe the changes in this PR.
 - [ ] Link to related issues.
 - [x] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [x] Add an entry to `CHANGELOG.md` under the `## main` section.
