### PR TITLE
Addition to sponsor section

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ Silver:
 
 <a href="https://www.mapme.com/"><img src="https://maplibre.org/img/mapme-logo.svg" alt="Logo mapme" width="25%"/></a>
 
+<a href="https://www.maptiler.com/"><img src="https://maplibre.org/img/maptiler-logo.svg" alt="Logo maptiler" width="25%"/></a>
+
 Backers and Supporters:
 
 <a href="https://opencollective.com/maplibre/backer/0/website?requireActive=false" target="_blank"><img src="https://opencollective.com/maplibre/backer/0/avatar.svg?requireActive=false"></a>


### PR DESCRIPTION
PR to add [MapTiler logo to sponsor list](https://maplibre.org/news/2025-03-31-maptiler-announcement/) in the readme file.