### PR TITLE
Fix invalid link in release notes

### DIFF
--- a/build/release-notes.js
+++ b/build/release-notes.js
@@ -35,7 +35,7 @@ const previous = releaseNotes[1];
 //  Print the release notes template.
 
 const templatedReleaseNotes = `https://github.com/maplibre/maplibre-gl-js
-[Changes](https://github.com/maplibre/maplibre-gl-js/compare/v${previous.version}...v${latest.version}) since [MapLibre GL JS v${previous.version}](https://github.com/maplibre/releases/tag/v${previous.version}):
+[Changes](https://github.com/maplibre/maplibre-gl-js/compare/v${previous.version}...v${latest.version}) since [MapLibre GL JS v${previous.version}](https://github.com/maplibre/maplibre-gl-js/releases/tag/v${previous.version}):
 
 ${latest.changelog}
 


### PR DESCRIPTION
## Launch Checklist

Release note generation message has been with a bug for a long time now.
I just saw it and fixed manually a lot of the release notes in github, but not all of them.
This will at least solve the next release notes

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.