### PR TITLE
improve GeolocateControl accuracy circle radius computation when movi…

### DIFF
--- a/src/ui/control/geolocate_control.test.ts
+++ b/src/ui/control/geolocate_control.test.ts
@@ -54,6 +54,16 @@ function createResizeObserverEntryMock() {
     };
 }
 
+function getPxNumber(circleWidthPx: string) {
+    return Number(circleWidthPx.substring(0, circleWidthPx.length - 2));
+}
+
+function expectBetween(pxValue: string, min: number, max: number) {
+    const value = getPxNumber(pxValue);
+    expect(value).toBeLessThan(max);
+    expect(value).toBeGreaterThan(min);
+}
+
 describe('GeolocateControl with no options', () => {
     geolocation.use();
     let map;
@@ -587,22 +597,22 @@ describe('GeolocateControl with no options', () => {
         let zoomendPromise = map.once('zoomend');
         map.zoomTo(12, {duration: 0});
         await zoomendPromise;
-        expect(geolocate._circleElement.style.width).toBe('79px');
+        expectBetween(geolocate._circleElement.style.width, 74, 75);
         zoomendPromise = map.once('zoomend');
         map.zoomTo(10, {duration: 0});
         await zoomendPromise;
-        expect(geolocate._circleElement.style.width).toBe('20px');
+        expectBetween(geolocate._circleElement.style.width, 18, 19);
         zoomendPromise = map.once('zoomend');
 
         // test with smaller radius
         geolocation.send({latitude: 10, longitude: 20, accuracy: 20});
         map.zoomTo(20, {duration: 0});
         await zoomendPromise;
-        expect(geolocate._circleElement.style.width).toBe('19982px');
+        expectBetween(geolocate._circleElement.style.width, 18881, 18882);
         zoomendPromise = map.once('zoomend');
         map.zoomTo(18, {duration: 0});
         await zoomendPromise;
-        expect(geolocate._circleElement.style.width).toBe('4996px');
+        expectBetween(geolocate._circleElement.style.width, 4766, 4767);
     });
 
     test('shown even if trackUserLocation = false', async () => {

--- a/src/ui/control/geolocate_control.ts
+++ b/src/ui/control/geolocate_control.ts
@@ -303,6 +303,8 @@ export class GeolocateControl extends Evented implements IControl {
         }
 
         DOM.remove(this._container);
+        this._map.off('move', this._onMove);
+        this._map.off('rotate', this._onRotate);
         this._map.off('zoom', this._onZoom);
         this._map = undefined;
         numberOfWatches = 0;
@@ -374,6 +376,11 @@ export class GeolocateControl extends Evented implements IControl {
             this._finish();
 
             return;
+        }
+
+        if (this.options.showAccuracyCircle) {
+            // this is needed by _updateCircleRadius()
+            this._lastKnownPosition = position;
         }
 
         if (this.options.trackUserLocation) {
@@ -460,15 +467,29 @@ export class GeolocateControl extends Evented implements IControl {
     };
 
     _updateCircleRadius() {
-        const bounds = this._map.getBounds();
-        const southEastPoint = bounds.getSouthEast();
-        const northEastPoint = bounds.getNorthEast();
-        const mapHeightInMeters = southEastPoint.distanceTo(northEastPoint);
-        const mapHeightInPixels = this._map._container.clientHeight;
-        const circleDiameter = Math.ceil(2 * (this._accuracy / (mapHeightInMeters / mapHeightInPixels)));
+        if (!this._lastKnownPosition) return;
+        const center = new LngLat(this._lastKnownPosition.coords.longitude, this._lastKnownPosition.coords.latitude);
+        const point = this._map.project(center);
+        const delta_x_pixels = 10; // arbitrary small offset, in x direction because there is no map tilting in the x direction
+        const delta = this._map.unproject([point.x + delta_x_pixels, point.y]);
+        const distance = delta.distanceTo(center);
+        const pixelScale = distance / delta_x_pixels;
+        const circleDiameter = 2 * (this._accuracy / pixelScale);
         this._circleElement.style.width = `${circleDiameter}px`;
         this._circleElement.style.height = `${circleDiameter}px`;
     }
+
+    _onMove = () => {
+        if (this.options.showUserLocation && this.options.showAccuracyCircle) {
+            this._updateCircleRadius();
+        }
+    };
+
+    _onRotate = () => {
+        if (this.options.showUserLocation && this.options.showAccuracyCircle) {
+            this._updateCircleRadius();
+        }
+    };
 
     _onZoom = () => {
         if (this.options.showUserLocation && this.options.showAccuracyCircle) {
@@ -571,6 +592,8 @@ export class GeolocateControl extends Evented implements IControl {
 
             if (this.options.trackUserLocation) this._watchState = 'OFF';
 
+            this._map.on('move', this._onMove);
+            this._map.on('rotate', this._onRotate);
             this._map.on('zoom', this._onZoom);
         }
 

--- a/test/build/min.test.ts
+++ b/test/build/min.test.ts
@@ -38,7 +38,7 @@ describe('test min build', () => {
         const decreaseQuota = 4096;
 
         // feel free to update this value after you've checked that it has changed on purpose :-)
-        const expectedBytes = 937197;
+        const expectedBytes = 937827;
 
         expect(actualBytes).toBeLessThan(expectedBytes + increaseQuota);
         expect(actualBytes).toBeGreaterThan(expectedBytes - decreaseQuota);


### PR DESCRIPTION
…ng map

Using the center position to calculate the pixel scale, and updating calculations at each move/rotate/zoom of the map, as those change the position of the accuracy circle.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [ ] Add an entry to `CHANGELOG.md` under the `## main` section.
