### PR TITLE
Docs: Fix a few links to examples

### DIFF
--- a/src/source/raster_tile_source.ts
+++ b/src/source/raster_tile_source.ts
@@ -46,8 +46,8 @@ import type {
  * });
  * ```
  * @see [Add a raster tile source](https://maplibre.org/maplibre-gl-js/docs/examples/map-tiles/)
- * @see [Add a WMS source](https://maplibre.org/maplibre-gl-js/docs/examples/wms/)
- * @see [Display a satellite map](https://maplibre.org/maplibre-gl-js/docs/examples/satellite-map/)
+ * @see [Add a WMS source](https://maplibre.org/maplibre-gl-js/docs/examples/add-a-wms-source/)
+ * @see [Display a satellite map](https://maplibre.org/maplibre-gl-js/docs/examples/display-a-satellite-map/)
  */
 export class RasterTileSource extends Evented implements Source {
     type: 'raster' | 'raster-dem';

--- a/src/ui/control/geolocate_control.ts
+++ b/src/ui/control/geolocate_control.ts
@@ -90,7 +90,7 @@ let noTimeout = false;
  *     trackUserLocation: true
  * }));
  * ```
- * @see [Locate the user](https://maplibre.org/maplibre-gl-js/docs/examples/locate-user/)
+ * @see [Locate the user](https://maplibre.org/maplibre-gl-js/docs/examples/locate-the-user/)
  *
  * ## Events
  *

--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -305,7 +305,7 @@ export type MapOptions = {
      * font-family for locally overriding generation of Chinese, Japanese, and Korean characters.
      * For these characters, font settings from the map's style will be ignored, except for font-weight keywords (light/regular/medium/bold).
      * Set to `false`, to enable font settings from the map's style for these glyph ranges.
-     * The purpose of this option is to avoid bandwidth-intensive glyph server requests. (See [Use locally generated ideographs](https://maplibre.org/maplibre-gl-js/docs/examples/local-ideographs).)
+     * The purpose of this option is to avoid bandwidth-intensive glyph server requests. (See [Use locally generated ideographs](https://maplibre.org/maplibre-gl-js/docs/examples/use-locally-generated-ideographs).)
      * @defaultValue 'sans-serif'
      */
     localIdeographFontFamily?: string | false;


### PR DESCRIPTION
This pull request updates documentation references across several files to ensure consistency and correctness in example URLs.

### Documentation Updates:

* **`src/source/raster_tile_source.ts`**: Updated example URLs for adding a WMS source and displaying a satellite map to reflect the correct paths in the documentation.
* **`src/ui/control/geolocate_control.ts`**: Corrected the example URL for locating the user to use the updated path in the documentation.
* **`src/ui/map.ts`**: Fixed the example URL for using locally generated ideographs to point to the correct documentation page.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [ ] Link to related issues.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [ ] Add an entry to `CHANGELOG.md` under the `## main` section.
