### PR TITLE
Disable geolocate control button when permission is denied and trackUserLocation is false

### DIFF
--- a/src/ui/control/geolocate_control.test.ts
+++ b/src/ui/control/geolocate_control.test.ts
@@ -55,6 +55,18 @@ describe('GeolocateControl with no options', () => {
         expect(geolocate._geolocateButton.disabled).toBeFalsy();
     });
 
+    test('is disabled when permission is denied and tracking is off', async () => {
+        const geolocate = new GeolocateControl({trackUserLocation: false});
+        map.addControl(geolocate);
+        await sleep(0);
+
+        const click = new window.Event('click');
+        geolocate._geolocateButton.dispatchEvent(click);
+        geolocation.sendError({code: 1, message: 'permission was denied'});
+
+        expect(geolocate._geolocateButton.disabled).toBeTruthy();
+    });
+
     test('has permissions', async () => {
 
         (window.navigator as any).permissions = {

--- a/src/ui/control/geolocate_control.ts
+++ b/src/ui/control/geolocate_control.ts
@@ -482,32 +482,30 @@ export class GeolocateControl extends Evented implements IControl {
             return;
         }
 
-        if (this.options.trackUserLocation) {
-            if (error.code === 1) {
-                // PERMISSION_DENIED
-                this._watchState = 'OFF';
-                this._geolocateButton.classList.remove('maplibregl-ctrl-geolocate-waiting');
-                this._geolocateButton.classList.remove('maplibregl-ctrl-geolocate-active');
-                this._geolocateButton.classList.remove('maplibregl-ctrl-geolocate-active-error');
-                this._geolocateButton.classList.remove('maplibregl-ctrl-geolocate-background');
-                this._geolocateButton.classList.remove('maplibregl-ctrl-geolocate-background-error');
-                this._geolocateButton.disabled = true;
-                const title = this._map._getUIString('GeolocateControl.LocationNotAvailable');
-                this._geolocateButton.title = title;
-                this._geolocateButton.setAttribute('aria-label', title);
+        if (error.code === 1) {
+            // PERMISSION_DENIED
+            this._watchState = 'OFF';
+            this._geolocateButton.classList.remove('maplibregl-ctrl-geolocate-waiting');
+            this._geolocateButton.classList.remove('maplibregl-ctrl-geolocate-active');
+            this._geolocateButton.classList.remove('maplibregl-ctrl-geolocate-active-error');
+            this._geolocateButton.classList.remove('maplibregl-ctrl-geolocate-background');
+            this._geolocateButton.classList.remove('maplibregl-ctrl-geolocate-background-error');
+            this._geolocateButton.disabled = true;
+            const title = this._map._getUIString('GeolocateControl.LocationNotAvailable');
+            this._geolocateButton.title = title;
+            this._geolocateButton.setAttribute('aria-label', title);
 
-                if (this._geolocationWatchID !== undefined) {
-                    this._clearWatch();
-                }
-            } else if (error.code === 3 && noTimeout) {
-                // this represents a forced error state
-                // this was triggered to force immediate geolocation when a watch is already present
-                // see https://github.com/mapbox/mapbox-gl-js/issues/8214
-                // and https://w3c.github.io/geolocation-api/#example-5-forcing-the-user-agent-to-return-a-fresh-cached-position
-                return;
-            } else {
-                this._setErrorState();
+            if (this._geolocationWatchID !== undefined) {
+                this._clearWatch();
             }
+        } else if (error.code === 3 && noTimeout) {
+            // this represents a forced error state
+            // this was triggered to force immediate geolocation when a watch is already present
+            // see https://github.com/mapbox/mapbox-gl-js/issues/8214
+            // and https://w3c.github.io/geolocation-api/#example-5-forcing-the-user-agent-to-return-a-fresh-cached-position
+            return;
+        } else if (this.options.trackUserLocation) {
+            this._setErrorState();
         }
 
         if (this._watchState !== 'OFF' && this.options.showUserLocation) {


### PR DESCRIPTION
If all three of the following conditions are true, then the geolocate control button should show as disabled, but doesn't:

1. The browser supports geolocation
2. The user denies geolocation permission when prompted
3. `trackUserLocation` is set to `false`

Instead, the button does nothing and appears unchanged. That's because the code for disabling the button only runs if `trackUserLocation` is `true`. I added a test for the new case and fixed it.