### PR TITLE
Add Bluesky social link to mkdocs config

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -16,6 +16,7 @@
     "bezier",
     "Blockly",
     "Bounde",
+    "bsky",
     "buble",
     "cadogan",
     "carto",

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -30,7 +30,7 @@ theme:
         icon: material/brightness-4
         name: Switch to system preference
     - media: "(prefers-color-scheme: light)"
-      scheme: default 
+      scheme: default
       toggle:
         icon: material/brightness-7
         name: Switch to dark mode
@@ -51,6 +51,8 @@ markdown_extensions:
 
 extra:
   social:
+    - icon: fontawesome/brands/bluesky
+      link: https://bsky.app/profile/maplibre.org
     - icon: fontawesome/brands/mastodon
       link: https://mastodon.social/@maplibre
     - icon: fontawesome/brands/x-twitter


### PR DESCRIPTION
Added a Bluesky icon and link to the social section in mkdocs.yml to provide users with an additional way to connect. Also removed trailing whitespace in the theme section.

## Launch Checklist

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [ ] Link to related issues.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [ ] Add an entry to `CHANGELOG.md` under the `## main` section.
