### PR TITLE
Fix initial position of pointer-tracked popup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Fix scroll min zoom on globe view ([#5775](https://github.com/maplibre/maplibre-gl-js/pull/5775))
 - ⚠️ Fix hillshade appearance change between 256x256 and 512x512 tiles. This will change the appearance of hillshade layers using 512x512 tiles. ([#5768](https://github.com/maplibre/maplibre-gl-js/pull/5768))
 - Fix tile expiry logic for raster and raster-dem tiles ([#5798](https://github.com/maplibre/maplibre-gl-js/pull/5798))
+- Fix initial position of pointer-tracked popup ([#5811](https://github.com/maplibre/maplibre-gl-js/pull/5811))
 - _...Add new stuff here..._
 
 ## 5.4.0

--- a/src/ui/handler_manager.ts
+++ b/src/ui/handler_manager.ts
@@ -150,6 +150,7 @@ export class HandlerManager {
         passive?: boolean;
         capture?: boolean;
     } | undefined]>;
+    _latestMousePos?: Point;
 
     constructor(map: Map, options: CompleteMapOptions) {
         this._map = map;
@@ -389,6 +390,7 @@ export class HandlerManager {
                 if (handler[eventName || e.type]) {
                     if (isPointableEvent(e, eventName || e.type)){
                         const point = DOM.mousePos(this._map.getCanvas(), e);
+                        this._latestMousePos = point;
                         data = handler[eventName || e.type](e, point);
                     } else if (isTouchableEvent(e, eventName || e.type)) {
                         const eventTouches = e.touches;

--- a/src/ui/popup.test.ts
+++ b/src/ui/popup.test.ts
@@ -667,6 +667,20 @@ describe('popup', () => {
         ).not.toContain('maplibregl-track-pointer');
     });
 
+    test('Pointer-tracked popup has latest mouse position when added to the map', () => {
+        const map = createMap();
+        const popup = new Popup()
+            .setText('Test')
+            .trackPointer();
+
+        simulate.mousemove(map.getCanvas(), {clientX: 256, clientY: 256});
+
+        popup.addTo(map);
+
+        expect(popup._pos.x).toEqual(256);
+        expect(popup._pos.y).toEqual(256);
+    });
+
     test('Positioned popup lacks pointer-tracking class', () => {
         const map = createMap();
         const popup = new Popup()

--- a/src/ui/popup.ts
+++ b/src/ui/popup.ts
@@ -618,7 +618,10 @@ export class Popup extends Evented {
 
         this._lngLat = smartWrap(this._lngLat, this._flatPos, this._map.transform, this._trackPointer);
 
-        if (this._trackPointer && !cursor) return;
+        if (this._trackPointer && !cursor) {
+            cursor = this._map.handlers._latestMousePos;
+            if (!cursor) return;
+        }
 
         const pos = this._flatPos = this._pos = this._trackPointer && cursor ? cursor : this._map.project(this._lngLat);
         if (this._map.terrain) {


### PR DESCRIPTION
Fixes the initial position of a pointer-tracked popup.
Currently the pointer has no position when added to the map, which results in it being displayed in the top left corner until the mouse is moved.
As initial position is now used the latest mouse position.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Write tests for all new functionality.
 - [x] Add an entry to `CHANGELOG.md` under the `## main` section.
