### PR TITLE
Add eslint rule named `stylistic/semi`

### DIFF
--- a/build/generate-docs.ts
+++ b/build/generate-docs.ts
@@ -9,7 +9,7 @@ type HtmlDoc = {
     title: string;
     description: string;
     mdFileName: string;
-}
+};
 
 function generateAPIIntroMarkdown(lines: string[]): string {
     let intro = `# Intro

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,5 +1,5 @@
 import typescriptEslint from '@typescript-eslint/eslint-plugin';
-import stylisticTs from '@stylistic/eslint-plugin-ts'
+import stylisticTs from '@stylistic/eslint-plugin-ts';
 import tsdoc from 'eslint-plugin-tsdoc';
 import vitest from 'eslint-plugin-vitest';
 import globals from 'globals';
@@ -96,6 +96,7 @@ export default [
             'no-useless-escape': 'off',
             indent: 'off',
             '@stylistic/indent': ['error'],
+            '@stylistic/semi': ['error'],
 
             'no-multiple-empty-lines': ['error', {
                 max: 1,

--- a/src/data/bucket/fill_extrusion_bucket.ts
+++ b/src/data/bucket/fill_extrusion_bucket.ts
@@ -56,7 +56,7 @@ type CentroidAccumulator = {
     x: number;
     y: number;
     sampleCount: number;
-}
+};
 
 export class FillExtrusionBucket implements Bucket {
     index: number;

--- a/src/data/dem_data.ts
+++ b/src/data/dem_data.ts
@@ -6,7 +6,7 @@ import {register} from '../util/web_worker_transfer';
 /**
  * The possible DEM encoding types
  */
-export type DEMEncoding = 'mapbox' | 'terrarium' | 'custom'
+export type DEMEncoding = 'mapbox' | 'terrarium' | 'custom';
 
 /**
  * DEMData is a data structure for decoding, backfilling, and storing elevation data for processing in the hillshade shaders

--- a/src/geo/projection/camera_helper.ts
+++ b/src/geo/projection/camera_helper.ts
@@ -16,7 +16,7 @@ export type MapControlsDeltas = {
     pitchDelta: number;
     rollDelta: number;
     around: Point;
-}
+};
 
 export type CameraForBoxAndBearingHandlerResult = {
     center: LngLat;
@@ -35,13 +35,13 @@ export type EaseToHandlerOptions = {
     center?: LngLatLike;
     zoom?: number;
     offset?: PointLike;
-}
+};
 
 export type EaseToHandlerResult = {
     easeFunc: (k: number) => void;
     elevationCenter: LngLat;
     isZooming: boolean;
-}
+};
 
 export type FlyToHandlerOptions = {
     bearing: number;
@@ -53,7 +53,7 @@ export type FlyToHandlerOptions = {
     locationAtOffset: LngLat;
     zoom?: number;
     minZoom?: number;
-}
+};
 
 export type FlyToHandlerResult = {
     easeFunc: (k: number, scale: number, centerFactor: number, pointAtOffset: Point) => void;
@@ -61,7 +61,7 @@ export type FlyToHandlerResult = {
     scaleOfMinZoom?: number;
     targetCenter: LngLat;
     pixelPathLength: number;
-}
+};
 
 export type UpdateRotationArgs = {
     /**
@@ -88,7 +88,7 @@ export type UpdateRotationArgs = {
      * If true, use spherical linear interpolation. If false, use linear interpolation of Euler angles.
      */
     useSlerp: boolean;
-}
+};
 
 /**
  * @internal

--- a/src/geo/projection/globe_projection.ts
+++ b/src/geo/projection/globe_projection.ts
@@ -13,11 +13,11 @@ import {type Mesh} from '../../render/mesh';
 
 type ProjectionProps = {
     type: DataConstantProperty<ProjectionDefinition>;
-}
+};
 
 type ProjectionPossiblyEvaluated = {
     type: ProjectionDefinitionSpecification;
-}
+};
 
 const properties: Properties<ProjectionProps> = new Properties({
     'type': new DataConstantProperty(styleSpec.projection.type as StylePropertySpecification)

--- a/src/geo/projection/globe_transform.ts
+++ b/src/geo/projection/globe_transform.ts
@@ -270,9 +270,9 @@ export class GlobeTransform implements ITransform {
         this._verticalPerspectiveTransform.apply(this, this._globeLatitudeErrorCorrectionRadians);
     }
 
-    public get projectionMatrix(): mat4 { return this.currentTransform.projectionMatrix }
+    public get projectionMatrix(): mat4 { return this.currentTransform.projectionMatrix; }
 
-    public get modelViewProjectionMatrix(): mat4 { return this.currentTransform.modelViewProjectionMatrix }
+    public get modelViewProjectionMatrix(): mat4 { return this.currentTransform.modelViewProjectionMatrix; }
 
     public get inverseProjectionMatrix(): mat4 { return this.currentTransform.inverseProjectionMatrix; }
 

--- a/src/geo/projection/mercator_covering_tiles_details_provider.ts
+++ b/src/geo/projection/mercator_covering_tiles_details_provider.ts
@@ -42,7 +42,7 @@ export class MercatorCoveringTilesDetailsProvider implements CoveringTilesDetail
     allowVariableZoom(transform: IReadonlyTransform, options: CoveringTilesOptions): boolean {
         const zfov = transform.fov * (Math.abs(Math.cos(transform.rollInRadians)) * transform.height + Math.abs(Math.sin(transform.rollInRadians)) * transform.width) / transform.height;
         const maxConstantZoomPitch = clamp(78.5 - zfov / 2, 0.0, 60.0);
-        return (!!options.terrain || transform.pitch > maxConstantZoomPitch || transform.padding.top >= 0.1)
+        return (!!options.terrain || transform.pitch > maxConstantZoomPitch || transform.padding.top >= 0.1);
     }
 
     allowWorldCopies(): boolean {

--- a/src/geo/projection/mercator_transform.ts
+++ b/src/geo/projection/mercator_transform.ts
@@ -416,7 +416,7 @@ export class MercatorTransform implements ITransform {
         const matrices = {
             f64: tileMatrix,
             f32: new Float32Array(tileMatrix), // Must have a 32 bit float version for WebGL, otherwise WebGL calls in Chrome get very slow.
-        }
+        };
         cache.set(posMatrixKey, matrices);
         // Make sure to return the correct precision
         return useFloat32 ? matrices.f32 : matrices.f64;

--- a/src/geo/projection/projection_data.ts
+++ b/src/geo/projection/projection_data.ts
@@ -44,7 +44,7 @@ export type ProjectionData = {
      * Uniform name: `u_projection_fallback_matrix`.
      */
     fallbackMatrix: mat4;
-}
+};
 
 /**
  * Parameters object for the transform's `getProjectionData` function.
@@ -67,4 +67,4 @@ export type ProjectionDataParams = {
      * Set to true if the globe matrix should be applied (i.e. when rendering globe)
      */
     applyGlobeMatrix?: boolean;
-}
+};

--- a/src/geo/projection/vertical_perspective_transform.ts
+++ b/src/geo/projection/vertical_perspective_transform.ts
@@ -300,7 +300,7 @@ export class VerticalPerspectiveTransform implements ITransform {
             clippingPlane: this._cachedClippingPlane as [number, number, number, number],
             projectionTransition: applyGlobeMatrix ? 1 : 0,
             fallbackMatrix: this._globeViewProjMatrix32f,
-        }
+        };
     }
 
     private _computeClippingPlane(globeRadiusPixels: number): vec4 {

--- a/src/render/line_atlas.ts
+++ b/src/render/line_atlas.ts
@@ -9,7 +9,7 @@ type DashEntry = {
     y: number;
     height: number;
     width: number;
-}
+};
 
 /**
  * @internal

--- a/src/render/painter.ts
+++ b/src/render/painter.ts
@@ -75,7 +75,7 @@ type PainterOptions = {
 export type RenderOptions = {
     isRenderingToTexture: boolean;
     isRenderingGlobe: boolean;
-}
+};
 
 /**
  * @internal

--- a/src/render/terrain.ts
+++ b/src/render/terrain.ts
@@ -35,7 +35,7 @@ export type TerrainData = {
     texture: WebGLTexture;
     depthTexture: WebGLTexture;
     tile: Tile;
-}
+};
 
 /**
  * @internal

--- a/src/source/geojson_source.ts
+++ b/src/source/geojson_source.ts
@@ -23,7 +23,7 @@ export type GeoJSONSourceOptions = GeoJSONSourceSpecification & {
     workerOptions?: GeoJSONWorkerOptions;
     collectResourceTiming?: boolean;
     data: GeoJSON.GeoJSON | string;
-}
+};
 
 export type GeoJSONSourceInternalOptions = {
     data?: GeoJSON.GeoJSON | string | undefined;
@@ -32,7 +32,7 @@ export type GeoJSONSourceInternalOptions = {
     clusterRadius?: number;
     clusterMinPoints?: number;
     generateId?: boolean;
-}
+};
 
 /**
  * The cluster options to set
@@ -50,7 +50,7 @@ export type SetClusterOptions = {
      * The cluster's radius
      */
     clusterRadius?: number;
-}
+};
 
 /**
  * A source containing GeoJSON.

--- a/src/source/geojson_source_diff.ts
+++ b/src/source/geojson_source_diff.ts
@@ -23,7 +23,7 @@ export type GeoJSONSourceDiff = {
      * An array of update objects
      */
     update?: Array<GeoJSONFeatureDiff>;
-}
+};
 
 /**
  * A geojson feature diff object
@@ -49,7 +49,7 @@ export type GeoJSONFeatureDiff = {
      * The properties to add or update along side their values
      */
     addOrUpdateProperties?: Array<{key: string; value: any}>;
-}
+};
 
 export type UpdateableGeoJSON = GeoJSON.Feature | GeoJSON.FeatureCollection | undefined;
 

--- a/src/source/geojson_worker_source.ts
+++ b/src/source/geojson_worker_source.ts
@@ -31,7 +31,7 @@ export type GeoJSONWorkerOptions = {
     filter?: Array<unknown>;
     promoteId?: string;
     collectResourceTiming?: boolean;
-}
+};
 
 /**
  * Parameters needed to load a geojson to the worker

--- a/src/source/image_source.ts
+++ b/src/source/image_source.ts
@@ -36,7 +36,7 @@ export type UpdateImageOptions = {
      * The image coordinates
      */
     coordinates?: Coordinates;
-}
+};
 
 /**
  * A data source containing an image.

--- a/src/source/load_tilejson.ts
+++ b/src/source/load_tilejson.ts
@@ -16,7 +16,7 @@ export type LoadTileJsonResponse = {
     tileSize: number;
     encoding: RasterDEMSourceSpecification['encoding'];
     vectorLayerIds?: Array<string>;
-}
+};
 
 export async function loadTileJson(
     options: RasterSourceSpecification | RasterDEMSourceSpecification | VectorSourceSpecification,

--- a/src/source/query_features.ts
+++ b/src/source/query_features.ts
@@ -33,7 +33,7 @@ export type QueryRenderedFeaturesOptions = {
 
 export type QueryRenderedFeaturesOptionsStrict = Omit<QueryRenderedFeaturesOptions, 'layers'> & {
     layers: Set<string> | null;
-}
+};
 
 /**
  * The options object related to the {@link Map#querySourceFeatures} method
@@ -53,7 +53,7 @@ export type QuerySourceFeatureOptions = {
      * @defaultValue true
      */
     validate?: boolean;
-}
+};
 
 /*
  * Returns a matrix that can be used to convert from tile coordinates to viewport pixel coordinates.

--- a/src/source/source.ts
+++ b/src/source/source.ts
@@ -128,7 +128,7 @@ export interface Source {
  */
 export type SourceClass = {
     new (id: string, specification: SourceSpecification | CanvasSourceSpecification, dispatcher: Dispatcher, eventedParent: Evented): Source;
-}
+};
 
 /**
  * Creates a tiled data source instance given an options object.

--- a/src/source/source_cache.ts
+++ b/src/source/source_cache.ts
@@ -31,7 +31,7 @@ type TileResult = {
     queryGeometry: Array<Point>;
     cameraQueryGeometry: Array<Point>;
     scale: number;
-}
+};
 
 /**
  * @internal

--- a/src/source/vector_tile_source.ts
+++ b/src/source/vector_tile_source.ts
@@ -17,7 +17,7 @@ import {MessageType} from '../util/actor_messages';
 export type VectorTileSourceOptions = VectorSourceSpecification & {
     collectResourceTiming?: boolean;
     tileSize?: number;
-}
+};
 
 /**
  * A source containing vector tiles in [Mapbox Vector Tile format](https://docs.mapbox.com/vector-tiles/reference/).

--- a/src/source/vector_tile_worker_source.ts
+++ b/src/source/vector_tile_worker_source.ts
@@ -27,7 +27,7 @@ type FetchingState = {
     rawTileData: ArrayBuffer;
     cacheControl: ExpiryData;
     resourceTiming: any;
-}
+};
 
 export type AbortVectorData = () => void;
 export type LoadVectorData = (params: WorkerTileParameters, abortController: AbortController) => Promise<LoadVectorTileResult | null>;

--- a/src/style/load_sprite.ts
+++ b/src/style/load_sprite.ts
@@ -13,7 +13,7 @@ export type LoadSpriteResult = {
     [spriteName: string]: {
         [id: string]: StyleImage;
     };
-}
+};
 
 export function normalizeSpriteURL(url: string, format: string, extension: string): string {
     try {
@@ -22,7 +22,7 @@ export function normalizeSpriteURL(url: string, format: string, extension: strin
         return parsed.toString();
     }
     catch {
-        throw new Error(`Invalid sprite URL "${url}", must be absolute. Modify style specification directly or use TransformStyleFunction to correct the issue dynamically`)
+        throw new Error(`Invalid sprite URL "${url}", must be absolute. Modify style specification directly or use TransformStyleFunction to correct the issue dynamically`);
     }
 }
 

--- a/src/style/style.ts
+++ b/src/style/style.ts
@@ -184,7 +184,7 @@ export type StyleSwapOptions = {
      * that allows to modify a style after it is fetched but before it is committed to the map state. Refer to {@link TransformStyleFunction}.
      */
     transformStyle?: TransformStyleFunction;
-}
+};
 
 /**
  * Specifies a layer to be added to a {@link Style}. In addition to a standard {@link LayerSpecification}

--- a/src/style/style_image.ts
+++ b/src/style/style_image.ts
@@ -7,7 +7,7 @@ export type SpriteJSON = {[id: string]: StyleImageMetadata & {
     height: number;
     x: number;
     y: number;
-};}
+};};
 
 /**
  * The sprite data

--- a/src/style/style_layer/custom_style_layer.ts
+++ b/src/style/style_layer/custom_style_layer.ts
@@ -105,7 +105,7 @@ export type CustomRenderMethodInput = {
      * or more accurately for globe, elevation above the surface of the perfect sphere used to render the planet.
      */
     defaultProjectionData: ProjectionData;
-}
+};
 
 /**
  * @param gl - The map's gl context.

--- a/src/symbol/grid_index.ts
+++ b/src/symbol/grid_index.ts
@@ -31,7 +31,7 @@ type QueryResult<T> = {
  */
 export type GridKey = {
     overlapMode?: OverlapMode;
-}
+};
 
 function overlapAllowed(overlapA: OverlapMode, overlapB: OverlapMode): boolean {
     let allowed = true;

--- a/src/symbol/projection.ts
+++ b/src/symbol/projection.ts
@@ -399,7 +399,7 @@ function requiresOrientationChange(writingMode, firstPoint, lastPoint, aspectRat
 
 type GlyphLinePlacementResult = OrientationChangeType & {
     notEnoughRoom?: boolean;
-}
+};
 
 type GlyphLinePlacementArgs = {
     projectionContext: SymbolProjectionContext;
@@ -412,7 +412,7 @@ type GlyphLinePlacementArgs = {
     dynamicLayoutVertexArray: StructArray;
     aspectRatio: number;
     rotateToLine: boolean;
-}
+};
 
 /*
 * Place first and last glyph along the line projected to label plane, and if they fit

--- a/src/ui/camera.test.ts
+++ b/src/ui/camera.test.ts
@@ -343,7 +343,7 @@ describe('#jumpTo', () => {
         let started, rotated, ended;
         const eventData = {data: 'ok'};
 
-        camera.on('rotatestart', (d) => { started = d.data; })
+        camera.on('rotatestart', (d) => { started = d.data; });
         camera.on('rotate', (d) => { rotated = d.data; });
         camera.on('rotateend', (d) => { ended = d.data; });
 
@@ -357,7 +357,7 @@ describe('#jumpTo', () => {
         let started, pitched, ended;
         const eventData = {data: 'ok'};
 
-        camera.on('pitchstart', (d) => { started = d.data; })
+        camera.on('pitchstart', (d) => { started = d.data; });
         camera.on('pitch', (d) => { pitched = d.data; });
         camera.on('pitchend', (d) => { ended = d.data; });
 
@@ -371,7 +371,7 @@ describe('#jumpTo', () => {
         let started, rolled, ended;
         const eventData = {data: 'ok'};
 
-        camera.on('rollstart', (d) => { started = d.data; })
+        camera.on('rollstart', (d) => { started = d.data; });
         camera.on('roll', (d) => { rolled = d.data; });
         camera.on('rollend', (d) => { ended = d.data; });
 
@@ -1485,16 +1485,16 @@ describe('#flyTo', () => {
         const eventData = {data: 'ok'};
 
         camera.on('movestart', (d) => { movestarted = d.data; });
-        camera.on('move', (d) => { moved = d.data; })
-        camera.on('zoomstart', (d) => { zoomstarted = d.data; })
-        camera.on('zoom', (d) => { zoomed = d.data; })
-        camera.on('zoomend', (d) => { zoomended = d.data; })
-        camera.on('rotatestart', (d) => { rotatestarted = d.data; })
-        camera.on('rotate', (d) => { rotated = d.data; })
-        camera.on('rotateend', (d) => { rotateended = d.data; })
-        camera.on('pitchstart', (d) => { pitchstarted = d.data; })
-        camera.on('pitch', (d) => { pitched = d.data; })
-        camera.on('pitchend', (d) => { pitchended = d.data; })
+        camera.on('move', (d) => { moved = d.data; });
+        camera.on('zoomstart', (d) => { zoomstarted = d.data; });
+        camera.on('zoom', (d) => { zoomed = d.data; });
+        camera.on('zoomend', (d) => { zoomended = d.data; });
+        camera.on('rotatestart', (d) => { rotatestarted = d.data; });
+        camera.on('rotate', (d) => { rotated = d.data; });
+        camera.on('rotateend', (d) => { rotateended = d.data; });
+        camera.on('pitchstart', (d) => { pitchstarted = d.data; });
+        camera.on('pitch', (d) => { pitched = d.data; });
+        camera.on('pitchend', (d) => { pitchended = d.data; });
         const promise = camera.once('moveend');
 
         const stub = vi.spyOn(browser, 'now');
@@ -2463,7 +2463,7 @@ describe('#transformCameraUpdate', () => {
         camera.on('move', () => {
             eventCount++;
             expect(eventCount).toBe(callbackCount);
-        })
+        });
         const promise = camera.once('moveend');
 
         camera.jumpTo({center: [100, 0]});
@@ -3292,17 +3292,17 @@ describe('#flyTo globe projection', () => {
                 pitchstarted, pitched, pitchended;
             const eventData = {data: 'ok'};
 
-            camera.on('movestart', (d) => { movestarted = d.data; })
-            camera.on('move', (d) => { moved = d.data; })
-            camera.on('zoomstart', (d) => { zoomstarted = d.data; })
-            camera.on('zoom', (d) => { zoomed = d.data; })
-            camera.on('zoomend', (d) => { zoomended = d.data; })
-            camera.on('rotatestart', (d) => { rotatestarted = d.data; })
-            camera.on('rotate', (d) => { rotated = d.data; })
-            camera.on('rotateend', (d) => { rotateended = d.data; })
-            camera.on('pitchstart', (d) => { pitchstarted = d.data; })
-            camera.on('pitch', (d) => { pitched = d.data; })
-            camera.on('pitchend', (d) => { pitchended = d.data; })
+            camera.on('movestart', (d) => { movestarted = d.data; });
+            camera.on('move', (d) => { moved = d.data; });
+            camera.on('zoomstart', (d) => { zoomstarted = d.data; });
+            camera.on('zoom', (d) => { zoomed = d.data; });
+            camera.on('zoomend', (d) => { zoomended = d.data; });
+            camera.on('rotatestart', (d) => { rotatestarted = d.data; });
+            camera.on('rotate', (d) => { rotated = d.data; });
+            camera.on('rotateend', (d) => { rotateended = d.data; });
+            camera.on('pitchstart', (d) => { pitchstarted = d.data; });
+            camera.on('pitch', (d) => { pitched = d.data; });
+            camera.on('pitchend', (d) => { pitchended = d.data; });
             const promise = camera.once('moveend');
 
             const stub = vi.spyOn(browser, 'now');
@@ -3689,7 +3689,7 @@ describe('#flyTo globe projection', () => {
             let startTime: number;
             const camera = createCameraGlobe({center: [37.63454, 55.75868], zoom: 18});
 
-            camera.on('movestart', () => { startTime = new Date().getTime(); })
+            camera.on('movestart', () => { startTime = new Date().getTime(); });
             const promise = camera.once('moveend');
 
             camera.flyTo({center: [-122.3998631, 37.7884307], maxDuration: 100});

--- a/src/ui/camera.ts
+++ b/src/ui/camera.ts
@@ -86,7 +86,7 @@ export type CenterZoomBearing = {
      * is "up". For example, `bearing: 90` orients the map so that east is up.
      */
     bearing?: number;
-}
+};
 
 /**
  * The options object related to the {@link Map#jumpTo} method
@@ -96,7 +96,7 @@ export type JumpToOptions = CameraOptions & {
      * Dimensions in pixels applied on each side of the viewport for shifting the vanishing point.
      */
     padding?: PaddingOptions;
-}
+};
 
 /**
  * A options object for the {@link Map#cameraForBounds} method
@@ -115,7 +115,7 @@ export type CameraForBoundsOptions = CameraOptions & {
      * The maximum zoom level to allow when the camera would transition to the specified bounds.
      */
     maxZoom?: number;
-}
+};
 
 /**
  * The {@link Map#flyTo} options object
@@ -159,7 +159,7 @@ export type FlyToOptions = AnimationOptions & CameraOptions & {
      * The amount of padding in pixels to add to the given bounds.
      */
     padding?: number | PaddingOptions;
-}
+};
 
 /**
  * The {@link Map#easeTo} options object
@@ -173,7 +173,7 @@ export type EaseToOptions = AnimationOptions & CameraOptions & {
     around?: LngLatLike;
     easeId?: string;
     noMoveStart?: boolean;
-}
+};
 
 /**
  * Options for {@link Map#fitBounds} method
@@ -194,7 +194,7 @@ export type FitBoundsOptions = FlyToOptions & {
      * The maximum zoom level to allow when the map view transitions to the specified bounds.
      */
     maxZoom?: number;
-}
+};
 
 /**
  * Options common to map movement methods that involve animation, such as {@link Map#panBy} and

--- a/src/ui/events.ts
+++ b/src/ui/events.ts
@@ -434,7 +434,7 @@ export type MapLibreEvent<TOrig = unknown> = {
     type: keyof MapEventType | keyof MapLayerEventType;
     target: Map;
     originalEvent: TOrig;
-}
+};
 
 /**
  * The style data event
@@ -443,7 +443,7 @@ export type MapLibreEvent<TOrig = unknown> = {
  */
 export type MapStyleDataEvent = MapLibreEvent & {
     dataType: 'style';
-}
+};
 
 /**
  * The source data event interface
@@ -468,7 +468,7 @@ export type MapSourceDataEvent = MapLibreEvent & {
      * the event is related to loading of a tile.
      */
     tile: any;
-}
+};
 /**
  * `MapMouseEvent` is the event type for mouse-related map events.
  *
@@ -753,7 +753,7 @@ export type MapProjectionEvent = {
      * Additionally includes 'globe-mercator' to describe globe that has internally switched to mercator.
      */
     newProjection: ProjectionSpecification['type'] | 'globe-mercator';
-}
+};
 
 /**
  * An event related to the web gl context
@@ -775,4 +775,4 @@ export type MapContextEvent = {
 export type MapStyleImageMissingEvent = MapLibreEvent & {
     type: 'styleimagemissing';
     id: string;
-}
+};

--- a/src/ui/handler/drag_handler.ts
+++ b/src/ui/handler/drag_handler.ts
@@ -62,7 +62,7 @@ export type DragMoveHandlerOptions<T, E extends Event> = {
      * If true, handler will be enabled during construction
      */
     enable?: boolean;
-}
+};
 
 /**
  * A generic class to create handlers for drag events, from both mouse and touch events.

--- a/src/ui/handler/shim/drag_rotate.ts
+++ b/src/ui/handler/shim/drag_rotate.ts
@@ -14,7 +14,7 @@ export type DragRotateHandlerOptions = {
      * @defaultValue false
      */
     rollEnabled: boolean;
-}
+};
 
 /**
  * The `DragRotateHandler` allows the user to rotate the map by clicking and

--- a/src/ui/handler/two_fingers_touch.ts
+++ b/src/ui/handler/two_fingers_touch.ts
@@ -11,7 +11,7 @@ export type AroundCenterOptions = {
      * If "center" is passed, map will zoom around the center of map
      */
     around: 'center';
-}
+};
 
 /**
  * The `TwoFingersTouchHandler`s allows the user to zoom, pitch and rotate the map using two fingers

--- a/src/ui/handler_manager.ts
+++ b/src/ui/handler_manager.ts
@@ -114,7 +114,7 @@ export type HandlerResult = {
 export type EventInProgress = {
     handlerName: string;
     originalEvent: Event;
-}
+};
 
 export type EventsInProgress = {
     zoom?: EventInProgress;
@@ -122,7 +122,7 @@ export type EventsInProgress = {
     pitch?: EventInProgress;
     rotate?: EventInProgress;
     drag?: EventInProgress;
-}
+};
 
 function hasChange(result: HandlerResult) {
     return (result.panDelta && result.panDelta.mag()) || result.zoomDelta || result.bearingDelta || result.pitchDelta || result.rollDelta;

--- a/src/ui/hash.test.ts
+++ b/src/ui/hash.test.ts
@@ -326,12 +326,12 @@ describe('hash', () => {
     });
 
     describe('#_isValidHash', () => {
-        let hash: Hash
+        let hash: Hash;
 
         beforeEach(() => {
             hash = createHash()
                 .addTo(map);
-        })
+        });
 
         test('validate correct hash', () => {
             window.location.hash = '#10/3.00/-1.00';

--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -69,7 +69,7 @@ import {isFramebufferNotCompleteError} from '../util/framebuffer_error';
 
 const version = packageJSON.version;
 
-type WebGLSupportedVersions = 'webgl2' | 'webgl' | undefined
+type WebGLSupportedVersions = 'webgl2' | 'webgl' | undefined;
 type WebGLContextAttributesWithType = WebGLContextAttributes & {contextType?: WebGLSupportedVersions};
 
 /**
@@ -358,7 +358,7 @@ export type MapOptions = {
 
 export type AddImageOptions = {
 
-}
+};
 
 // This type is used inside map since all properties are assigned a default value.
 export type CompleteMapOptions = Complete<MapOptions>;
@@ -367,7 +367,7 @@ type DelegatedListener = {
     layers: string[];
     listener: Listener;
     delegates: {[E in keyof MapEventType]?: Delegate<MapEventType[E]>};
-}
+};
 
 type Delegate<E extends Event = Event> = (e: E) => void;
 

--- a/src/ui/map_tests/map_canvas.test.ts
+++ b/src/ui/map_tests/map_canvas.test.ts
@@ -68,7 +68,7 @@ describe('WebGLContextAttributes options', () => {
             powerPreference: 'default',
             failIfMajorPerformanceCaveat: true,
             desynchronized: true,
-        }
+        };
         Object.defineProperty(container, 'clientWidth', {value: 2048});
         Object.defineProperty(container, 'clientHeight', {value: 2048});
         const map = createMap({container, canvasContextAttributes});
@@ -88,7 +88,7 @@ describe('WebGLContextAttributes options', () => {
             depth: false,
             stencil: false,
             premultipliedAlpha: false,
-        }
+        };
         Object.defineProperty(container, 'clientWidth', {value: 2048});
         Object.defineProperty(container, 'clientHeight', {value: 2048});
         const map = createMap({container, canvasContextAttributes});

--- a/src/ui/map_tests/map_webgl.test.ts
+++ b/src/ui/map_tests/map_webgl.test.ts
@@ -90,7 +90,7 @@ test('Check Map falls back to WebGL if WebGL 2 is not supported', () => {
         if (type === 'webgl2') {return null;}
         return originalGetContext.apply(this, [type]);
     });
-    HTMLCanvasElement.prototype.getContext = mockGetContext
+    HTMLCanvasElement.prototype.getContext = mockGetContext;
   
     try {
         createMap();

--- a/src/ui/marker.test.ts
+++ b/src/ui/marker.test.ts
@@ -12,7 +12,7 @@ type MapOptions = {
     locale?: Partial<typeof defaultLocale>;
     width?: number;
     renderWorldCopies?: boolean;
-}
+};
 
 function createMap(options: MapOptions = {}) {
     const container = window.document.createElement('div');
@@ -980,7 +980,7 @@ describe('marker', () => {
             .addTo(map);
 
         map.terrain = createTerrain();
-        map.terrain.depthAtPoint = () => .95
+        map.terrain.depthAtPoint = () => .95;
         await sleep(100);
         map.fire('terrain');
 

--- a/src/util/actor.test.ts
+++ b/src/util/actor.test.ts
@@ -88,7 +88,7 @@ describe('Actor', () => {
             // Allows the cancel to be processed at the right point in time
             await sleep(200);
             worker.worker.actor.process();
-        }
+        };
 
         let received = false;
         const abortController = new AbortController();

--- a/src/util/actor.ts
+++ b/src/util/actor.ts
@@ -29,12 +29,12 @@ type MessageData = {
     mustQueue?: boolean;
     error?: Serialized | null;
     sourceMapId: string | number | null;
-}
+};
 
 type ResolveReject = {
     resolve: (value?: RequestResponseMessageMap[MessageType][1]) => void;
     reject: (reason?: Error) => void;
-}
+};
 
 /**
  * This interface allowing to substitute only the sendAsync method of the Actor class.
@@ -43,7 +43,7 @@ export interface IActor {
     sendAsync<T extends MessageType>(message: ActorMessage<T>, abortController?: AbortController): Promise<RequestResponseMessageMap[T][1]>;
 }
 
-export type MessageHandler<T extends MessageType> = (mapId: string | number, params: RequestResponseMessageMap[T][0], abortController?: AbortController) => Promise<RequestResponseMessageMap[T][1]>
+export type MessageHandler<T extends MessageType> = (mapId: string | number, params: RequestResponseMessageMap[T][0], abortController?: AbortController) => Promise<RequestResponseMessageMap[T][1]>;
 
 /**
  * An implementation of the [Actor design pattern](https://en.wikipedia.org/wiki/Actor_model)

--- a/src/util/actor_messages.ts
+++ b/src/util/actor_messages.ts
@@ -36,7 +36,7 @@ export type GeoJSONWorkerSourceLoadDataResult = {
 export type RemoveSourceParams = {
     source: string;
     type: string;
-}
+};
 
 /**
  * Parameters needed to update the layers
@@ -44,7 +44,7 @@ export type RemoveSourceParams = {
 export type UpdateLayersParamaeters = {
     layers: Array<LayerSpecification>;
     removedIds: Array<string>;
-}
+};
 
 /**
  * Parameters needed to get the images
@@ -54,7 +54,7 @@ export type GetImagesParameters = {
     source: string;
     tileID: OverscaledTileID;
     type: string;
-}
+};
 
 /**
  * Parameters needed to get the glyphs
@@ -64,7 +64,7 @@ export type GetGlyphsParameters = {
     stacks: {[_: string]: Array<number>};
     source: string;
     tileID: OverscaledTileID;
-}
+};
 
 /**
  * A response object returned when requesting glyphs
@@ -73,12 +73,12 @@ export type GetGlyphsResponse = {
     [stack: string]: {
         [id: number]: StyleGlyph;
     };
-}
+};
 
 /**
  * A response object returned when requesting images
  */
-export type GetImagesResponse = {[_: string]: StyleImage}
+export type GetImagesResponse = {[_: string]: StyleImage};
 
 /**
  * All the possible message types that can be sent to and from the worker
@@ -135,7 +135,7 @@ export type RequestResponseMessageMap = {
     [MessageType.abortTile]: [TileParameters, void];
     [MessageType.removeDEMTile]: [TileParameters, void];
     [MessageType.getResource]: [RequestParameters, GetResourceResponse<any>];
-}
+};
 
 /**
  * The message to be sent by the actor

--- a/src/util/ajax.ts
+++ b/src/util/ajax.ts
@@ -69,7 +69,7 @@ export type RequestParameters = {
  */
 export type GetResourceResponse<T> = ExpiryData & {
     data: T;
-}
+};
 
 /**
  * The response callback used in various places

--- a/src/util/config.ts
+++ b/src/util/config.ts
@@ -5,7 +5,7 @@ import type {RequestParameters, GetResourceResponse} from './ajax';
  * Use the abort controller for aborting requests.
  * Return a promise with the relevant resource response.
  */
-export type AddProtocolAction = (requestParameters: RequestParameters, abortController: AbortController) => Promise<GetResourceResponse<any>>
+export type AddProtocolAction = (requestParameters: RequestParameters, abortController: AbortController) => Promise<GetResourceResponse<any>>;
 
 /**
  * This is a global config object used to store the configuration

--- a/src/util/create_tile_mesh.test.ts
+++ b/src/util/create_tile_mesh.test.ts
@@ -20,11 +20,11 @@ describe('create_tile_mesh', () => {
         const mesh = createTileMesh({}, '32bit');
         expect(mesh.indices.byteLength).toBe(6 * 2 * 2); // 32bit
         expect(mesh.vertices.byteLength).toBe(8 * 2); // 16bit
-    })
+    });
 
     test('createTileMesh 16bit', () => {
         const mesh = createTileMesh({}, '16bit');
         expect(mesh.indices.byteLength).toBe(6 * 2); // 16bit
         expect(mesh.vertices.byteLength).toBe(8 * 2); // 16bit
-    })
-})
+    });
+});

--- a/src/util/image_request.ts
+++ b/src/util/image_request.ts
@@ -14,11 +14,11 @@ export type ImageRequestQueueItem  = {
     abortController: AbortController;
     onError: (error: Error) => void;
     onSuccess: (response: GetResourceResponse<HTMLImageElement | ImageBitmap | null>) => void;
-}
+};
 
 type ImageQueueThrottleCallbackDictionary = {
     [Key: number]: ImageQueueThrottleControlCallback;
-}
+};
 
 type HTMLImageElementWithPriority = HTMLImageElement &
 {

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -998,7 +998,7 @@ export function rollPitchBearingToQuat(roll: number, pitch: number, bearing: num
 
 export type Complete<T> = {
     [P in keyof Required<T>]: Pick<T, P> extends Required<Pick<T, P>> ? T[P] : (T[P] | undefined);
-}
+};
 
 /**
  * A helper to allow require of at least one property

--- a/src/util/vectortile_to_geojson.ts
+++ b/src/util/vectortile_to_geojson.ts
@@ -20,7 +20,7 @@ export type MapGeoJSONFeature = GeoJSONFeature & {
     source: string;
     sourceLayer?: string;
     state: { [key: string]: any };
-}
+};
 
 /**
  * A geojson feature

--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -1,8 +1,0 @@
-{
-  "plugins": [
-    "html"
-  ],
-  "rules": {
-    "no-restricted-properties": "off"
-  }
-}

--- a/test/integration/render/run_render_tests.ts
+++ b/test/integration/render/run_render_tests.ts
@@ -56,7 +56,7 @@ type TestData = {
     actual: string;
     diff: string;
     expected: string;
-}
+};
 
 type RenderOptions = {
     tests: any[];
@@ -65,13 +65,13 @@ type RenderOptions = {
     seed: string;
     debug: boolean;
     openBrowser: boolean;
-}
+};
 
 type StyleWithTestData = StyleSpecification & {
     metadata : {
         test: TestData;
     };
-}
+};
 
 type TestStats = {
     total: number;

--- a/test/unit/lib/mesh_utils.ts
+++ b/test/unit/lib/mesh_utils.ts
@@ -13,7 +13,7 @@ export type SimpleMesh = {
     vertices: Array<number>;
     indicesTriangles: Array<number>;
     indicesLines: Array<number>;
-}
+};
 
 /**
  * Generates a simple grid mesh that has `size` by `size` quads.


### PR DESCRIPTION
This PR adds eslint rule that is `stylistic/semi`. Many source files are missing semicolons.
Therefore, the codes are enforced by rule.

According to the official TypeScript document, The `type` has semicolons. [link](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#type-aliases)


## Launch Checklist
 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [ ] Link to related issues.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [ ] Add an entry to `CHANGELOG.md` under the `## main` section.
