### PR TITLE
Fix URL hash bearing validation range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐞 Bug fixes
 - _...Add new stuff here..._
 - Fix how padding is applied when using flyTo() with Globe ([#5406](https://github.com/maplibre/maplibre-gl-js/pull/5406))
+- Fix URL hash validation to support bearing range -180 to 180 ([#5461](https://github.com/maplibre/maplibre-gl-js/issues/5461))
 
 ## 5.1.0
 

--- a/src/ui/hash.test.ts
+++ b/src/ui/hash.test.ts
@@ -341,6 +341,10 @@ describe('hash', () => {
             window.location.hash = '#5/1.00/0.50/30/60';
 
             expect(hash._isValidHash(hash._getCurrentHash())).toBeTruthy();
+
+            window.location.hash = '#5/1.00/0.50/-30/60';
+
+            expect(hash._isValidHash(hash._getCurrentHash())).toBeTruthy();
         });
 
         test('invalidate hash with string values', () => {
@@ -363,6 +367,16 @@ describe('hash', () => {
 
         test('invalidate hash, latitude out of range', () => {
             window.location.hash = '#10/100.00/-1.00';
+
+            expect(hash._isValidHash(hash._getCurrentHash())).toBeFalsy();
+        });
+
+        test('invalidate hash, bearing out of range', () => {
+            window.location.hash = '#10/3.00/-1.00/450';
+
+            expect(hash._isValidHash(hash._getCurrentHash())).toBeFalsy();
+
+            window.location.hash = '#10/3.00/-1.00/-450';
 
             expect(hash._isValidHash(hash._getCurrentHash())).toBeFalsy();
         });

--- a/src/ui/hash.ts
+++ b/src/ui/hash.ts
@@ -172,7 +172,7 @@ export class Hash {
         const pitch = +(hash[4] || 0);
 
         return zoom >= this._map.getMinZoom() && zoom <= this._map.getMaxZoom() &&
-            bearing >= 0 && bearing <= 180 &&
+            bearing >= -180 && bearing <= 180 &&
             pitch >= this._map.getMinPitch() && pitch <= this._map.getMaxPitch();
     };
 }


### PR DESCRIPTION
Bearing rotation of the map has range: -180 to 180. In this PR: #5241 URL hash validation was introduced, however the allowed bearing range is set to 0 - 180. This PR fixes the value, and added tests to cover bearing range below zero.

Related to #5461 .

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [x] Add an entry to `CHANGELOG.md` under the `## main` section.
