### PR TITLE
Revert popup close memory leak fix attempt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐞 Bug fixes
 
 - The state of `glPixelStore` is now properly cleaned after texture updates to avoid `glTexSubImage2D` calls made on the same gl context acting differently at random ([#5730](https://github.com/maplibre/maplibre-gl-js/pull/5730))
+- Fixes an issue with popup close button not working ([#5754](https://github.com/maplibre/maplibre-gl-js/pull/5754))
 - _...Add new stuff here..._
 
 ## 5.3.0

--- a/src/ui/marker.test.ts
+++ b/src/ui/marker.test.ts
@@ -161,18 +161,19 @@ describe('marker', () => {
     });
 
     test('Marker#setPopup binds a popup and allow closing it with click', () => {
+        const map = createMap();
         const popup = new Popup()
             .setText('Test');
         const marker = new Marker()
             .setLngLat([0,0])
             .setPopup(popup)
-            .addTo(createMap());
+            .addTo(map);
         
         // open popup
         marker.togglePopup();
         const spy = vi.fn();
         popup.on('close', spy);
-        (document.getElementsByClassName('maplibregl-popup-close-button')[0] as HTMLButtonElement).click();
+        (map.getContainer().querySelector('.maplibregl-popup-close-button') as HTMLButtonElement).click();
 
         expect(spy).toHaveBeenCalled();
     });

--- a/src/ui/marker.test.ts
+++ b/src/ui/marker.test.ts
@@ -170,7 +170,7 @@ describe('marker', () => {
         
         // open popup
         marker.togglePopup();
-        let spy = vi.fn();
+        const spy = vi.fn();
         popup.on('close', spy);
         (document.getElementsByClassName('maplibregl-popup-close-button')[0] as HTMLButtonElement).click();
 

--- a/src/ui/marker.test.ts
+++ b/src/ui/marker.test.ts
@@ -160,6 +160,23 @@ describe('marker', () => {
         expect(!marker.getPopup()).toBeTruthy();
     });
 
+    test('Marker#setPopup binds a popup and allow closing it with click', () => {
+        const popup = new Popup()
+            .setText('Test');
+        const marker = new Marker()
+            .setLngLat([0,0])
+            .setPopup(popup)
+            .addTo(createMap());
+        
+        // open popup
+        marker.togglePopup();
+        let spy = vi.fn();
+        popup.on('close', spy);
+        (document.getElementsByClassName('maplibregl-popup-close-button')[0] as HTMLButtonElement).click();
+
+        expect(spy).toHaveBeenCalled();
+    });
+
     test('Marker#togglePopup opens a popup that was closed', async () => {
         const map = createMap();
         const marker = new Marker()

--- a/src/ui/popup.test.ts
+++ b/src/ui/popup.test.ts
@@ -498,6 +498,20 @@ describe('popup', () => {
         expect(map.getContainer().querySelectorAll('.maplibregl-popup')).toHaveLength(1);
     });
 
+    test('Popup can be removed and added again can be closed with click (#5576)', () => {
+        const map = createMap();
+
+        new Popup()
+            .setText('Test')
+            .setLngLat([0, 0])
+            .addTo(map)
+            .addTo(map);
+
+        (map.getContainer().querySelector('.maplibregl-popup-close-button') as HTMLButtonElement).click();
+
+        expect(map.getContainer().querySelectorAll('.maplibregl-popup')).toHaveLength(0);
+    });
+
     test('Popup#addTo is idempotent (#1811)', () => {
         const map = createMap();
 

--- a/src/ui/popup.ts
+++ b/src/ui/popup.ts
@@ -273,10 +273,6 @@ export class Popup extends Evented {
             delete this._container;
         }
 
-        if(this._closeButton){
-            this._closeButton.removeEventListener('click', this._onClose);
-        }
-
         if (this._map) {
             this._map.off('move', this._update);
             this._map.off('move', this._onClose);


### PR DESCRIPTION
## Launch Checklist

- This reverts #5564
- Fixes #5718
- Fixes #5576

It adds the relevant test to make sure this won't break in the future, hopefully.

CC: @kamil-sienkiewicz-asi 

Looking at the code and at the fix I think the removeevent and addevent are not symmetrical, which is what is causing the issue. The creation of the button is not done when adding to the map and so the removal can't be done when removing from the map.
I'll be happy to review a different fix to this issue.


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [x] Write tests for all new functionality.
 - [x] Add an entry to `CHANGELOG.md` under the `## main` section.
