### PR TITLE
Enable Multi-MouseButton Support for dragPan

### DIFF
--- a/src/ui/handler/drag_handler.ts
+++ b/src/ui/handler/drag_handler.ts
@@ -62,6 +62,8 @@ export type DragMoveHandlerOptions<T, E extends Event> = {
      * If true, handler will be enabled during construction
      */
     enable?: boolean;
+
+    buttons?: number[];
 };
 
 /**
@@ -95,6 +97,9 @@ export class DragHandler<T extends DragMovementResult, E extends Event> implemen
 
         options.assignEvents(this);
 
+        if (options.buttons) {
+            this._moveStateManager.updateButtons(options.buttons);
+        }
         this.reset();
     }
 
@@ -155,7 +160,10 @@ export class DragHandler<T extends DragMovementResult, E extends Event> implemen
         this.reset(e);
     }
 
-    enable() {
+    enable(options?: { buttons?: number[] }): void {
+        if (options && options.buttons) {
+            this._moveStateManager.updateButtons(options.buttons);
+        }
         this._enabled = true;
     }
 

--- a/src/ui/handler/drag_move_state_manager.ts
+++ b/src/ui/handler/drag_move_state_manager.ts
@@ -1,12 +1,14 @@
 import {DOM} from '../../util/dom';
 
 const LEFT_BUTTON = 0;
+const MIDDLE_BUTTON = 1;
 const RIGHT_BUTTON = 2;
 
 // the values for each button in MouseEvent.buttons
 const BUTTONS_FLAGS = {
     [LEFT_BUTTON]: 1,
-    [RIGHT_BUTTON]: 2
+    [MIDDLE_BUTTON]: 4,
+    [RIGHT_BUTTON]: 2,
 };
 
 function buttonNoLongerPressed(e: MouseEvent, button: number) {
@@ -36,14 +38,16 @@ export interface DragMoveStateManager<E extends Event> {
     isValidStartEvent: (e: E) => boolean;
     isValidMoveEvent: (e: E) => boolean;
     isValidEndEvent: (e?: E) => boolean;
+    updateButtons?: (buttons: number[]) => void;
 }
 
 export class MouseMoveStateManager implements DragMoveStateManager<MouseEvent> {
     _eventButton: number | undefined;
-    _correctEvent: (e: MouseEvent) => boolean;
+    _correctEvent: (e: MouseEvent, buttons?: number[]) => boolean;
+    _buttons: number[] = [LEFT_BUTTON];
 
     constructor(options: {
-        checkCorrectEvent: (e: MouseEvent) => boolean;
+        checkCorrectEvent: (e: MouseEvent, buttons?:number[]) => boolean;
     }) {
         this._correctEvent = options.checkCorrectEvent;
     }
@@ -58,7 +62,7 @@ export class MouseMoveStateManager implements DragMoveStateManager<MouseEvent> {
     }
 
     isValidStartEvent(e: MouseEvent) {
-        return this._correctEvent(e);
+        return this._correctEvent(e, this._buttons);
     }
 
     isValidMoveEvent(e: MouseEvent) {
@@ -74,6 +78,10 @@ export class MouseMoveStateManager implements DragMoveStateManager<MouseEvent> {
     isValidEndEvent(e: MouseEvent) {
         const eventButton = DOM.mouseButton(e);
         return eventButton === this._eventButton;
+    }
+
+    updateButtons(buttons: number[]) {
+        this._buttons = buttons;
     }
 }
 
@@ -116,7 +124,7 @@ export class OneFingerTouchMoveStateManager implements DragMoveStateManager<Touc
 
 export class MouseOrTouchMoveStateManager implements DragMoveStateManager<MouseEvent | TouchEvent> {
     constructor(
-        private mouseMoveStateManager = new MouseMoveStateManager({checkCorrectEvent: () => true}), 
+        private mouseMoveStateManager = new MouseMoveStateManager({checkCorrectEvent: () => true}),
         private oneFingerTouchMoveStateManager = new OneFingerTouchMoveStateManager()
     ) {}
 

--- a/src/ui/handler/shim/drag_pan.ts
+++ b/src/ui/handler/shim/drag_pan.ts
@@ -26,6 +26,12 @@ export type DragPanOptions = {
      * @defaultValue 2500
      */
     maxSpeed?: number;
+    /**
+     * the buttons that can be used to drag the map.
+     * @defaultValue [0]
+     * @see https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/button
+     */
+    buttons?: number[];
 };
 
 /**
@@ -60,12 +66,13 @@ export class DragPanHandler {
      *      easing: bezier(0, 0, 0.3, 1),
      *      maxSpeed: 1400,
      *      deceleration: 2500,
+     *      buttons: [0,1] // left and middle mouse buttons
      *   });
      * ```
      */
     enable(options?: DragPanOptions | boolean) {
         this._inertiaOptions = options || {};
-        this._mousePan.enable();
+        this._mousePan.enable(this._inertiaOptions);
         this._touchPan.enable();
         this._el.classList.add('maplibregl-touch-drag-pan');
     }

--- a/src/ui/handler_inertia.ts
+++ b/src/ui/handler_inertia.ts
@@ -40,7 +40,6 @@ export type InertiaOptions = {
     easing: (t: number) => number;
     deceleration: number;
     maxSpeed: number;
-    buttons?: number[]; // buttons that can be used to trigger pan
 };
 
 export class HandlerInertia {

--- a/src/ui/handler_inertia.ts
+++ b/src/ui/handler_inertia.ts
@@ -40,6 +40,7 @@ export type InertiaOptions = {
     easing: (t: number) => number;
     deceleration: number;
     maxSpeed: number;
+    buttons?: number[]; // buttons that can be used to trigger pan
 };
 
 export class HandlerInertia {

--- a/src/ui/handler_manager.ts
+++ b/src/ui/handler_manager.ts
@@ -38,7 +38,7 @@ class RenderFrameEvent extends Event {
  * would return a `panDelta` on the mousemove.
  */
 export interface Handler {
-    enable(): void;
+    enable(options?): void;
     disable(): void;
     isEnabled(): boolean;
     /**


### PR DESCRIPTION
This PR enhances the functionality of dragPan in MapLibre GL JS, addressing feature request #5341.
It introduces the ability to configure one or multiple mouse buttons for the dragPan interaction using the [MouseEvent.button](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/button) property.

Previously, dragPan was limited to left mouse button, restricting user interaction and personalization. This improvement provides greater flexibility for users who want to customize the drag behavior of the map.


## Examples

**1. Configuring on Map Initialization:**

``` javascript
const map = maplibregl.Map({
    container: 'map',
    dragPan: {
        buttons: [0,1]  // Enable left button (0) and middle button (1)
    }
});
```

**2. Updating on DragPan Enable:**

``` javascript
map.dragPan.enable({
    buttons: [1]  // Enable only middle button (1)
})
```

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [ ] Add an entry to `CHANGELOG.md` under the `## main` section.
