### PR TITLE
docs: upgrade maplibre-gl-terradraw to v1.0.1

### DIFF
--- a/test/examples/maplibre-gl-terradraw.html
+++ b/test/examples/maplibre-gl-terradraw.html
@@ -14,10 +14,10 @@
 </head>
 <body>
 
-<script src="https://cdn.jsdelivr.net/npm/@watergis/maplibre-gl-terradraw@0.6.4/dist/maplibre-gl-terradraw.umd.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/@watergis/maplibre-gl-terradraw@1.0.1/dist/maplibre-gl-terradraw.umd.js"></script>
 <link
     rel="stylesheet"
-    href="https://cdn.jsdelivr.net/npm/@watergis/maplibre-gl-terradraw@0.6.4/dist/maplibre-gl-terradraw.css"
+    href="https://cdn.jsdelivr.net/npm/@watergis/maplibre-gl-terradraw@1.0.1/dist/maplibre-gl-terradraw.css"
 />
 <div id="map"></div>
 
@@ -34,7 +34,7 @@
     // you can disable some of modes in the constructor options if you want.
     const draw = new MaplibreTerradrawControl.MaplibreTerradrawControl({
         modes: [
-            'render',
+            // 'render', comment this to always show drawing tool
             'point',
             'linestring',
             'polygon',
@@ -46,11 +46,12 @@
             'sector',
             'select',
             'delete-selection',
-            'delete'
+            'delete',
+            'download'
         ],
         open: true,
     });
-    map.addControl(draw, 'top-right');
+    map.addControl(draw, 'top-left');
 </script>
 </body>
 </html>


### PR DESCRIPTION
maplibre-gl-terradraw is now v1.0.1, I have updated the plugin version in the example page

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [ ] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [ ] Link to related issues.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [ ] Add an entry to `CHANGELOG.md` under the `## main` section.
