### PR TITLE
Fix vector tile reload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,12 @@
 ## main
 
 ### ✨ Features and improvements
-- Fix `refreshTiles()` for vector tiles ([#5875](https://github.com/maplibre/maplibre-gl-js/pull/5875))
+
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes
 - Fix handling invalid glyph placement results along lines ([#5118](https://github.com/maplibre/maplibre-gl-js/pull/5118))
+- Fix `refreshTiles()` for vector tiles ([#5875](https://github.com/maplibre/maplibre-gl-js/pull/5875))
 - _...Add new stuff here..._
 
 ## 5.5.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## main
 
 ### ✨ Features and improvements
-
+- Fix `refreshTiles()` for vector tiles ([#5875](https://github.com/maplibre/maplibre-gl-js/pull/5875))
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes

--- a/src/source/source_cache.ts
+++ b/src/source/source_cache.ts
@@ -263,7 +263,9 @@ export class SourceCache extends Evented {
         this._cache.reset();
 
         for (const i in this._tiles) {
-            if (sourceDataChanged || this._tiles[i].state !== 'errored') {
+            if (sourceDataChanged) {
+                this._reloadTile(i, 'expired');
+            } else if (this._tiles[i].state !== 'errored') {
                 this._reloadTile(i, 'reloading');
             }
         }
@@ -899,7 +901,7 @@ export class SourceCache extends Evented {
      */
     refreshTiles(tileIds: Array<ICanonicalTileID>) {
         for (const id in this._tiles) {
-            if (!this._isIdRenderable(id)) {
+            if (!this._isIdRenderable(id) && this._tiles[id].state != 'errored') {
                 continue;
             }
             if (tileIds.some(tid => tid.equals(this._tiles[id].tileID.canonical))) {

--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -2230,8 +2230,7 @@ export class Map extends Camera {
             throw new Error(`There is no source cache with ID "${sourceId}", cannot refresh tile`);
         }
         if (tileIds === undefined) {
-            const sourceDataChanged = true;
-            sourceCache.reload(sourceDataChanged);
+            sourceCache.reload(true);
         } else {
             sourceCache.refreshTiles(tileIds.map((tileId) => {return new CanonicalTileID(tileId.z, tileId.x, tileId.y);}));
         }

--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -2230,7 +2230,8 @@ export class Map extends Camera {
             throw new Error(`There is no source cache with ID "${sourceId}", cannot refresh tile`);
         }
         if (tileIds === undefined) {
-            sourceCache.reload();
+            const sourceDataChanged = true;
+            sourceCache.reload(sourceDataChanged);
         } else {
             sourceCache.refreshTiles(tileIds.map((tileId) => {return new CanonicalTileID(tileId.z, tileId.x, tileId.y);}));
         }

--- a/src/ui/map_tests/map_refresh_tiles.test.ts
+++ b/src/ui/map_tests/map_refresh_tiles.test.ts
@@ -44,5 +44,6 @@ describe('Map::refreshTiles', () => {
 
         map.refreshTiles('source-id1');
         expect(spy).toHaveBeenCalledOnce();
+        expect(spy.mock.calls[0][0]).toBe(true);
     });
 });


### PR DESCRIPTION
Fixes #5806 to get `refreshTiles()` to work for an entire vector layer (before this change, `refreshTiles()` worked on vector layers only when provided a list of tiles to refresh).

Before, `SourceCache::_reloadTile()` was called with `state = 'reloading'`. This caused `VectorTileSource::reloadTile()` to be called, instead of the desired `VectorTileSource::loadTile()`. According to the docs, `WorkerSource::reloadTile()` "re-parses a tile that has already been loaded", which is why `loadTile()` must be called instead.

After this change, `SourceCache::_reloadTile()` is called with `state = 'expired'`. This results in the tile being re-requested, just as it already was when a list of tile IDs was provided to `refreshTiles()`.

 - [X] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [X] Briefly describe the changes in this PR.
 - [X] Link to related issues.
 - [X] Write tests for all new functionality.
 - [x] Add an entry to `CHANGELOG.md` under the `## main` section.
