### PR TITLE
Fix 6010

### DIFF
--- a/src/geo/projection/covering_tiles.test.ts
+++ b/src/geo/projection/covering_tiles.test.ts
@@ -260,6 +260,27 @@ describe('coveringTiles', () => {
                 new OverscaledTileID(11, 0, 11, 688, 1024)
             ]);
         });
+        
+
+        test('nonzero center', () => {
+            const options = {
+                minzoom: 1,
+                maxzoom: 15,
+                tileSize: 512,
+                reparseOverscaled: true
+            };
+        
+            const transform = new GlobeTransform();
+            transform.resize(128, 128);
+            transform.setZoom(11);
+            transform.setCenter(new LngLat(0.021, 0.0915));
+            transform.setElevation(20000);
+
+            expect(coveringTiles(transform, options)).toEqual([
+                new OverscaledTileID(11, 0, 11, 1024, 1023),
+                new OverscaledTileID(11, 0, 11, 1023, 1023)
+            ]);
+        });
     });
 
     describe('mercator', () => {
@@ -628,6 +649,26 @@ describe('coveringTiles', () => {
         
             expect(coveringTiles(transform, options)).toEqual([
                 new OverscaledTileID(11, 0, 11, 688, 1024)
+            ]);
+        });
+
+        test('nonzero center', () => {
+            const options = {
+                minzoom: 1,
+                maxzoom: 15,
+                tileSize: 512,
+                reparseOverscaled: true
+            };
+        
+            const transform = new MercatorTransform(0, 15, 0, 85, true);
+            transform.resize(128, 128);
+            transform.setZoom(11);
+            transform.setCenter(new LngLat(0.03, 0.0915));
+            transform.setElevation(20000);
+
+            expect(coveringTiles(transform, options)).toEqual([
+                new OverscaledTileID(11, 0, 11, 1024, 1023),
+                new OverscaledTileID(11, 0, 11, 1023, 1023)
             ]);
         });
     

--- a/src/geo/projection/globe_covering_tiles_details_provider.ts
+++ b/src/geo/projection/globe_covering_tiles_details_provider.ts
@@ -109,13 +109,13 @@ export class GlobeCoveringTilesDetailsProvider implements CoveringTilesDetailsPr
     }
 
     private _computeTileBoundingVolume(tileID: {x: number; y: number; z: number}, wrap: number, elevation: number, options: CoveringTilesOptions): ConvexVolume {
-        let minElevation = elevation;
-        let maxElevation = elevation;
+        let minElevation = 0;
+        let maxElevation = 0;
         if (options?.terrain) {
             const overscaledTileID = new OverscaledTileID(tileID.z, wrap, tileID.z, tileID.x, tileID.y);
             const minMax = options.terrain.getMinMaxElevation(overscaledTileID);
-            minElevation = minMax.minElevation ?? elevation;
-            maxElevation = minMax.maxElevation ?? elevation;
+            minElevation = minMax.minElevation ?? Math.min(0, elevation);
+            maxElevation = minMax.maxElevation ?? Math.max(0, elevation);
         }
         // Convert elevation to distances from center of a unit sphere planet (so that 1 is surface)
         minElevation /= earthRadius;

--- a/src/geo/projection/mercator_covering_tiles_details_provider.ts
+++ b/src/geo/projection/mercator_covering_tiles_details_provider.ts
@@ -26,13 +26,13 @@ export class MercatorCoveringTilesDetailsProvider implements CoveringTilesDetail
      * @param tileID - Tile x, y and z for zoom.
      */
     getTileBoundingVolume(tileID: {x: number; y: number; z: number}, wrap: number, elevation: number, options: CoveringTilesOptions): Aabb {
-        let minElevation = elevation;
-        let maxElevation = elevation;
+        let minElevation = 0;
+        let maxElevation = 0;
         if (options?.terrain) {
             const overscaledTileID = new OverscaledTileID(tileID.z, wrap, tileID.z, tileID.x, tileID.y);
             const minMax = options.terrain.getMinMaxElevation(overscaledTileID);
-            minElevation = minMax.minElevation ?? elevation;
-            maxElevation = minMax.maxElevation ?? elevation;
+            minElevation = minMax.minElevation ?? Math.min(0, elevation);
+            maxElevation = minMax.maxElevation ?? Math.max(0, elevation);
         }
         const numTiles = 1 << tileID.z;
         return new Aabb([wrap + tileID.x / numTiles, tileID.y / numTiles, minElevation],


### PR DESCRIPTION
Fixes #6010 by making sure the tile bounding volume includes altitude zero (where tiles are placed in the absence of terrain).

 - [X] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [X] Briefly describe the changes in this PR.
 - [X] Link to related issues.
 - [X] Write tests for all new functionality.
 - [ ] Add an entry to `CHANGELOG.md` under the `## main` section.
