### PR TITLE
Add refreshTiles() to map public API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### ✨ Features and improvements
 - Add additional hillshade methods ([#5768](https://github.com/maplibre/maplibre-gl-js/pull/5768))
+- Add `refreshTile()` and `refreshTiles()` to the map public API ([#5806](https://github.com/maplibre/maplibre-gl-js/pull/5806))
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### ✨ Features and improvements
 - Add additional hillshade methods ([#5768](https://github.com/maplibre/maplibre-gl-js/pull/5768))
-- Add `refreshTile()` and `refreshTiles()` to the map public API ([#5806](https://github.com/maplibre/maplibre-gl-js/pull/5806))
+- Add `refreshTiles()` to the map public API ([#5806](https://github.com/maplibre/maplibre-gl-js/pull/5806))
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes

--- a/src/source/source_cache.test.ts
+++ b/src/source/source_cache.test.ts
@@ -2161,7 +2161,6 @@ describe('SourceCache::refreshTiles', () => {
         expect(spy).toHaveBeenCalledOnce();
         expect(spy.mock.calls[0][1]).toBe('expired');
     });
-
     
     test('does not call reloadTile when tile does not exist', async () => {
         const coord = new OverscaledTileID(1, 0, 1, 1, 1);

--- a/src/source/source_cache.ts
+++ b/src/source/source_cache.ts
@@ -19,7 +19,7 @@ import type {Style} from '../style/style';
 import type {Dispatcher} from '../util/dispatcher';
 import type {IReadonlyTransform, ITransform} from '../geo/transform_interface';
 import type {TileState} from './tile';
-import type {SourceSpecification} from '@maplibre/maplibre-gl-style-spec';
+import type {ICanonicalTileID, SourceSpecification} from '@maplibre/maplibre-gl-style-spec';
 import type {MapSourceDataEvent} from '../ui/events';
 import type {Terrain} from '../render/terrain';
 import type {CanvasSourceSpecification} from './canvas_source';
@@ -891,6 +891,13 @@ export class SourceCache extends Evented {
                 this._reloadTile(id, 'expired');
                 delete this._timers[id];
             }, expiryTimeout);
+        }
+    }
+
+    refreshTile(tileID: ICanonicalTileID)
+    {
+        if(this._isIdRenderable(tileID.key)) {
+            this._reloadTile(tileID.key, 'expired');
         }
     }
 

--- a/src/source/source_cache.ts
+++ b/src/source/source_cache.ts
@@ -900,7 +900,7 @@ export class SourceCache extends Evented {
     refreshTiles(tileIds: Array<ICanonicalTileID>) {
         for (const id in this._tiles) {
             if (this._isIdRenderable(id)){
-                for (let refreshId of tileIds) {
+                for (const refreshId of tileIds) {
                     if (refreshId.equals(this._tiles[id].tileID.canonical)) {
                         this._reloadTile(id, 'expired');
                     }

--- a/src/source/source_cache.ts
+++ b/src/source/source_cache.ts
@@ -894,6 +894,9 @@ export class SourceCache extends Evented {
         }
     }
 
+    /**
+     * Reload any currently renderable tiles that are match one of the incoming `tileId` x/y/z
+     */
     refreshTiles(tileIds: Array<ICanonicalTileID>) {
         for (const id in this._tiles) {
             if (this._isIdRenderable(id)){

--- a/src/source/source_cache.ts
+++ b/src/source/source_cache.ts
@@ -894,10 +894,15 @@ export class SourceCache extends Evented {
         }
     }
 
-    refreshTile(tileID: ICanonicalTileID)
-    {
-        if(this._isIdRenderable(tileID.key)) {
-            this._reloadTile(tileID.key, 'expired');
+    refreshTiles(tileIds: Array<ICanonicalTileID>) {
+        for (const id in this._tiles) {
+            if (this._isIdRenderable(id)){
+                for (let refreshId of tileIds) {
+                    if (refreshId.equals(this._tiles[id].tileID.canonical)) {
+                        this._reloadTile(id, 'expired');
+                    }
+                }
+            }
         }
     }
 

--- a/src/source/source_cache.ts
+++ b/src/source/source_cache.ts
@@ -902,11 +902,8 @@ export class SourceCache extends Evented {
             if (!this._isIdRenderable(id)) {
                 continue;
             }
-            for (const refreshId of tileIds) {
-                if (refreshId.equals(this._tiles[id].tileID.canonical)) {
-                    this._reloadTile(id, 'expired');
-                    break;
-                }
+            if (tileIds.some(tid => tid.equals(this._tiles[id].tileID.canonical))) {
+                this._reloadTile(id, 'expired');
             }
         }
     }

--- a/src/source/source_cache.ts
+++ b/src/source/source_cache.ts
@@ -899,11 +899,13 @@ export class SourceCache extends Evented {
      */
     refreshTiles(tileIds: Array<ICanonicalTileID>) {
         for (const id in this._tiles) {
-            if (this._isIdRenderable(id)){
-                for (const refreshId of tileIds) {
-                    if (refreshId.equals(this._tiles[id].tileID.canonical)) {
-                        this._reloadTile(id, 'expired');
-                    }
+            if (!this._isIdRenderable(id)) {
+                continue;
+            }
+            for (const refreshId of tileIds) {
+                if (refreshId.equals(this._tiles[id].tileID.canonical)) {
+                    this._reloadTile(id, 'expired');
+                    break;
                 }
             }
         }

--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -2217,19 +2217,23 @@ export class Map extends Camera {
     /**
      * Triggers a reload of the selected tiles
      *
-     * @param tileIds - An array of tile IDs to be reloaded
      * @param sourceId - The ID of the source
+     * @param tileIds - An array of tile IDs to be reloaded. If not defined, all tiles will be reloaded.
      * @example
      * ```ts
-     * map.refreshTiles([{x:1024, y: 1023, z: 11}, {x:1023, y: 1023, z: 11}], 'satellite');
+     * map.refreshTiles('satellite', [{x:1024, y: 1023, z: 11}, {x:1023, y: 1023, z: 11}]);
      * ```
      */
-    refreshTiles(tileIds: Array<{x: number; y: number; z: number}>, sourceId: string) {
+    refreshTiles(sourceId: string, tileIds?: Array<{x: number; y: number; z: number}>) {
         const sourceCache = this.style.sourceCaches[sourceId];
         if(!sourceCache) {
             throw new Error(`There is no source cache with ID "${sourceId}", cannot refresh tile`);
         }
-        sourceCache.refreshTiles(tileIds.map((tileId) => {return new CanonicalTileID(tileId.z, tileId.x, tileId.y);}));
+        if (tileIds === undefined) {
+            sourceCache.reload();
+        } else {
+            sourceCache.refreshTiles(tileIds.map((tileId) => {return new CanonicalTileID(tileId.z, tileId.x, tileId.y);}));
+        }
     }
 
     /**

--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -2215,11 +2215,15 @@ export class Map extends Camera {
     }
 
     refreshTile(x: number, y: number, z: number, sourceId: string) {
+        this.refreshTiles([{x,y,z}], sourceId);
+    }
+
+    refreshTiles(tileIds: Array<{x: number, y: number, z: number}>, sourceId: string) {
         const sourceCache = this.style.sourceCaches[sourceId];
         if(!sourceCache) {
             throw new Error(`There is no source cache with ID "${sourceId}", cannot refresh tile`);
         }
-        sourceCache.refreshTile(new CanonicalTileID(z, x, y));
+        sourceCache.refreshTiles(tileIds.map((tileId) => {return new CanonicalTileID(tileId.z, tileId.x, tileId.y);}));
     }
 
     /**

--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -67,6 +67,7 @@ import {MercatorCameraHelper} from '../geo/projection/mercator_camera_helper';
 import {isAbortError} from '../util/abort_error';
 import {isFramebufferNotCompleteError} from '../util/framebuffer_error';
 import {createCalculateTileZoomFunction} from '../geo/projection/covering_tiles';
+import {CanonicalTileID} from '../source/tile_id';
 
 const version = packageJSON.version;
 
@@ -2211,6 +2212,14 @@ export class Map extends Camera {
         }
         this._update(true);
         return this;
+    }
+
+    refreshTile(x: number, y: number, z: number, sourceId: string) {
+        const sourceCache = this.style.sourceCaches[sourceId];
+        if(!sourceCache) {
+            throw new Error(`There is no source cache with ID "${sourceId}", cannot refresh tile`);
+        }
+        sourceCache.refreshTile(new CanonicalTileID(z, x, y));
     }
 
     /**

--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -2214,11 +2214,32 @@ export class Map extends Camera {
         return this;
     }
 
+    /**
+     * Triggers a reload of the selected tile
+     *
+     * @param x - The tile X coordinate
+     * @param y - The tile Y coordinate
+     * @param z - The tile Z coordinate
+     * @param sourceId - The ID of the source
+     * @example
+     * ```ts
+     * map.refreshTile(1024, 1023, 11, 'satellite');
+     * ```
+     */
     refreshTile(x: number, y: number, z: number, sourceId: string) {
         this.refreshTiles([{x,y,z}], sourceId);
     }
-
-    refreshTiles(tileIds: Array<{x: number, y: number, z: number}>, sourceId: string) {
+    /**
+     * Triggers a reload of the selected tiles
+     *
+     * @param tileIds - An array of tile IDs to be reloaded
+     * @param sourceId - The ID of the source
+     * @example
+     * ```ts
+     * map.refreshTiles([{x:1024, y: 1023, z: 11}, {x:1023, y: 1023, z: 11}], 'satellite');
+     * ```
+     */
+    refreshTiles(tileIds: Array<{x: number; y: number; z: number}>, sourceId: string) {
         const sourceCache = this.style.sourceCaches[sourceId];
         if(!sourceCache) {
             throw new Error(`There is no source cache with ID "${sourceId}", cannot refresh tile`);

--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -2215,21 +2215,6 @@ export class Map extends Camera {
     }
 
     /**
-     * Triggers a reload of the selected tile
-     *
-     * @param x - The tile X coordinate
-     * @param y - The tile Y coordinate
-     * @param z - The tile Z coordinate
-     * @param sourceId - The ID of the source
-     * @example
-     * ```ts
-     * map.refreshTile(1024, 1023, 11, 'satellite');
-     * ```
-     */
-    refreshTile(x: number, y: number, z: number, sourceId: string) {
-        this.refreshTiles([{x,y,z}], sourceId);
-    }
-    /**
      * Triggers a reload of the selected tiles
      *
      * @param tileIds - An array of tile IDs to be reloaded

--- a/src/ui/map_tests/map_refresh_tiles.test.ts
+++ b/src/ui/map_tests/map_refresh_tiles.test.ts
@@ -22,19 +22,3 @@ test('refreshTiles', async () => {
     expect(spy).toHaveBeenCalledOnce();
     expect(spy.mock.calls[0][0]).toEqual([new CanonicalTileID(11, 1024, 1023)]);
 });
-
-test('refreshTile', async () => {
-    const map = createMap({interactive: false});
-    await map.once('style.load');
-
-    map.addSource('source-id1', {type: 'raster', url: ''});
-    const spy = vi.fn();
-    map.style.sourceCaches['source-id1'].refreshTiles = spy;
-
-    expect(() => {map.refreshTile(1024, 1023, 11, 'source-id2');})
-        .toThrow('There is no source cache with ID "source-id2", cannot refresh tile');
-    expect(spy).toHaveBeenCalledTimes(0);
-    map.refreshTile(1024, 1023, 11, 'source-id1');
-    expect(spy).toHaveBeenCalledOnce();
-    expect(spy.mock.calls[0][0]).toEqual([new CanonicalTileID(11, 1024, 1023)]);
-});

--- a/src/ui/map_tests/map_refresh_tiles.test.ts
+++ b/src/ui/map_tests/map_refresh_tiles.test.ts
@@ -1,4 +1,4 @@
-import {beforeEach, test, expect, vi} from 'vitest';
+import {beforeEach, test, expect, vi, describe} from 'vitest';
 import {createMap, beforeMapTest} from '../../util/test/util';
 import {CanonicalTileID} from '../../source/tile_id';
 
@@ -7,40 +7,42 @@ beforeEach(() => {
     global.fetch = null;
 });
 
-test('refreshTiles, non-existent source', async () => {
-    const map = createMap({interactive: false});
-    await map.once('style.load');
+describe('Map::refreshTiles', () => {
+    test('refreshTiles, non-existent source', async () => {
+        const map = createMap({interactive: false});
+        await map.once('style.load');
 
-    map.addSource('source-id1', {type: 'raster', url: ''});
-    const spy = vi.fn();
-    map.style.sourceCaches['source-id1'].refreshTiles = spy;
+        map.addSource('source-id1', {type: 'raster', url: ''});
+        const spy = vi.fn();
+        map.style.sourceCaches['source-id1'].refreshTiles = spy;
 
-    expect(() => {map.refreshTiles('source-id2', [{x: 1024, y: 1023, z: 11}]);})
-        .toThrow('There is no source cache with ID "source-id2", cannot refresh tile');
-    expect(spy).toHaveBeenCalledTimes(0);
-});
+        expect(() => {map.refreshTiles('source-id2', [{x: 1024, y: 1023, z: 11}]);})
+            .toThrow('There is no source cache with ID "source-id2", cannot refresh tile');
+        expect(spy).toHaveBeenCalledTimes(0);
+    });
 
-test('refreshTiles, existing source', async () => {
-    const map = createMap({interactive: false});
-    await map.once('style.load');
+    test('refreshTiles, existing source', async () => {
+        const map = createMap({interactive: false});
+        await map.once('style.load');
 
-    map.addSource('source-id1', {type: 'raster', url: ''});
-    const spy = vi.fn();
-    map.style.sourceCaches['source-id1'].refreshTiles = spy;
+        map.addSource('source-id1', {type: 'raster', url: ''});
+        const spy = vi.fn();
+        map.style.sourceCaches['source-id1'].refreshTiles = spy;
 
-    map.refreshTiles('source-id1', [{x: 1024, y: 1023, z: 11}]);
-    expect(spy).toHaveBeenCalledOnce();
-    expect(spy.mock.calls[0][0]).toEqual([new CanonicalTileID(11, 1024, 1023)]);
-});
+        map.refreshTiles('source-id1', [{x: 1024, y: 1023, z: 11}]);
+        expect(spy).toHaveBeenCalledOnce();
+        expect(spy.mock.calls[0][0]).toEqual([new CanonicalTileID(11, 1024, 1023)]);
+    });
 
-test('refreshTiles, existing source, undefined tileIds', async () => {
-    const map = createMap({interactive: false});
-    await map.once('style.load');
+    test('refreshTiles, existing source, undefined tileIds', async () => {
+        const map = createMap({interactive: false});
+        await map.once('style.load');
 
-    map.addSource('source-id1', {type: 'raster', url: ''});
-    const spy = vi.fn();
-    map.style.sourceCaches['source-id1'].reload = spy;
+        map.addSource('source-id1', {type: 'raster', url: ''});
+        const spy = vi.fn();
+        map.style.sourceCaches['source-id1'].reload = spy;
 
-    map.refreshTiles('source-id1');
-    expect(spy).toHaveBeenCalledOnce();
+        map.refreshTiles('source-id1');
+        expect(spy).toHaveBeenCalledOnce();
+    });
 });

--- a/src/ui/map_tests/map_refresh_tiles.test.ts
+++ b/src/ui/map_tests/map_refresh_tiles.test.ts
@@ -1,0 +1,40 @@
+import {beforeEach, test, expect, vi} from 'vitest';
+import {createMap, beforeMapTest} from '../../util/test/util';
+import {CanonicalTileID} from '../../source/tile_id';
+
+beforeEach(() => {
+    beforeMapTest();
+    global.fetch = null;
+});
+
+test('refreshTiles', async () => {
+    const map = createMap({interactive: false});
+    await map.once('style.load');
+
+    map.addSource('source-id1', {type: 'raster', url: ''});
+    const spy = vi.fn();
+    map.style.sourceCaches['source-id1'].refreshTiles = spy;
+
+    expect(() => {map.refreshTiles([{x: 1024, y: 1023, z: 11}], 'source-id2');})
+        .toThrow('There is no source cache with ID "source-id2", cannot refresh tile');
+    expect(spy).toHaveBeenCalledTimes(0);
+    map.refreshTiles([{x: 1024, y: 1023, z: 11}], 'source-id1');
+    expect(spy).toHaveBeenCalledOnce();
+    expect(spy.mock.calls[0][0]).toEqual([new CanonicalTileID(11, 1024, 1023)]);
+});
+
+test('refreshTile', async () => {
+    const map = createMap({interactive: false});
+    await map.once('style.load');
+
+    map.addSource('source-id1', {type: 'raster', url: ''});
+    const spy = vi.fn();
+    map.style.sourceCaches['source-id1'].refreshTiles = spy;
+
+    expect(() => {map.refreshTile(1024, 1023, 11, 'source-id2');})
+        .toThrow('There is no source cache with ID "source-id2", cannot refresh tile');
+    expect(spy).toHaveBeenCalledTimes(0);
+    map.refreshTile(1024, 1023, 11, 'source-id1');
+    expect(spy).toHaveBeenCalledOnce();
+    expect(spy.mock.calls[0][0]).toEqual([new CanonicalTileID(11, 1024, 1023)]);
+});

--- a/src/ui/map_tests/map_refresh_tiles.test.ts
+++ b/src/ui/map_tests/map_refresh_tiles.test.ts
@@ -7,7 +7,7 @@ beforeEach(() => {
     global.fetch = null;
 });
 
-test('refreshTiles', async () => {
+test('refreshTiles, non-existent source', async () => {
     const map = createMap({interactive: false});
     await map.once('style.load');
 
@@ -18,6 +18,16 @@ test('refreshTiles', async () => {
     expect(() => {map.refreshTiles([{x: 1024, y: 1023, z: 11}], 'source-id2');})
         .toThrow('There is no source cache with ID "source-id2", cannot refresh tile');
     expect(spy).toHaveBeenCalledTimes(0);
+});
+
+test('refreshTiles, existing source', async () => {
+    const map = createMap({interactive: false});
+    await map.once('style.load');
+
+    map.addSource('source-id1', {type: 'raster', url: ''});
+    const spy = vi.fn();
+    map.style.sourceCaches['source-id1'].refreshTiles = spy;
+
     map.refreshTiles([{x: 1024, y: 1023, z: 11}], 'source-id1');
     expect(spy).toHaveBeenCalledOnce();
     expect(spy.mock.calls[0][0]).toEqual([new CanonicalTileID(11, 1024, 1023)]);

--- a/src/ui/map_tests/map_refresh_tiles.test.ts
+++ b/src/ui/map_tests/map_refresh_tiles.test.ts
@@ -15,7 +15,7 @@ test('refreshTiles, non-existent source', async () => {
     const spy = vi.fn();
     map.style.sourceCaches['source-id1'].refreshTiles = spy;
 
-    expect(() => {map.refreshTiles([{x: 1024, y: 1023, z: 11}], 'source-id2');})
+    expect(() => {map.refreshTiles('source-id2', [{x: 1024, y: 1023, z: 11}]);})
         .toThrow('There is no source cache with ID "source-id2", cannot refresh tile');
     expect(spy).toHaveBeenCalledTimes(0);
 });
@@ -28,7 +28,19 @@ test('refreshTiles, existing source', async () => {
     const spy = vi.fn();
     map.style.sourceCaches['source-id1'].refreshTiles = spy;
 
-    map.refreshTiles([{x: 1024, y: 1023, z: 11}], 'source-id1');
+    map.refreshTiles('source-id1', [{x: 1024, y: 1023, z: 11}]);
     expect(spy).toHaveBeenCalledOnce();
     expect(spy.mock.calls[0][0]).toEqual([new CanonicalTileID(11, 1024, 1023)]);
+});
+
+test('refreshTiles, existing source, undefined tileIds', async () => {
+    const map = createMap({interactive: false});
+    await map.once('style.load');
+
+    map.addSource('source-id1', {type: 'raster', url: ''});
+    const spy = vi.fn();
+    map.style.sourceCaches['source-id1'].reload = spy;
+
+    map.refreshTiles('source-id1');
+    expect(spy).toHaveBeenCalledOnce();
 });


### PR DESCRIPTION
This PR adds `refreshTiles()` to the map public API.

- resolves #3419 
- resolves #415 

This allows tiles to be force-reloaded from outside MapLibre. The use case I've got in mind is that when tiles on the server change, a WebSocket message is sent to the client (using a to-be-developed plugin) notifying it of changed tiles. The plugin can then call `map.refreshTiles()` with the modified tile IDs, causing the map to reload the tiles and display the new data.

You can check out a demo [here](https://nathanmolson.github.io/live_tiles). Clicking on a tile will call `map.refreshTiles()` on the tile. I'm using `addProtocol()` to draw a timestamp (from `performance.now()`) on each tile, representing the time it was loaded. Zoom all the way out to see that it behaves correctly for wrapped tiles (all tiles sharing an x/y/z are updated when a tile is clicked). Zoom past z3 to see that it behaves correctly for overscaled tiles.

Marginally related to #5799, which is also intended to help with the use case where server-side data is changing rapidly.

 - [X] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [X] Briefly describe the changes in this PR.
 - [X] Link to related issues.
 - [X] Write tests for all new functionality.
 - [X] Document any changes to public APIs.
 - [X] Add an entry to `CHANGELOG.md` under the `## main` section.
