### PR TITLE
Cleanup GL pixelStore state after texture upload

### DIFF
--- a/src/render/texture.ts
+++ b/src/render/texture.ts
@@ -78,6 +78,10 @@ export class Texture {
         if (this.useMipmap && this.isSizePowerOfTwo()) {
             gl.generateMipmap(gl.TEXTURE_2D);
         }
+
+        context.pixelStoreUnpackFlipY.setDefault();
+        context.pixelStoreUnpack.setDefault();
+        context.pixelStoreUnpackPremultiplyAlpha.setDefault();
     }
 
     bind(filter: TextureFilter, wrap: TextureWrap, minFilter?: TextureFilter | null) {


### PR DESCRIPTION
Cleans up glPixelStore state after texture updates in MapLibre.

This is global GL state that affects how texture uploads work (glTexSubImage2D, etc.). Not cleaning it would cause glTexSubImage2D calls made by the user to randomly act differently, depending on whether MapLibre did any texture updates that frame or not. Note that the cleanup is only necessary in texture.ts, changing pixelStore state during rendering of an actual frame is okay, since painter calls `context.setDefault();` at the very end, which resets it to default. 