### PR TITLE
Fix Hypsometric Tint float precision

### DIFF
--- a/src/shaders/color_relief.fragment.glsl
+++ b/src/shaders/color_relief.fragment.glsl
@@ -1,3 +1,7 @@
+#ifdef GL_ES
+precision highp float;
+#endif
+
 uniform sampler2D u_image;
 uniform vec4 u_unpack;
 uniform sampler2D u_elevation_stops;


### PR DESCRIPTION
This change is required to get the `color_relief` feature to work in the LINZ test environment.

The same code is used in `hillshade_prepare.fragment.glsl`, which also gets elevation from raster DEM tiles.