### PR TITLE
Correct Mapbox name capitalization

### DIFF
--- a/docs/guides/mapbox-migration-guide.md
+++ b/docs/guides/mapbox-migration-guide.md
@@ -1,4 +1,4 @@
-# MapBox migration guide
+# Mapbox migration guide
 
 This part of the docs is dedicated to the migration from `mapbox-gl` to `maplibre-gl`.
 


### PR DESCRIPTION
Simply correct Mapbox capitalization for the migration guide.
