### PR TITLE
Remove top level promise in tests

### DIFF
--- a/src/source/canvas_source.test.ts
+++ b/src/source/canvas_source.test.ts
@@ -116,7 +116,7 @@ describe('CanvasSource', () => {
 
         source.onAdd(map);
 
-        await expect(promise).resolves.toBeUndefined();
+        await expect(promise).resolves.toBeDefined();
     });
 
     test('can be static', async () => {
@@ -131,7 +131,7 @@ describe('CanvasSource', () => {
 
         source.onAdd(map);
 
-        await expect(promise).resolves.toBeUndefined();
+        await expect(promise).resolves.toBeDefined();
         expect(spy).not.toHaveBeenCalled();
     });
 

--- a/src/source/canvas_source.test.ts
+++ b/src/source/canvas_source.test.ts
@@ -1,13 +1,14 @@
 import {describe, beforeEach, test, expect, vi} from 'vitest';
 import {CanvasSource} from '../source/canvas_source';
-import {type IReadonlyTransform} from '../geo/transform_interface';
 import {Event, Evented} from '../util/evented';
 import {extend} from '../util/util';
-
-import type {Dispatcher} from '../util/dispatcher';
 import {Tile} from './tile';
 import {OverscaledTileID} from './tile_id';
 import {MercatorTransform} from '../geo/projection/mercator_transform';
+import {waitForEvent} from '../util/test/util';
+import type {IReadonlyTransform} from '../geo/transform_interface';
+import type {Dispatcher} from '../util/dispatcher';
+import type {MapSourceDataEvent} from '../ui/events';
 
 function createSource(options?) {
     const c = options && options.canvas || window.document.createElement('canvas');
@@ -53,22 +54,21 @@ describe('CanvasSource', () => {
         map = new StubMap();
     });
 
-    test('constructor', () => new Promise<void>(done => {
+    test('constructor', async () => {
         const source = createSource();
 
         expect(source.minzoom).toBe(0);
         expect(source.maxzoom).toBe(22);
         expect(source.tileSize).toBe(512);
         expect(source.animate).toBe(true);
-        source.on('data', (e) => {
-            if (e.dataType === 'source' && e.sourceDataType === 'metadata') {
-                expect(typeof source.play).toBe('function');
-                done();
-            }
-        });
+
+        const promise = waitForEvent(source, 'data', (e: MapSourceDataEvent) => e.dataType === 'source' && e.sourceDataType === 'metadata');
 
         source.onAdd(map);
-    }));
+        await promise;
+
+        expect(typeof source.play).toBe('function');
+    });
 
     test('self-validates', () => {
         const stub = vi.spyOn(console, 'error').mockImplementation(() => {});
@@ -95,53 +95,45 @@ describe('CanvasSource', () => {
 
     });
 
-    test('can be initialized with HTML element', () => new Promise<void>(done => {
+    test('can be initialized with HTML element', async () => {
         const el = window.document.createElement('canvas');
         const source = createSource({
             canvas: el
         });
 
-        source.on('data', (e) => {
-            if (e.dataType === 'source' && e.sourceDataType === 'metadata') {
-                expect(source.canvas).toBe(el);
-                done();
-            }
-        });
+        const prmoise = waitForEvent(source, 'data', (e: MapSourceDataEvent) => e.dataType === 'source' && e.sourceDataType === 'metadata');
 
         source.onAdd(map);
-    }));
 
-    test('rerenders if animated', () => new Promise<void>(done => {
+        await prmoise;
+        expect(source.canvas).toBe(el);
+    });
+
+    test('rerenders if animated', async () => {
         const source = createSource();
 
-        map.on('rerender', () => {
-            expect(true).toBeTruthy();
-            done();
-        });
+        const promise = waitForEvent(map, 'rerender', () => true);
 
         source.onAdd(map);
-    }));
 
-    test('can be static', () => new Promise<void>(done => {
+        await expect(promise).resolves.toBeUndefined();
+    });
+
+    test('can be static', async () => {
         const source = createSource({
             animate: false
         });
 
-        map.on('rerender', () => {
-            // this just confirms it didn't happen, so no need to run done() here
-            // if called the test will fail
-            expect(true).toBeFalsy();
-        });
+        const spy = vi.fn();
+        map.on('rerender', spy);
 
-        source.on('data', (e) => {
-            if (e.sourceDataType === 'metadata' && e.dataType === 'source') {
-                expect(true).toBeTruthy();
-                done();
-            }
-        });
+        const promise = waitForEvent(source, 'data', (e: MapSourceDataEvent) => e.dataType === 'source' && e.sourceDataType === 'metadata');
 
         source.onAdd(map);
-    }));
+
+        await expect(promise).resolves.toBeUndefined();
+        expect(spy).not.toHaveBeenCalled();
+    });
 
     test('onRemove stops animation', () => {
         const source = createSource();
@@ -177,15 +169,11 @@ describe('CanvasSource', () => {
 
     });
 
-    test('fires idle event on prepare call when there is at least one not loaded tile', () => new Promise<void>(done => {
+    test('fires idle event on prepare call when there is at least one not loaded tile', async () => {
         const source = createSource();
         const tile = new Tile(new OverscaledTileID(1, 0, 1, 0, 0), 512);
-        source.on('data', (e) => {
-            if (e.dataType === 'source' && e.sourceDataType === 'idle') {
-                expect(tile.state).toBe('loaded');
-                done();
-            }
-        });
+
+        const promise = waitForEvent(source, 'data', (e: MapSourceDataEvent) => e.dataType === 'source' && e.sourceDataType === 'idle');
         source.onAdd(map);
 
         source.tiles[String(tile.tileID.wrap)] = tile;
@@ -194,7 +182,10 @@ describe('CanvasSource', () => {
             update: () => {}
         } as any;
         source.prepare();
-    }));
+
+        await promise;
+        expect(tile.state).toBe('loaded');
+    });
 
 });
 

--- a/src/source/image_source.test.ts
+++ b/src/source/image_source.test.ts
@@ -5,7 +5,7 @@ import {type IReadonlyTransform} from '../geo/transform_interface';
 import {extend, MAX_TILE_ZOOM} from '../util/util';
 import {type FakeServer, fakeServer} from 'nise';
 import {type RequestManager} from '../util/request_manager';
-import {sleep, stubAjaxGetImage} from '../util/test/util';
+import {sleep, stubAjaxGetImage, waitForEvent} from '../util/test/util';
 import {Tile} from './tile';
 import {OverscaledTileID} from './tile_id';
 import {type Texture} from '../render/texture';
@@ -128,38 +128,27 @@ describe('ImageSource', () => {
         expect(afterSerialized.coordinates).toEqual([[0, 0], [-1, 0], [-1, -1], [0, -1]]);
     });
 
-    test('fires data event when content is loaded', () => new Promise<void>(done => {
+    test('fires data event when content is loaded', async () => {
         const source = createSource({url: '/image.png'});
-        source.on('data', (e) => {
-            if (e.dataType === 'source' && e.sourceDataType === 'content') {
-                expect(typeof source.tileID == 'object').toBeTruthy();
-                done();
-            }
-        });
+        const promise = waitForEvent(source, 'data', (e) => e.dataType === 'source' && e.sourceDataType === 'content');
         source.onAdd(new StubMap() as any);
         server.respond();
-    }));
+        await promise;
+        expect(typeof source.tileID == 'object').toBeTruthy();
+    });
 
-    test('fires data event when metadata is loaded', () => new Promise<void>(done => {
+    test('fires data event when metadata is loaded', async () => {
         const source = createSource({url: '/image.png'});
-        source.on('data', (e) => {
-            if (e.dataType === 'source' && e.sourceDataType === 'metadata') {
-                done();
-            }
-        });
+        const promise = waitForEvent(source, 'data', (e) => e.dataType === 'source' && e.sourceDataType === 'metadata');
         source.onAdd(new StubMap() as any);
         server.respond();
-    }));
+        await expect(promise).resolves.toBeDefined();
+    });
 
-    test('fires idle event on prepare call when there is at least one not loaded tile', () => new Promise<void>(done => {
+    test('fires idle event on prepare call when there is at least one not loaded tile', async () => {
         const source = createSource({url: '/image.png'});
         const tile = new Tile(new OverscaledTileID(1, 0, 1, 0, 0), 512);
-        source.on('data', (e) => {
-            if (e.dataType === 'source' && e.sourceDataType === 'idle') {
-                expect(tile.state).toBe('loaded');
-                done();
-            }
-        });
+        const promise = waitForEvent(source, 'data', (e) => e.dataType === 'source' && e.sourceDataType === 'idle');
         source.onAdd(new StubMap() as any);
         server.respond();
 
@@ -168,7 +157,9 @@ describe('ImageSource', () => {
         // assign dummies directly so we don't need to stub the gl things
         source.texture = {} as Texture;
         source.prepare();
-    }));
+        await promise;
+        expect(tile.state).toBe('loaded');
+    });
 
     test('serialize url and coordinates', () => {
         const source = createSource({url: '/image.png'});

--- a/src/source/raster_tile_source.test.ts
+++ b/src/source/raster_tile_source.test.ts
@@ -5,7 +5,8 @@ import {RequestManager} from '../util/request_manager';
 import {type Dispatcher} from '../util/dispatcher';
 import {fakeServer, type FakeServer} from 'nise';
 import {type Tile} from './tile';
-import {stubAjaxGetImage} from '../util/test/util';
+import {stubAjaxGetImage, waitForEvent} from '../util/test/util';
+import {type MapSourceDataEvent} from '../ui/events';
 
 function createSource(options, transformCallback?) {
     const source = new RasterTileSource('id', options, {send() {}} as any as Dispatcher, options.eventedParent);
@@ -51,7 +52,7 @@ describe('RasterTileSource', () => {
         expect(transformSpy.mock.calls[0][1]).toBe('Source');
     });
 
-    test('respects TileJSON.bounds', () => new Promise<void>(done => {
+    test('respects TileJSON.bounds', async () => {
         const source = createSource({
             minzoom: 0,
             maxzoom: 22,
@@ -59,16 +60,14 @@ describe('RasterTileSource', () => {
             tiles: ['http://example.com/{z}/{x}/{y}.png'],
             bounds: [-47, -7, -45, -5]
         });
-        source.on('data', (e) => {
-            if (e.sourceDataType === 'metadata') {
-                expect(source.hasTile(new OverscaledTileID(8, 0, 8, 96, 132))).toBeFalsy();
-                expect(source.hasTile(new OverscaledTileID(8, 0, 8, 95, 132))).toBeTruthy();
-                done();
-            }
-        });
-    }));
 
-    test('does not error on invalid bounds', () => new Promise<void>(done => {
+        await waitForEvent(source, 'data', (e: MapSourceDataEvent) => e.sourceDataType === 'metadata');
+
+        expect(source.hasTile(new OverscaledTileID(8, 0, 8, 96, 132))).toBeFalsy();
+        expect(source.hasTile(new OverscaledTileID(8, 0, 8, 95, 132))).toBeTruthy();
+    });
+
+    test('does not error on invalid bounds', async () => {
         const source = createSource({
             minzoom: 0,
             maxzoom: 22,
@@ -77,15 +76,12 @@ describe('RasterTileSource', () => {
             bounds: [-47, -7, -45, 91]
         });
 
-        source.on('data', (e) => {
-            if (e.sourceDataType === 'metadata') {
-                expect(source.tileBounds.bounds).toEqual({_sw: {lng: -47, lat: -7}, _ne: {lng: -45, lat: 90}});
-                done();
-            }
-        });
-    }));
+        await waitForEvent(source, 'data', (e: MapSourceDataEvent) => e.sourceDataType === 'metadata');
 
-    test('respects TileJSON.bounds when loaded from TileJSON', () => new Promise<void>(done => {
+        expect(source.tileBounds.bounds).toEqual({_sw: {lng: -47, lat: -7}, _ne: {lng: -45, lat: 90}});  
+    });
+
+    test('respects TileJSON.bounds when loaded from TileJSON', async () => {
         server.respondWith('/source.json', JSON.stringify({
             minzoom: 0,
             maxzoom: 22,
@@ -95,17 +91,15 @@ describe('RasterTileSource', () => {
         }));
         const source = createSource({url: '/source.json'});
 
-        source.on('data', (e) => {
-            if (e.sourceDataType === 'metadata') {
-                expect(source.hasTile(new OverscaledTileID(8, 0, 8, 96, 132))).toBeFalsy();
-                expect(source.hasTile(new OverscaledTileID(8, 0, 8, 95, 132))).toBeTruthy();
-                done();
-            }
-        });
+        const promise = waitForEvent(source, 'data', (e: MapSourceDataEvent) => e.sourceDataType === 'metadata');
         server.respond();
-    }));
 
-    test('transforms tile urls before requesting', () => new Promise<void>(done => {
+        await promise;
+        expect(source.hasTile(new OverscaledTileID(8, 0, 8, 96, 132))).toBeFalsy();
+        expect(source.hasTile(new OverscaledTileID(8, 0, 8, 95, 132))).toBeTruthy();
+    });
+
+    test('transforms tile urls before requesting', async () => {
         server.respondWith('/source.json', JSON.stringify({
             minzoom: 0,
             maxzoom: 22,
@@ -115,25 +109,22 @@ describe('RasterTileSource', () => {
         }));
         const source = createSource({url: '/source.json'});
         const transformSpy = vi.spyOn(source.map._requestManager, 'transformRequest');
-        source.on('data', (e) => {
-            if (e.sourceDataType === 'metadata') {
-                const tile = {
-                    tileID: new OverscaledTileID(10, 0, 10, 5, 5),
-                    state: 'loading',
-                    loadVectorData () {},
-                    setExpiryData() {}
-                } as any as Tile;
-                source.loadTile(tile);
-                expect(transformSpy).toHaveBeenCalledTimes(1);
-                expect(transformSpy.mock.calls[0][0]).toBe('http://example.com/10/5/5.png');
-                expect(transformSpy.mock.calls[0][1]).toBe('Tile');
-                done();
-            }
-        });
+        const promise = waitForEvent(source, 'data', (e: MapSourceDataEvent) => e.sourceDataType === 'metadata');
         server.respond();
-    }));
+        await promise;
+        const tile = {
+            tileID: new OverscaledTileID(10, 0, 10, 5, 5),
+            state: 'loading',
+            loadVectorData () {},
+            setExpiryData() {}
+        } as any as Tile;
+        source.loadTile(tile);
+        expect(transformSpy).toHaveBeenCalledTimes(1);
+        expect(transformSpy.mock.calls[0][0]).toBe('http://example.com/10/5/5.png');
+        expect(transformSpy.mock.calls[0][1]).toBe('Tile');
+    });
 
-    test('HttpImageElement used to get image when refreshExpiredTiles is false', () => new Promise<void>(done => {
+    test('HttpImageElement used to get image when refreshExpiredTiles is false', async () => {
         stubAjaxGetImage(undefined);
         server.respondWith('/source.json', JSON.stringify({
             minzoom: 0,
@@ -147,21 +138,17 @@ describe('RasterTileSource', () => {
         source.map._refreshExpiredTiles = false;
 
         const imageConstructorSpy = vi.spyOn(global, 'Image');
-        source.on('data', (e) => {
-            if (e.sourceDataType === 'metadata') {
-                const tile = {
-                    tileID: new OverscaledTileID(10, 0, 10, 5, 5),
-                    state: 'loading'
-                } as any as Tile;
-                source.loadTile(tile).then(() => {
-                    expect(imageConstructorSpy).toHaveBeenCalledTimes(1);
-                    expect(tile.state).toBe('loaded');
-                    done();
-                });
-            }
-        });
+        const promise = waitForEvent(source, 'data', (e: MapSourceDataEvent) => e.sourceDataType === 'metadata');
         server.respond();
-    }));
+        await promise;
+        const tile = {
+            tileID: new OverscaledTileID(10, 0, 10, 5, 5),
+            state: 'loading'
+        } as any as Tile;
+        await source.loadTile(tile);
+        expect(imageConstructorSpy).toHaveBeenCalledTimes(1);
+        expect(tile.state).toBe('loaded');
+    });
 
     test('supports updating tiles', () => {
         const source = createSource({url: '/source.json'});

--- a/src/source/vector_tile_source.test.ts
+++ b/src/source/vector_tile_source.test.ts
@@ -7,7 +7,7 @@ import {OverscaledTileID} from './tile_id';
 import {Evented} from '../util/evented';
 import {RequestManager} from '../util/request_manager';
 import fixturesSource from '../../test/unit/assets/source.json' with {type: 'json'};
-import {getMockDispatcher, getWrapDispatcher, sleep, waitForMetadataEvent} from '../util/test/util';
+import {getMockDispatcher, getWrapDispatcher, sleep, waitForEvent, waitForMetadataEvent} from '../util/test/util';
 import {type Map} from '../ui/map';
 import {type WorkerTileParameters} from './worker_source';
 import {SubdivisionGranularitySetting} from '../render/subdivision_granularity_settings';
@@ -87,14 +87,13 @@ describe('VectorTileSource', () => {
         expect(transformSpy).toHaveBeenCalledWith('/source.json', 'Source');
     });
 
-    test('fires event with metadata property', () => new Promise<void>(done => {
+    test('fires event with metadata property', async () => {
         server.respondWith('/source.json', JSON.stringify(fixturesSource));
         const source = createSource({url: '/source.json'});
-        source.on('data', (e) => {
-            if (e.sourceDataType === 'content') done();
-        });
+        const dataEvent = waitForEvent(source, 'data', (e) => e.sourceDataType === 'content');
         server.respond();
-    }));
+        await expect(dataEvent).resolves.toBeDefined();
+    });
 
     test('fires "dataloading" event', async () => {
         server.respondWith('/source.json', JSON.stringify(fixturesSource));

--- a/src/source/video_source.test.ts
+++ b/src/source/video_source.test.ts
@@ -1,7 +1,7 @@
 import {describe, test, expect} from 'vitest';
 import {VideoSource} from './video_source';
 import {extend} from '../util/util';
-import {getMockDispatcher} from '../util/test/util';
+import {getMockDispatcher, waitForEvent} from '../util/test/util';
 
 import type {Coordinates} from './image_source';
 import {Tile} from './tile';
@@ -87,7 +87,7 @@ describe('VideoSource', () => {
         expect(source.getVideo()).toBe(el);
     });
 
-    test('fires idle event on prepare call when there is at least one not loaded tile', () => new Promise<void>(done => {
+    test('fires idle event on prepare call when there is at least one not loaded tile', async () => {
         const source = createSource({
             type: 'video',
             urls: [],
@@ -103,12 +103,7 @@ describe('VideoSource', () => {
             ]
         });
         const tile = new Tile(new OverscaledTileID(1, 0, 1, 0, 0), 512);
-        source.on('data', (e) => {
-            if (e.dataType === 'source' && e.sourceDataType === 'idle') {
-                expect(tile.state).toBe('loaded');
-                done();
-            }
-        });
+        const dataEvent = waitForEvent(source, 'data', (e) => e.dataType === 'source' && e.sourceDataType === 'idle');
         source.onAdd(new StubMap() as any);
 
         source.tiles[String(tile.tileID.wrap)] = tile;
@@ -118,5 +113,7 @@ describe('VideoSource', () => {
             bind: () => {}
         } as any;
         source.prepare();
-    }));
+        await dataEvent;
+        expect(tile.state).toBe('loaded');
+    });
 });

--- a/src/style/style.test.ts
+++ b/src/style/style.test.ts
@@ -12,8 +12,8 @@ import {fakeServer, type FakeServer} from 'nise';
 
 import {type EvaluationParameters} from './evaluation_parameters';
 import {type LayerSpecification, type GeoJSONSourceSpecification, type FilterSpecification, type SourceSpecification, type StyleSpecification, type SymbolLayerSpecification, type SkySpecification} from '@maplibre/maplibre-gl-style-spec';
-import {type GeoJSONSource} from '../source/geojson_source';
-import {StubMap, sleep} from '../util/test/util';
+import {GeoJSONSource} from '../source/geojson_source';
+import {StubMap, sleep, waitForEvent} from '../util/test/util';
 import {RTLPluginLoadedEventName} from '../source/rtl_text_plugin_status';
 import {MessageType} from '../util/actor_messages';
 import {MercatorTransform} from '../geo/projection/mercator_transform';
@@ -130,19 +130,19 @@ describe('Style#loadURL', () => {
         expect(spy.mock.calls[0][1]).toBe('Style');
     });
 
-    test('validates the style', () => new Promise<void>(done => {
+    test('validates the style', async () => {
         const style = new Style(getStubMap());
 
-        style.on('error', ({error}) => {
-            expect(error).toBeTruthy();
-            expect(error.message).toMatch(/version/);
-            done();
-        });
+        const errorPromise = style.once('error');
 
         style.loadURL('style.json');
         server.respondWith(JSON.stringify(createStyleJSON({version: 'invalid'})));
         server.respond();
-    }));
+
+        const {error} = await errorPromise;
+        expect(error).toBeTruthy();
+        expect(error.message).toMatch(/version/);
+    });
 
     test('cancels pending requests if removed', () => {
         const style = new Style(getStubMap());
@@ -349,7 +349,7 @@ describe('Style#loadJSON', () => {
         expect(transformSpy.mock.calls[1][1]).toBe('SpriteImage');
     });
 
-    test('emits an error on non-existant vector source layer', () => new Promise<void>(done => {
+    test('emits an error on non-existant vector source layer', async () => {
         const style = createStyle();
         style.loadJSON(createStyleJSON({
             sources: {
@@ -358,33 +358,29 @@ describe('Style#loadJSON', () => {
             layers: []
         }));
 
-        style.on('style.load', () => {
-            style.removeSource('-source-id-');
+        await style.once('style.load');
+        style.removeSource('-source-id-');
 
-            const source = createSource();
-            source['vector_layers'] = [{id: 'green'}];
-            style.addSource('-source-id-', source);
-            style.addLayer({
-                'id': '-layer-id-',
-                'type': 'circle',
-                'source': '-source-id-',
-                'source-layer': '-source-layer-'
-            });
-            style.update({} as EvaluationParameters);
+        const source = createSource();
+        source['vector_layers'] = [{id: 'green'}];
+        style.addSource('-source-id-', source);
+        style.addLayer({
+            'id': '-layer-id-',
+            'type': 'circle',
+            'source': '-source-id-',
+            'source-layer': '-source-layer-'
         });
+        style.update({} as EvaluationParameters);
 
-        style.on('error', (event) => {
-            const err = event.error;
-            expect(err).toBeTruthy();
-            expect(err.toString().indexOf('-source-layer-') !== -1).toBeTruthy();
-            expect(err.toString().indexOf('-source-id-') !== -1).toBeTruthy();
-            expect(err.toString().indexOf('-layer-id-') !== -1).toBeTruthy();
+        const event = await style.once('error');
+        const err = event.error;
+        expect(err).toBeTruthy();
+        expect(err.toString().indexOf('-source-layer-') !== -1).toBeTruthy();
+        expect(err.toString().indexOf('-source-id-') !== -1).toBeTruthy();
+        expect(err.toString().indexOf('-layer-id-') !== -1).toBeTruthy();
+    });
 
-            done();
-        });
-    }));
-
-    test('sets up layer event forwarding', () => new Promise<void>(done => {
+    test('sets up layer event forwarding', async () => {
         const style = new Style(getStubMap());
         style.loadJSON(createStyleJSON({
             layers: [{
@@ -393,16 +389,15 @@ describe('Style#loadJSON', () => {
             }]
         }));
 
-        style.on('error', (e) => {
-            expect(e.layer).toEqual({id: 'background'});
-            expect(e.mapLibre).toBeTruthy();
-            done();
-        });
+        const errorPromise = style.once('error');
 
-        style.on('style.load', () => {
-            style._layers.background.fire(new Event('error', {mapLibre: true}));
-        });
-    }));
+        await style.once('style.load');
+        style._layers.background.fire(new Event('error', {mapLibre: true}));
+
+        const e = await errorPromise;
+        expect(e.layer).toEqual({id: 'background'});
+        expect(e.mapLibre).toBeTruthy();
+    });
 
     test('sets terrain if defined', async () => {
         const map = getStubMap();
@@ -610,7 +605,7 @@ describe('Style#_remove', () => {
 });
 
 describe('Style#update', () => {
-    test('on error', () => new Promise<void>(done => {
+    test('on error', async () => {
         const style = createStyle();
         style.loadJSON({
             'version': 8,
@@ -629,22 +624,21 @@ describe('Style#update', () => {
 
         style.on('error', (error) => { expect(error).toBeFalsy(); });
 
-        style.on('style.load', () => {
-            style.addLayer({id: 'first', source: 'source', type: 'fill', 'source-layer': 'source-layer'}, 'second');
-            style.addLayer({id: 'third', source: 'source', type: 'fill', 'source-layer': 'source-layer'});
-            style.removeLayer('second');
+        await style.once('style.load');
+        style.addLayer({id: 'first', source: 'source', type: 'fill', 'source-layer': 'source-layer'}, 'second');
+        style.addLayer({id: 'third', source: 'source', type: 'fill', 'source-layer': 'source-layer'});
+        style.removeLayer('second');
 
-            style.dispatcher.broadcast = (key, value) => {
-                expect(key).toBe(MessageType.updateLayers);
-                expect(value['layers'].map((layer) => { return layer.id; })).toEqual(['first', 'third']);
-                expect(value['removedIds']).toEqual(['second']);
-                done();
-                return Promise.resolve({} as any);
-            };
+        const spy = vi.fn().mockResolvedValue(Promise.resolve({} as any));
+        style.dispatcher.broadcast = spy;
 
-            style.update({} as EvaluationParameters);
-        });
-    }));
+        style.update({} as EvaluationParameters);
+
+        expect(spy).toHaveBeenCalled();
+        expect(spy.mock.calls[0][0]).toBe(MessageType.updateLayers);
+        expect(spy.mock.calls[0][1]['layers'].map((layer) => { return layer.id; })).toEqual(['first', 'third']);
+        expect(spy.mock.calls[0][1]['removedIds']).toEqual(['second']);
+    });
 });
 
 describe('Style#setState', () => {
@@ -1168,44 +1162,38 @@ describe('Style#removeSprite', () => {
         expect(() => style.removeSprite('test')).toThrow(/load/i);
     });
 
-    test('fires an error when trying to delete an non-existing sprite (sprite: undefined)', () => new Promise<void>(done => {
+    test('fires an error when trying to delete an non-existing sprite (sprite: undefined)', async () => {
         const style = new Style(getStubMap());
         style.loadJSON(createStyleJSON());
-        style.on('style.load', () => {
-            style.on('error', (error) => {
-                expect(error.error.message).toMatch(/Sprite \"test\" doesn't exists on this map./);
-                done();
-            });
+        await style.once('style.load');
+        const errorPromise = style.once('error');
+        style.removeSprite('test');
+        const {error} = await errorPromise;
+        expect(error.message).toMatch(/Sprite \"test\" doesn't exists on this map./);
+    });
 
-            style.removeSprite('test');
-        });
-    }));
-
-    test('fires an error when trying to delete an non-existing sprite (sprite: single url)', () => new Promise<void>(done => {
+    test('fires an error when trying to delete an non-existing sprite (sprite: single url)', async () => {
         const style = new Style(getStubMap());
         style.loadJSON(createStyleJSON({sprite: 'https://example.com/sprite'}));
-        style.on('style.load', () => {
-            style.on('error', (error) => {
-                expect(error.error.message).toMatch(/Sprite \"test\" doesn't exists on this map./);
-                done();
-            });
+        await style.once('style.load');
+        const errorPromise = style.once('error');
 
-            style.removeSprite('test');
-        });
-    }));
+        style.removeSprite('test');
+        const {error} = await errorPromise;
+        expect(error.message).toMatch(/Sprite \"test\" doesn't exists on this map./);
+    });
 
-    test('fires an error when trying to delete an non-existing sprite (sprite: array)', () => new Promise<void>(done => {
+    test('fires an error when trying to delete an non-existing sprite (sprite: array)', async () => {
         const style = new Style(getStubMap());
         style.loadJSON(createStyleJSON({sprite: [{id: 'default', url: 'https://example.com/sprite'}]}));
-        style.on('style.load', () => {
-            style.on('error', (error) => {
-                expect(error.error.message).toMatch(/Sprite \"test\" doesn't exists on this map./);
-                done();
-            });
+        await style.once('style.load');
+        const errorPromise = style.once('error');
 
-            style.removeSprite('test');
-        });
-    }));
+        style.removeSprite('test');
+
+        const {error} = await errorPromise;
+        expect(error.message).toMatch(/Sprite \"test\" doesn't exists on this map./);
+    });
 
     test('removes the sprite when it\'s a single URL', async () => {
         const style = new Style(getStubMap());
@@ -1246,26 +1234,26 @@ describe('Style#addLayer', () => {
         expect(() => style.addLayer({id: 'background', type: 'background'})).toThrow(/load/i);
     });
 
-    test('sets up layer event forwarding', () => new Promise<void>(done => {
+    test('sets up layer event forwarding', async () => {
         const style = new Style(getStubMap());
         style.loadJSON(createStyleJSON());
 
-        style.on('error', (e) => {
-            expect(e.layer).toEqual({id: 'background'});
-            expect(e.mapLibre).toBeTruthy();
-            done();
+        const errorPromise = style.once('error');
+
+        await style.once('style.load');
+        style.addLayer({
+            id: 'background',
+            type: 'background'
         });
 
-        style.on('style.load', () => {
-            style.addLayer({
-                id: 'background',
-                type: 'background'
-            });
-            style._layers.background.fire(new Event('error', {mapLibre: true}));
-        });
-    }));
+        style._layers.background.fire(new Event('error', {mapLibre: true}));
 
-    test('throws on non-existant vector source layer', () => new Promise<void>(done => {
+        const e = await errorPromise;
+        expect(e.layer).toEqual({id: 'background'});
+        expect(e.mapLibre).toBeTruthy();
+    });
+
+    test('throws on non-existant vector source layer', async () => {
         const style = createStyle();
         style.loadJSON(createStyleJSON({
             sources: {
@@ -1274,47 +1262,43 @@ describe('Style#addLayer', () => {
             }
         }));
 
-        style.on('style.load', () => {
-            const source = createSource();
-            source['vector_layers'] = [{id: 'green'}];
-            style.addSource('-source-id-', source);
-            style.addLayer({
-                'id': '-layer-id-',
-                'type': 'circle',
-                'source': '-source-id-',
-                'source-layer': '-source-layer-'
-            });
+        await style.once('style.load');
+        const source = createSource();
+        source['vector_layers'] = [{id: 'green'}];
+        style.addSource('-source-id-', source);
+        style.addLayer({
+            'id': '-layer-id-',
+            'type': 'circle',
+            'source': '-source-id-',
+            'source-layer': '-source-layer-'
         });
 
-        style.on('error', (event) => {
-            const err = event.error;
+        const event = await style.once('error');
+        const err = event.error;
 
-            expect(err).toBeTruthy();
-            expect(err.toString().indexOf('-source-layer-') !== -1).toBeTruthy();
-            expect(err.toString().indexOf('-source-id-') !== -1).toBeTruthy();
-            expect(err.toString().indexOf('-layer-id-') !== -1).toBeTruthy();
+        expect(err).toBeTruthy();
+        expect(err.toString().indexOf('-source-layer-') !== -1).toBeTruthy();
+        expect(err.toString().indexOf('-source-id-') !== -1).toBeTruthy();
+        expect(err.toString().indexOf('-layer-id-') !== -1).toBeTruthy();
+    });
 
-            done();
-        });
-    }));
-
-    test('emits error on invalid layer', () => new Promise<void>(done => {
+    test('emits error on invalid layer', async () => {
         const style = new Style(getStubMap());
         style.loadJSON(createStyleJSON());
-        style.on('style.load', () => {
-            style.on('error', () => {
-                expect(style.getLayer('background')).toBeFalsy();
-                done();
-            });
-            style.addLayer({
-                id: 'background',
-                type: 'background',
-                paint: {
-                    'background-opacity': 5
-                }
-            });
+        await style.once('style.load');
+        const errorPromise = style.once('error');
+            
+        style.addLayer({
+            id: 'background',
+            type: 'background',
+            paint: {
+                'background-opacity': 5
+            }
         });
-    }));
+
+        await errorPromise;
+        expect(style.getLayer('background')).toBeFalsy();
+    });
 
     test('#4040 does not mutate source property when provided inline', async () => {
         const style = new Style(getStubMap());
@@ -1332,7 +1316,7 @@ describe('Style#addLayer', () => {
         expect((layer as any).source).toEqual(source);
     });
 
-    test('reloads source', () => new Promise<void>(done => {
+    test('reloads source', async () => {
         const style = createStyle();
         style.loadJSON(extend(createStyleJSON(), {
             'sources': {
@@ -1350,16 +1334,16 @@ describe('Style#addLayer', () => {
             'filter': ['==', 'id', 0]
         } as LayerSpecification;
 
-        style.on('data', (e) => {
-            if (e.dataType === 'source' && e.sourceDataType === 'content') {
-                style.sourceCaches['mapLibre'].reload = () => { done(); };
-                style.addLayer(layer);
-                style.update({} as EvaluationParameters);
-            }
-        });
-    }));
+        await waitForEvent(style, 'data', (e) => e.dataType === 'source' && e.sourceDataType === 'content');
 
-    test('#3895 reloads source (instead of clearing) if adding this layer with the same type, immediately after removing it', () => new Promise<void>((done) => {
+        const spy = vi.fn();
+        style.sourceCaches['mapLibre'].reload = spy;
+        style.addLayer(layer);
+        style.update({} as EvaluationParameters);
+        expect(spy).toHaveBeenCalled();
+    });
+
+    test('#3895 reloads source (instead of clearing) if adding this layer with the same type, immediately after removing it', async () => {
         const style = createStyle();
         style.loadJSON(extend(createStyleJSON(), {
             'sources': {
@@ -1384,19 +1368,18 @@ describe('Style#addLayer', () => {
             'source-layer': 'libremap'
         }as LayerSpecification;
 
-        style.on('data', (e) => {
-            if (e.dataType === 'source' && e.sourceDataType === 'content') {
-                style.sourceCaches['mapLibre'].reload = () => { done(); };
-                style.sourceCaches['mapLibre'].clearTiles =  () => { throw new Error('test failed'); };
-                style.removeLayer('my-layer');
-                style.addLayer(layer);
-                style.update({} as EvaluationParameters);
-            }
-        });
 
-    }));
+        await waitForEvent(style, 'data', (e) => e.dataType === 'source' && e.sourceDataType === 'content');
+        const spy = vi.fn();
+        style.sourceCaches['mapLibre'].reload = spy;
+        style.sourceCaches['mapLibre'].clearTiles =  () => { throw new Error('test failed'); };
+        style.removeLayer('my-layer');
+        style.addLayer(layer);
+        style.update({} as EvaluationParameters);
+        expect(spy).toHaveBeenCalled();
+    });
 
-    test('clears source (instead of reloading) if adding this layer with a different type, immediately after removing it', () => new Promise<void>((done) => {
+    test('clears source (instead of reloading) if adding this layer with a different type, immediately after removing it', async () => {
         const style = createStyle();
         style.loadJSON(extend(createStyleJSON(), {
             'sources': {
@@ -1420,17 +1403,15 @@ describe('Style#addLayer', () => {
             'source': 'mapLibre',
             'source-layer': 'libremap'
         }as LayerSpecification;
-        style.on('data', (e) => {
-            if (e.dataType === 'source' && e.sourceDataType === 'content') {
-                style.sourceCaches['mapLibre'].reload =  () => { throw new Error('test failed'); };
-                style.sourceCaches['mapLibre'].clearTiles = () => { done(); };
-                style.removeLayer('my-layer');
-                style.addLayer(layer);
-                style.update({} as EvaluationParameters);
-            }
-        });
-
-    }));
+        await waitForEvent(style, 'data', (e) => e.dataType === 'source' && e.sourceDataType === 'content');
+        const spy = vi.fn();
+        style.sourceCaches['mapLibre'].reload =  () => { throw new Error('test failed'); };
+        style.sourceCaches['mapLibre'].clearTiles = spy;
+        style.removeLayer('my-layer');
+        style.addLayer(layer);
+        style.update({} as EvaluationParameters);
+        expect(spy).toHaveBeenCalled();
+    });
 
     test('fires "data" event', async () => {
         const style = new Style(getStubMap());
@@ -1446,21 +1427,18 @@ describe('Style#addLayer', () => {
         await dataPromise;
     });
 
-    test('emits error on duplicates', () => new Promise<void>(done => {
+    test('emits error on duplicates', async () => {
         const style = new Style(getStubMap());
         style.loadJSON(createStyleJSON());
         const layer = {id: 'background', type: 'background'} as LayerSpecification;
 
-        style.on('error', (e) => {
-            expect(e.error.message).toMatch(/already exists/);
-            done();
-        });
-
-        style.on('style.load', () => {
-            style.addLayer(layer);
-            style.addLayer(layer);
-        });
-    }));
+        await style.once('style.load');
+        style.addLayer(layer);
+        const errorPromise = style.once('error');
+        style.addLayer(layer);
+        const e = await errorPromise;
+        expect(e.error.message).toMatch(/already exists/);
+    });
 
     test('adds to the end by default', async () => {
         const style = new Style(getStubMap());
@@ -1498,7 +1476,7 @@ describe('Style#addLayer', () => {
         expect(style._order).toEqual(['c', 'a', 'b']);
     });
 
-    test('fire error if before layer does not exist', () => new Promise<void>(done => {
+    test('fire error if before layer does not exist', async () => {
         const style = new Style(getStubMap());
         style.loadJSON(createStyleJSON({
             layers: [{
@@ -1511,16 +1489,14 @@ describe('Style#addLayer', () => {
         }));
         const layer = {id: 'c', type: 'background'} as LayerSpecification;
 
-        style.on('style.load', () => {
-            style.on('error', (error) => {
-                expect(error.error.message).toMatch(/Cannot add layer "c" before non-existing layer "z"./);
-                done();
-            });
-            style.addLayer(layer, 'z');
-        });
-    }));
+        await style.once('style.load');
+        const errorPromise = style.once('error');
+        style.addLayer(layer, 'z');
+        const {error} = await errorPromise;
+        expect(error.message).toMatch(/Cannot add layer "c" before non-existing layer "z"./);
+    });
 
-    test('fires an error on non-existant source layer', () => new Promise<void>(done => {
+    test('fires an error on non-existant source layer', async () => {
         const style = new Style(getStubMap());
         style.loadJSON(extend(createStyleJSON(), {
             sources: {
@@ -1538,15 +1514,13 @@ describe('Style#addLayer', () => {
             'source-layer': 'dummy'
         }as LayerSpecification;
 
-        style.on('style.load', () => {
-            style.on('error', ({error}) => {
-                expect(error.message).toMatch(/does not exist on source/);
-                done();
-            });
-            style.addLayer(layer);
-        });
-
-    }));
+        await style.once('style.load');
+        const errorPromise = style.once('error');      
+        style.addLayer(layer);
+        
+        const {error} = await errorPromise;
+        expect(error.message).toMatch(/does not exist on source/);
+    });
 });
 
 describe('Style#removeLayer', () => {
@@ -1571,7 +1545,7 @@ describe('Style#removeLayer', () => {
         await dataPromise;
     });
 
-    test('tears down layer event forwarding', () => new Promise<void>((done) => {
+    test('tears down layer event forwarding', async () => {
         const style = new Style(getStubMap());
         style.loadJSON(createStyleJSON({
             layers: [{
@@ -1584,17 +1558,15 @@ describe('Style#removeLayer', () => {
             throw new Error('test failed');
         });
 
-        style.on('style.load', () => {
-            const layer = style._layers.background;
-            style.removeLayer('background');
+        await style.once('style.load');
+        const layer = style._layers.background;
+        style.removeLayer('background');
 
-            // Bind a listener to prevent fallback Evented error reporting.
-            layer.on('error', () => {});
+        // Bind a listener to prevent fallback Evented error reporting.
+        layer.on('error', () => {});
 
-            layer.fire(new Event('error', {mapLibre: true}));
-            done();
-        });
-    }));
+        layer.fire(new Event('error', {mapLibre: true}));
+    });
 
     test('fires an error on non-existence', async () => {
         const style = new Style(getStubMap());
@@ -1706,7 +1678,7 @@ describe('Style#moveLayer', () => {
 });
 
 describe('Style#setPaintProperty', () => {
-    test('#4738 postpones source reload until layers have been broadcast to workers', () => new Promise<void>(done => {
+    test('#4738 postpones source reload until layers have been broadcast to workers', async () => {
         const style = new Style(getStubMap());
         style.loadJSON(extend(createStyleJSON(), {
             'sources': {
@@ -1727,39 +1699,23 @@ describe('Style#setPaintProperty', () => {
         const tr = new MercatorTransform();
         tr.resize(512, 512);
 
-        style.once('style.load', () => {
-            style.update(tr.zoom as any as EvaluationParameters);
-            const sourceCache = style.sourceCaches['geojson'];
-            const source = style.getSource('geojson');
+        await style.once('style.load');
+        style.update(tr.zoom as any as EvaluationParameters);
+        const sourceCache = style.sourceCaches['geojson'];
+        const source = style.getSource('geojson') as GeoJSONSource;
 
-            let begun = false;
-            let styleUpdateCalled = false;
+        await source.once('data');
+        vi.spyOn(sourceCache, 'reload');
+            
+        source.setData({'type': 'FeatureCollection', 'features': []});
+        style.setPaintProperty('circle', 'circle-color', {type: 'identity', property: 'foo'});
+        await waitForEvent(source, 'data', (e) => e.sourceDataType === 'content');
 
-            (source as any).on('data', (e) => setTimeout(() => {
-                if (!begun) {
-                    begun = true;
-                    vi.spyOn(sourceCache, 'reload').mockImplementation(() => {
-                        expect(styleUpdateCalled).toBeTruthy();
-                        done();
-                    });
+        await sleep(50);
+        style.update({} as EvaluationParameters);
 
-                    (source as any).setData({'type': 'FeatureCollection', 'features': []});
-                    style.setPaintProperty('circle', 'circle-color', {type: 'identity', property: 'foo'});
-                }
-
-                if (begun && e.sourceDataType === 'content') {
-                    // setData() worker-side work is complete; simulate an
-                    // animation frame a few ms later, so that this test can
-                    // confirm that SourceCache#reload() isn't called until
-                    // after the next Style#update()
-                    setTimeout(() => {
-                        styleUpdateCalled = true;
-                        style.update({} as EvaluationParameters);
-                    }, 50);
-                }
-            }));
-        });
-    }));
+        expect(sourceCache.reload).toHaveBeenCalled();
+    });
 
     test('#5802 clones the input', async () => {
         const style = new Style(getStubMap());
@@ -1974,23 +1930,21 @@ describe('Style#setFilter', () => {
         return style;
     }
 
-    test('sets filter', () => new Promise<void>(done => {
+    test('sets filter', async () => {
         const style = createStyle();
 
-        style.on('style.load', () => {
-            style.dispatcher.broadcast = (key, value) => {
-                expect(key).toBe(MessageType.updateLayers);
-                expect(value['layers'][0].id).toBe('symbol');
-                expect(value['layers'][0].filter).toEqual(['==', 'id', 1]);
-                done();
-                return Promise.resolve({} as any);
-            };
+        await style.once('style.load');
+        const spy = vi.fn().mockReturnValue(Promise.resolve({}));
+        style.dispatcher.broadcast = spy;
 
-            style.setFilter('symbol', ['==', 'id', 1]);
-            expect(style.getFilter('symbol')).toEqual(['==', 'id', 1]);
-            style.update({} as EvaluationParameters); // trigger dispatcher broadcast
-        });
-    }));
+        style.setFilter('symbol', ['==', 'id', 1]);
+        expect(style.getFilter('symbol')).toEqual(['==', 'id', 1]);
+        style.update({} as EvaluationParameters); // trigger dispatcher broadcast
+
+        expect(spy.mock.calls[0][0]).toBe(MessageType.updateLayers);
+        expect(spy.mock.calls[0][1]['layers'][0].id).toBe('symbol');
+        expect(spy.mock.calls[0][1]['layers'][0].filter).toEqual(['==', 'id', 1]);
+    });
 
     test('gets a clone of the filter', async () => {
         const style = createStyle();
@@ -2006,26 +1960,23 @@ describe('Style#setFilter', () => {
         expect(filter2).not.toBe(filter3);
     });
 
-    test('sets again mutated filter', () => new Promise<void>(done => {
+    test('sets again mutated filter', async () => {
         const style = createStyle();
 
-        style.on('style.load', () => {
-            const filter = ['==', 'id', 1] as FilterSpecification;
-            style.setFilter('symbol', filter);
-            style.update({} as EvaluationParameters); // flush pending operations
+        await style.once('style.load');
+        const filter = ['==', 'id', 1] as FilterSpecification;
+        style.setFilter('symbol', filter);
+        style.update({} as EvaluationParameters); // flush pending operations
 
-            style.dispatcher.broadcast = (key, value) => {
-                expect(key).toBe(MessageType.updateLayers);
-                expect(value['layers'][0].id).toBe('symbol');
-                expect(value['layers'][0].filter).toEqual(['==', 'id', 2]);
-                done();
-                return Promise.resolve({} as any);
-            };
-            filter[2] = 2;
-            style.setFilter('symbol', filter);
-            style.update({} as EvaluationParameters); // trigger dispatcher broadcast
-        });
-    }));
+        const spy = vi.fn().mockReturnValue(Promise.resolve({}));
+        style.dispatcher.broadcast = spy;
+        filter[2] = 2;
+        style.setFilter('symbol', filter);
+        style.update({} as EvaluationParameters); // trigger dispatcher broadcast
+        expect(spy.mock.calls[0][0]).toBe(MessageType.updateLayers);
+        expect(spy.mock.calls[0][1]['layers'][0].id).toBe('symbol');
+        expect(spy.mock.calls[0][1]['layers'][0].filter).toEqual(['==', 'id', 2]);
+    });
 
     test('unsets filter', async () => {
         const style = createStyle();
@@ -2062,23 +2013,20 @@ describe('Style#setFilter', () => {
         style.update({} as EvaluationParameters); // trigger dispatcher broadcast
     });
 
-    test('respects validate option', () => new Promise<void>(done => {
+    test('respects validate option', async () => {
         const style = createStyle();
 
-        style.on('style.load', () => {
-            style.dispatcher.broadcast = (key, value) => {
-                expect(key).toBe(MessageType.updateLayers);
-                expect(value['layers'][0].id).toBe('symbol');
-                expect(value['layers'][0].filter).toBe('notafilter');
-                done();
-                return Promise.resolve({} as any);
-            };
+        await style.once('style.load');
+        const spy = vi.fn().mockReturnValue(Promise.resolve({}));
+        style.dispatcher.broadcast = spy;
 
-            style.setFilter('symbol', 'notafilter' as any as FilterSpecification, {validate: false});
-            expect(style.getFilter('symbol')).toBe('notafilter');
-            style.update({} as EvaluationParameters); // trigger dispatcher broadcast
-        });
-    }));
+        style.setFilter('symbol', 'notafilter' as any as FilterSpecification, {validate: false});
+        expect(style.getFilter('symbol')).toBe('notafilter');
+        style.update({} as EvaluationParameters); // trigger dispatcher broadcast
+        expect(spy.mock.calls[0][0]).toBe(MessageType.updateLayers);
+        expect(spy.mock.calls[0][1]['layers'][0].id).toBe('symbol');
+        expect(spy.mock.calls[0][1]['layers'][0].filter).toBe('notafilter');
+    });
 });
 
 describe('Style#setLayerZoomRange', () => {
@@ -2103,22 +2051,19 @@ describe('Style#setLayerZoomRange', () => {
         return style;
     }
 
-    test('sets zoom range', () => new Promise<void>(done => {
+    test('sets zoom range', async () => {
         const style = createStyle();
 
-        style.on('style.load', () => {
-            style.dispatcher.broadcast = (key, value) => {
-                expect(key).toBe(MessageType.updateLayers);
-                expect(value['layers'].map((layer) => { return layer.id; })).toEqual(['symbol']);
-                done();
-                return Promise.resolve({} as any);
-            };
-            style.setLayerZoomRange('symbol', 5, 12);
-            expect(style.getLayer('symbol').minzoom).toBe(5);
-            expect(style.getLayer('symbol').maxzoom).toBe(12);
-            style.update({} as EvaluationParameters); // trigger dispatcher broadcast
-        });
-    }));
+        await style.once('style.load');
+        const spy = vi.fn().mockReturnValue(Promise.resolve({}));
+        style.dispatcher.broadcast = spy;
+        style.setLayerZoomRange('symbol', 5, 12);
+        expect(style.getLayer('symbol').minzoom).toBe(5);
+        expect(style.getLayer('symbol').maxzoom).toBe(12);
+        style.update({} as EvaluationParameters); // trigger dispatcher broadcast
+        expect(spy.mock.calls[0][0]).toBe(MessageType.updateLayers);
+        expect(spy.mock.calls[0][1]['layers'].map((layer) => { return layer.id; })).toEqual(['symbol']);
+    });
 
     test('fires an error if layer not found', async () => {
         const style = createStyle();

--- a/src/style/style.test.ts
+++ b/src/style/style.test.ts
@@ -12,7 +12,7 @@ import {fakeServer, type FakeServer} from 'nise';
 
 import {type EvaluationParameters} from './evaluation_parameters';
 import {type LayerSpecification, type GeoJSONSourceSpecification, type FilterSpecification, type SourceSpecification, type StyleSpecification, type SymbolLayerSpecification, type SkySpecification} from '@maplibre/maplibre-gl-style-spec';
-import {GeoJSONSource} from '../source/geojson_source';
+import {type GeoJSONSource} from '../source/geojson_source';
 import {StubMap, sleep, waitForEvent} from '../util/test/util';
 import {RTLPluginLoadedEventName} from '../source/rtl_text_plugin_status';
 import {MessageType} from '../util/actor_messages';
@@ -1367,7 +1367,6 @@ describe('Style#addLayer', () => {
             'source': 'mapLibre',
             'source-layer': 'libremap'
         }as LayerSpecification;
-
 
         await waitForEvent(style, 'data', (e) => e.dataType === 'source' && e.sourceDataType === 'content');
         const spy = vi.fn();

--- a/src/style/style_layer.test.ts
+++ b/src/style/style_layer.test.ts
@@ -93,34 +93,34 @@ describe('StyleLayer#setPaintProperty', () => {
         expect(layer.getPaintProperty('background-color-transition')).toEqual({duration: 400});
     });
 
-    test('emits on an invalid property value', () => new Promise<void>(done => {
+    test('emits on an invalid property value', async () => {
         const layer = createStyleLayer({
             'id': 'background',
             'type': 'background'
         });
 
-        layer.on('error', () => {
-            expect(layer.getPaintProperty('background-opacity')).toBeUndefined();
-            done();
-        });
+        const errorPromise = layer.once('error');
 
         layer.setPaintProperty('background-opacity', 5);
-    }));
 
-    test('emits on an invalid transition property value', () => new Promise<void>(done => {
+        await errorPromise;
+        expect(layer.getPaintProperty('background-opacity')).toBeUndefined();
+    });
+
+    test('emits on an invalid transition property value', async () => {
         const layer = createStyleLayer({
             'id': 'background',
             'type': 'background'
         });
 
-        layer.on('error', () => {
-            done();
-        });
+        const errorPromise = layer.once('error');
 
         layer.setPaintProperty('background-opacity-transition', {
             duration: -10
         });
-    }));
+
+        await expect(errorPromise).resolves.toBeDefined();
+    });
 
     test('can unset fill-outline-color #2886', () => {
         const layer = createStyleLayer({
@@ -199,18 +199,17 @@ describe('StyleLayer#setLayoutProperty', () => {
         expect(layer.getLayoutProperty('text-transform')).toBe('lowercase');
     });
 
-    test('emits on an invalid property value', () => new Promise<void>(done => {
+    test('emits on an invalid property value', async () => {
         const layer = createStyleLayer({
             'id': 'symbol',
             'type': 'symbol'
         } as LayerSpecification);
 
-        layer.on('error', () => {
-            done();
-        });
+        const errorPromise = layer.once('error');
 
         layer.setLayoutProperty('text-transform', 'invalidValue');
-    }));
+        await expect(errorPromise).resolves.toBeDefined();
+    });
 
     test('updates property value', () => {
         const layer = createStyleLayer({

--- a/src/ui/control/attribution_control.test.ts
+++ b/src/ui/control/attribution_control.test.ts
@@ -18,7 +18,7 @@ function createMap() {
             id: 'demotiles',
         },
         hash: true
-    }, undefined);
+    });
 }
 
 let map: Map;

--- a/src/ui/control/fullscreen_control.test.ts
+++ b/src/ui/control/fullscreen_control.test.ts
@@ -12,7 +12,7 @@ describe('FullscreenControl', () => {
             value: true,
             writable: true,
         });
-        const map = createMap(undefined, undefined);
+        const map = createMap();
         const fullscreen = new FullscreenControl({});
         map.addControl(fullscreen);
 
@@ -25,7 +25,7 @@ describe('FullscreenControl', () => {
             writable: true,
         });
 
-        const map = createMap(undefined, undefined);
+        const map = createMap();
         const container = window.document.querySelector('body')!;
         const fullscreen = new FullscreenControl({container});
         map.addControl(fullscreen);
@@ -38,7 +38,7 @@ describe('FullscreenControl', () => {
     });
 
     test('uses pseudo fullscreen when fullscreen is not supported', () => {
-        const map = createMap(undefined, undefined);
+        const map = createMap();
         const mapContainer = map.getContainer();
 
         const fullscreen = new FullscreenControl({});
@@ -55,7 +55,7 @@ describe('FullscreenControl', () => {
     });
 
     test('start and end events fire for fullscreen button clicks', () => {
-        const map = createMap(undefined, undefined);
+        const map = createMap();
         const fullscreen = new FullscreenControl({});
 
         const fullscreenstart = vi.fn();

--- a/src/ui/control/geolocate_control.test.ts
+++ b/src/ui/control/geolocate_control.test.ts
@@ -30,7 +30,7 @@ describe('GeolocateControl with no options', () => {
 
     beforeEach(() => {
         beforeMapTest();
-        map = createMap(undefined, undefined);
+        map = createMap();
         (checkGeolocationSupport as unknown as MockInstance).mockImplementationOnce(() => Promise.resolve(true));
     });
 

--- a/src/ui/control/globe_control.test.ts
+++ b/src/ui/control/globe_control.test.ts
@@ -13,7 +13,7 @@ function createMap() {
             id: 'basic'
         },
         hash: true
-    }, undefined);
+    });
 }
 
 let map;

--- a/src/ui/control/logo_control.test.ts
+++ b/src/ui/control/logo_control.test.ts
@@ -13,7 +13,7 @@ function createMap(logoPosition, maplibreLogo) {
         }
     };
 
-    return globalCreateMap(mapobj, undefined);
+    return globalCreateMap(mapobj);
 }
 
 beforeEach(() => {
@@ -29,35 +29,29 @@ describe('LogoControl', () => {
         )).toHaveLength(0);
     });
 
-    test('is not displayed when the maplibreLogo property is false', () => new Promise<void>(done => {
+    test('is not displayed when the maplibreLogo property is false', async () => {
         const map = createMap(undefined, false);
-        map.on('load', () => {
-            expect(map.getContainer().querySelectorAll(
-                '.maplibregl-ctrl-logo'
-            )).toHaveLength(0);
-            done();
-        });
-    }));
+        await map.once('load');
+        expect(map.getContainer().querySelectorAll(
+            '.maplibregl-ctrl-logo'
+        )).toHaveLength(0);
+    });
 
-    test('appears in bottom-left when maplibreLogo is true and logoPosition is undefined', () => new Promise<void>(done => {
+    test('appears in bottom-left when maplibreLogo is true and logoPosition is undefined', async () => {
         const map = createMap(undefined, true);
-        map.on('load', () => {
-            expect(map.getContainer().querySelectorAll(
-                '.maplibregl-ctrl-bottom-left .maplibregl-ctrl-logo'
-            )).toHaveLength(1);
-            done();
-        });
-    }));
+        await map.once('load');
+        expect(map.getContainer().querySelectorAll(
+            '.maplibregl-ctrl-bottom-left .maplibregl-ctrl-logo'
+        )).toHaveLength(1);
+    });
 
-    test('appears in the position specified by the position option', () => new Promise<void>(done => {
+    test('appears in the position specified by the position option', async () => {
         const map = createMap('top-left', true);
-        map.on('load', () => {
-            expect(map.getContainer().querySelectorAll(
-                '.maplibregl-ctrl-top-left .maplibregl-ctrl-logo'
-            )).toHaveLength(1);
-            done();
-        });
-    }));
+        await map.once('load');
+        expect(map.getContainer().querySelectorAll(
+            '.maplibregl-ctrl-top-left .maplibregl-ctrl-logo'
+        )).toHaveLength(1);
+    });
 
     test('appears in compact mode if container is less then 640 pixel wide', () => {
         const map = createMap(undefined, true);
@@ -76,14 +70,12 @@ describe('LogoControl', () => {
         ).toHaveLength(1);
     });
 
-    test('has `rel` noopener and nofollow', () => new Promise<void>(done => {
+    test('has `rel` noopener and nofollow', async () => {
         const map = createMap(undefined, true);
 
-        map.on('load', () => {
-            const container = map.getContainer();
-            const logo = container.querySelector('.maplibregl-ctrl-logo');
-            expect(logo).toHaveProperty('rel', 'noopener nofollow');
-            done();
-        });
-    }));
+        await map.once('load');
+        const container = map.getContainer();
+        const logo = container.querySelector('.maplibregl-ctrl-logo');
+        expect(logo).toHaveProperty('rel', 'noopener nofollow');
+    });
 });

--- a/src/ui/control/navigation_control.test.ts
+++ b/src/ui/control/navigation_control.test.ts
@@ -4,7 +4,7 @@ import {createMap as globalCreateMap, beforeMapTest} from '../../util/test/util'
 import {NavigationControl} from './navigation_control';
 
 function createMap() {
-    return globalCreateMap({});
+    return globalCreateMap();
 }
 
 let map;

--- a/src/ui/control/scale_control.test.ts
+++ b/src/ui/control/scale_control.test.ts
@@ -8,7 +8,7 @@ beforeEach(() => {
 
 describe('ScaleControl', () => {
     test('appears in bottom-left by default', () => {
-        const map = createMap(undefined, undefined);
+        const map = createMap();
         map.addControl(new ScaleControl(undefined));
 
         expect(
@@ -17,7 +17,7 @@ describe('ScaleControl', () => {
     });
 
     test('appears in the position specified by the position option', () => {
-        const map = createMap(undefined, undefined);
+        const map = createMap();
         map.addControl(new ScaleControl(undefined), 'top-left');
 
         expect(
@@ -26,7 +26,7 @@ describe('ScaleControl', () => {
     });
 
     test('should change unit of distance after calling setUnit', () => {
-        const map = createMap(undefined, undefined);
+        const map = createMap();
         const scale = new ScaleControl(undefined);
         const selector = '.maplibregl-ctrl-bottom-left .maplibregl-ctrl-scale';
         map.addControl(scale);
@@ -40,7 +40,7 @@ describe('ScaleControl', () => {
     });
 
     test('should respect the maxWidth regardless of the unit and actual scale', () => {
-        const map = createMap(undefined, undefined);
+        const map = createMap();
         const maxWidth = 100;
         const scale = new ScaleControl({maxWidth, unit: 'nautical'});
         const selector = '.maplibregl-ctrl-bottom-left .maplibregl-ctrl-scale';

--- a/src/ui/control/terrain_control.test.ts
+++ b/src/ui/control/terrain_control.test.ts
@@ -22,7 +22,7 @@ function createMap() {
             id: 'demotiles',
         },
         hash: true
-    }, undefined);
+    });
 }
 
 let map;

--- a/src/ui/handler/scroll_zoom.test.ts
+++ b/src/ui/handler/scroll_zoom.test.ts
@@ -145,7 +145,7 @@ describe('ScrollZoomHandler', () => {
         map.remove();
     });
 
-    test('Zooms for single mouse wheel tick with non-magical deltaY', () => new Promise<void>(done => {
+    test('Zooms for single mouse wheel tick with non-magical deltaY', async () => {
         const browserNow = vi.spyOn(browser, 'now');
         const now = 1555555555555;
         browserNow.mockReturnValue(now);
@@ -157,11 +157,9 @@ describe('ScrollZoomHandler', () => {
         // This requires the handler to briefly wait to see if a subsequent
         // event is coming in order to guess trackpad vs. mouse wheel
         simulate.wheel(map.getCanvas(), {type: 'wheel', deltaY: -20});
-        map.on('zoomstart', () => {
-            map.remove();
-            done();
-        });
-    }));
+        await map.once('zoomstart');
+        map.remove();  
+    });
 
     test('Zooms for single mouse wheel tick with non-magical deltaY with easing for smooth zooming', () => {
         const browserNow = vi.spyOn(browser, 'now');

--- a/src/ui/handler/two_fingers_touch.ts
+++ b/src/ui/handler/two_fingers_touch.ts
@@ -40,7 +40,6 @@ abstract class TwoFingersTouchHandler implements Handler {
     abstract _move(points: [Point, Point], pinchAround: Point | null, e: TouchEvent): HandlerResult | void;
 
     touchstart(e: TouchEvent, points: Array<Point>, mapTouches: Array<Touch>): void {
-        //log('touchstart', points, e.target.innerHTML, e.targetTouches.length ? e.targetTouches[0].target.innerHTML: undefined);
         if (this._firstTwoTouches || mapTouches.length < 2) return;
 
         this._firstTwoTouches = [

--- a/src/ui/hash.test.ts
+++ b/src/ui/hash.test.ts
@@ -14,7 +14,7 @@ describe('hash', () => {
         const container = window.document.createElement('div');
         Object.defineProperty(container, 'clientWidth', {value: 512});
         Object.defineProperty(container, 'clientHeight', {value: 512});
-        return globalCreateMap({container}, undefined);
+        return globalCreateMap({container});
     }
 
     let map: Map;

--- a/src/ui/map_tests/map_feature_state.test.ts
+++ b/src/ui/map_tests/map_feature_state.test.ts
@@ -7,7 +7,7 @@ beforeEach(() => {
 });
 
 describe('#setFeatureState', () => {
-    test('sets state', () => new Promise<void>(done => {
+    test('sets state', async () => {
         const map = createMap({
             style: {
                 'version': 8,
@@ -17,14 +17,13 @@ describe('#setFeatureState', () => {
                 'layers': []
             }
         });
-        map.on('load', () => {
-            map.setFeatureState({source: 'geojson', id: 12345}, {'hover': true});
-            const fState = map.getFeatureState({source: 'geojson', id: 12345});
-            expect(fState.hover).toBe(true);
-            done();
-        });
-    }));
-    test('works with string ids', () => new Promise<void>(done => {
+        await map.once('load');
+        map.setFeatureState({source: 'geojson', id: 12345}, {'hover': true});
+        const fState = map.getFeatureState({source: 'geojson', id: 12345});
+        expect(fState.hover).toBe(true);
+    });
+
+    test('works with string ids', async () => {
         const map = createMap({
             style: {
                 'version': 8,
@@ -34,14 +33,13 @@ describe('#setFeatureState', () => {
                 'layers': []
             }
         });
-        map.on('load', () => {
-            map.setFeatureState({source: 'geojson', id: 'foo'}, {'hover': true});
-            const fState = map.getFeatureState({source: 'geojson', id: 'foo'});
-            expect(fState.hover).toBe(true);
-            done();
-        });
-    }));
-    test('parses feature id as an int', () => new Promise<void>(done => {
+        await map.once('load');
+        map.setFeatureState({source: 'geojson', id: 'foo'}, {'hover': true});
+        const fState = map.getFeatureState({source: 'geojson', id: 'foo'});
+        expect(fState.hover).toBe(true);
+    });
+
+    test('parses feature id as an int', async () => {
         const map = createMap({
             style: {
                 'version': 8,
@@ -51,13 +49,12 @@ describe('#setFeatureState', () => {
                 'layers': []
             }
         });
-        map.on('load', () => {
-            map.setFeatureState({source: 'geojson', id: '12345'}, {'hover': true});
-            const fState = map.getFeatureState({source: 'geojson', id: 12345});
-            expect(fState.hover).toBe(true);
-            done();
-        });
-    }));
+        await map.once('load');
+        map.setFeatureState({source: 'geojson', id: '12345'}, {'hover': true});
+        const fState = map.getFeatureState({source: 'geojson', id: 12345});
+        expect(fState.hover).toBe(true);
+    });
+
     test('throw before loaded', () => {
         const map = createMap({
             style: {
@@ -72,7 +69,8 @@ describe('#setFeatureState', () => {
             map.setFeatureState({source: 'geojson', id: 12345}, {'hover': true});
         }).toThrow(Error);
     });
-    test('fires an error if source not found', () => new Promise<void>(done => {
+
+    test('fires an error if source not found', async () => {
         const map = createMap({
             style: {
                 'version': 8,
@@ -82,15 +80,14 @@ describe('#setFeatureState', () => {
                 'layers': []
             }
         });
-        map.on('load', () => {
-            map.on('error', ({error}) => {
-                expect(error.message).toMatch(/source/);
-                done();
-            });
-            map.setFeatureState({source: 'vector', id: 12345}, {'hover': true});
-        });
-    }));
-    test('fires an error if sourceLayer not provided for a vector source', () => new Promise<void>(done => {
+        await map.once('load');
+        const errorPromise = map.once('error');
+        map.setFeatureState({source: 'vector', id: 12345}, {'hover': true});
+        const {error} = await errorPromise;
+        expect(error.message).toMatch(/source/);
+    });
+
+    test('fires an error if sourceLayer not provided for a vector source', async () => {
         const map = createMap({
             style: {
                 'version': 8,
@@ -103,15 +100,15 @@ describe('#setFeatureState', () => {
                 'layers': []
             }
         });
-        map.on('load', () => {
-            map.on('error', ({error}) => {
-                expect(error.message).toMatch(/sourceLayer/);
-                done();
-            });
-            (map as any).setFeatureState({source: 'vector', sourceLayer: 0, id: 12345}, {'hover': true});
-        });
-    }));
-    test('fires an error if id not provided', () => new Promise<void>(done => {
+        await map.once('load');
+        const errorPromise = map.once('error');
+                
+        map.setFeatureState({source: 'vector', id: 12345}, {'hover': true});
+        const {error} = await errorPromise;
+        expect(error.message).toMatch(/sourceLayer/);
+    });
+
+    test('fires an error if id not provided', async () => {
         const map = createMap({
             style: {
                 'version': 8,
@@ -124,19 +121,17 @@ describe('#setFeatureState', () => {
                 'layers': []
             }
         });
-        map.on('load', () => {
-            map.on('error', ({error}) => {
-                expect(error.message).toMatch(/id/);
-                done();
-            });
-            (map as any).setFeatureState({source: 'vector', sourceLayer: '1'}, {'hover': true});
-        });
-    }));
+        await map.once('load');
+        const errorPromise = map.once('error');
+        map.setFeatureState({source: 'vector', sourceLayer: '1'}, {'hover': true});
+        const {error} = await errorPromise;
+        expect(error.message).toMatch(/id/);
+    });
 });
 
 describe('#removeFeatureState', () => {
 
-    test('accepts "0" id', () => new Promise<void>(done => {
+    test('accepts "0" id', async () => {
         const map = createMap({
             style: {
                 'version': 8,
@@ -146,16 +141,15 @@ describe('#removeFeatureState', () => {
                 'layers': []
             }
         });
-        map.on('load', () => {
-            map.setFeatureState({source: 'geojson', id: 0}, {'hover': true, 'click': true});
-            map.removeFeatureState({source: 'geojson', id: 0}, 'hover');
-            const fState = map.getFeatureState({source: 'geojson', id: 0});
-            expect(fState.hover).toBeUndefined();
-            expect(fState.click).toBe(true);
-            done();
-        });
-    }));
-    test('accepts string id', () => new Promise<void>(done => {
+        await map.once('load');
+        map.setFeatureState({source: 'geojson', id: 0}, {'hover': true, 'click': true});
+        map.removeFeatureState({source: 'geojson', id: 0}, 'hover');
+        const fState = map.getFeatureState({source: 'geojson', id: 0});
+        expect(fState.hover).toBeUndefined();
+        expect(fState.click).toBe(true);
+    });
+
+    test('accepts string id', async () => {
         const map = createMap({
             style: {
                 'version': 8,
@@ -165,16 +159,15 @@ describe('#removeFeatureState', () => {
                 'layers': []
             }
         });
-        map.on('load', () => {
-            map.setFeatureState({source: 'geojson', id: 'foo'}, {'hover': true, 'click': true});
-            map.removeFeatureState({source: 'geojson', id: 'foo'}, 'hover');
-            const fState = map.getFeatureState({source: 'geojson', id: 'foo'});
-            expect(fState.hover).toBeUndefined();
-            expect(fState.click).toBe(true);
-            done();
-        });
-    }));
-    test('remove specific state property', () => new Promise<void>(done => {
+        await map.once('load');
+        map.setFeatureState({source: 'geojson', id: 'foo'}, {'hover': true, 'click': true});
+        map.removeFeatureState({source: 'geojson', id: 'foo'}, 'hover');
+        const fState = map.getFeatureState({source: 'geojson', id: 'foo'});
+        expect(fState.hover).toBeUndefined();
+        expect(fState.click).toBe(true);
+    });
+
+    test('remove specific state property', async () => {
         const map = createMap({
             style: {
                 'version': 8,
@@ -184,15 +177,14 @@ describe('#removeFeatureState', () => {
                 'layers': []
             }
         });
-        map.on('load', () => {
-            map.setFeatureState({source: 'geojson', id: 12345}, {'hover': true});
-            map.removeFeatureState({source: 'geojson', id: 12345}, 'hover');
-            const fState = map.getFeatureState({source: 'geojson', id: 12345});
-            expect(fState.hover).toBeUndefined();
-            done();
-        });
-    }));
-    test('remove all state properties of one feature', () => new Promise<void>(done => {
+        await map.once('load');
+        map.setFeatureState({source: 'geojson', id: 12345}, {'hover': true});
+        map.removeFeatureState({source: 'geojson', id: 12345}, 'hover');
+        const fState = map.getFeatureState({source: 'geojson', id: 12345});
+        expect(fState.hover).toBeUndefined();
+    });
+
+    test('remove all state properties of one feature', async () => {
         const map = createMap({
             style: {
                 'version': 8,
@@ -202,18 +194,16 @@ describe('#removeFeatureState', () => {
                 'layers': []
             }
         });
-        map.on('load', () => {
-            map.setFeatureState({source: 'geojson', id: 1}, {'hover': true, 'foo': true});
-            map.removeFeatureState({source: 'geojson', id: 1});
+        await map.once('load');
+        map.setFeatureState({source: 'geojson', id: 1}, {'hover': true, 'foo': true});
+        map.removeFeatureState({source: 'geojson', id: 1});
 
-            const fState = map.getFeatureState({source: 'geojson', id: 1});
-            expect(fState.hover).toBeUndefined();
-            expect(fState.foo).toBeUndefined();
+        const fState = map.getFeatureState({source: 'geojson', id: 1});
+        expect(fState.hover).toBeUndefined();
+        expect(fState.foo).toBeUndefined();
+    });
 
-            done();
-        });
-    }));
-    test('remove properties for zero-based feature IDs.', () => new Promise<void>(done => {
+    test('remove properties for zero-based feature IDs.', async () => {
         const map = createMap({
             style: {
                 'version': 8,
@@ -223,18 +213,16 @@ describe('#removeFeatureState', () => {
                 'layers': []
             }
         });
-        map.on('load', () => {
-            map.setFeatureState({source: 'geojson', id: 0}, {'hover': true, 'foo': true});
-            map.removeFeatureState({source: 'geojson', id: 0});
+        await map.once('load');
+        map.setFeatureState({source: 'geojson', id: 0}, {'hover': true, 'foo': true});
+        map.removeFeatureState({source: 'geojson', id: 0});
 
-            const fState = map.getFeatureState({source: 'geojson', id: 0});
-            expect(fState.hover).toBeUndefined();
-            expect(fState.foo).toBeUndefined();
+        const fState = map.getFeatureState({source: 'geojson', id: 0});
+        expect(fState.hover).toBeUndefined();
+        expect(fState.foo).toBeUndefined();
+    });
 
-            done();
-        });
-    }));
-    test('other properties persist when removing specific property', () => new Promise<void>(done => {
+    test('other properties persist when removing specific property', async () => {
         const map = createMap({
             style: {
                 'version': 8,
@@ -244,17 +232,15 @@ describe('#removeFeatureState', () => {
                 'layers': []
             }
         });
-        map.on('load', () => {
-            map.setFeatureState({source: 'geojson', id: 1}, {'hover': true, 'foo': true});
-            map.removeFeatureState({source: 'geojson', id: 1}, 'hover');
+        await map.once('load');
+        map.setFeatureState({source: 'geojson', id: 1}, {'hover': true, 'foo': true});
+        map.removeFeatureState({source: 'geojson', id: 1}, 'hover');
 
-            const fState = map.getFeatureState({source: 'geojson', id: 1});
-            expect(fState.foo).toBe(true);
+        const fState = map.getFeatureState({source: 'geojson', id: 1});
+        expect(fState.foo).toBe(true);
+    });
 
-            done();
-        });
-    }));
-    test('remove all state properties of all features in source', () => new Promise<void>(done => {
+    test('remove all state properties of all features in source', async () => {
         const map = createMap({
             style: {
                 'version': 8,
@@ -264,24 +250,22 @@ describe('#removeFeatureState', () => {
                 'layers': []
             }
         });
-        map.on('load', () => {
-            map.setFeatureState({source: 'geojson', id: 1}, {'hover': true, 'foo': true});
-            map.setFeatureState({source: 'geojson', id: 2}, {'hover': true, 'foo': true});
+        await map.once('load');
+        map.setFeatureState({source: 'geojson', id: 1}, {'hover': true, 'foo': true});
+        map.setFeatureState({source: 'geojson', id: 2}, {'hover': true, 'foo': true});
 
-            map.removeFeatureState({source: 'geojson'});
+        map.removeFeatureState({source: 'geojson'});
 
-            const fState1 = map.getFeatureState({source: 'geojson', id: 1});
-            expect(fState1.hover).toBeUndefined();
-            expect(fState1.foo).toBeUndefined();
+        const fState1 = map.getFeatureState({source: 'geojson', id: 1});
+        expect(fState1.hover).toBeUndefined();
+        expect(fState1.foo).toBeUndefined();
 
-            const fState2 = map.getFeatureState({source: 'geojson', id: 2});
-            expect(fState2.hover).toBeUndefined();
-            expect(fState2.foo).toBeUndefined();
+        const fState2 = map.getFeatureState({source: 'geojson', id: 2});
+        expect(fState2.hover).toBeUndefined();
+        expect(fState2.foo).toBeUndefined();
+    });
 
-            done();
-        });
-    }));
-    test('specific state deletion should not interfere with broader state deletion', () => new Promise<void>(done => {
+    test('specific state deletion should not interfere with broader state deletion', async () => {
         const map = createMap({
             style: {
                 'version': 8,
@@ -291,34 +275,32 @@ describe('#removeFeatureState', () => {
                 'layers': []
             }
         });
-        map.on('load', () => {
-            map.setFeatureState({source: 'geojson', id: 1}, {'hover': true, 'foo': true});
-            map.setFeatureState({source: 'geojson', id: 2}, {'hover': true, 'foo': true});
+        await map.once('load');
+        map.setFeatureState({source: 'geojson', id: 1}, {'hover': true, 'foo': true});
+        map.setFeatureState({source: 'geojson', id: 2}, {'hover': true, 'foo': true});
 
-            map.removeFeatureState({source: 'geojson', id: 1});
-            map.removeFeatureState({source: 'geojson', id: 1}, 'foo');
+        map.removeFeatureState({source: 'geojson', id: 1});
+        map.removeFeatureState({source: 'geojson', id: 1}, 'foo');
 
-            const fState1 = map.getFeatureState({source: 'geojson', id: 1});
-            expect(fState1.hover).toBeUndefined();
+        const fState1 = map.getFeatureState({source: 'geojson', id: 1});
+        expect(fState1.hover).toBeUndefined();
 
-            map.setFeatureState({source: 'geojson', id: 1}, {'hover': true, 'foo': true});
-            map.removeFeatureState({source: 'geojson'});
-            map.removeFeatureState({source: 'geojson', id: 1}, 'foo');
+        map.setFeatureState({source: 'geojson', id: 1}, {'hover': true, 'foo': true});
+        map.removeFeatureState({source: 'geojson'});
+        map.removeFeatureState({source: 'geojson', id: 1}, 'foo');
 
-            const fState2 = map.getFeatureState({source: 'geojson', id: 2});
-            expect(fState2.hover).toBeUndefined();
+        const fState2 = map.getFeatureState({source: 'geojson', id: 2});
+        expect(fState2.hover).toBeUndefined();
 
-            map.setFeatureState({source: 'geojson', id: 2}, {'hover': true, 'foo': true});
-            map.removeFeatureState({source: 'geojson'});
-            map.removeFeatureState({source: 'geojson', id: 2}, 'foo');
+        map.setFeatureState({source: 'geojson', id: 2}, {'hover': true, 'foo': true});
+        map.removeFeatureState({source: 'geojson'});
+        map.removeFeatureState({source: 'geojson', id: 2}, 'foo');
 
-            const fState3 = map.getFeatureState({source: 'geojson', id: 2});
-            expect(fState3.hover).toBeUndefined();
+        const fState3 = map.getFeatureState({source: 'geojson', id: 2});
+        expect(fState3.hover).toBeUndefined();
+    });
 
-            done();
-        });
-    }));
-    test('add/remove and remove/add state', () => new Promise<void>(done => {
+    test('add/remove and remove/add state', async () => {
         const map = createMap({
             style: {
                 'version': 8,
@@ -328,23 +310,21 @@ describe('#removeFeatureState', () => {
                 'layers': []
             }
         });
-        map.on('load', () => {
-            map.setFeatureState({source: 'geojson', id: 12345}, {'hover': true});
+        await map.once('load');
+        map.setFeatureState({source: 'geojson', id: 12345}, {'hover': true});
 
-            map.removeFeatureState({source: 'geojson', id: 12345});
-            map.setFeatureState({source: 'geojson', id: 12345}, {'hover': true});
+        map.removeFeatureState({source: 'geojson', id: 12345});
+        map.setFeatureState({source: 'geojson', id: 12345}, {'hover': true});
 
-            const fState1 = map.getFeatureState({source: 'geojson', id: 12345});
-            expect(fState1.hover).toBe(true);
+        const fState1 = map.getFeatureState({source: 'geojson', id: 12345});
+        expect(fState1.hover).toBe(true);
 
-            map.removeFeatureState({source: 'geojson', id: 12345});
+        map.removeFeatureState({source: 'geojson', id: 12345});
 
-            const fState2 = map.getFeatureState({source: 'geojson', id: 12345});
-            expect(fState2.hover).toBeUndefined();
+        const fState2 = map.getFeatureState({source: 'geojson', id: 12345});
+        expect(fState2.hover).toBeUndefined();
+    });
 
-            done();
-        });
-    }));
     test('throw before loaded', () => {
         const map = createMap({
             style: {
@@ -359,7 +339,7 @@ describe('#removeFeatureState', () => {
             (map as any).removeFeatureState({source: 'geojson', id: 12345}, {'hover': true});
         }).toThrow(Error);
     });
-    test('fires an error if source not found', () => new Promise<void>(done => {
+    test('fires an error if source not found', async () => {
         const map = createMap({
             style: {
                 'version': 8,
@@ -369,15 +349,16 @@ describe('#removeFeatureState', () => {
                 'layers': []
             }
         });
-        map.on('load', () => {
-            map.on('error', ({error}) => {
-                expect(error.message).toMatch(/source/);
-                done();
-            });
-            (map as any).removeFeatureState({source: 'vector', id: 12345}, {'hover': true});
-        });
-    }));
-    test('fires an error if sourceLayer not provided for a vector source', () => new Promise<void>(done => {
+        await map.once('load');
+        const errorPromise = map.once('error');
+                
+        map.removeFeatureState({source: 'vector', id: 12345});
+
+        const {error} = await errorPromise;
+        expect(error.message).toMatch(/source/);
+    });
+
+    test('fires an error if sourceLayer not provided for a vector source', async () => {
         const map = createMap({
             style: {
                 'version': 8,
@@ -390,15 +371,14 @@ describe('#removeFeatureState', () => {
                 'layers': []
             }
         });
-        map.on('load', () => {
-            map.on('error', ({error}) => {
-                expect(error.message).toMatch(/sourceLayer/);
-                done();
-            });
-            (map as any).removeFeatureState({source: 'vector', sourceLayer: 0, id: 12345}, {'hover': true});
-        });
-    }));
-    test('fires an error if state property is provided without a feature id', () => new Promise<void>(done => {
+        await map.once('load');
+        const errorPromise = map.once('error');
+        map.removeFeatureState({source: 'vector', id: 12345});
+        const {error} = await errorPromise;
+        expect(error.message).toMatch(/sourceLayer/);
+    });
+
+    test('fires an error if state property is provided without a feature id', async () => {
         const map = createMap({
             style: {
                 'version': 8,
@@ -411,12 +391,10 @@ describe('#removeFeatureState', () => {
                 'layers': []
             }
         });
-        map.on('load', () => {
-            map.on('error', ({error}) => {
-                expect(error.message).toMatch(/id/);
-                done();
-            });
-            (map as any).removeFeatureState({source: 'vector', sourceLayer: '1'}, {'hover': true});
-        });
-    }));
+        await map.once('load');
+        const errorPromise = map.once('error');
+        map.removeFeatureState({source: 'vector', sourceLayer: '1'}, 'hover');
+        const {error} = await errorPromise;
+        expect(error.message).toMatch(/id/);
+    });
 });

--- a/src/ui/map_tests/map_images.test.ts
+++ b/src/ui/map_tests/map_images.test.ts
@@ -150,7 +150,6 @@ test('map does not fire `styleimagemissing` for empty icon values', async () => 
     const map = createMap();
 
     await map.once('load');
-    
 
     map.addSource('foo', {
         type: 'geojson',

--- a/src/ui/map_tests/map_images.test.ts
+++ b/src/ui/map_tests/map_images.test.ts
@@ -7,20 +7,18 @@ beforeEach(() => {
     global.fetch = null;
 });
 
-test('#listImages', () => new Promise<void>(done => {
+test('#listImages', async () => {
     const map = createMap();
 
-    map.on('load', () => {
-        expect(map.listImages()).toHaveLength(0);
+    await map.once('load');
+    expect(map.listImages()).toHaveLength(0);
 
-        map.addImage('img', {width: 1, height: 1, data: new Uint8Array(4)});
+    map.addImage('img', {width: 1, height: 1, data: new Uint8Array(4)});
 
-        const images = map.listImages();
-        expect(images).toHaveLength(1);
-        expect(images[0]).toBe('img');
-        done();
-    });
-}));
+    const images = map.listImages();
+    expect(images).toHaveLength(1);
+    expect(images[0]).toBe('img');  
+});
 
 test('#listImages throws an error if called before "load"', () => {
     const map = createMap();

--- a/src/ui/map_tests/map_is_moving.test.ts
+++ b/src/ui/map_tests/map_is_moving.test.ts
@@ -28,20 +28,20 @@ describe('Map#isMoving', () => {
         expect(map.isMoving()).toBe(false);
     });
 
-    test('returns true during a camera zoom animation', () => new Promise<void>(done => {
+    test('returns true during a camera zoom animation', async () => {
         map.on('zoomstart', () => {
             expect(map.isMoving()).toBe(true);
         });
 
-        map.on('zoomend', () => {
-            expect(map.isMoving()).toBe(false);
-            done();
-        });
+        const zoomEndPromise = map.once('zoomend');
 
         map.zoomTo(5, {duration: 0});
-    }));
 
-    test('returns true when drag panning', () => new Promise<void>(done => {
+        await zoomEndPromise;
+        expect(map.isMoving()).toBe(false);
+    });
+
+    test('returns true when drag panning', async () => {
         map.on('movestart', () => {
             expect(map.isMoving()).toBe(true);
         });
@@ -52,10 +52,7 @@ describe('Map#isMoving', () => {
         map.on('dragend', () => {
             expect(map.isMoving()).toBe(false);
         });
-        map.on('moveend', () => {
-            expect(map.isMoving()).toBe(false);
-            done();
-        });
+        const moveEndPromise = map.once('moveend');
 
         simulate.mousedown(map.getCanvas());
         map._renderTaskQueue.run();
@@ -65,9 +62,12 @@ describe('Map#isMoving', () => {
 
         simulate.mouseup(map.getCanvas());
         map._renderTaskQueue.run();
-    }));
 
-    test('returns true when drag rotating', () => new Promise<void>(done => {
+        await moveEndPromise;
+        expect(map.isMoving()).toBe(false);
+    });
+
+    test('returns true when drag rotating', async () => {
         // Prevent inertial rotation.
         vi.spyOn(browser, 'now').mockImplementation(() => { return 0; });
 
@@ -85,8 +85,9 @@ describe('Map#isMoving', () => {
 
         map.on('moveend', () => {
             expect(map.isMoving()).toBe(false);
-            done();
         });
+
+        const moveEndPromise = map.once('moveend');
 
         simulate.mousedown(map.getCanvas(), {buttons: 2, button: 2});
         map._renderTaskQueue.run();
@@ -96,17 +97,16 @@ describe('Map#isMoving', () => {
 
         simulate.mouseup(map.getCanvas(),   {buttons: 0, button: 2});
         map._renderTaskQueue.run();
-    }));
 
-    test('returns true when scroll zooming', () => new Promise<void>(done => {
+        await expect(moveEndPromise).resolves.toBeDefined();        
+    });
+
+    test('returns true when scroll zooming', async () => {
         map.on('zoomstart', () => {
             expect(map.isMoving()).toBe(true);
         });
 
-        map.on('zoomend', () => {
-            expect(map.isMoving()).toBe(false);
-            done();
-        });
+        const moveEndPromise = map.once('zoomend');
 
         let now = 0;
         vi.spyOn(browser, 'now').mockImplementation(() => { return now; });
@@ -118,9 +118,12 @@ describe('Map#isMoving', () => {
         setTimeout(() => {
             map._renderTaskQueue.run();
         }, 400);
-    }));
 
-    test('returns true when drag panning and scroll zooming interleave', () => new Promise<void>(done => {
+        await moveEndPromise;
+        expect(map.isMoving()).toBe(false);
+    });
+
+    test('returns true when drag panning and scroll zooming interleave', async () => {
         map.on('dragstart', () => {
             expect(map.isMoving()).toBe(true);
         });
@@ -129,14 +132,7 @@ describe('Map#isMoving', () => {
             expect(map.isMoving()).toBe(true);
         });
 
-        map.on('zoomend', () => {
-            expect(map.isMoving()).toBe(true);
-            simulate.mouseup(map.getCanvas());
-            setTimeout(() => {
-                map._renderTaskQueue.run();
-                done();
-            });
-        });
+        const zoomEndPromise = map.once('zoomend');
 
         map.on('dragend', () => {
             expect(map.isMoving()).toBe(false);
@@ -161,5 +157,10 @@ describe('Map#isMoving', () => {
         setTimeout(() => {
             map._renderTaskQueue.run();
         }, 400);
-    }));
+
+        await zoomEndPromise;
+        expect(map.isMoving()).toBe(true);
+        simulate.mouseup(map.getCanvas());
+        map._renderTaskQueue.run();
+    });
 });

--- a/src/ui/map_tests/map_is_rotating.test.ts
+++ b/src/ui/map_tests/map_is_rotating.test.ts
@@ -3,7 +3,7 @@ import {Map} from '../map';
 import {DOM} from '../../util/dom';
 import simulate from '../../../test/unit/lib/simulate_interaction';
 import {browser} from '../../util/browser';
-import {beforeMapTest, sleep} from '../../util/test/util';
+import {beforeMapTest} from '../../util/test/util';
 
 let map;
 

--- a/src/ui/map_tests/map_is_rotating.test.ts
+++ b/src/ui/map_tests/map_is_rotating.test.ts
@@ -3,7 +3,7 @@ import {Map} from '../map';
 import {DOM} from '../../util/dom';
 import simulate from '../../../test/unit/lib/simulate_interaction';
 import {browser} from '../../util/browser';
-import {beforeMapTest} from '../../util/test/util';
+import {beforeMapTest, sleep} from '../../util/test/util';
 
 let map;
 
@@ -25,20 +25,20 @@ describe('Map#isRotating', () => {
         expect(map.isRotating()).toBe(false);
     });
 
-    test('returns true during a camera rotate animation', () => new Promise<void>(done => {
+    test('returns true during a camera rotate animation', async () => {
         map.on('rotatestart', () => {
             expect(map.isRotating()).toBe(true);
         });
 
-        map.on('rotateend', () => {
-            expect(map.isRotating()).toBe(false);
-            done();
-        });
+        const rotateEndPromise = map.once('rotateend');
 
         map.rotateTo(5, {duration: 0});
-    }));
 
-    test('returns true when drag rotating', () => new Promise<void>(done => {
+        await rotateEndPromise;
+        expect(map.isRotating()).toBe(false);
+    });
+
+    test('returns true when drag rotating', async () => {
         // Prevent inertial rotation.
         vi.spyOn(browser, 'now').mockImplementation(() => { return 0; });
 
@@ -48,8 +48,9 @@ describe('Map#isRotating', () => {
 
         map.on('rotateend', () => {
             expect(map.isRotating()).toBe(false);
-            done();
         });
+
+        const promise = map.once('rotateend');
 
         simulate.mousedown(map.getCanvas(), {buttons: 2, button: 2});
         map._renderTaskQueue.run();
@@ -59,5 +60,7 @@ describe('Map#isRotating', () => {
 
         simulate.mouseup(map.getCanvas(),   {buttons: 0, button: 2});
         map._renderTaskQueue.run();
-    }));
+
+        await expect(promise).resolves.toBeDefined();
+    });
 });

--- a/src/ui/map_tests/map_query_rendered_features.test.ts
+++ b/src/ui/map_tests/map_query_rendered_features.test.ts
@@ -10,7 +10,7 @@ beforeEach(() => {
 describe('#queryRenderedFeatures', () => {
 
     test('if no arguments provided', async () => {
-        const map = createMap({});
+        const map = createMap();
         await map.once('load');
         const spy = vi.spyOn(map.style, 'queryRenderedFeatures');
 
@@ -23,7 +23,7 @@ describe('#queryRenderedFeatures', () => {
     });
 
     test('if only "geometry" provided', async () => {
-        const map = createMap({});
+        const map = createMap();
         await map.once('load');
         const spy = vi.spyOn(map.style, 'queryRenderedFeatures');
 
@@ -37,7 +37,7 @@ describe('#queryRenderedFeatures', () => {
     });
 
     test('if only "params" provided', async () => {
-        const map = createMap({});
+        const map = createMap();
         await map.once('load');
         const spy = vi.spyOn(map.style, 'queryRenderedFeatures');
 
@@ -50,7 +50,7 @@ describe('#queryRenderedFeatures', () => {
     });
 
     test('if both "geometry" and "params" provided', async () => {
-        const map = createMap({});
+        const map = createMap();
         await map.once('load');
         const spy = vi.spyOn(map.style, 'queryRenderedFeatures');
 
@@ -63,7 +63,7 @@ describe('#queryRenderedFeatures', () => {
     });
 
     test('if "geometry" with unwrapped coords provided', async () => {
-        const map = createMap({});
+        const map = createMap();
         await map.once('load');
         const spy = vi.spyOn(map.style, 'queryRenderedFeatures');
 

--- a/src/ui/map_tests/map_query_rendered_features.test.ts
+++ b/src/ui/map_tests/map_query_rendered_features.test.ts
@@ -9,82 +9,68 @@ beforeEach(() => {
 
 describe('#queryRenderedFeatures', () => {
 
-    test('if no arguments provided', () => new Promise<void>(done => {
-        createMap({}, (err, map) => {
-            expect(err).toBeFalsy();
-            const spy = vi.spyOn(map.style, 'queryRenderedFeatures');
+    test('if no arguments provided', async () => {
+        const map = createMap({});
+        await map.once('load');
+        const spy = vi.spyOn(map.style, 'queryRenderedFeatures');
 
-            const output = map.queryRenderedFeatures();
+        const output = map.queryRenderedFeatures();
 
-            const args = spy.mock.calls[0];
-            expect(args[0]).toBeTruthy();
-            expect(args[1]).toEqual({availableImages: []});
-            expect(output).toEqual([]);
+        const args = spy.mock.calls[0];
+        expect(args[0]).toBeTruthy();
+        expect(args[1]).toEqual({availableImages: []});
+        expect(output).toEqual([]);
+    });
 
-            done();
-        });
-    }));
+    test('if only "geometry" provided', async () => {
+        const map = createMap({});
+        await map.once('load');
+        const spy = vi.spyOn(map.style, 'queryRenderedFeatures');
 
-    test('if only "geometry" provided', () => new Promise<void>(done => {
-        createMap({}, (err, map) => {
-            expect(err).toBeFalsy();
-            const spy = vi.spyOn(map.style, 'queryRenderedFeatures');
+        const output = map.queryRenderedFeatures(map.project(new LngLat(0, 0)));
 
-            const output = map.queryRenderedFeatures(map.project(new LngLat(0, 0)));
+        const args = spy.mock.calls[0];
+        expect(args[0]).toEqual([{x: 100, y: 100}]); // query geometry
+        expect(args[1]).toEqual({availableImages: []}); // params
+        expect(args[2]).toEqual(map.transform); // transform
+        expect(output).toEqual([]);
+    });
 
-            const args = spy.mock.calls[0];
-            expect(args[0]).toEqual([{x: 100, y: 100}]); // query geometry
-            expect(args[1]).toEqual({availableImages: []}); // params
-            expect(args[2]).toEqual(map.transform); // transform
-            expect(output).toEqual([]);
+    test('if only "params" provided', async () => {
+        const map = createMap({});
+        await map.once('load');
+        const spy = vi.spyOn(map.style, 'queryRenderedFeatures');
 
-            done();
-        });
-    }));
+        const output = map.queryRenderedFeatures({filter: ['all']});
 
-    test('if only "params" provided', () => new Promise<void>(done => {
-        createMap({}, (err, map) => {
-            expect(err).toBeFalsy();
-            const spy = vi.spyOn(map.style, 'queryRenderedFeatures');
+        const args = spy.mock.calls[0];
+        expect(args[0]).toBeTruthy();
+        expect(args[1]).toEqual({availableImages: [], filter: ['all']});
+        expect(output).toEqual([]);
+    });
 
-            const output = map.queryRenderedFeatures({filter: ['all']});
+    test('if both "geometry" and "params" provided', async () => {
+        const map = createMap({});
+        await map.once('load');
+        const spy = vi.spyOn(map.style, 'queryRenderedFeatures');
 
-            const args = spy.mock.calls[0];
-            expect(args[0]).toBeTruthy();
-            expect(args[1]).toEqual({availableImages: [], filter: ['all']});
-            expect(output).toEqual([]);
+        const output = map.queryRenderedFeatures({filter: ['all']});
 
-            done();
-        });
-    }));
+        const args = spy.mock.calls[0];
+        expect(args[0]).toBeTruthy();
+        expect(args[1]).toEqual({availableImages: [], filter: ['all']});
+        expect(output).toEqual([]);
+    });
 
-    test('if both "geometry" and "params" provided', () => new Promise<void>(done => {
-        createMap({}, (err, map) => {
-            expect(err).toBeFalsy();
-            const spy = vi.spyOn(map.style, 'queryRenderedFeatures');
+    test('if "geometry" with unwrapped coords provided', async () => {
+        const map = createMap({});
+        await map.once('load');
+        const spy = vi.spyOn(map.style, 'queryRenderedFeatures');
 
-            const output = map.queryRenderedFeatures({filter: ['all']});
+        map.queryRenderedFeatures(map.project(new LngLat(360, 0)));
 
-            const args = spy.mock.calls[0];
-            expect(args[0]).toBeTruthy();
-            expect(args[1]).toEqual({availableImages: [], filter: ['all']});
-            expect(output).toEqual([]);
-
-            done();
-        });
-    }));
-
-    test('if "geometry" with unwrapped coords provided', () => new Promise<void>(done => {
-        createMap({}, (err, map) => {
-            expect(err).toBeFalsy();
-            const spy = vi.spyOn(map.style, 'queryRenderedFeatures');
-
-            map.queryRenderedFeatures(map.project(new LngLat(360, 0)));
-
-            expect(spy.mock.calls[0][0]).toEqual([{x: 612, y: 100}]);
-            done();
-        });
-    }));
+        expect(spy.mock.calls[0][0]).toEqual([{x: 612, y: 100}]);
+    });
 
     test('returns an empty array when no style is loaded', () => {
         const map = createMap({style: undefined});

--- a/src/ui/map_tests/map_render.test.ts
+++ b/src/ui/map_tests/map_render.test.ts
@@ -1,5 +1,5 @@
 import {beforeEach, afterEach, test, expect, vi} from 'vitest';
-import {createMap, beforeMapTest, createStyle} from '../../util/test/util';
+import {createMap, beforeMapTest, createStyle, sleep, waitForEvent} from '../../util/test/util';
 import {fakeServer, type FakeServer} from 'nise';
 
 let server: FakeServer;
@@ -14,9 +14,9 @@ afterEach(() => {
     server.restore();
 });
 
-test('render stabilizes', () => new Promise<void>((done) => {
+test('render stabilizes', async () => {
     const style = createStyle();
-    style.sources.mapbox = {
+    style.sources.maplibre = {
         type: 'vector',
         minzoom: 1,
         maxzoom: 10,
@@ -25,12 +25,13 @@ test('render stabilizes', () => new Promise<void>((done) => {
     style.layers.push({
         id: 'layerId',
         type: 'circle',
-        source: 'mapbox',
+        source: 'maplibre',
         'source-layer': 'sourceLayer'
     });
 
     let timer;
     const map = createMap({style});
+    const spy = vi.fn();
     map.on('render', () => {
         if (timer) clearTimeout(timer);
         timer = setTimeout(() => {
@@ -39,25 +40,24 @@ test('render stabilizes', () => new Promise<void>((done) => {
                 throw new Error('test failed');
             });
             expect((map as any)._frameId).toBeFalsy();
-            done();
+            spy();
         }, 100);
     });
-}));
+    await sleep(300);
+    expect(spy).toHaveBeenCalled();
+});
 
-test('no render after idle event', () => new Promise<void>((done) => {
+test('no render after idle event', async () => {
     const style = createStyle();
     const map = createMap({style});
-    map.on('idle', () => {
-        map.on('render', () => {
-            throw new Error('test failed');
-        });
-        setTimeout(() => {
-            done();
-        }, 100);
-    });
-}));
+    await map.once('idle');
+    const spy = vi.fn();
+    map.on('render', spy);
+    await sleep(100);
+    expect(spy).not.toHaveBeenCalled();
+});
 
-test('no render before style loaded', () => new Promise<void>((done) => {
+test('no render before style loaded', async () => {
     server.respondWith('/styleUrl', JSON.stringify(createStyle()));
     const map = createMap({style: '/styleUrl'});
 
@@ -66,19 +66,19 @@ test('no render before style loaded', () => new Promise<void>((done) => {
             throw new Error('test failed');
         }
     });
+
+    let loaded = true;
     map.on('render', () => {
-        if (map.style._loaded) {
-            done();
-        } else {
-            throw new Error('test failed');
-        }
+        loaded = map.style._loaded;
     });
 
     // Force a update should not call triggerRepaint till style is loaded.
     // Once style is loaded, it will trigger the update.
     map._update();
+    expect(loaded).toBeTruthy();
     server.respond();
-}));
+    expect(loaded).toBeTruthy();
+});
 
 test('#redraw', async () => {
     const map = createMap();

--- a/src/ui/map_tests/map_render.test.ts
+++ b/src/ui/map_tests/map_render.test.ts
@@ -43,7 +43,7 @@ test('render stabilizes', async () => {
             spy();
         }, 100);
     });
-    await sleep(300);
+    await sleep(700);
     expect(spy).toHaveBeenCalled();
 });
 

--- a/src/ui/map_tests/map_render.test.ts
+++ b/src/ui/map_tests/map_render.test.ts
@@ -1,5 +1,5 @@
 import {beforeEach, afterEach, test, expect, vi} from 'vitest';
-import {createMap, beforeMapTest, createStyle, sleep, waitForEvent} from '../../util/test/util';
+import {createMap, beforeMapTest, createStyle, sleep} from '../../util/test/util';
 import {fakeServer, type FakeServer} from 'nise';
 
 let server: FakeServer;

--- a/src/ui/map_tests/map_request_render_frame.test.ts
+++ b/src/ui/map_tests/map_request_render_frame.test.ts
@@ -7,21 +7,19 @@ beforeEach(() => {
 
 describe('requestRenderFrame', () => {
 
-    test('Map#_requestRenderFrame schedules a new render frame if necessary', () => new Promise<void>(done => {
+    test('Map#_requestRenderFrame schedules a new render frame if necessary', async () => {
         const map = createMap();
         const spy = vi.spyOn(map, 'triggerRepaint');
         map._requestRenderFrame(() => {});
         expect(spy).toHaveBeenCalledTimes(0);
 
         // wait for style to be loaded
-        map.once('data', () => {
-            spy.mockReset();
-            map._requestRenderFrame(() => {});
-            expect(spy).toHaveBeenCalledTimes(1);
-            map.remove();
-            done();
-        });
-    }));
+        await map.once('data');
+        spy.mockReset();
+        map._requestRenderFrame(() => {});
+        expect(spy).toHaveBeenCalledTimes(1);
+        map.remove();
+    });
 
     test('Map#_requestRenderFrame should not schedule a render frame before style load', () => {
         const map = createMap();

--- a/src/ui/map_tests/map_style.test.ts
+++ b/src/ui/map_tests/map_style.test.ts
@@ -31,61 +31,57 @@ describe('#setStyle', () => {
         })).toBe(map);
     });
 
-    test('sets up event forwarding', () => {
-        createMap({}, (error, map) => {
-            expect(error).toBeFalsy();
+    test('sets up event forwarding', async () => {
+        const map = createMap();
+        await map.once('load');
 
-            const events = [];
-            function recordEvent(event) { events.push(event.type); }
+        const events = [];
+        function recordEvent(event) { events.push(event.type); }
 
-            map.on('error', recordEvent);
-            map.on('data', recordEvent);
-            map.on('dataloading', recordEvent);
+        map.on('error', recordEvent);
+        map.on('data', recordEvent);
+        map.on('dataloading', recordEvent);
 
-            map.style.fire(new EventedEvent('error'));
-            map.style.fire(new EventedEvent('data'));
-            map.style.fire(new EventedEvent('dataloading'));
+        map.style.fire(new EventedEvent('error'));
+        map.style.fire(new EventedEvent('data'));
+        map.style.fire(new EventedEvent('dataloading'));
 
-            expect(events).toEqual([
-                'error',
-                'data',
-                'dataloading',
-            ]);
-
-        });
+        expect(events).toEqual([
+            'error',
+            'data',
+            'dataloading',
+        ]);
     });
 
-    test('fires *data and *dataloading events', () => {
-        createMap({}, (error, map: Map) => {
-            expect(error).toBeFalsy();
+    test('fires *data and *dataloading events', async () => {
+        const map = createMap();
+        await map.once('load');
 
-            const events = [];
-            function recordEvent(event) { events.push(event.type); }
+        const events = [];
+        function recordEvent(event) { events.push(event.type); }
 
-            map.on('styledata', recordEvent);
-            map.on('styledataloading', recordEvent);
-            map.on('sourcedata', recordEvent);
-            map.on('sourcedataloading', recordEvent);
-            map.on('tiledata', recordEvent);
-            map.on('tiledataloading', recordEvent);
+        map.on('styledata', recordEvent);
+        map.on('styledataloading', recordEvent);
+        map.on('sourcedata', recordEvent);
+        map.on('sourcedataloading', recordEvent);
+        map.on('tiledata', recordEvent);
+        map.on('tiledataloading', recordEvent);
 
-            map.style.fire(new EventedEvent('data', {dataType: 'style'}));
-            map.style.fire(new EventedEvent('dataloading', {dataType: 'style'}));
-            map.style.fire(new EventedEvent('data', {dataType: 'source'}));
-            map.style.fire(new EventedEvent('dataloading', {dataType: 'source'}));
-            map.style.fire(new EventedEvent('data', {dataType: 'tile'}));
-            map.style.fire(new EventedEvent('dataloading', {dataType: 'tile'}));
+        map.style.fire(new EventedEvent('data', {dataType: 'style'}));
+        map.style.fire(new EventedEvent('dataloading', {dataType: 'style'}));
+        map.style.fire(new EventedEvent('data', {dataType: 'source'}));
+        map.style.fire(new EventedEvent('dataloading', {dataType: 'source'}));
+        map.style.fire(new EventedEvent('data', {dataType: 'tile'}));
+        map.style.fire(new EventedEvent('dataloading', {dataType: 'tile'}));
 
-            expect(events).toEqual([
-                'styledata',
-                'styledataloading',
-                'sourcedata',
-                'sourcedataloading',
-                'tiledata',
-                'tiledataloading'
-            ]);
-
-        });
+        expect(events).toEqual([
+            'styledata',
+            'styledataloading',
+            'sourcedata',
+            'sourcedataloading',
+            'tiledata',
+            'tiledataloading'
+        ]);
     });
 
     test('can be called more than once', () => {

--- a/src/ui/map_tests/map_style.test.ts
+++ b/src/ui/map_tests/map_style.test.ts
@@ -1,6 +1,6 @@
 import {describe, beforeEach, afterEach, test, expect, vi} from 'vitest';
 import {Map, type MapOptions} from '../map';
-import {createMap, beforeMapTest, createStyle, createStyleSource} from '../../util/test/util';
+import {createMap, beforeMapTest, createStyle, createStyleSource, sleep} from '../../util/test/util';
 import {Event as EventedEvent} from '../../util/evented';
 import {fixedLngLat, fixedNum} from '../../../test/unit/lib/fixed';
 import {extend} from '../../util/util';
@@ -109,50 +109,44 @@ describe('#setStyle', () => {
         spy.mockRestore();
     });
 
-    test('style transform overrides unmodified map transform', () => new Promise<void>(done => {
+    test('style transform overrides unmodified map transform', async () => {
         const map = new Map({container: window.document.createElement('div')} as any as MapOptions);
         map.transform.setMaxBounds(new LngLatBounds([-120, -60], [140, 80]));
         map.transform.resize(600, 400, true);
         expect(map.transform.zoom).toBe(0.6983039737971013);
         expect(map.transform.unmodified).toBeTruthy();
         map.setStyle(createStyle());
-        map.on('style.load', () => {
-            expect(fixedLngLat(map.transform.center)).toEqual(fixedLngLat({lng: -73.9749, lat: 40.7736}));
-            expect(fixedNum(map.transform.zoom)).toBe(12.5);
-            expect(fixedNum(map.transform.bearing)).toBe(29);
-            expect(fixedNum(map.transform.pitch)).toBe(50);
-            done();
-        });
-    }));
+        await map.once('style.load');
+        expect(fixedLngLat(map.transform.center)).toEqual(fixedLngLat({lng: -73.9749, lat: 40.7736}));
+        expect(fixedNum(map.transform.zoom)).toBe(12.5);
+        expect(fixedNum(map.transform.bearing)).toBe(29);
+        expect(fixedNum(map.transform.pitch)).toBe(50);
+    });
 
-    test('style transform does not override map transform modified via options', () => new Promise<void>(done => {
+    test('style transform does not override map transform modified via options', async () => {
         const map = new Map({container: window.document.createElement('div'), zoom: 10, center: [-77.0186, 38.8888]} as any as MapOptions);
         expect(map.transform.unmodified).toBeFalsy();
         map.setStyle(createStyle());
-        map.on('style.load', () => {
-            expect(fixedLngLat(map.transform.center)).toEqual(fixedLngLat({lng: -77.0186, lat: 38.8888}));
-            expect(fixedNum(map.transform.zoom)).toBe(10);
-            expect(fixedNum(map.transform.bearing)).toBe(0);
-            expect(fixedNum(map.transform.pitch)).toBe(0);
-            done();
-        });
-    }));
+        await map.once('style.load');
+        expect(fixedLngLat(map.transform.center)).toEqual(fixedLngLat({lng: -77.0186, lat: 38.8888}));
+        expect(fixedNum(map.transform.zoom)).toBe(10);
+        expect(fixedNum(map.transform.bearing)).toBe(0);
+        expect(fixedNum(map.transform.pitch)).toBe(0);
+    });
 
-    test('style transform does not override map transform modified via setters', () => new Promise<void>(done => {
+    test('style transform does not override map transform modified via setters', async () => {
         const map = new Map({container: window.document.createElement('div')} as any as MapOptions);
         expect(map.transform.unmodified).toBeTruthy();
         map.setZoom(10);
         map.setCenter([-77.0186, 38.8888]);
         expect(map.transform.unmodified).toBeFalsy();
         map.setStyle(createStyle());
-        map.on('style.load', () => {
-            expect(fixedLngLat(map.transform.center)).toEqual(fixedLngLat({lng: -77.0186, lat: 38.8888}));
-            expect(fixedNum(map.transform.zoom)).toBe(10);
-            expect(fixedNum(map.transform.bearing)).toBe(0);
-            expect(fixedNum(map.transform.pitch)).toBe(0);
-            done();
-        });
-    }));
+        map.once('style.load');
+        expect(fixedLngLat(map.transform.center)).toEqual(fixedLngLat({lng: -77.0186, lat: 38.8888}));
+        expect(fixedNum(map.transform.zoom)).toBe(10);
+        expect(fixedNum(map.transform.bearing)).toBe(0);
+        expect(fixedNum(map.transform.pitch)).toBe(0);
+    });
 
     test('passing null removes style', () => {
         const map = createMap();
@@ -182,7 +176,7 @@ describe('#setStyle', () => {
         spyWorkerPoolRelease.mockClear();
     });
 
-    test('transformStyle should copy the source and the layer into next style', () => new Promise<void>(done => {
+    test('transformStyle should copy the source and the layer into next style', async () => {
         const style = extend(createStyle(), {
             sources: {
                 maplibre: {
@@ -221,16 +215,14 @@ describe('#setStyle', () => {
             })
         });
 
-        map.on('style.load', () => {
-            const loadedStyle = map.style.serialize();
-            expect('maplibre' in loadedStyle.sources).toBeTruthy();
-            expect(loadedStyle.layers[0].id).toBe(style.layers[0].id);
-            expect(loadedStyle.layers).toHaveLength(1);
-            done();
-        });
-    }));
+        await map.once('style.load');
+        const loadedStyle = map.style.serialize();
+        expect('maplibre' in loadedStyle.sources).toBeTruthy();
+        expect(loadedStyle.layers[0].id).toBe(style.layers[0].id);
+        expect(loadedStyle.layers).toHaveLength(1);
+    });
 
-    test('delayed setStyle with transformStyle should copy the source and the layer into next style with diffing', () => new Promise<void>(done => {
+    test('delayed setStyle with transformStyle should copy the source and the layer into next style with diffing', async () => {
         const style = extend(createStyle(), {
             sources: {
                 maplibre: {
@@ -254,31 +246,30 @@ describe('#setStyle', () => {
         });
 
         const map = createMap({style});
-        window.setTimeout(() => {
-            map.setStyle(createStyle(), {
-                diff: true,
-                transformStyle: (prevStyle, nextStyle) => ({
-                    ...nextStyle,
-                    sources: {
-                        ...nextStyle.sources,
-                        maplibre: prevStyle.sources.maplibre
-                    },
-                    layers: [
-                        ...nextStyle.layers,
-                        prevStyle.layers[0]
-                    ]
-                })
-            });
+        await sleep(100);
 
-            const loadedStyle = map.style.serialize();
-            expect('maplibre' in loadedStyle.sources).toBeTruthy();
-            expect(loadedStyle.layers[0].id).toBe(style.layers[0].id);
-            expect(loadedStyle.layers).toHaveLength(1);
-            done();
-        }, 100);
-    }));
+        map.setStyle(createStyle(), {
+            diff: true,
+            transformStyle: (prevStyle, nextStyle) => ({
+                ...nextStyle,
+                sources: {
+                    ...nextStyle.sources,
+                    maplibre: prevStyle.sources.maplibre
+                },
+                layers: [
+                    ...nextStyle.layers,
+                    prevStyle.layers[0]
+                ]
+            })
+        });
 
-    test('transformStyle should get called when passed to setStyle after the map is initialised without a style', () => new Promise<void>(done => {
+        const loadedStyle = map.style.serialize();
+        expect('maplibre' in loadedStyle.sources).toBeTruthy();
+        expect(loadedStyle.layers[0].id).toBe(style.layers[0].id);
+        expect(loadedStyle.layers).toHaveLength(1);
+    });
+
+    test('transformStyle should get called when passed to setStyle after the map is initialised without a style', async () => {
         const map = createMap({deleteStyle: true});
         map.setStyle(createStyle(), {
             diff: true,
@@ -305,15 +296,13 @@ describe('#setStyle', () => {
             }
         });
 
-        map.on('style.load', () => {
-            const loadedStyle = map.style.serialize();
-            expect('maplibre' in loadedStyle.sources).toBeTruthy();
-            expect(loadedStyle.layers[0].id).toBe('layerId0');
-            done();
-        });
-    }));
+        await map.once('style.load');
+        const loadedStyle = map.style.serialize();
+        expect('maplibre' in loadedStyle.sources).toBeTruthy();
+        expect(loadedStyle.layers[0].id).toBe('layerId0');
+    });
 
-    test('map load should be fired when transformStyle is used on setStyle after the map is initialised without a style', () => new Promise<void>(done => {
+    test('map load should be fired when transformStyle is used on setStyle after the map is initialised without a style', async () => {
         const map = createMap({deleteStyle: true});
         map.setStyle({version: 8, sources: {}, layers: []}, {
             diff: true,
@@ -323,8 +312,8 @@ describe('#setStyle', () => {
                 return createStyle();
             }
         });
-        map.on('load', () => done());
-    }));
+        await map.once('load');
+    });
 
     test('Override default style validation', () => {
         let validationOption = true;
@@ -345,15 +334,13 @@ describe('#getStyle', () => {
         expect(map.getStyle()).toBeUndefined();
     });
 
-    test('returns the style', () => new Promise<void>(done => {
+    test('returns the style', async () => {
         const style = createStyle();
         const map = createMap({style});
 
-        map.on('load', () => {
-            expect(map.getStyle()).toEqual(style);
-            done();
-        });
-    }));
+        await map.once('load');
+        expect(map.getStyle()).toEqual(style);
+    });
 
     test('returns the previous style even if modified', async () => {
         const style = {
@@ -379,33 +366,29 @@ describe('#getStyle', () => {
         expect(map.getStyle()).toEqual(style);
     });
 
-    test('returns the style with added sources', () => new Promise<void>(done => {
+    test('returns the style with added sources', async () => {
         const style = createStyle();
         const map = createMap({style});
 
-        map.on('load', () => {
-            map.addSource('geojson', createStyleSource());
-            expect(map.getStyle()).toEqual(extend(createStyle(), {
-                sources: {geojson: createStyleSource()}
-            }));
-            done();
-        });
-    }));
+        await map.once('load');
+        map.addSource('geojson', createStyleSource());
+        expect(map.getStyle()).toEqual(extend(createStyle(), {
+            sources: {geojson: createStyleSource()}
+        }));
+    });
 
-    test('fires an error on checking if non-existant source is loaded', () => new Promise<void>(done => {
+    test('fires an error on checking if non-existant source is loaded', async () => {
         const style = createStyle();
         const map = createMap({style});
 
-        map.on('load', () => {
-            map.on('error', ({error}) => {
-                expect(error.message).toMatch(/There is no source with ID/);
-                done();
-            });
-            map.isSourceLoaded('geojson');
-        });
-    }));
+        await map.once('load');
+        const errorPromise = map.once('error');
+        map.isSourceLoaded('geojson');
+        const error = await errorPromise;
+        expect(error.error.message).toMatch(/There is no source with ID/);
+    });
 
-    test('returns the style with added layers', () => new Promise<void>(done => {
+    test('returns the style with added layers', async () => {
         const style = createStyle();
         const map = createMap({style});
         const layer = {
@@ -413,14 +396,12 @@ describe('#getStyle', () => {
             type: 'background'
         } as LayerSpecification;
 
-        map.on('load', () => {
-            map.addLayer(layer);
-            expect(map.getStyle()).toEqual(extend(createStyle(), {
-                layers: [layer]
-            }));
-            done();
-        });
-    }));
+        await map.once('load');
+        map.addLayer(layer);
+        expect(map.getStyle()).toEqual(extend(createStyle(), {
+            layers: [layer]
+        }));
+    });
 
     test('a layer can be added even if a map is created without a style', () => {
         const map = createMap({deleteStyle: true});
@@ -450,7 +431,7 @@ describe('#getStyle', () => {
         });
     });
 
-    test('returns the style with added source and layer', () => new Promise<void>(done => {
+    test('returns the style with added source and layer', async () => {
         const style = createStyle();
         const map = createMap({style});
         const source = createStyleSource();
@@ -460,16 +441,14 @@ describe('#getStyle', () => {
             source: 'fill'
         } as LayerSpecification;
 
-        map.on('load', () => {
-            map.addSource('fill', source);
-            map.addLayer(layer);
-            expect(map.getStyle()).toEqual(extend(createStyle(), {
-                sources: {fill: source},
-                layers: [layer]
-            }));
-            done();
-        });
-    }));
+        await map.once('load');
+        map.addSource('fill', source);
+        map.addLayer(layer);
+        expect(map.getStyle()).toEqual(extend(createStyle(), {
+            sources: {fill: source},
+            layers: [layer]
+        }));
+    });
 
     test('creates a new Style if diff fails', () => {
         const style = createStyle();

--- a/src/ui/map_tests/map_terrain.test.ts
+++ b/src/ui/map_tests/map_terrain.test.ts
@@ -21,7 +21,7 @@ afterEach(() => {
 });
 
 describe('#setTerrain', () => {
-    test('warn when terrain and hillshade source identical', () => new Promise<void>(done => {
+    test('warn when terrain and hillshade source identical', async () => {
         server.respondWith('/source.json', JSON.stringify({
             minzoom: 5,
             maxzoom: 12,
@@ -30,19 +30,17 @@ describe('#setTerrain', () => {
             bounds: [-47, -7, -45, -5]
         }));
 
-        map.on('load', () => {
-            map.addSource('terrainrgb', {type: 'raster-dem', url: '/source.json'});
-            server.respond();
-            map.addLayer({id: 'hillshade', type: 'hillshade', source: 'terrainrgb'});
-            const stub = vi.spyOn(console, 'warn').mockImplementation(() => { });
-            stub.mockReset();
-            map.setTerrain({
-                source: 'terrainrgb'
-            });
-            expect(console.warn).toHaveBeenCalledTimes(1);
-            done();
+        await map.once('load');
+        map.addSource('terrainrgb', {type: 'raster-dem', url: '/source.json'});
+        server.respond();
+        map.addLayer({id: 'hillshade', type: 'hillshade', source: 'terrainrgb'});
+        const stub = vi.spyOn(console, 'warn').mockImplementation(() => { });
+        stub.mockReset();
+        map.setTerrain({
+            source: 'terrainrgb'
         });
-    }));
+        expect(console.warn).toHaveBeenCalledTimes(1);
+    });
 });
 
 describe('#getTerrain', () => {

--- a/src/util/actor.test.ts
+++ b/src/util/actor.test.ts
@@ -178,18 +178,18 @@ describe('Actor', () => {
         expect(spy).not.toHaveBeenCalled();
     });
 
-    test('#remove unbinds event listener', () => new Promise<void>(done => {
+    test('#remove unbinds event listener', () => {
+        const addEventListenerSpy = vi.fn();
+        const removeEventListenerSpy = vi.fn();
         const actor = new Actor({
-            addEventListener(type, callback, useCapture) {
-                this._addEventListenerArgs = [type, callback, useCapture];
-            },
-            removeEventListener(type, callback, useCapture) {
-                expect([type, callback, useCapture]).toEqual(this._addEventListenerArgs);
-                done();
-            }
-        } as ActorTarget, null);
+            addEventListener: addEventListenerSpy,
+            removeEventListener: removeEventListenerSpy,
+        } as any as ActorTarget, null);
         actor.remove();
-    }));
+        expect(addEventListenerSpy).toHaveBeenCalled();
+        expect(removeEventListenerSpy).toHaveBeenCalled();
+        expect(addEventListenerSpy.mock.calls[0]).toEqual(removeEventListenerSpy.mock.calls[0]);
+    });
 
     test('send a message that is rejected', async () => {
         const worker = workerFactory() as any as WorkerGlobalScopeInterface & ActorTarget;

--- a/src/util/test/util.ts
+++ b/src/util/test/util.ts
@@ -255,11 +255,11 @@ export function createFramebuffer() {
     };
 }
 
-export function waitForEvent(evented: Evented, eventName: string, predicate: (e: any) => boolean): Promise<void> {
+export function waitForEvent(evented: Evented, eventName: string, predicate: (e: any) => boolean): Promise<any> {
     return new Promise((resolve) => {
         const listener = (e: Event) => {
             if (predicate(e)) {
-                resolve();
+                resolve(e);
             }
         };
         evented.on(eventName, listener);

--- a/src/util/test/util.ts
+++ b/src/util/test/util.ts
@@ -254,3 +254,14 @@ export function createFramebuffer() {
         destroy: () => {}
     };
 }
+
+export function waitForEvent(evented: Evented, eventName: string, predicate: (e: any) => boolean): Promise<void> {
+    return new Promise((resolve) => {
+        const listener = (e: Event) => {
+            if (predicate(e)) {
+                resolve();
+            }
+        };
+        evented.on(eventName, listener);
+    });
+}

--- a/src/util/test/util.ts
+++ b/src/util/test/util.ts
@@ -40,7 +40,7 @@ export class StubMap extends Evented {
     }
 }
 
-export function createMap(options?, callback?) {
+export function createMap(options?) {
     const container = window.document.createElement('div');
     const defaultOptions = {
         container,
@@ -61,9 +61,6 @@ export function createMap(options?, callback?) {
     if (options?.deleteStyle) delete defaultOptions.style;
 
     const map = new Map(extend(defaultOptions, options));
-    if (callback) map.on('load', () => {
-        callback(null, map);
-    });
 
     return map;
 }


### PR DESCRIPTION
## Launch Checklist

This PR removes most of the top level `Promise` from the tests to showcase better how to write tests and avoid the copy paste of "old style" tests that do not use `once` and use `done`.
**This doesn't change any production code.**

It is best to review this by hiding whitespace changes.

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
