### PR TITLE
Only apply css hover effect on non-touch devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes
-- _...Add new stuff here..._
+
+- Skip control button css hover effects on touch devices (https://github.com/maplibre/maplibre-gl-js/pull/5285)
 
 ## 5.0.0
 

--- a/src/css/maplibre-gl.css
+++ b/src/css/maplibre-gl.css
@@ -180,8 +180,14 @@
     opacity: 0.25;
 }
 
-.maplibregl-ctrl button:not(:disabled):hover {
-    background-color: rgb(0 0 0 / 5%);
+@media (hover: hover) {
+    .maplibregl-ctrl button:not(:disabled):hover {
+        background-color: rgb(0 0 0/5%);
+    }
+}
+
+.maplibregl-ctrl button:not(:disabled):active {
+    background-color: rgb(0 0 0/5%);
 }
 
 .maplibregl-ctrl-group button:focus:focus-visible {


### PR DESCRIPTION
Applying hover effect on touch devices has an undesired effect: The element gets set to hover state on touch and stays like that until the next touch event.  Using the :active state gives a nicer feedback by highlighting the button only for the duration of the touch. (fixes https://github.com/maplibre/maplibre-gl-js/issues/5284)

Before: 

https://github.com/user-attachments/assets/4ae6b618-f900-4099-bc97-152f6bdc67a6

After: 

https://github.com/user-attachments/assets/3484d1dc-80e4-4c93-9f6e-46db14d280bd


## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [x] Include before/after visuals or gifs if this PR includes visual changes.
 - [/] Write tests for all new functionality.
 - [/] Document any changes to public APIs.
 - [/] Post benchmark scores.
 - [/] Add an entry to `CHANGELOG.md` under the `## main` section.
