### PR TITLE
Update run_render_tests.ts to allow creating images when missing

### DIFF
--- a/test/integration/render/run_render_tests.ts
+++ b/test/integration/render/run_render_tests.ts
@@ -182,9 +182,12 @@ function compareRenderResults(directory: string, testData: TestData, data: Uint8
         }
     }
 
-    const diffBuf = PNG.sync.write(minDiffImg, {filterType: 4});
-
-    fs.writeFileSync(diffPath, diffBuf);
+    if (minDiffImg) {
+        const diffBuf = PNG.sync.write(minDiffImg, {filterType: 4});
+        fs.writeFileSync(diffPath, diffBuf);
+        testData.diff = diffBuf.toString('base64');
+        testData.expected = minExpectedBuf.toString('base64');
+    }
     fs.writeFileSync(actualPath, actualBuf);
 
     testData.difference = minDiff;
@@ -194,9 +197,6 @@ function compareRenderResults(directory: string, testData: TestData, data: Uint8
         console.log(`Updating ${expectedPath}`);
         fs.writeFileSync(expectedPath, PNG.sync.write(actualImg));
     }
-
-    testData.expected = minExpectedBuf.toString('base64');
-    testData.diff = diffBuf.toString('base64');
 }
 
 /**


### PR DESCRIPTION
## Launch Checklist

- Fixes #5714

Moving some logic of the render test into an if to avoid harness failure in case of missing expected image (the case of adding a new render test by creating a folder and placing a style.json file only).

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
