### PR TITLE
Move source cache tests to use async

### DIFF
--- a/src/source/source_cache.test.ts
+++ b/src/source/source_cache.test.ts
@@ -11,7 +11,7 @@ import {extend} from '../util/util';
 import {browser} from '../util/browser';
 import {type Dispatcher} from '../util/dispatcher';
 import {TileBounds} from './tile_bounds';
-import {sleep} from '../util/test/util';
+import {sleep, waitForEvent} from '../util/test/util';
 import {type TileCache} from './tile_cache';
 import {MercatorTransform} from '../geo/projection/mercator_transform';
 import {GlobeTransform} from '../geo/projection/globe_transform';
@@ -105,45 +105,45 @@ afterEach(() => {
 });
 
 describe('SourceCache#addTile', () => {
-    test('loads tile when uncached', () => new Promise<void>(done => {
+    test('loads tile when uncached', () => {
         const tileID = new OverscaledTileID(0, 0, 0, 0, 0);
         const sourceCache = createSourceCache();
-        sourceCache._source.loadTile = async (tile) => {
-            expect(tile.tileID).toEqual(tileID);
-            expect(tile.uses).toBe(0);
-            done();
-        };
+        const spy = vi.fn();
+        sourceCache._source.loadTile = spy;
+        
         sourceCache.onAdd(undefined);
         sourceCache._addTile(tileID);
-    }));
+        expect(spy).toHaveBeenCalledTimes(1);
+        expect(spy.mock.calls[0][0].tileID).toEqual(tileID);
+        expect(spy.mock.calls[0][0].uses).toBe(1);
+    });
 
-    test('adds tile when uncached', () => new Promise<void>(done => {
+    test('adds tile when uncached', async () => {
         const tileID = new OverscaledTileID(0, 0, 0, 0, 0);
         const sourceCache = createSourceCache({});
-        sourceCache.on('dataloading', (data) => {
-            expect(data.tile.tileID).toEqual(tileID);
-            expect(data.tile.uses).toBe(1);
-            done();
-        });
+        const dataLoadingPromise = sourceCache.once('dataloading');
         sourceCache.onAdd(undefined);
         sourceCache._addTile(tileID);
-    }));
+        const data = await dataLoadingPromise;
+        expect(data.tile.tileID).toEqual(tileID);
+        expect(data.tile.uses).toBe(1);
+    });
 
-    test('updates feature state on added uncached tile', () => new Promise<void>(done => {
+    test('updates feature state on added uncached tile', async () => {
         const tileID = new OverscaledTileID(0, 0, 0, 0, 0);
         let updateFeaturesSpy;
         const sourceCache = createSourceCache({});
+        let dataPromise: any;
         sourceCache._source.loadTile = async (tile) => {
-            sourceCache.on('data', () => {
-                expect(updateFeaturesSpy).toHaveBeenCalledTimes(1);
-                done();
-            });
+            dataPromise = sourceCache.once('data');
             updateFeaturesSpy = vi.spyOn(tile, 'setFeatureState');
             tile.state = 'loaded';
         };
         sourceCache.onAdd(undefined);
         sourceCache._addTile(tileID);
-    }));
+        await dataPromise;
+        expect(updateFeaturesSpy).toHaveBeenCalledTimes(1);
+    });
 
     test('uses cached tile', () => {
         const tileID = new OverscaledTileID(0, 0, 0, 0, 0);
@@ -278,16 +278,14 @@ describe('SourceCache#addTile', () => {
 });
 
 describe('SourceCache#removeTile', () => {
-    test('removes tile', () => new Promise<void>(done => {
+    test('removes tile', async () => {
         const tileID = new OverscaledTileID(0, 0, 0, 0, 0);
         const sourceCache = createSourceCache({});
         sourceCache._addTile(tileID);
-        sourceCache.on('data', () => {
-            sourceCache._removeTile(tileID.key);
-            expect(sourceCache._tiles[tileID.key]).toBeFalsy();
-            done();
-        });
-    }));
+        await sourceCache.once('data');
+        sourceCache._removeTile(tileID.key);
+        expect(sourceCache._tiles[tileID.key]).toBeFalsy();
+    });
 
     test('caches (does not unload) loaded tile', () => {
         const tileID = new OverscaledTileID(0, 0, 0, 0, 0);
@@ -389,38 +387,37 @@ describe('SourceCache#removeTile', () => {
 });
 
 describe('SourceCache / Source lifecycle', () => {
-    test('does not fire load or change before source load event', () => new Promise<void>((done) => {
+    test('does not fire load or change before source load event', async () => {
         const sourceCache = createSourceCache({noLoad: true});
-        sourceCache.on('data', () => { throw new Error('test failed: data event fired'); });
+        const spy = vi.fn();
+        sourceCache.on('data', spy);
         sourceCache.onAdd(undefined);
-        setTimeout(() => done(), 1);
-    }));
+        await sleep(1);
+        expect(spy).not.toHaveBeenCalled();
+    });
 
-    test('forward load event', () => new Promise<void>(done => {
+    test('forward load event', async () => {
         const sourceCache = createSourceCache({});
-        sourceCache.on('data', (e) => {
-            if (e.sourceDataType === 'metadata') done();
-        });
+        const dataPromise = waitForEvent(sourceCache, 'data', e => e.sourceDataType === 'metadata');
         sourceCache.onAdd(undefined);
-    }));
+        await expect(dataPromise).resolves.toBeDefined();
+    });
 
-    test('forward change event', () => new Promise<void>(done => {
+    test('forward change event', async () => {
         const sourceCache = createSourceCache();
-        sourceCache.on('data', (e) => {
-            if (e.sourceDataType === 'metadata') done();
-        });
+        const dataPromise = waitForEvent(sourceCache, 'data', e => e.sourceDataType === 'metadata');
         sourceCache.onAdd(undefined);
         sourceCache.getSource().fire(new Event('data'));
-    }));
+        await expect(dataPromise).resolves.toBeDefined();
+    });
 
-    test('forward error event', () => new Promise<void>(done => {
+    test('forward error event', async () => {
         const sourceCache = createSourceCache({error: 'Error loading source'});
-        sourceCache.on('error', (err) => {
-            expect(err.error).toBe('Error loading source');
-            done();
-        });
+        const errorPromise = sourceCache.once('error');
         sourceCache.onAdd(undefined);
-    }));
+        const err = await errorPromise;
+        expect(err.error).toBe('Error loading source');
+    });
 
     test('suppress 404 errors', () => {
         const sourceCache = createSourceCache({status: 404, message: 'Not found'});
@@ -428,16 +425,15 @@ describe('SourceCache / Source lifecycle', () => {
         sourceCache.onAdd(undefined);
     });
 
-    test('loaded() true after source error', () => new Promise<void>(done => {
+    test('loaded() true after source error', async () => {
         const sourceCache = createSourceCache({error: 'Error loading source'});
-        sourceCache.on('error', () => {
-            expect(sourceCache.loaded()).toBeTruthy();
-            done();
-        });
+        const errorPromise = sourceCache.once('error');
         sourceCache.onAdd(undefined);
-    }));
+        await errorPromise;
+        expect(sourceCache.loaded()).toBeTruthy();
+    });
 
-    test('loaded() true after tile error', () => new Promise<void>(done => {
+    test('loaded() true after tile error', async () => {
         const transform = new MercatorTransform();
         transform.resize(511, 511);
         transform.setZoom(0);
@@ -450,28 +446,25 @@ describe('SourceCache / Source lifecycle', () => {
                 sourceCache.update(transform);
             }
         });
-        sourceCache.on('error', () => {
-            expect(sourceCache.loaded()).toBeTruthy();
-            done();
-        });
+        const errorPromise = sourceCache.once('error');
 
         sourceCache.onAdd(undefined);
-    }));
+        await errorPromise;
+        expect(sourceCache.loaded()).toBeTruthy();
+    });
 
-    test('loaded() false after source begins loading following error', () => new Promise<void>(done => {
+    test('loaded() false after source begins loading following error', async () => {
         const sourceCache = createSourceCache({error: 'Error loading source'});
-        sourceCache.on('error', () => {
-            sourceCache.on('dataloading', () => {
-                expect(sourceCache.loaded()).toBeFalsy();
-                done();
-            });
-            sourceCache.getSource().fire(new Event('dataloading'));
-        });
-
+        const errorPromise = sourceCache.once('error');
         sourceCache.onAdd(undefined);
-    }));
+        await errorPromise;
+        const dataLoadingProimse = sourceCache.once('dataloading');
+        sourceCache.getSource().fire(new Event('dataloading'));
+        await dataLoadingProimse;
+        expect(sourceCache.loaded()).toBeFalsy();
+    });
 
-    test('loaded() false when error occurs while source is not loaded', () => new Promise<void>(done => {
+    test('loaded() false when error occurs while source is not loaded', async () => {
         const sourceCache = createSourceCache({
             error: 'Error loading source',
 
@@ -479,13 +472,11 @@ describe('SourceCache / Source lifecycle', () => {
                 return false;
             }
         });
-        sourceCache.on('error', () => {
-            expect(sourceCache.loaded()).toBeFalsy();
-            done();
-        });
-
+        const errorPromise = sourceCache.once('error');
         sourceCache.onAdd(undefined);
-    }));
+        await errorPromise;
+        expect(sourceCache.loaded()).toBeFalsy();
+    });
 
     test('reloads tiles after a data event where source is updated', () => {
         const transform = new MercatorTransform();
@@ -567,39 +558,34 @@ describe('SourceCache / Source lifecycle', () => {
 });
 
 describe('SourceCache#update', () => {
-    test('loads no tiles if used is false', () => new Promise<void>(done => {
+    test('loads no tiles if used is false', async () => {
         const transform = new MercatorTransform();
         transform.resize(512, 512);
         transform.setZoom(0);
 
         const sourceCache = createSourceCache({}, false);
-        sourceCache.on('data', (e) => {
-            if (e.sourceDataType === 'metadata') {
-                sourceCache.update(transform);
-                expect(sourceCache.getIds()).toEqual([]);
-                done();
-            }
-        });
-        sourceCache.onAdd(undefined);
-    }));
+        const dataPromise = waitForEvent(sourceCache, 'data', e => e.sourceDataType === 'metadata');
 
-    test('loads covering tiles', () => new Promise<void>(done => {
+        sourceCache.onAdd(undefined);
+        await dataPromise;
+        sourceCache.update(transform);
+        expect(sourceCache.getIds()).toEqual([]);
+    });
+
+    test('loads covering tiles', async () => {
         const transform = new MercatorTransform();
         transform.resize(511, 511);
         transform.setZoom(0);
 
         const sourceCache = createSourceCache({});
-        sourceCache.on('data', (e) => {
-            if (e.sourceDataType === 'metadata') {
-                sourceCache.update(transform);
-                expect(sourceCache.getIds()).toEqual([new OverscaledTileID(0, 0, 0, 0, 0).key]);
-                done();
-            }
-        });
+        const dataPromise = waitForEvent(sourceCache, 'data', e => e.sourceDataType === 'metadata');
         sourceCache.onAdd(undefined);
-    }));
+        await dataPromise;
+        sourceCache.update(transform);
+        expect(sourceCache.getIds()).toEqual([new OverscaledTileID(0, 0, 0, 0, 0).key]);
+    });
 
-    test('respects Source#hasTile method if it is present', () => new Promise<void>(done => {
+    test('respects Source#hasTile method if it is present', async () => {
         const transform = new MercatorTransform();
         transform.resize(511, 511);
         transform.setZoom(1);
@@ -607,20 +593,18 @@ describe('SourceCache#update', () => {
         const sourceCache = createSourceCache({
             hasTile: (coord) => (coord.canonical.x !== 0)
         });
-        sourceCache.on('data', (e) => {
-            if (e.sourceDataType === 'metadata') {
-                sourceCache.update(transform);
-                expect(sourceCache.getIds().sort()).toEqual([
-                    new OverscaledTileID(1, 0, 1, 1, 0).key,
-                    new OverscaledTileID(1, 0, 1, 1, 1).key
-                ].sort());
-                done();
-            }
-        });
+        const dataPromise = waitForEvent(sourceCache, 'data', e => e.sourceDataType === 'metadata');
+                
         sourceCache.onAdd(undefined);
-    }));
+        await dataPromise;
+        sourceCache.update(transform);
+        expect(sourceCache.getIds().sort()).toEqual([
+            new OverscaledTileID(1, 0, 1, 1, 0).key,
+            new OverscaledTileID(1, 0, 1, 1, 1).key
+        ].sort());
+    });
 
-    test('removes unused tiles', () => new Promise<void>(done => {
+    test('removes unused tiles', async () => {
         const transform = new MercatorTransform();
         transform.resize(511, 511);
         transform.setZoom(0);
@@ -630,28 +614,24 @@ describe('SourceCache#update', () => {
             tile.state = 'loaded';
         };
 
-        sourceCache.on('data', (e) => {
-            if (e.sourceDataType === 'metadata') {
-                sourceCache.update(transform);
-                expect(sourceCache.getIds()).toEqual([new OverscaledTileID(0, 0, 0, 0, 0).key]);
-
-                transform.setZoom(1);
-                sourceCache.update(transform);
-
-                expect(sourceCache.getIds()).toEqual([
-                    new OverscaledTileID(1, 0, 1, 1, 1).key,
-                    new OverscaledTileID(1, 0, 1, 0, 1).key,
-                    new OverscaledTileID(1, 0, 1, 1, 0).key,
-                    new OverscaledTileID(1, 0, 1, 0, 0).key
-                ]);
-                done();
-            }
-        });
-
+        const dataPromise = waitForEvent(sourceCache, 'data', e => e.sourceDataType === 'metadata');
         sourceCache.onAdd(undefined);
-    }));
+        await dataPromise;
+        sourceCache.update(transform);
+        expect(sourceCache.getIds()).toEqual([new OverscaledTileID(0, 0, 0, 0, 0).key]);
 
-    test('retains parent tiles for pending children', () => new Promise<void>(done => {
+        transform.setZoom(1);
+        sourceCache.update(transform);
+
+        expect(sourceCache.getIds()).toEqual([
+            new OverscaledTileID(1, 0, 1, 1, 1).key,
+            new OverscaledTileID(1, 0, 1, 0, 1).key,
+            new OverscaledTileID(1, 0, 1, 1, 0).key,
+            new OverscaledTileID(1, 0, 1, 0, 0).key
+        ]);
+    });
+
+    test('retains parent tiles for pending children', async () => {
         const transform = new MercatorTransform();
         (transform as any)._test = 'retains';
         transform.resize(511, 511);
@@ -662,28 +642,26 @@ describe('SourceCache#update', () => {
             tile.state = (tile.tileID.key === new OverscaledTileID(0, 0, 0, 0, 0).key) ? 'loaded' : 'loading';
         };
 
-        sourceCache.on('data', (e) => {
-            if (e.sourceDataType === 'metadata') {
-                sourceCache.update(transform);
-                expect(sourceCache.getIds()).toEqual([new OverscaledTileID(0, 0, 0, 0, 0).key]);
+        const dataPromise = waitForEvent(sourceCache, 'data', e => e.sourceDataType === 'metadata');
 
-                transform.setZoom(1);
-                sourceCache.update(transform);
-
-                expect(sourceCache.getIds()).toEqual([
-                    new OverscaledTileID(0, 0, 0, 0, 0).key,
-                    new OverscaledTileID(1, 0, 1, 1, 1).key,
-                    new OverscaledTileID(1, 0, 1, 0, 1).key,
-                    new OverscaledTileID(1, 0, 1, 1, 0).key,
-                    new OverscaledTileID(1, 0, 1, 0, 0).key
-                ]);
-                done();
-            }
-        });
         sourceCache.onAdd(undefined);
-    }));
+        await dataPromise;
+        sourceCache.update(transform);
+        expect(sourceCache.getIds()).toEqual([new OverscaledTileID(0, 0, 0, 0, 0).key]);
 
-    test('retains parent tiles for pending children (wrapped)', () => new Promise<void>(done => {
+        transform.setZoom(1);
+        sourceCache.update(transform);
+
+        expect(sourceCache.getIds()).toEqual([
+            new OverscaledTileID(0, 0, 0, 0, 0).key,
+            new OverscaledTileID(1, 0, 1, 1, 1).key,
+            new OverscaledTileID(1, 0, 1, 0, 1).key,
+            new OverscaledTileID(1, 0, 1, 1, 0).key,
+            new OverscaledTileID(1, 0, 1, 0, 0).key
+        ]);
+    });
+
+    test('retains parent tiles for pending children (wrapped)', async () => {
         const transform = new MercatorTransform();
         transform.resize(511, 511);
         transform.setZoom(0);
@@ -694,28 +672,25 @@ describe('SourceCache#update', () => {
             tile.state = (tile.tileID.key === new OverscaledTileID(0, 1, 0, 0, 0).key) ? 'loaded' : 'loading';
         };
 
-        sourceCache.on('data', (e) => {
-            if (e.sourceDataType === 'metadata') {
-                sourceCache.update(transform);
-                expect(sourceCache.getIds()).toEqual([new OverscaledTileID(0, 1, 0, 0, 0).key]);
-
-                transform.setZoom(1);
-                sourceCache.update(transform);
-
-                expect(sourceCache.getIds()).toEqual([
-                    new OverscaledTileID(0, 1, 0, 0, 0).key,
-                    new OverscaledTileID(1, 1, 1, 1, 1).key,
-                    new OverscaledTileID(1, 1, 1, 0, 1).key,
-                    new OverscaledTileID(1, 1, 1, 1, 0).key,
-                    new OverscaledTileID(1, 1, 1, 0, 0).key
-                ]);
-                done();
-            }
-        });
+        const dataPromise = waitForEvent(sourceCache, 'data', e => e.sourceDataType === 'metadata');
         sourceCache.onAdd(undefined);
-    }));
+        await dataPromise;
+        sourceCache.update(transform);
+        expect(sourceCache.getIds()).toEqual([new OverscaledTileID(0, 1, 0, 0, 0).key]);
 
-    test('retains covered child tiles while parent tile is fading in', () => new Promise<void>(done => {
+        transform.setZoom(1);
+        sourceCache.update(transform);
+
+        expect(sourceCache.getIds()).toEqual([
+            new OverscaledTileID(0, 1, 0, 0, 0).key,
+            new OverscaledTileID(1, 1, 1, 1, 1).key,
+            new OverscaledTileID(1, 1, 1, 0, 1).key,
+            new OverscaledTileID(1, 1, 1, 1, 0).key,
+            new OverscaledTileID(1, 1, 1, 0, 0).key
+        ]);
+    });
+
+    test('retains covered child tiles while parent tile is fading in', async () => {
         const transform = new MercatorTransform();
         transform.resize(511, 511);
         transform.setZoom(2);
@@ -729,27 +704,24 @@ describe('SourceCache#update', () => {
 
         (sourceCache._source as any).type = 'raster';
 
-        sourceCache.on('data', (e) => {
-            if (e.sourceDataType === 'metadata') {
-                sourceCache.update(transform);
-                expect(sourceCache.getIds()).toEqual([
-                    new OverscaledTileID(2, 0, 2, 2, 2).key,
-                    new OverscaledTileID(2, 0, 2, 1, 2).key,
-                    new OverscaledTileID(2, 0, 2, 2, 1).key,
-                    new OverscaledTileID(2, 0, 2, 1, 1).key
-                ]);
-
-                transform.setZoom(0);
-                sourceCache.update(transform);
-
-                expect(sourceCache.getRenderableIds()).toHaveLength(5);
-                done();
-            }
-        });
+        const dataPromise = waitForEvent(sourceCache, 'data', e => e.sourceDataType === 'metadata');
         sourceCache.onAdd(undefined);
-    }));
+        await dataPromise;
+        sourceCache.update(transform);
+        expect(sourceCache.getIds()).toEqual([
+            new OverscaledTileID(2, 0, 2, 2, 2).key,
+            new OverscaledTileID(2, 0, 2, 1, 2).key,
+            new OverscaledTileID(2, 0, 2, 2, 1).key,
+            new OverscaledTileID(2, 0, 2, 1, 1).key
+        ]);
 
-    test('retains a parent tile for fading even if a tile is partially covered by children', () => new Promise<void>(done => {
+        transform.setZoom(0);
+        sourceCache.update(transform);
+
+        expect(sourceCache.getRenderableIds()).toHaveLength(5);
+    });
+
+    test('retains a parent tile for fading even if a tile is partially covered by children', async () => {
         const transform = new MercatorTransform();
         transform.resize(511, 511);
         transform.setZoom(0);
@@ -763,24 +735,21 @@ describe('SourceCache#update', () => {
 
         (sourceCache._source as any).type = 'raster';
 
-        sourceCache.on('data', (e) => {
-            if (e.sourceDataType === 'metadata') {
-                sourceCache.update(transform);
-
-                transform.setZoom(2);
-                sourceCache.update(transform);
-
-                transform.setZoom(1);
-                sourceCache.update(transform);
-
-                expect(sourceCache._coveredTiles[(new OverscaledTileID(0, 0, 0, 0, 0).key)]).toBe(true);
-                done();
-            }
-        });
+        const dataPromise = waitForEvent(sourceCache, 'data', e => e.sourceDataType === 'metadata');
         sourceCache.onAdd(undefined);
-    }));
+        await dataPromise;
+        sourceCache.update(transform);
 
-    test('retain children for fading fadeEndTime is 0 (added but registerFadeDuration() is not called yet)', () => new Promise<void>(done => {
+        transform.setZoom(2);
+        sourceCache.update(transform);
+
+        transform.setZoom(1);
+        sourceCache.update(transform);
+
+        expect(sourceCache._coveredTiles[(new OverscaledTileID(0, 0, 0, 0, 0).key)]).toBe(true);
+    });
+
+    test('retain children for fading fadeEndTime is 0 (added but registerFadeDuration() is not called yet)', async () => {
         const transform = new MercatorTransform();
         transform.resize(511, 511);
         transform.setZoom(1);
@@ -794,21 +763,18 @@ describe('SourceCache#update', () => {
 
         (sourceCache._source as any).type = 'raster';
 
-        sourceCache.on('data', (e) => {
-            if (e.sourceDataType === 'metadata') {
-                sourceCache.update(transform);
-
-                transform.setZoom(0);
-                sourceCache.update(transform);
-
-                expect(sourceCache.getRenderableIds()).toHaveLength(5);
-                done();
-            }
-        });
+        const dataPromise = waitForEvent(sourceCache, 'data', e => e.sourceDataType === 'metadata');
         sourceCache.onAdd(undefined);
-    }));
+        await dataPromise;
+        sourceCache.update(transform);
 
-    test('retains children when tile.fadeEndTime is in the future', () => new Promise<void>(done => {
+        transform.setZoom(0);
+        sourceCache.update(transform);
+
+        expect(sourceCache.getRenderableIds()).toHaveLength(5);
+    });
+
+    test('retains children when tile.fadeEndTime is in the future', async () => {
         const transform = new MercatorTransform();
         transform.resize(511, 511);
         transform.setZoom(1);
@@ -828,29 +794,26 @@ describe('SourceCache#update', () => {
 
         (sourceCache._source as any).type = 'raster';
 
-        sourceCache.on('data', (e) => {
-            if (e.sourceDataType === 'metadata') {
-                // load children
-                sourceCache.update(transform);
-
-                transform.setZoom(0);
-                sourceCache.update(transform);
-
-                expect(sourceCache.getRenderableIds()).toHaveLength(5);
-
-                time = start + 98;
-                sourceCache.update(transform);
-                expect(sourceCache.getRenderableIds()).toHaveLength(5);
-
-                time = start + fadeTime + 1;
-                sourceCache.update(transform);
-                expect(sourceCache.getRenderableIds()).toHaveLength(1);
-                done();
-            }
-        });
+        const dataPromise = waitForEvent(sourceCache, 'data', e => e.sourceDataType === 'metadata');
 
         sourceCache.onAdd(undefined);
-    }));
+        await dataPromise;
+        // load children
+        sourceCache.update(transform);
+
+        transform.setZoom(0);
+        sourceCache.update(transform);
+
+        expect(sourceCache.getRenderableIds()).toHaveLength(5);
+
+        time = start + 98;
+        sourceCache.update(transform);
+        expect(sourceCache.getRenderableIds()).toHaveLength(5);
+
+        time = start + fadeTime + 1;
+        sourceCache.update(transform);
+        expect(sourceCache.getRenderableIds()).toHaveLength(1);
+    });
 
     test('retains children tiles for pending parents', () => {
         const transform = new GlobeTransform();
@@ -888,7 +851,7 @@ describe('SourceCache#update', () => {
         sourceCache.onAdd(undefined);
     });
 
-    test('retains overscaled loaded children', () => new Promise<void>(done => {
+    test('retains overscaled loaded children', async () => {
         const transform = new MercatorTransform();
         transform.resize(511, 511);
         transform.setZoom(16);
@@ -901,56 +864,50 @@ describe('SourceCache#update', () => {
             tile.state = tile.tileID.overscaledZ === 16 ? 'loaded' : 'loading';
         };
 
-        sourceCache.on('data', (e) => {
-            if (e.sourceDataType === 'metadata') {
-                sourceCache.update(transform);
-                expect(sourceCache.getRenderableIds()).toEqual([
-                    new OverscaledTileID(16, 0, 14, 8192, 8192).key,
-                    new OverscaledTileID(16, 0, 14, 8191, 8192).key,
-                    new OverscaledTileID(16, 0, 14, 8192, 8191).key,
-                    new OverscaledTileID(16, 0, 14, 8191, 8191).key
-                ]);
-
-                transform.setZoom(15);
-                sourceCache.update(transform);
-
-                expect(sourceCache.getRenderableIds()).toEqual([
-                    new OverscaledTileID(16, 0, 14, 8192, 8192).key,
-                    new OverscaledTileID(16, 0, 14, 8191, 8192).key,
-                    new OverscaledTileID(16, 0, 14, 8192, 8191).key,
-                    new OverscaledTileID(16, 0, 14, 8191, 8191).key
-                ]);
-                done();
-            }
-        });
+        const dataPromise = waitForEvent(sourceCache, 'data', e => e.sourceDataType === 'metadata');
         sourceCache.onAdd(undefined);
-    }));
+        await dataPromise;
+        sourceCache.update(transform);
+        expect(sourceCache.getRenderableIds()).toEqual([
+            new OverscaledTileID(16, 0, 14, 8192, 8192).key,
+            new OverscaledTileID(16, 0, 14, 8191, 8192).key,
+            new OverscaledTileID(16, 0, 14, 8192, 8191).key,
+            new OverscaledTileID(16, 0, 14, 8191, 8191).key
+        ]);
 
-    test('reassigns tiles for large jumps in longitude', () => new Promise<void>(done => {
+        transform.setZoom(15);
+        sourceCache.update(transform);
+
+        expect(sourceCache.getRenderableIds()).toEqual([
+            new OverscaledTileID(16, 0, 14, 8192, 8192).key,
+            new OverscaledTileID(16, 0, 14, 8191, 8192).key,
+            new OverscaledTileID(16, 0, 14, 8192, 8191).key,
+            new OverscaledTileID(16, 0, 14, 8191, 8191).key
+        ]);
+    });
+
+    test('reassigns tiles for large jumps in longitude', async () => {
 
         const transform = new MercatorTransform();
         transform.resize(511, 511);
         transform.setZoom(0);
 
         const sourceCache = createSourceCache({});
-        sourceCache.on('data', (e) => {
-            if (e.sourceDataType === 'metadata') {
-                transform.setCenter(new LngLat(360, 0));
-                const tileID = new OverscaledTileID(0, 1, 0, 0, 0);
-                sourceCache.update(transform);
-                expect(sourceCache.getIds()).toEqual([tileID.key]);
-                const tile = sourceCache.getTile(tileID);
-
-                transform.setCenter(new LngLat(0, 0));
-                const wrappedTileID = new OverscaledTileID(0, 0, 0, 0, 0);
-                sourceCache.update(transform);
-                expect(sourceCache.getIds()).toEqual([wrappedTileID.key]);
-                expect(sourceCache.getTile(wrappedTileID)).toBe(tile);
-                done();
-            }
-        });
+        const dataPromise = waitForEvent(sourceCache, 'data', e => e.sourceDataType === 'metadata');
         sourceCache.onAdd(undefined);
-    }));
+        await dataPromise;
+        transform.setCenter(new LngLat(360, 0));
+        const tileID = new OverscaledTileID(0, 1, 0, 0, 0);
+        sourceCache.update(transform);
+        expect(sourceCache.getIds()).toEqual([tileID.key]);
+        const tile = sourceCache.getTile(tileID);
+
+        transform.setCenter(new LngLat(0, 0));
+        const wrappedTileID = new OverscaledTileID(0, 0, 0, 0, 0);
+        sourceCache.update(transform);
+        expect(sourceCache.getIds()).toEqual([wrappedTileID.key]);
+        expect(sourceCache.getTile(wrappedTileID)).toBe(tile);
+    });
 
 });
 
@@ -1458,7 +1415,7 @@ describe('SourceCache#tilesIn', () => {
         });
     }
 
-    test('regular tiles', () => new Promise<void>(done => {
+    test('regular tiles', async () => {
         const transform = new MercatorTransform();
         transform.resize(512, 512);
         transform.setZoom(1);
@@ -1469,40 +1426,36 @@ describe('SourceCache#tilesIn', () => {
             tile.state = 'loaded';
         };
 
-        sourceCache.on('data', (e) => {
-            if (e.sourceDataType === 'metadata') {
-                sourceCache.update(transform);
-
-                expect(sourceCache.getIds()).toEqual([
-                    new OverscaledTileID(1, 0, 1, 1, 1).key,
-                    new OverscaledTileID(1, 0, 1, 0, 1).key,
-                    new OverscaledTileID(1, 0, 1, 1, 0).key,
-                    new OverscaledTileID(1, 0, 1, 0, 0).key
-                ]);
-
-                const tiles = sourceCache.tilesIn([
-                    new Point(0, 0),
-                    new Point(512, 256)
-                ], 1, true);
-
-                tiles.sort((a, b) => { return a.tile.tileID.canonical.x - b.tile.tileID.canonical.x; });
-                tiles.forEach((result) => { delete result.tile.uid; });
-
-                expect(tiles[0].tile.tileID.key).toBe('011');
-                expect(tiles[0].tile.tileSize).toBe(512);
-                expect(tiles[0].scale).toBe(1);
-                expect(round(tiles[0].queryGeometry)).toEqual([{x: 4096, y: 4050}, {x: 12288, y: 8146}]);
-
-                expect(tiles[1].tile.tileID.key).toBe('111');
-                expect(tiles[1].tile.tileSize).toBe(512);
-                expect(tiles[1].scale).toBe(1);
-                expect(round(tiles[1].queryGeometry)).toEqual([{x: -4096, y: 4050}, {x: 4096, y: 8146}]);
-
-                done();
-            }
-        });
+        const dataPromise = waitForEvent(sourceCache, 'data', e => e.sourceDataType === 'metadata');
         sourceCache.onAdd(undefined);
-    }));
+        await dataPromise;
+        sourceCache.update(transform);
+
+        expect(sourceCache.getIds()).toEqual([
+            new OverscaledTileID(1, 0, 1, 1, 1).key,
+            new OverscaledTileID(1, 0, 1, 0, 1).key,
+            new OverscaledTileID(1, 0, 1, 1, 0).key,
+            new OverscaledTileID(1, 0, 1, 0, 0).key
+        ]);
+
+        const tiles = sourceCache.tilesIn([
+            new Point(0, 0),
+            new Point(512, 256)
+        ], 1, true);
+
+        tiles.sort((a, b) => { return a.tile.tileID.canonical.x - b.tile.tileID.canonical.x; });
+        tiles.forEach((result) => { delete result.tile.uid; });
+
+        expect(tiles[0].tile.tileID.key).toBe('011');
+        expect(tiles[0].tile.tileSize).toBe(512);
+        expect(tiles[0].scale).toBe(1);
+        expect(round(tiles[0].queryGeometry)).toEqual([{x: 4096, y: 4050}, {x: 12288, y: 8146}]);
+
+        expect(tiles[1].tile.tileID.key).toBe('111');
+        expect(tiles[1].tile.tileSize).toBe(512);
+        expect(tiles[1].scale).toBe(1);
+        expect(round(tiles[1].queryGeometry)).toEqual([{x: -4096, y: 4050}, {x: 4096, y: 8146}]);
+    });
 
     test('reparsed overscaled tiles', () => {
         const sourceCache = createSourceCache({
@@ -1553,7 +1506,7 @@ describe('SourceCache#tilesIn', () => {
         sourceCache.onAdd(undefined);
     });
 
-    test('overscaled tiles', () => new Promise<void>(done => {
+    test('overscaled tiles', async () => {
         const sourceCache = createSourceCache({
             reparseOverscaled: false,
             minzoom: 1,
@@ -1564,18 +1517,14 @@ describe('SourceCache#tilesIn', () => {
             tile.state = 'loaded';
         };
 
-        sourceCache.on('data', (e) => {
-            if (e.sourceDataType === 'metadata') {
-                const transform = new MercatorTransform();
-                transform.resize(512, 512);
-                transform.setZoom(2.0);
-                sourceCache.update(transform);
-
-                done();
-            }
-        });
+        const dataPromise = waitForEvent(sourceCache, 'data', e => e.sourceDataType === 'metadata');
         sourceCache.onAdd(undefined);
-    }));
+        await dataPromise;
+        const transform = new MercatorTransform();
+        transform.resize(512, 512);
+        transform.setZoom(2.0);
+        sourceCache.update(transform);
+    });
 
     test('globe wrap', () => async () => {
         const transform = new GlobeTransform();
@@ -1588,7 +1537,7 @@ describe('SourceCache#tilesIn', () => {
             tile.state = 'loaded';
         };
 
-        while ((await sourceCache.once('data')).sourceDataType !== 'metadata') {}
+        await waitForEvent(sourceCache, 'data', e => e.sourceDataType === 'metadata');
 
         sourceCache.update(transform);
 
@@ -1639,7 +1588,7 @@ describe('SourceCache#tilesIn', () => {
             tile.state = 'loaded';
         };
 
-        while ((await sourceCache.once('data')).sourceDataType !== 'metadata') {}
+        await waitForEvent(sourceCache, 'data', e => e.sourceDataType === 'metadata');
 
         sourceCache.update(transform);
 
@@ -1681,68 +1630,59 @@ describe('SourceCache#tilesIn', () => {
 });
 
 describe('source cache loaded', () => {
-    test('SourceCache#loaded (no errors)', () => new Promise<void>(done => {
+    test('SourceCache#loaded (no errors)', async () => {
         const sourceCache = createSourceCache();
         sourceCache._source.loadTile = async (tile) => {
             tile.state = 'loaded';
         };
 
-        sourceCache.on('data', (e) => {
-            if (e.sourceDataType === 'metadata') {
-                const tr = new MercatorTransform();
-                tr.resize(512, 512);
-                sourceCache.update(tr);
-
-                const coord = new OverscaledTileID(0, 0, 0, 0, 0);
-                sourceCache._addTile(coord);
-
-                expect(sourceCache.loaded()).toBeTruthy();
-                done();
-            }
-        });
+        const dataPromise = waitForEvent(sourceCache, 'data', e => e.sourceDataType === 'metadata');
         sourceCache.onAdd(undefined);
-    }));
+        await dataPromise;
+        const tr = new MercatorTransform();
+        tr.resize(512, 512);
+        sourceCache.update(tr);
 
-    test('SourceCache#loaded (with errors)', () => new Promise<void>(done => {
+        const coord = new OverscaledTileID(0, 0, 0, 0, 0);
+        sourceCache._addTile(coord);
+
+        expect(sourceCache.loaded()).toBeTruthy();
+    });
+
+    test('SourceCache#loaded (with errors)', async () => {
         const sourceCache = createSourceCache();
         sourceCache._source.loadTile = async (tile) => {
             tile.state = 'errored';
             throw new Error('Error');
         };
 
-        sourceCache.on('data', (e) => {
-            if (e.sourceDataType === 'metadata') {
-                const tr = new MercatorTransform();
-                tr.resize(512, 512);
-                sourceCache.update(tr);
-
-                const coord = new OverscaledTileID(0, 0, 0, 0, 0);
-                sourceCache._addTile(coord);
-
-                expect(sourceCache.loaded()).toBeTruthy();
-                done();
-            }
-        });
+        const dataPromise = waitForEvent(sourceCache, 'data', e => e.sourceDataType === 'metadata');
         sourceCache.onAdd(undefined);
-    }));
+        await dataPromise;
+        const tr = new MercatorTransform();
+        tr.resize(512, 512);
+        sourceCache.update(tr);
 
-    test('SourceCache#loaded (unused)', () => new Promise<void>(done => {
+        const coord = new OverscaledTileID(0, 0, 0, 0, 0);
+        sourceCache._addTile(coord);
+
+        expect(sourceCache.loaded()).toBeTruthy();
+    });
+
+    test('SourceCache#loaded (unused)', async () => {
         const sourceCache = createSourceCache(undefined, false);
         sourceCache._source.loadTile = async (tile) => {
             tile.state = 'errored';
             throw new Error('Error');
         };
 
-        sourceCache.on('data', (e) => {
-            if (e.sourceDataType === 'metadata') {
-                expect(sourceCache.loaded()).toBeTruthy();
-                done();
-            }
-        });
+        const dataPromise = waitForEvent(sourceCache, 'data', e => e.sourceDataType === 'metadata');
         sourceCache.onAdd(undefined);
-    }));
+        await dataPromise;
+        expect(sourceCache.loaded()).toBeTruthy();
+    });
 
-    test('SourceCache#loaded (unusedForTerrain)', () => new Promise<void>(done => {
+    test('SourceCache#loaded (unusedForTerrain)', async () => {
         const sourceCache = createSourceCache(undefined, false);
         sourceCache._source.loadTile = async (tile) => {
             tile.state = 'errored';
@@ -1750,32 +1690,26 @@ describe('source cache loaded', () => {
         };
         sourceCache.usedForTerrain = false;
 
-        sourceCache.on('data', (e) => {
-            if (e.sourceDataType === 'metadata') {
-                expect(sourceCache.loaded()).toBeTruthy();
-                done();
-            }
-        });
+        const dataPromise = waitForEvent(sourceCache, 'data', e => e.sourceDataType === 'metadata');
         sourceCache.onAdd(undefined);
-    }));
+        await dataPromise;
+        expect(sourceCache.loaded()).toBeTruthy();
+    });
 
-    test('SourceCache#loaded (not loaded when no update)', () => new Promise<void>(done => {
+    test('SourceCache#loaded (not loaded when no update)', async () => {
         const sourceCache = createSourceCache();
         sourceCache._source.loadTile = async (tile) => {
             tile.state = 'errored';
             throw new Error('Error');
         };
 
-        sourceCache.on('data', (e) => {
-            if (e.sourceDataType === 'metadata') {
-                expect(sourceCache.loaded()).toBeFalsy();
-                done();
-            }
-        });
+        const dataPromise = waitForEvent(sourceCache, 'data', e => e.sourceDataType === 'metadata');
         sourceCache.onAdd(undefined);
-    }));
+        await dataPromise;
+        expect(sourceCache.loaded()).toBeFalsy();
+    });
 
-    test('SourceCache#loaded (on last tile load)', () => new Promise<void>(done => {
+    test('SourceCache#loaded (on last tile load)', async () => {
         const sourceCache = createSourceCache();
         sourceCache._source.loadTile = async (tile) => {
             tile.state = 'loading';
@@ -1793,26 +1727,19 @@ describe('source cache loaded', () => {
         const tr = new MercatorTransform();
         tr.setZoom(10);
         tr.resize(512, 512);
-        const expectedTilesLoaded = 4;
-        let loaded = 0;
 
-        sourceCache.on('data', (e) => {
-            if (e.sourceDataType === 'metadata') {
-                expect(sourceCache.loaded()).toBeFalsy();
-            } else if (e.tile !== undefined) {
-                loaded += 1;
-                if (sourceCache.loaded()) {
-                    expect(loaded).toBe(expectedTilesLoaded);
-                    done();
-                }
-            }
-        });
+        const sourceLoadedPromise = waitForEvent(sourceCache, 'data', () => sourceCache.loaded());
+        const spy = vi.fn();
+        sourceCache.on('data', spy);
 
         sourceCache.onAdd(undefined);
         sourceCache.update(tr);
-    }));
 
-    test('SourceCache#loaded (tiles outside bounds, idle)', () => new Promise<void>(done => {
+        await sourceLoadedPromise;
+        expect(spy.mock.calls.length).toBe(5); // 4 tiles + 1 source loaded
+    });
+
+    test('SourceCache#loaded (tiles outside bounds, idle)', async () => {
         const japan = new TileBounds([122.74, 19.33, 149.0, 45.67]);
         const sourceCache = createSourceCache();
         sourceCache._source.loadTile = async (tile) => {
@@ -1837,13 +1764,12 @@ describe('source cache loaded', () => {
             return japan.contains(tileID.canonical);
         };
 
+        const sourceLoadedPromise = waitForEvent(sourceCache, 'data', () => sourceCache.loaded());
+
         sourceCache.on('data', (e) => {
             if (e.sourceDataType !== 'idle') {
                 expect(sourceCache.loaded()).toBeFalsy();
                 // 'idle' emission when source bounds are outside of viewport bounds
-            } else {
-                expect(sourceCache.loaded()).toBeTruthy();
-                done();
             }
         });
 
@@ -1852,7 +1778,8 @@ describe('source cache loaded', () => {
         tr.setZoom(10);
         tr.resize(512, 512);
         sourceCache.update(tr);
-    }));
+        await sourceLoadedPromise;
+    });
 });
 
 describe('source cache get ids', () => {
@@ -2077,20 +2004,21 @@ describe('SourceCache#reload', () => {
 });
 
 describe('SourceCache reloads expiring tiles', () => {
-    test('calls reloadTile when tile expires', () => new Promise<void>(done => {
+    test('calls reloadTile when tile expires', async () => {
         const coord = new OverscaledTileID(1, 0, 1, 0, 1);
 
         const expiryDate = new Date();
         expiryDate.setMilliseconds(expiryDate.getMilliseconds() + 50);
         const sourceCache = createSourceCache({expires: expiryDate});
 
-        sourceCache._reloadTile = async (id, state) => {
-            expect(state).toBe('expired');
-            done();
-        };
+        const spy = vi.fn();
+        sourceCache._reloadTile = spy;
 
         sourceCache._addTile(coord);
-    }));
+        await sleep(100);
+        expect(spy).toHaveBeenCalled();
+        expect(spy.mock.calls[0][1]).toBe('expired');
+    });
 
 });
 
@@ -2146,7 +2074,7 @@ describe('SourceCache#onRemove', () => {
 });
 
 describe('SourceCache#usedForTerrain', () => {
-    test('loads covering tiles with usedForTerrain with source zoom 0-14', () => new Promise<void>(done => {
+    test('loads covering tiles with usedForTerrain with source zoom 0-14', async () => {
         const transform = new MercatorTransform();
         transform.resize(511, 511);
         transform.setZoom(10);
@@ -2155,19 +2083,16 @@ describe('SourceCache#usedForTerrain', () => {
         sourceCache.usedForTerrain = true;
         sourceCache.tileSize = 1024;
         expect(sourceCache.usedForTerrain).toBeTruthy();
-        sourceCache.on('data', (e) => {
-            if (e.sourceDataType === 'metadata') {
-                sourceCache.update(transform);
-                expect(Object.values(sourceCache._tiles).map(t => t.tileID.key)).toEqual(
-                    ['2tc099', '2tbz99', '2sxs99', '2sxr99', 'pds88', 'eo55', 'pdr88', 'en55', 'p6o88', 'ds55', 'p6n88', 'dr55']
-                );
-                done();
-            }
-        });
+        const dataPromise = waitForEvent(sourceCache, 'data', e => e.sourceDataType === 'metadata');
         sourceCache.onAdd(undefined);
-    }));
+        await dataPromise;
+        sourceCache.update(transform);
+        expect(Object.values(sourceCache._tiles).map(t => t.tileID.key)).toEqual(
+            ['2tc099', '2tbz99', '2sxs99', '2sxr99', 'pds88', 'eo55', 'pdr88', 'en55', 'p6o88', 'ds55', 'p6n88', 'dr55']
+        );
+    });
 
-    test('loads covering tiles with usedForTerrain with source zoom 8-14', () => new Promise<void>(done => {
+    test('loads covering tiles with usedForTerrain with source zoom 8-14', async () => {
         const transform = new MercatorTransform();
         transform.resize(511, 511);
         transform.setZoom(10);
@@ -2175,19 +2100,16 @@ describe('SourceCache#usedForTerrain', () => {
         const sourceCache = createSourceCache({minzoom: 8, maxzoom: 14});
         sourceCache.usedForTerrain = true;
         sourceCache.tileSize = 1024;
-        sourceCache.on('data', (e) => {
-            if (e.sourceDataType === 'metadata') {
-                sourceCache.update(transform);
-                expect(Object.values(sourceCache._tiles).map(t => t.tileID.key)).toEqual(
-                    ['2tc099', '2tbz99', '2sxs99', '2sxr99', 'pds88', 'pdr88', 'p6o88', 'p6n88']
-                );
-                done();
-            }
-        });
+        const dataPromise = waitForEvent(sourceCache, 'data', e => e.sourceDataType === 'metadata');
         sourceCache.onAdd(undefined);
-    }));
+        await dataPromise;
+        sourceCache.update(transform);
+        expect(Object.values(sourceCache._tiles).map(t => t.tileID.key)).toEqual(
+            ['2tc099', '2tbz99', '2sxs99', '2sxr99', 'pds88', 'pdr88', 'p6o88', 'p6n88']
+        );
+    });
 
-    test('loads covering tiles with usedForTerrain with source zoom 0-4', () => new Promise<void>(done => {
+    test('loads covering tiles with usedForTerrain with source zoom 0-4', async () => {
         const transform = new MercatorTransform();
         transform.resize(511, 511);
         transform.setZoom(10);
@@ -2195,19 +2117,16 @@ describe('SourceCache#usedForTerrain', () => {
         const sourceCache = createSourceCache({minzoom: 0, maxzoom: 4});
         sourceCache.usedForTerrain = true;
         sourceCache.tileSize = 1024;
-        sourceCache.on('data', (e) => {
-            if (e.sourceDataType === 'metadata') {
-                sourceCache.update(transform);
-                expect(Object.values(sourceCache._tiles).map(t => t.tileID.key)).toEqual(
-                    ['1033', '3s44', '3r44', '3c44', '3b44', 'z33', 's33', 'r33']
-                );
-                done();
-            }
-        });
+        const dataPromise = waitForEvent(sourceCache, 'data', e => e.sourceDataType === 'metadata');
         sourceCache.onAdd(undefined);
-    }));
+        await dataPromise;
+        sourceCache.update(transform);
+        expect(Object.values(sourceCache._tiles).map(t => t.tileID.key)).toEqual(
+            ['1033', '3s44', '3r44', '3c44', '3b44', 'z33', 's33', 'r33']
+        );
+    });
 
-    test('loads covering tiles with usedForTerrain with source zoom 4-4', () => new Promise<void>(done => {
+    test('loads covering tiles with usedForTerrain with source zoom 4-4', async () => {
         const transform = new MercatorTransform();
         transform.resize(511, 511);
         transform.setZoom(10);
@@ -2215,15 +2134,12 @@ describe('SourceCache#usedForTerrain', () => {
         const sourceCache = createSourceCache({minzoom: 4, maxzoom: 4});
         sourceCache.usedForTerrain = true;
         sourceCache.tileSize = 1024;
-        sourceCache.on('data', (e) => {
-            if (e.sourceDataType === 'metadata') {
-                sourceCache.update(transform);
-                expect(Object.values(sourceCache._tiles).map(t => t.tileID.key)).toEqual(
-                    ['3s44', '3r44', '3c44', '3b44']
-                );
-                done();
-            }
-        });
+        const dataPromise = waitForEvent(sourceCache, 'data', e => e.sourceDataType === 'metadata');
         sourceCache.onAdd(undefined);
-    }));
+        await dataPromise;
+        sourceCache.update(transform);
+        expect(Object.values(sourceCache._tiles).map(t => t.tileID.key)).toEqual(
+            ['3s44', '3r44', '3c44', '3b44']
+        );
+    });
 });


### PR DESCRIPTION
## Launch Checklist

- This is in continue to #5777

This removes the top level promise from the tests and make the tests more async style.

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.