### PR TITLE
feat(events): check if event instanceof MouseEvent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### ✨ Features and improvements
 
+- Add a check for MouseEvent, to avoid errors when bot were crawling on website using Event instance instead of MouseEvent instance for types like mouseover, mouseout etc.. ([#5466](https://github.com/maplibre/maplibre-gl-js/pull/5466)).
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes

--- a/src/ui/events.ts
+++ b/src/ui/events.ts
@@ -536,6 +536,7 @@ export class MapMouseEvent extends Event implements MapLibreEvent<MouseEvent> {
     _defaultPrevented: boolean;
 
     constructor(type: string, map: Map, originalEvent: MouseEvent, data: any = {}) {
+        originalEvent = originalEvent instanceof MouseEvent ? originalEvent : new MouseEvent(type, originalEvent);
         const point = DOM.mousePos(map.getCanvas(), originalEvent);
         const lngLat = map.unproject(point);
         super(type, extend({point, lngLat, originalEvent}, data));

--- a/src/ui/handler/map_event.test.ts
+++ b/src/ui/handler/map_event.test.ts
@@ -156,4 +156,29 @@ describe('map events', () => {
         simulate.contextmenu(map.getCanvas(), {target, button: 2, clientX: 10, clientY: 10}); // triggered only after mouseup
         expect(contextmenu).toHaveBeenCalledTimes(0);
     });
+
+    test('MapMouseEvent constructor does not throw error with Event instance instead of MouseEvent as originalEvent param', () => {
+        const map = createMap();
+        const target = map.getCanvasContainer();
+
+        expect(()=> {
+            target.dispatchEvent(new Event('mousedown'));
+            target.dispatchEvent(new Event('mouseup'));
+            target.dispatchEvent(new Event('click'));
+            target.dispatchEvent(new Event('dblclick'));
+            target.dispatchEvent(new Event('mousemove'));
+            target.dispatchEvent(new Event('mouseover'));
+            target.dispatchEvent(new Event('mouseenter'));
+            target.dispatchEvent(new Event('mouseleave'));
+            target.dispatchEvent(new Event('mouseout'));
+            target.dispatchEvent(new Event('contextmenu'));
+            target.dispatchEvent(new Event('wheel'));
+
+            target.dispatchEvent(new Event('touchstart'));
+            target.dispatchEvent(new Event('touchmove'));
+            target.dispatchEvent(new Event('touchmoveWindow'));
+            target.dispatchEvent(new Event('touchend'));
+            target.dispatchEvent(new Event('touchcancel'));
+        }).not.toThrow();
+    });
 });

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -6,6 +6,7 @@ import type {WorkerGlobalScopeInterface} from './web_worker';
 import {mat3, mat4, quat, vec2, type vec3, type vec4} from 'gl-matrix';
 import {pixelsToTileUnits} from '../source/pixels_to_tile_units';
 import {type OverscaledTileID} from '../source/tile_id';
+import type {Event} from './evented';
 
 /**
  * Returns a new 64 bit float vec4 of zeroes.
@@ -1035,3 +1036,37 @@ export const MAX_TILE_ZOOM = 25;
 export const MIN_TILE_ZOOM = 0;
 
 export const MAX_VALID_LATITUDE = 85.051129;
+
+const touchableEvents = {
+    touchstart: true,
+    touchmove: true,
+    touchmoveWindow: true,
+    touchend: true,
+    touchcancel: true
+};
+
+const pointableEvents = {
+    dblclick: true,
+    click: true,
+    mouseover: true,
+    mouseout: true,
+    mousedown: true,
+    mousemove: true,
+    mousemoveWindow: true,
+    mouseup: true,
+    mouseupWindow: true,
+    contextmenu: true,
+    wheel: true
+};
+
+export function isTouchableEvent(event: Event, eventType: string): event is TouchEvent {
+    return touchableEvents[eventType] && 'touches' in event;
+}
+
+export function isPointableEvent(event: Event, eventType: string): event is MouseEvent {
+    return pointableEvents[eventType] && (event instanceof MouseEvent || event instanceof WheelEvent);
+}
+
+export function isTouchableOrPointableType(eventType: string): boolean {
+    return touchableEvents[eventType] || pointableEvents[eventType];
+}

--- a/test/build/min.test.ts
+++ b/test/build/min.test.ts
@@ -38,7 +38,7 @@ describe('test min build', () => {
         const decreaseQuota = 4096;
 
         // feel free to update this value after you've checked that it has changed on purpose :-)
-        const expectedBytes = 909795;
+        const expectedBytes = 910913;
 
         expect(actualBytes).toBeLessThan(expectedBytes + increaseQuota);
         expect(actualBytes).toBeGreaterThan(expectedBytes - decreaseQuota);


### PR DESCRIPTION
Fix an error that could happen if a instance of Event is dispatched with MouseEvent types. This error has been encountered only when bots were crawling a website where a maplibre map was instanced.

- Fixes https://github.com/maplibre/maplibre-gl-js/issues/5464

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [x] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality.
 - [x] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [x] Add an entry to `CHANGELOG.md` under the `## main` section.
