### PR TITLE
Group vitest dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,8 +14,7 @@ updates:
     groups:
       vitest:
         patterns:
-          - "vitest"
-          - "@vitest/*"
+          - "*vitest*"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
## Launch Checklist

This is related to this issue:
https://github.com/vitest-dev/vitest/issues/8140

Groups vitest dependencies (hopefully).

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
