### PR TITLE
fix: correct Y axis transformation in projectFromLabelPlaneToClipSpace

### DIFF
--- a/src/symbol/projection.ts
+++ b/src/symbol/projection.ts
@@ -685,7 +685,7 @@ function projectFromLabelPlaneToClipSpace(x: number, y: number, projectionContex
     } else {
         return {
             x: (x / projectionContext.width) * 2.0 - 1.0,
-            y: (y / projectionContext.height) * 2.0 - 1.0
+            y: 1.0 - (y / projectionContext.height) * 2.0
         };
     }
 }


### PR DESCRIPTION
## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

Fixes a Y-axis projection error in the `projectFromLabelPlaneToClipSpace` function when `pitchWithMap` is `false`.

Previously, the calculation for the Y coordinate incorrectly subtracted an extra `1.0`, resulting in incorrect vertical positioning of labels.

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 Fixes #5779
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [ ] Add an entry to `CHANGELOG.md` under the `## main` section.
