### PR TITLE
fix: remove old comment from rollup.config.ts

### DIFF
--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -10,7 +10,6 @@ const production = BUILD === 'production';
 const outputFile = production ? 'dist/maplibre-gl.js' : 'dist/maplibre-gl-dev.js';
 
 const config: RollupOptions[] = [{
-    // Before rollup you should run build-tsc to transpile from typescript to javascript (except when running rollup in watch mode)
     // Rollup will use code splitting to bundle GL JS into three "chunks":
     // - staging/maplibregl/index.js: the main module, plus all its dependencies not shared by the worker module
     // - staging/maplibregl/worker.js: the worker module, plus all dependencies not shared by the main module


### PR DESCRIPTION

This PR removes an outdated comment in rollup.config.ts that refers to a build-tsc npm script which no longer exists.

## Changes made:
- Removed comment line suggesting to run `build-tsc` before rollup
- The comment was obsolete since this script no longer exists in package.json

## What I verified:
- Checked package.json scripts to confirm build-tsc doesn't exist
- Verified current build process uses @rollup/plugin-typescript directly
- Confirmed that existing build commands (build-dev, build-prod) already handle TypeScript transpilation 
- Examined other comments in the file and found no other issues

## Impact:
- Reduces confusion for new contributors (as reported in issue #5651)
- No functional changes to the codebase
- Only removes outdated documentation

## Launch Checklist

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [ ] Add an entry to `CHANGELOG.md` under the `## main` section.

Close: #5651

---

Thank you for developing such great software!
This is my first pull request to maplibre project and maplibre-gl-js. If you find any mistakes, please let me know. Thanks!
