### PR TITLE
Examples: Change filter input type from text to search

### DIFF
--- a/test/examples/filter-symbols-by-text-input.html
+++ b/test/examples/filter-symbols-by-text-input.html
@@ -21,9 +21,8 @@
         z-index: 1;
     }
 
-    .filter-ctrl input[type='text'] {
+    .filter-ctrl input[type='search'] {
         font: 12px/20px 'Helvetica Neue', Arial, Helvetica, sans-serif;
-        width: 100%;
         border: 0;
         background-color: #fff;
         margin: 0;
@@ -38,7 +37,7 @@
 <div class="filter-ctrl">
     <input
         id="filter-input"
-        type="text"
+        type="search"
         name="filter"
         placeholder="Filter by name"
     />


### PR DESCRIPTION
- Updated the filter input field and its CSS selector to use type='search' instead of type='text' for improved semantics and browser behavior. (UI improvement as it allows user to Press Escape to clear the input)
- Removed duplicate width value from CSS

## Launch Checklist

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [ ] Link to related issues.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [ ] Add an entry to `CHANGELOG.md` under the `## main` section.
