### PR TITLE
Use high contrast MapLibre logo for dark mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 <p align="center">
-  <img src="https://maplibre.org/img/maplibre-logo-big.svg" alt="MapLibre Logo">
+  <img src="https://github.com/user-attachments/assets/7ff2cda8-f564-4e70-a971-d34152f969f0#gh-light-mode-only" alt="MapLibre Logo" width="200">
+  <img src="https://github.com/user-attachments/assets/cee8376b-9812-40ff-91c6-2d53f9581b83#gh-dark-mode-only" alt="MapLibre Logo" width="200">
 </p>
 
 # MapLibre GL JS


### PR DESCRIPTION
GitHub has had a feature to [Specify theme context for images in Markdown](https://github.blog/changelog/2021-11-24-specify-theme-context-for-images-in-markdown/) for a while (works with GitHub hosted images).

Since we have a MapLibre logo for a dark background... I think it looks nice.

Light mode

<img width="1099" alt="Screenshot 2025-06-30 at 01 43 42" src="https://github.com/user-attachments/assets/3ff908e0-31cc-47e4-95aa-e0fd37af34b8" />

Dark mode

<img width="1069" alt="Screenshot 2025-06-30 at 01 43 16" src="https://github.com/user-attachments/assets/a933b98b-d0c2-4352-997c-3cb57a1f7be1" />

If this is approved I will change it for Native too.

Also fixes that the logo is super tiny on hidpi screens, **current**:

<img width="940" alt="image" src="https://github.com/user-attachments/assets/30dd75d2-0182-48ab-a1c6-596a87d528f3" />

