### PR TITLE
chore: Update comment to clarify field of view setting in Camera class

### DIFF
--- a/src/ui/camera.ts
+++ b/src/ui/camera.ts
@@ -1465,7 +1465,7 @@ export abstract class Camera extends Evented {
         const r0 = zoomOutFactor(false);
 
         // w(s): Returns the visible span on the ground, measured in pixels with respect to the
-        // initial scale. Assumes an angular field of view of 2 arctan ½ ≈ 53°.
+        // initial scale. Uses the current vertical field of view setting.
         let w: (_: number) => number = function (s) {
             return (cosh(r0) / cosh(r0 + rho * s));
         };


### PR DESCRIPTION
## Launch Checklist

- [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license)
  - this change is entirely new
- [x] Briefly describe the changes in this PR.
- [x] Link to related issues.
- [ ] Include before/after visuals or gifs if this PR includes visual changes.
- [ ] Write tests for all new functionality.
- [ ] Document any changes to public APIs.
- [ ] Post benchmark scores.
- [ ] Add an entry to `CHANGELOG.md` under the `## main` section.

## Description

This PR updates the comments in `camera.ts` to correct outdated information about the camera's field of view (FOV). The previous comment incorrectly assumed a fixed FOV of "2 arctan ½ ≈ 53°", but the current implementation allows users to set custom FOV values using the `getVerticalFieldOfView()`/`setVerticalFieldOfView()` APIs.

This PR updates the old comment to more accurately state that it "uses the current vertical field of view setting," ensuring the code documentation matches its actual behavior.

## Related Issues

This PR closes Issue #5078.
- Close: #5078

## Documentation of API Changes

No changes to public APIs, only code comments were updated.
