### PR TITLE
Fix excessive attribution control rerendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 - Fix intersection detection between MultiPolygons and Points ([#5590](https://github.com/maplibre/maplibre-gl-js/pull/5590))
 - Fix issue with image rendered partially on terrain tiles ([#1559](https://github.com/maplibre/maplibre-gl-js/issues/1559)).
+- Fix excessive attribution control rerendering ([#5673](https://github.com/maplibre/maplibre-gl-js/pull/5673))
 - _...Add new stuff here..._
 
 ## 5.2.0

--- a/src/ui/control/attribution_control.test.ts
+++ b/src/ui/control/attribution_control.test.ts
@@ -359,6 +359,31 @@ describe('AttributionControl', () => {
         expect(attribution._innerContainer.innerHTML).toBe('Used');
     });
 
+    test('sanitizes html content in attributions', async () => {
+        const attributionControl = new AttributionControl({
+            customAttribution: 'MapLibre<script>alert("xss")</script>'
+        });
+        map.addControl(attributionControl);
+        await map.once('load');
+
+        expect(attributionControl._innerContainer.innerHTML).toBe('MapLibre');
+    });
+
+    test('only recreates attributions if sanitized attribution content changes', async () => {
+        const attributionControl = new AttributionControl({
+            customAttribution: 'MapLibre<script>alert("xss")</script>'
+        });
+        map.addControl(attributionControl);
+        await map.once('load');
+
+        // this will be overwritten if the attribution control re-renders for any reason
+        attributionControl._innerContainer.innerHTML = 'unchanged';
+        map.addSource('1', {type: 'geojson', data: {type: 'FeatureCollection', features: []}});
+
+        await sleep(100);
+
+        expect(attributionControl._innerContainer.innerHTML).toBe('unchanged');
+    });
 });
 
 describe('AttributionControl test regarding the HTML elements details and summary', () => {

--- a/src/ui/control/attribution_control.ts
+++ b/src/ui/control/attribution_control.ts
@@ -44,7 +44,7 @@ export class AttributionControl implements IControl {
     _innerContainer: HTMLElement;
     _compactButton: HTMLElement;
     _editLink: HTMLAnchorElement;
-    _sanitizedAttributionHTML: string;
+    _attribHTML: string;
     styleId: string;
     styleOwner: string;
 
@@ -93,7 +93,7 @@ export class AttributionControl implements IControl {
 
         this._map = undefined;
         this._compact = undefined;
-        this._sanitizedAttributionHTML = undefined;
+        this._attribHTML = undefined;
     }
 
     _setElementTitle(element: HTMLElement, title: 'ToggleAttribution' | 'MapFeedback') {
@@ -168,12 +168,12 @@ export class AttributionControl implements IControl {
 
         // check if attribution string is different to minimize DOM changes
         const attribHTML = attributions.join(' | ');
-        if (attribHTML === this._sanitizedAttributionHTML) return;
+        if (attribHTML === this._attribHTML) return;
 
-        this._sanitizedAttributionHTML = DOM.sanitize(attribHTML);
+        this._attribHTML = attribHTML;
 
         if (attributions.length) {
-            this._innerContainer.innerHTML = this._sanitizedAttributionHTML;
+            this._innerContainer.innerHTML = DOM.sanitize(attribHTML);
             this._container.classList.remove('maplibregl-attrib-empty');
         } else {
             this._container.classList.add('maplibregl-attrib-empty');


### PR DESCRIPTION
## The lead-up

In one of my projects I noticed a weird flickering on the attribution control that seemed to be related to rapid data updates. Notably, it only occurred in Firefox and not in Chromium, so I started to investigate.

## The issue

Since attribution strings can include untrusted HTML, PR #5057 introduces a bit of input sanitization to mitigate potential XSS attacks trough the `attribution` field. The attribution control includes a mechanism to suppress excessive re-renders, but #5057 introduced a bug: The suppression logic compares the cached **sanitized** result with the new **unsanitized** result. This will lead to excessive DOM updates if the sanitized attribution actually differs from the unsanitized one, for instance if it contains a `&copy;` HTML entity that gets transformed into a `©` literal.

## The fix

This PR reverts some of the changes in #5057: The attribution control will cache the unsanitized input again instead of the sanitized result and only call the sanitizer directly when updating the DOM. This might even bring a minor performance improvement since the sanitizer will no longer be called on every update, but only if the unsanitized input has been changed.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [x] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality.
 - [x] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [x] Add an entry to `CHANGELOG.md` under the `## main` section.
