### PR TITLE
add migrateProjection to bench StubMap

### DIFF
--- a/test/bench/lib/tile_parser.ts
+++ b/test/bench/lib/tile_parser.ts
@@ -39,6 +39,8 @@ class StubMap extends Evented {
     _getMapId() {
         return 1;
     }
+
+    migrateProjection() {}
 }
 
 function createStyle(styleJSON: StyleSpecification): Promise<Style> {


### PR DESCRIPTION
Quick little PR to fix an issue with the Layout benchmarks. Trying to load the style would result in a silent exception that made the test just sit there and spin.