### PR TITLE
Wrap FlipY / PremultiplyAlpha in isDomElement condition

### DIFF
--- a/src/render/texture.ts
+++ b/src/render/texture.ts
@@ -53,14 +53,19 @@ export class Texture {
         this.useMipmap = Boolean(options && options.useMipmap);
         gl.bindTexture(gl.TEXTURE_2D, this.texture);
 
-        context.pixelStoreUnpackFlipY.set(false);
+        const isDOMElement = image instanceof HTMLImageElement || image instanceof HTMLCanvasElement || image instanceof HTMLVideoElement || image instanceof ImageData || isImageBitmap(image);
+
         context.pixelStoreUnpack.set(1);
-        context.pixelStoreUnpackPremultiplyAlpha.set(this.format === gl.RGBA && (!options || options.premultiply !== false));
+
+        if (isDOMElement) {
+            context.pixelStoreUnpackFlipY.set(false);
+            context.pixelStoreUnpackPremultiplyAlpha.set(this.format === gl.RGBA && (!options || options.premultiply !== false));
+        }
 
         if (resize) {
             this.size = [width, height];
 
-            if (image instanceof HTMLImageElement || image instanceof HTMLCanvasElement || image instanceof HTMLVideoElement || image instanceof ImageData || isImageBitmap(image)) {
+            if (isDOMElement) {
                 gl.texImage2D(gl.TEXTURE_2D, 0, this.format, this.format, gl.UNSIGNED_BYTE, image);
             } else {
                 gl.texImage2D(gl.TEXTURE_2D, 0, this.format, width, height, 0, this.format, gl.UNSIGNED_BYTE, (image as DataTextureImage).data);
@@ -68,7 +73,7 @@ export class Texture {
 
         } else {
             const {x, y} = position || {x: 0, y: 0};
-            if (image instanceof HTMLImageElement || image instanceof HTMLCanvasElement || image instanceof HTMLVideoElement || image instanceof ImageData || isImageBitmap(image)) {
+            if (isDOMElement) {
                 gl.texSubImage2D(gl.TEXTURE_2D, 0, x, y, gl.RGBA, gl.UNSIGNED_BYTE, image);
             } else {
                 gl.texSubImage2D(gl.TEXTURE_2D, 0, x, y, width, height, gl.RGBA, gl.UNSIGNED_BYTE, (image as DataTextureImage).data);
@@ -79,9 +84,12 @@ export class Texture {
             gl.generateMipmap(gl.TEXTURE_2D);
         }
 
-        context.pixelStoreUnpackFlipY.setDefault();
         context.pixelStoreUnpack.setDefault();
-        context.pixelStoreUnpackPremultiplyAlpha.setDefault();
+
+        if (isDOMElement) {
+            context.pixelStoreUnpackFlipY.setDefault();
+            context.pixelStoreUnpackPremultiplyAlpha.setDefault();
+        }
     }
 
     bind(filter: TextureFilter, wrap: TextureWrap, minFilter?: TextureFilter | null) {


### PR DESCRIPTION
Closes #2030
- https://github.com/maplibre/maplibre-gl-js/issues/2030

Make an isDomElement, and only run the FlipY / PremultiplyAlpha within that condition, which is what Firefox is trying to nudge us towards.

## Launch Checklist

Before
<img width="687" alt="Screenshot 2025-06-25 at 19 15 58" src="https://github.com/user-attachments/assets/8ce11157-189d-452b-9be2-48691c970946" />

After
<img width="815" alt="Screenshot 2025-06-25 at 19 16 06" src="https://github.com/user-attachments/assets/478c8939-be15-4ee6-8d00-1e4dcfbcef75" />
 

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [X] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [X] Briefly describe the changes in this PR.
 - [X] Link to related issues.
 - [X] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [ ] Add an entry to `CHANGELOG.md` under the `## main` section.
