### PR TITLE
Fix raster-dem glitches for "no content" tiles (status 204)

### DIFF
--- a/src/source/raster_dem_tile_worker_source.ts
+++ b/src/source/raster_dem_tile_worker_source.ts
@@ -1,6 +1,7 @@
 import {DEMData} from '../data/dem_data';
 import {RGBAImage} from '../util/image';
 import type {Actor} from '../util/actor';
+import {AJAXError} from '../util/ajax';
 import type {
     WorkerDEMTileParameters,
     TileParameters
@@ -17,6 +18,10 @@ export class RasterDEMTileWorkerSource {
 
     async loadTile(params: WorkerDEMTileParameters): Promise<DEMData | null> {
         const {uid, encoding, rawImageData, redFactor, greenFactor, blueFactor, baseShift} = params;
+        if (rawImageData.width === 1) {
+            // 1x1 images should not be loaded. They are meant to cache tiles without content (204).
+            throw new AJAXError(404, 'not found', '', new Blob());
+        }
         const width = rawImageData.width + 2;
         const height = rawImageData.height + 2;
         const imagePixels: RGBAImage | ImageData = isImageBitmap(rawImageData) ?


### PR DESCRIPTION
Raster-DEM sources like Martin return 204 when there is no content. Maplibre stores such tiles as 1x1 images, introduced in PR https://github.com/maplibre/maplibre-gl-js/pull/3428 .

This creates glitches while rendering. Elevation looks random and there are backfill errors.

My PR skips 1x1 images and throws 404 instead. This follows the legacy code path for no content tiles.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [x] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [ ] Add an entry to `CHANGELOG.md` under the `## main` section.

Before
![Screenshot From 2025-01-23 02-46-44](https://github.com/user-attachments/assets/0dd78616-d68b-482a-89ef-5c76d39a702b)

After
![Screenshot From 2025-01-23 02-47-49](https://github.com/user-attachments/assets/aaad95bb-f526-476e-8f93-bbf52a0a8847)

