### PR TITLE
fix: opacityWhenCovered not working to hide the marker behind the globe if terrain is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -316,6 +316,7 @@
 - Fixed a performance regression related to symbol placement ([#4599](https://github.com/maplibre/maplibre-gl-js/pull/4599))
 - Fix a bug where cloning a Transform instance didn't include the `lngRange`. This caused a bug where
 using `transformCameraUpdate` caused the `maxBounds` to stop working just for east/west bounds. ([#4625](https://github.com/maplibre/maplibre-gl-js/pull/4625))
+- Fix opacityWhenCovered not working to hide the marker behind the globe if terrain is enabled. ([#5838](https://github.com/maplibre/maplibre-gl-js/pull/5838))
 
 ## 4.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Fix scroll min zoom on globe view ([#5775](https://github.com/maplibre/maplibre-gl-js/pull/5775))
 - ⚠️ Fix hillshade appearance change between 256x256 and 512x512 tiles. This will change the appearance of hillshade layers using 512x512 tiles. ([#5768](https://github.com/maplibre/maplibre-gl-js/pull/5768))
 - Fix tile expiry logic for raster and raster-dem tiles ([#5798](https://github.com/maplibre/maplibre-gl-js/pull/5798))
+- Fix opacityWhenCovered not working to hide the marker behind the globe if terrain is enabled. ([#5838](https://github.com/maplibre/maplibre-gl-js/pull/5838))
 - _...Add new stuff here..._
 
 ## 5.4.0
@@ -316,7 +317,6 @@
 - Fixed a performance regression related to symbol placement ([#4599](https://github.com/maplibre/maplibre-gl-js/pull/4599))
 - Fix a bug where cloning a Transform instance didn't include the `lngRange`. This caused a bug where
 using `transformCameraUpdate` caused the `maxBounds` to stop working just for east/west bounds. ([#4625](https://github.com/maplibre/maplibre-gl-js/pull/4625))
-- Fix opacityWhenCovered not working to hide the marker behind the globe if terrain is enabled. ([#5838](https://github.com/maplibre/maplibre-gl-js/pull/5838))
 
 ## 4.6.0
 

--- a/src/ui/marker.test.ts
+++ b/src/ui/marker.test.ts
@@ -1077,6 +1077,7 @@ describe('marker', () => {
         await sleep(100); // Give time for the projection to load
         expect(marker.getElement().style.opacity).toBe('0.3');
         marker.setLngLat([0, 0]);
+        await sleep(100); // Give time for the projection to load
         expect(marker.getElement().style.opacity).toBe('0.7');
 
         map.terrain = createTerrain(); // Enable terrain
@@ -1085,6 +1086,7 @@ describe('marker', () => {
         marker.setLngLat([180, 0]);
         expect(marker.getElement().style.opacity).toBe('0.3');
         marker.setLngLat([0, 0]);
+        await sleep(100); // Give time for the projection to load
         expect(marker.getElement().style.opacity).toBe('0.7');
 
         map.remove();

--- a/src/ui/marker.test.ts
+++ b/src/ui/marker.test.ts
@@ -1077,16 +1077,17 @@ describe('marker', () => {
         await sleep(100); // Give time for the projection to load
         expect(marker.getElement().style.opacity).toBe('0.3');
         marker.setLngLat([0, 0]);
-        await sleep(100); // Give time for the projection to load
+        await sleep(100); // Give marker change time to load
         expect(marker.getElement().style.opacity).toBe('0.7');
 
         map.terrain = createTerrain(); // Enable terrain
         await sleep(100); // Give time for the terrain to load
         map.fire('terrain'); // Trigger terrain event for marker
         marker.setLngLat([180, 0]);
+        await sleep(100); // Give marker change time to load
         expect(marker.getElement().style.opacity).toBe('0.3');
         marker.setLngLat([0, 0]);
-        await sleep(100); // Give time for the projection to load
+        await sleep(100); // Give marker change time to load
         expect(marker.getElement().style.opacity).toBe('0.7');
 
         map.remove();

--- a/src/ui/marker.test.ts
+++ b/src/ui/marker.test.ts
@@ -1073,8 +1073,6 @@ describe('marker', () => {
             .setLngLat([180, 0])
             .addTo(map);
 
-        expect(marker.getElement().style.opacity).toBe('0.7');
-
         map.setProjection({type: 'globe'}); // Enable the globe projection
         await sleep(100); // Give time for the projection to load
         expect(marker.getElement().style.opacity).toBe('0.3');

--- a/src/ui/marker.test.ts
+++ b/src/ui/marker.test.ts
@@ -1065,6 +1065,40 @@ describe('marker', () => {
         map.remove();
     });
 
+    test('Applies options.opacityWhenCovered when marker is covered by globe with terrain disabled or enabled', async () => {
+        const map = createMap({width: 1024, renderWorldCopies: true});
+        await map.once('load');
+
+        const marker = new CustomMarker({opacity: 0.7, opacityWhenCovered: 0.3})
+            .setLngLat([180, 0])
+            .addTo(map);
+
+        expect(marker.getElement().style.opacity).toBe('0.7');
+
+        map.setProjection({type: 'globe'}); // Enable the globe projection
+        await sleep(100); // Give time for the projection to load
+        expect(marker.getElement().style.opacity).toBe('0.3');
+        marker.setLngLat([0, 0]);
+        expect(marker.getElement().style.opacity).toBe('0.7');
+
+        map.terrain = createTerrain(); // Enable terrain
+        await sleep(100); // Give time for the terrain to load
+        map.fire('terrain'); // Trigger terrain event for marker
+        marker.setLngLat([180, 0]);
+        expect(marker.getElement().style.opacity).toBe('0.3');
+        marker.setLngLat([0, 0]);
+        expect(marker.getElement().style.opacity).toBe('0.7');
+
+        map.terrain = null; // Disable terrain
+        await sleep(100);
+        marker.setLngLat([180, 0]);
+        expect(marker.getElement().style.opacity).toBe('0.3');
+        marker.setLngLat([0, 0]);
+        expect(marker.getElement().style.opacity).toBe('0.7');
+
+        map.remove();
+    });
+
     test('Removes an open popup when going behind 3d terrain', async () => {
         const map = createMap();
         const marker = new Marker()

--- a/src/ui/marker.test.ts
+++ b/src/ui/marker.test.ts
@@ -1089,13 +1089,6 @@ describe('marker', () => {
         marker.setLngLat([0, 0]);
         expect(marker.getElement().style.opacity).toBe('0.7');
 
-        map.terrain = null; // Disable terrain
-        await sleep(100);
-        marker.setLngLat([180, 0]);
-        expect(marker.getElement().style.opacity).toBe('0.3');
-        marker.setLngLat([0, 0]);
-        expect(marker.getElement().style.opacity).toBe('0.7');
-
         map.remove();
     });
 

--- a/src/ui/marker.test.ts
+++ b/src/ui/marker.test.ts
@@ -1069,7 +1069,7 @@ describe('marker', () => {
         const map = createMap({width: 1024, renderWorldCopies: true});
         await map.once('load');
 
-        const marker = new CustomMarker({opacity: 0.7, opacityWhenCovered: 0.3})
+        const marker = new Marker({opacity: 0.7, opacityWhenCovered: 0.3})
             .setLngLat([180, 0])
             .addTo(map);
 

--- a/src/ui/marker.test.ts
+++ b/src/ui/marker.test.ts
@@ -1069,7 +1069,7 @@ describe('marker', () => {
         const map = createMap({width: 1024, renderWorldCopies: true});
         await map.once('load');
 
-        const marker = new Marker({opacity: 0.7, opacityWhenCovered: 0.3})
+        const marker = new Marker({opacity: '0.7', opacityWhenCovered: '0.3'})
             .setLngLat([180, 0])
             .addTo(map);
 

--- a/src/ui/marker.ts
+++ b/src/ui/marker.ts
@@ -553,8 +553,8 @@ export class Marker extends Evented {
 
     _updateOpacity(force: boolean = false) {
         const terrain = this._map?.terrain;
-        const occluded = this._map.transform.isLocationOccluded(this._lngLat);
-        if (!terrain || occluded) {
+        if (!terrain) {
+            const occluded = this._map.transform.isLocationOccluded(this._lngLat);
             const targetOpacity = occluded ? this._opacityWhenCovered : this._opacity;
             if (this._element.style.opacity !== targetOpacity) { this._element.style.opacity = targetOpacity; }
             return;

--- a/src/ui/marker.ts
+++ b/src/ui/marker.ts
@@ -588,9 +588,7 @@ export class Marker extends Evented {
         // Display at full opacity if center is visible.
         const centerIsInvisible = markerDistanceCenter - terrainDistanceCenter > forgiveness;
 
-        if (this._popup?.isOpen() && centerIsInvisible) {
-            this._popup.remove();
-        }
+        if (this._popup?.isOpen() && centerIsInvisible) this._popup.remove();
         this._element.style.opacity = centerIsInvisible ? this._opacityWhenCovered : this._opacity;
     }
 

--- a/src/ui/marker.ts
+++ b/src/ui/marker.ts
@@ -561,11 +561,14 @@ export class Marker extends Evented {
             }, 100);
         }
 
+        const terrain = this._map?.terrain
         const occluded = this._map.transform.isLocationOccluded(this._lngLat);
-        console.log(occluded);
-        if (occluded) {
+
+        if (!terrain || occluded) {
             // Display at _opacityWhenCovered when occluded
-            if (this._element.style.opacity !== this._opacityWhenCovered) { this._element.style.opacity = this._opacityWhenCovered; }
+            const targetOpacity = occluded ? this._opacityWhenCovered : this._opacity;
+            if (this._element.style.opacity !== targetOpacity) { this._element.style.opacity = targetOpacity; }
+            return;
         } else {
             const map = this._map;
 
@@ -575,8 +578,6 @@ export class Marker extends Evented {
             const elevation = map.terrain.getElevationForLngLatZoom(this._lngLat, map.transform.tileZoom);
             const markerDistance = map.transform.lngLatToCameraDepth(this._lngLat, elevation);
             const forgiveness = .006;
-            console.log('markerDistance - terrainDistance');
-            console.log(markerDistance - terrainDistance);
             if (markerDistance - terrainDistance < forgiveness) {
                 this._element.style.opacity = this._opacity;
                 return;
@@ -588,8 +589,6 @@ export class Marker extends Evented {
             const markerDistanceCenter = map.transform.lngLatToCameraDepth(this._lngLat, elevation + elevationToCenter);
             // Display at full opacity if center is visible.
             const centerIsInvisible = markerDistanceCenter - terrainDistanceCenter > forgiveness;
-            console.log('centerIsInvisible');
-            console.log(centerIsInvisible);
 
             if (this._popup?.isOpen() && centerIsInvisible) {
                 this._popup.remove();

--- a/src/ui/marker.ts
+++ b/src/ui/marker.ts
@@ -552,13 +552,6 @@ export class Marker extends Evented {
     }
 
     _updateOpacity(force: boolean = false) {
-        const terrain = this._map?.terrain;
-        if (!terrain) {
-            const occluded = this._map.transform.isLocationOccluded(this._lngLat);
-            const targetOpacity = occluded ? this._opacityWhenCovered : this._opacity;
-            if (this._element.style.opacity !== targetOpacity) { this._element.style.opacity = targetOpacity; }
-            return;
-        }
         if (force) {
             this._opacityTimeout = null;
         } else {
@@ -568,29 +561,41 @@ export class Marker extends Evented {
             }, 100);
         }
 
-        const map = this._map;
+        const occluded = this._map.transform.isLocationOccluded(this._lngLat);
+        console.log(occluded);
+        if (occluded) {
+            // Display at _opacityWhenCovered when occluded
+            if (this._element.style.opacity !== this._opacityWhenCovered) { this._element.style.opacity = this._opacityWhenCovered; }
+        } else {
+            const map = this._map;
 
-        // Read depth framebuffer, getting position of terrain in line of sight to marker
-        const terrainDistance = map.terrain.depthAtPoint(this._pos);
-        // Transform marker position to clip space
-        const elevation = map.terrain.getElevationForLngLatZoom(this._lngLat, map.transform.tileZoom);
-        const markerDistance = map.transform.lngLatToCameraDepth(this._lngLat, elevation);
+            // Read depth framebuffer, getting position of terrain in line of sight to marker
+            const terrainDistance = map.terrain.depthAtPoint(this._pos);
+            // Transform marker position to clip space
+            const elevation = map.terrain.getElevationForLngLatZoom(this._lngLat, map.transform.tileZoom);
+            const markerDistance = map.transform.lngLatToCameraDepth(this._lngLat, elevation);
+            const forgiveness = .006;
+            console.log('markerDistance - terrainDistance');
+            console.log(markerDistance - terrainDistance);
+            if (markerDistance - terrainDistance < forgiveness) {
+                this._element.style.opacity = this._opacity;
+                return;
+            }
+            // If the base is obscured, use the offset to check if the marker's center is obscured.
+            const metersToCenter = -this._offset.y / map.transform.pixelsPerMeter;
+            const elevationToCenter = Math.sin(map.getPitch() * Math.PI / 180) * metersToCenter;
+            const terrainDistanceCenter = map.terrain.depthAtPoint(new Point(this._pos.x, this._pos.y - this._offset.y));
+            const markerDistanceCenter = map.transform.lngLatToCameraDepth(this._lngLat, elevation + elevationToCenter);
+            // Display at full opacity if center is visible.
+            const centerIsInvisible = markerDistanceCenter - terrainDistanceCenter > forgiveness;
+            console.log('centerIsInvisible');
+            console.log(centerIsInvisible);
 
-        const forgiveness = .006;
-        if (markerDistance - terrainDistance < forgiveness) {
-            this._element.style.opacity = this._opacity;
-            return;
+            if (this._popup?.isOpen() && centerIsInvisible) {
+                this._popup.remove();
+            }
+            this._element.style.opacity = centerIsInvisible ? this._opacityWhenCovered : this._opacity;
         }
-        // If the base is obscured, use the offset to check if the marker's center is obscured.
-        const metersToCenter = -this._offset.y / map.transform.pixelsPerMeter;
-        const elevationToCenter = Math.sin(map.getPitch() * Math.PI / 180) * metersToCenter;
-        const terrainDistanceCenter = map.terrain.depthAtPoint(new Point(this._pos.x, this._pos.y - this._offset.y));
-        const markerDistanceCenter = map.transform.lngLatToCameraDepth(this._lngLat, elevation + elevationToCenter);
-        // Display at full opacity if center is visible.
-        const centerIsInvisible = markerDistanceCenter - terrainDistanceCenter > forgiveness;
-
-        if (this._popup?.isOpen() && centerIsInvisible) this._popup.remove();
-        this._element.style.opacity = centerIsInvisible ? this._opacityWhenCovered : this._opacity;
     }
 
     _update = (e?: { type: 'move' | 'moveend' | 'terrain' | 'render' }) => {

--- a/src/ui/marker.ts
+++ b/src/ui/marker.ts
@@ -553,8 +553,8 @@ export class Marker extends Evented {
 
     _updateOpacity(force: boolean = false) {
         const terrain = this._map?.terrain;
-        if (!terrain) {
-            const occluded = this._map.transform.isLocationOccluded(this._lngLat);
+        const occluded = this._map.transform.isLocationOccluded(this._lngLat);
+        if (!terrain || occluded) {
             const targetOpacity = occluded ? this._opacityWhenCovered : this._opacity;
             if (this._element.style.opacity !== targetOpacity) { this._element.style.opacity = targetOpacity; }
             return;

--- a/src/ui/marker.ts
+++ b/src/ui/marker.ts
@@ -561,7 +561,7 @@ export class Marker extends Evented {
             }, 100);
         }
 
-        const terrain = this._map?.terrain
+        const terrain = this._map?.terrain;
         const occluded = this._map.transform.isLocationOccluded(this._lngLat);
 
         if (!terrain || occluded) {


### PR DESCRIPTION
This PR fixes https://github.com/maplibre/maplibre-gl-js/issues/5829

Looking into the issue I found when terrain is enabled, _opacityWhenCovered is only applied when terrain is blocking and not if occluded (which if i understand correctly is when the tile is not visible)

This reworks the opacity so it always first checks if the marker is 'occluded ' first. If it is, the _opacityWhenCovered  value is always applied. If it is not, it does the existing checks to see if it behind terrain.

## Example (rotate the map so the marker goes behind the globe with terrain enabled)
Example with v5.4.0
https://stackblitz.com/edit/web-platform-6xsbznqb?file=index.html
![image](https://github.com/user-attachments/assets/fb949383-5fb6-45dc-b53c-9ea371ea6c93)

Example with this PR code
https://stackblitz.com/edit/web-platform-mrytnhfv?file=index.html 
![image](https://github.com/user-attachments/assets/80775b05-e4f6-44dd-b28d-12bea555e41c)

## Other Issues Found (not fixed by this PR)

When globe is enabled and terrain is enabled, it does not apply _opacityWhenCovered  when the marker is behind terrain. this is not working in the current release or in this PR. I noticed centerIsInvisible was returning false. I also notice the marker tended to float and not be in a consistent location when globe+terrain is enabled

![opacity_terrain-globe](https://github.com/user-attachments/assets/841451da-4f85-4ae7-8e5e-077954669f60)

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [X] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [X] Briefly describe the changes in this PR.
 - [X] Link to related issues.
 - [X] Include before/after visuals or gifs if this PR includes visual changes.
 - [X] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [ ] Add an entry to `CHANGELOG.md` under the `## main` section.
