### PR TITLE
update mapbox gl draw example

### DIFF
--- a/test/examples/mapbox-gl-draw.html
+++ b/test/examples/mapbox-gl-draw.html
@@ -31,10 +31,10 @@
         font-size: 13px;
     }
 </style>
-    <script src="https://www.unpkg.com/@mapbox/mapbox-gl-draw@1.4.3/dist/mapbox-gl-draw.js"></script>
+    <script src="https://www.unpkg.com/@mapbox/mapbox-gl-draw@1.5.0/dist/mapbox-gl-draw.js"></script>
     <link
         rel="stylesheet"
-        href="https://www.unpkg.com/@mapbox/mapbox-gl-draw@1.4.3/dist/mapbox-gl-draw.css"
+        href="https://www.unpkg.com/@mapbox/mapbox-gl-draw@1.5.0/dist/mapbox-gl-draw.css"
     />
     <div id="map"></div>
     <div class="calculation-box">
@@ -47,9 +47,11 @@
 
     import * as turf from 'https://esm.sh/@turf/turf@7.1.0';
 
+    MapboxDraw.constants.classes.CANVAS  = 'maplibregl-canvas';
     MapboxDraw.constants.classes.CONTROL_BASE  = 'maplibregl-ctrl';
     MapboxDraw.constants.classes.CONTROL_PREFIX = 'maplibregl-ctrl-';
     MapboxDraw.constants.classes.CONTROL_GROUP = 'maplibregl-ctrl-group';
+    MapboxDraw.constants.classes.ATTRIBUTION = 'maplibregl-ctrl-attrib';
 
     const map = new maplibregl.Map({
         container: 'map', // container id

--- a/test/examples/mapbox-gl-draw.html
+++ b/test/examples/mapbox-gl-draw.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <title>Draw polygon with maplibre-gl-draw</title>
-    <meta property="og:description" content="Use jsr:@birkskyum/maplibre-gl-draw to draw a polygon and Turf.js to calculate its area in square meters." />
+    <title>Draw polygon with mapbox-gl-draw</title>
+    <meta property="og:description" content="Use mapbox-gl-draw to draw a polygon and Turf.js to calculate its area in square meters." />
     <meta charset='utf-8'>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel='stylesheet' href='../../dist/maplibre-gl.css' />


### PR DESCRIPTION
## Launch Checklist

As raised via a comment in #5138, the [mapbox-gl-draw example](https://maplibre.org/maplibre-gl-js/docs/examples/mapbox-gl-draw/) currently provides an example of using mapbox-gl-draw however the description mentioned maplibre-gl-draw.

This PR updates the description to match the example given.

We also update to mapbox-gl-draw 1.5.0 since from this version the CANVAS class is exposed which we need to override to match the maplibre class. This is necessary for the delete a vertex feature to work and possibly other features.

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [ ] Add an entry to `CHANGELOG.md` under the `## main` section.

Is this done for examples as well?
