### PR TITLE
ensure opacity is reset when locationOccludedOpacity no longer applicable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fix use of `textureSize` call in color relief shader ([#5980](https://github.com/maplibre/maplibre-gl-js/pull/5980))
 - Fix Y axis transformation in projectFromLabelPlaneToClipSpace ([#6021](https://github.com/maplibre/maplibre-gl-js/pull/6021))
 - Alpha-sort all examples ([#6049](https://github.com/maplibre/maplibre-gl-js/pull/6049))
+- ensure opacity is reset for popups when `locationOccludedOpacity` no longer applicable [PR link incoming]
 
 - _...Add new stuff here..._
 

--- a/src/ui/popup.test.ts
+++ b/src/ui/popup.test.ts
@@ -870,4 +870,21 @@ describe('popup', () => {
         map.setCenter([180, 0]);
         expect(popup.getElement().style.opacity).toBe('0.2');
     });
+    test('Popup resets opacity when no longer behind globe', async () => {
+        const map = createMap();
+
+        const popup = new Popup({locationOccludedOpacity: 0.3})
+            .setLngLat([0, 0])
+            .setText('Test')
+            .addTo(map);
+
+        await map.once('load');
+        map.setProjection({
+            type: 'globe'
+        });
+        map.setCenter([180, 0]);
+        expect(popup.getElement().style.opacity).toBe('0.3');
+        map.setCenter([0, 0]);
+        expect(popup.getElement().style.opacity).toBe('');
+    });
 });

--- a/src/ui/popup.ts
+++ b/src/ui/popup.ts
@@ -243,7 +243,7 @@ export class Popup extends Evented {
         if (this._map.transform.isLocationOccluded(this.getLngLat())) {
             this._container.style.opacity = `${this.options.locationOccludedOpacity}`;
         } else {
-            this._container.style.opacity = undefined;
+            this._container.style.opacity = "";
         }
     };
 

--- a/src/ui/popup.ts
+++ b/src/ui/popup.ts
@@ -243,7 +243,7 @@ export class Popup extends Evented {
         if (this._map.transform.isLocationOccluded(this.getLngLat())) {
             this._container.style.opacity = `${this.options.locationOccludedOpacity}`;
         } else {
-            this._container.style.opacity = "";
+            this._container.style.opacity = '';
         }
     };
 


### PR DESCRIPTION
This is a fix for the issue raised here https://github.com/maplibre/maplibre-gl-js/issues/6071

The reset attempt for locationOccludedOpacity was flawed in that browsers will ignore an attempt to set a style to undefined. Setting it to `''` instead solves that.

Markers do not have the same issue because they have better handling for this.

## Launch Checklist

 - [X] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [X] Briefly describe the changes in this PR.
 - [X] Link to related issues.
 - [X] Write tests for all new functionality.
 - [X] Add an entry to `CHANGELOG.md` under the `## main` section.
