### PR TITLE
Fix #5473 - Marker drag Coordinates give Longitude off by ±360° with Globe

### DIFF
--- a/src/ui/marker.ts
+++ b/src/ui/marker.ts
@@ -601,7 +601,7 @@ export class Marker extends Evented {
             this._map.once('render', this._update);
         }
 
-        if (this._map.transform.renderWorldCopies) {
+        if (this._map.transform.renderWorldCopies && this._map.getProjection().type != 'globe') {
             this._lngLat = smartWrap(this._lngLat, this._flatPos, this._map.transform);
         } else {
             this._lngLat = this._lngLat?.wrap();


### PR DESCRIPTION
In marker update added check if projection is not equal to `globe`. Fixes https://github.com/maplibre/maplibre-gl-js/issues/5473

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Document any changes to public APIs.
 - [ ] Add an entry to `CHANGELOG.md` under the `## main` section.
