### PR TITLE
Bugfix/6179 set transform request types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fix white artifacts when using non-zero elevation ([#6032](https://github.com/maplibre/maplibre-gl-js/pull/6032))
 - Fix geolocate control lock loss on window resize ([#3504](https://github.com/maplibre/maplibre-gl-js/issues/3504))
 - Fix a memory leak in `GeoJSONSource` when rapidly updating data ([#6163](https://github.com/maplibre/maplibre-gl-js/pull/6163))
+- Fix `Map.setTransformRequest` parameter type to include `null` ([#6179](https://github.com/maplibre/maplibre-gl-js/issues/6179))
 
 - _...Add new stuff here..._
 

--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -1875,7 +1875,7 @@ export class Map extends Camera {
      * map.setTransformRequest((url: string, resourceType: string) => {});
      * ```
      */
-    setTransformRequest(transformRequest: RequestTransformFunction): this {
+    setTransformRequest(transformRequest: RequestTransformFunction | null): this {
         this._requestManager.setTransformRequest(transformRequest);
         return this;
     }
@@ -2205,12 +2205,12 @@ export class Map extends Camera {
     }
 
     /**
-     * Change the tile Level of Detail behavior of the specified source. These parameters have no effect when 
+     * Change the tile Level of Detail behavior of the specified source. These parameters have no effect when
      * pitch == 0, and the largest effect when the horizon is visible on screen.
      *
      * @param maxZoomLevelsOnScreen - The maximum number of distinct zoom levels allowed on screen at a time.
      * There will generally be fewer zoom levels on the screen, the maximum can only be reached when the horizon
-     * is at the top of the screen. Increasing the maximum number of zoom levels causes the zoom level to decay 
+     * is at the top of the screen. Increasing the maximum number of zoom levels causes the zoom level to decay
      * faster toward the horizon.
      * @param tileCountMaxMinRatio - The ratio of the maximum number of tiles loaded (at high pitch) to the minimum
      * number of tiles loaded. Increasing this ratio allows more tiles to be loaded at high pitch angles. If the ratio

--- a/src/ui/map_tests/map_basic.test.ts
+++ b/src/ui/map_tests/map_basic.test.ts
@@ -69,6 +69,15 @@ describe('Map', () => {
             map.setTransformRequest(transformRequest);
             map.setTransformRequest(transformRequest);
         });
+
+        test('removes function when called with null', () => {
+            const map = createMap();
+
+            const transformRequest = (() => {}) as any as RequestTransformFunction;
+            map.setTransformRequest(transformRequest);
+            map.setTransformRequest(null);
+            expect(map._requestManager._transformRequestFn).not.toBe(transformRequest);
+        });
     });
 
     describe('is_Loaded', () => {
@@ -117,7 +126,7 @@ describe('Map', () => {
 
             expect(map.isStyleLoaded()).toBe(false);
             await map.once('load');
-            expect(map.isStyleLoaded()).toBe(true);  
+            expect(map.isStyleLoaded()).toBe(true);
         });
 
         test('Map.areTilesLoaded', async () => {
@@ -130,7 +139,7 @@ describe('Map', () => {
             map.style.sourceCaches.geojson._tiles[fakeTileId.key] = new Tile(fakeTileId, undefined);
             expect(map.areTilesLoaded()).toBe(false);
             map.style.sourceCaches.geojson._tiles[fakeTileId.key].state = 'loaded';
-            expect(map.areTilesLoaded()).toBe(true);  
+            expect(map.areTilesLoaded()).toBe(true);
         });
     });
 

--- a/src/util/request_manager.ts
+++ b/src/util/request_manager.ts
@@ -21,10 +21,10 @@ export const enum ResourceType {
 export type RequestTransformFunction = (url: string, resourceType?: ResourceType) => RequestParameters | undefined;
 
 export class RequestManager {
-    _transformRequestFn: RequestTransformFunction;
+    _transformRequestFn: RequestTransformFunction | null;
 
-    constructor(transformRequestFn?: RequestTransformFunction) {
-        this._transformRequestFn = transformRequestFn;
+    constructor(transformRequestFn?: RequestTransformFunction | null) {
+        this._transformRequestFn = transformRequestFn ?? null;
     }
 
     transformRequest(url: string, type: ResourceType) {
@@ -35,7 +35,7 @@ export class RequestManager {
         return {url};
     }
 
-    setTransformRequest(transformRequest: RequestTransformFunction) {
+    setTransformRequest(transformRequest: RequestTransformFunction | null) {
         this._transformRequestFn = transformRequest;
     }
 }


### PR DESCRIPTION
## Summary

Fixes #6179 

This PR fixes the typing of the `Map.setTransformRequest` parameter to include `null` (which allows to remove the previous `transformRequest` function).

## Changes

- Adding `null` to `transformRequest` type in `Map.setTransformRequest` and in `RequestManager`.
- Setting `RequestManager._transformRequestFn` to `null` if the constructor parameter is `undefined`. This is not required, but it ensures two things : 
  - The type definition is strict, meaning it is valid even with TypeScript strict mode on.
  - The value is consitent : it's either a function or `null`, but not `undefined` sometimes and `null` some other times.
    > Note : the value can still be `undefined` with `setTransformRequest(undefined)`, but this would only be allowed if strict mode is off.
- Adding a test to check that `transformRequest` is removed when set to null.
- Other changes are automatic removal of trailing spaces.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [x] Add an entry to `CHANGELOG.md` under the `## main` section.
