### PR TITLE
feat: GeoJSON Foreign Members Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### ✨ Features and improvements
 
+- Add support for GeoJSON Foreign Members to maintain additional data in GeoJSON objects ([#5747](https://github.com/maplibre/maplibre-gl-js/issues/5747))
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes

--- a/src/util/vectortile_to_geojson.test.ts
+++ b/src/util/vectortile_to_geojson.test.ts
@@ -1,0 +1,143 @@
+import {describe, expect, test} from 'vitest';
+import {GeoJSONFeature} from './vectortile_to_geojson';
+import type {MapGeoJSONFeature} from './vectortile_to_geojson';
+import type {VectorTileFeature} from '@mapbox/vector-tile';
+
+describe('vectortile_to_geojson', () => {
+    const mockPointGeometry: GeoJSON.Geometry = {
+        type: 'Point',
+        coordinates: [100, 0]
+    };
+
+    const createMockVectorTileFeature = (properties = {}, extraFields = {}): VectorTileFeature => {
+        return {
+            properties,
+            extent: 4096,
+            type: 1,
+            loadGeometry: () => [],
+            toGeoJSON: (_x, _y, _z) => {
+                return {
+                    type: 'Feature',
+                    geometry: mockPointGeometry,
+                    properties: properties
+                };
+            },
+            ...extraFields
+        } as unknown as VectorTileFeature;
+    };
+
+    describe('GeoJSONFeature', () => {
+
+        test('constructor properly initializes properties', () => {
+            const mockProperties = {name: 'Test Feature', value: 42};
+            const mockExtraFields = {extraField: 'extra value'};
+            const id = 'feature-123';
+
+            const vectorTileFeature = createMockVectorTileFeature(mockProperties, mockExtraFields);
+            const feature = new GeoJSONFeature(vectorTileFeature, 14, 8254, 5463, id);
+
+            expect(feature.type).toBe('Feature');
+            expect(feature.properties).toEqual(mockProperties);
+            expect(feature.id).toBe(id);
+
+            expect((vectorTileFeature as any)._z).toBe(14);
+            expect((vectorTileFeature as any)._x).toBe(8254);
+            expect((vectorTileFeature as any)._y).toBe(5463);
+
+            expect(feature.foreignMembers.extraField).toBe('extra value');
+
+            expect(feature.foreignMembers.properties).toBeUndefined();
+            expect(feature.foreignMembers.extent).toBeUndefined();
+            expect(feature.foreignMembers.type).toBeUndefined();
+        });
+
+        test('geometry getter lazily loads geometry', () => {
+            const vectorTileFeature = createMockVectorTileFeature();
+            const feature = new GeoJSONFeature(vectorTileFeature, 14, 8254, 5463, 'feature-123');
+
+            expect(feature._geometry).toBeUndefined();
+
+            const geometry = feature.geometry;
+            expect(geometry).toEqual(mockPointGeometry);
+
+            expect(feature.geometry).toBe(geometry);
+        });
+
+        test('geometry setter updates _geometry', () => {
+            const vectorTileFeature = createMockVectorTileFeature();
+            const feature = new GeoJSONFeature(vectorTileFeature, 14, 8254, 5463, 'feature-123');
+
+            const newGeometry: GeoJSON.Geometry = {
+                type: 'LineString',
+                coordinates: [[0, 0], [1, 1]]
+            };
+
+            feature.geometry = newGeometry;
+            expect(feature._geometry).toBe(newGeometry);
+            expect(feature.geometry).toBe(newGeometry);
+        });
+
+        test('toJSON outputs correct GeoJSON structure', () => {
+            const mockProperties = {name: 'Test Feature', value: 42};
+            const mockExtraFields = {extraField: 'extra value'};
+            const id = 'feature-123';
+
+            const vectorTileFeature = createMockVectorTileFeature(mockProperties, mockExtraFields);
+            const feature = new GeoJSONFeature(vectorTileFeature, 14, 8254, 5463, id);
+
+            feature.geometry;
+
+            const json = feature.toJSON();
+
+            expect(json.type).toBe('Feature');
+            expect(json.geometry).toEqual(mockPointGeometry);
+            expect(json.properties).toEqual(mockProperties);
+            expect(json.id).toBe(id);
+            expect(json.extraField).toBe('extra value');
+
+            expect(json._geometry).toBeUndefined();
+            expect(json._vectorTileFeature).toBeUndefined();
+        });
+
+        test('handles feature without id', () => {
+            const vectorTileFeature = createMockVectorTileFeature();
+            const feature = new GeoJSONFeature(vectorTileFeature, 14, 8254, 5463, undefined);
+
+            expect(feature.id).toBeUndefined();
+
+            const json = feature.toJSON();
+            expect(json.id).toBeUndefined();
+        });
+    });
+
+    describe('MapGeoJSONFeature type', () => {
+        test('can create object of MapGeoJSONFeature type', () => {
+            const mockVectorTileFeature = createMockVectorTileFeature({name: 'Test Feature'});
+            const geoJSONFeature = new GeoJSONFeature(mockVectorTileFeature, 14, 8254, 5463, 'feature-123');
+
+            const mapFeature = {
+                ...geoJSONFeature.toJSON(),
+                layer: {
+                    id: 'test-layer',
+                    type: 'fill',
+                    source: 'test-source'
+                },
+                source: 'test-source',
+                sourceLayer: 'test-source-layer',
+                state: {
+                    hover: false,
+                    selected: true
+                }
+            } as MapGeoJSONFeature;
+
+            expect(mapFeature.type).toBe('Feature');
+            expect(mapFeature.geometry).toEqual(geoJSONFeature.geometry);
+            expect(mapFeature.layer.id).toBe('test-layer');
+            expect(mapFeature.layer.source).toBe('test-source');
+            expect(mapFeature.source).toBe('test-source');
+            expect(mapFeature.sourceLayer).toBe('test-source-layer');
+            expect(mapFeature.state.hover).toBe(false);
+            expect(mapFeature.state.selected).toBe(true);
+        });
+    });
+});

--- a/src/util/vectortile_to_geojson.ts
+++ b/src/util/vectortile_to_geojson.ts
@@ -30,6 +30,7 @@ export class GeoJSONFeature {
     _geometry: GeoJSON.Geometry;
     properties: { [name: string]: any };
     id: number | string | undefined;
+    foreignMembers: { [name: string]: any };
 
     _vectorTileFeature: VectorTileFeature;
 
@@ -43,6 +44,15 @@ export class GeoJSONFeature {
 
         this.properties = vectorTileFeature.properties;
         this.id = id;
+        this.foreignMembers = {};
+
+        for (const key in vectorTileFeature) {
+            if (key !== 'type' && key !== 'properties' && key !== 'id' &&
+                key !== '_z' && key !== '_x' && key !== '_y' &&
+                key !== 'extent' && key !== 'loadGeometry' && key !== 'toGeoJSON') {
+                this.foreignMembers[key] = (vectorTileFeature as any)[key];
+            }
+        }
     }
 
     get geometry(): GeoJSON.Geometry {
@@ -67,6 +77,11 @@ export class GeoJSONFeature {
             if (i === '_geometry' || i === '_vectorTileFeature') continue;
             json[i] = (this)[i];
         }
+
+        for (const key in this.foreignMembers) {
+            json[key] = this.foreignMembers[key];
+        }
+
         return json;
     }
 }


### PR DESCRIPTION
Hi!

I am excited to contribute to this wonderful project by implementing support for "Foreign Members" as defined in [RFC7946 Section 6.1](https://www.rfc-editor.org/rfc/rfc7946#section-6.1), ensuring that GeoJSON objects can maintain additional data throughout their lifecycle.

## Summary of Changes

- Added a `foreignMembers` property to the GeoJSONFeature class to retain additional fields from VectorTileFeature objects
- Extended the `toJSON()` method to include Foreign Members in the generated GeoJSON output
- Added comprehensive test file `vectortile_to_geojson.test.ts` to validate the implementation

This implementation fully complies with the RFC7946 Section 6.1 specification, which states:

> "Members not described in this specification ('foreign members') MAY be used in a GeoJSON document."

This change allows MapLibre GeoJSON objects to preserve any non-standard attributes that were present in the source data, making them available in events and other contexts where these objects are used.

## Modified Files

- `src/util/vectortile_to_geojson.ts`
  - Added `foreignMembers` property to GeoJSONFeature class
  - Implemented logic to extract Foreign Members from VectorTileFeature
  - Extended `toJSON()` method to include Foreign Members in output

## Added Files

- `src/util/vectortile_to_geojson.test.ts`
  - Tests for basic functionality of GeoJSONFeature class
  - Tests for extraction and retention of Foreign Members
  - Tests for MapGeoJSONFeature type

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [x] Add an entry to `CHANGELOG.md` under the `## main` section.