### PR TITLE
Corrected parameters in example for CustomLayerInterface

### DIFF
--- a/src/style/style_layer/custom_style_layer.ts
+++ b/src/style/style_layer/custom_style_layer.ts
@@ -141,7 +141,7 @@ type CustomRenderMethod = (gl: WebGLRenderingContext|WebGL2RenderingContext, opt
  *         this.renderingMode = '2d';
  *     }
  *
- *     onAdd(map, gl) {
+ *      onAdd(map: maplibregl.Map, gl: WebGLRenderingContext | WebGL2RenderingContext) {
  *         const vertexSource = `
  *         uniform mat4 u_matrix;
  *         void main() {
@@ -167,7 +167,13 @@ type CustomRenderMethod = (gl: WebGLRenderingContext|WebGL2RenderingContext, opt
  *         gl.linkProgram(this.program);
  *     }
  *
- *     render(gl, matrix) {
+ *     render({
+ *      gl,
+ *      modelViewProjectionMatrix: matrix
+ *      }: {
+ *      gl: WebGLRenderingContext | WebGL2RenderingContext;
+ *      modelViewProjectionMatrix: Float32Array;
+ *      }) {
  *         gl.useProgram(this.program);
  *         gl.uniformMatrix4fv(gl.getUniformLocation(this.program, "u_matrix"), false, matrix);
  *         gl.drawArrays(gl.POINTS, 0, 1);


### PR DESCRIPTION
## Launch Checklist
fixes #5987 
Here i am Explicitly typing both `map: Map, gl: WebGLRenderingContext | WebGL2RenderingContext` and destructuring `modelViewProjectionMatrix: Float32Array` in the example


 - [ ] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality.
 - [x] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [ ] Add an entry to `CHANGELOG.md` under the `## main` section.

@HarelM If anything needs to be change please let me know, i will love to address those.