### PR TITLE
[docs] update map on index to globe

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -4,16 +4,16 @@ MapLibre GL JS is a TypeScript library that uses WebGL to render interactive map
 
 ## Quickstart
 
-<iframe src="./examples/display-a-map.html" width="100%" height="400px" style="border:none"></iframe>
+<iframe src="./examples/display-a-globe-with-a-vector-map.html" width="100%" height="400px" style="border:none"></iframe>
 
 ```html
 <div id="map"></div>
 <script>
     var map = new maplibregl.Map({
         container: 'map', // container id
-        style: 'https://demotiles.maplibre.org/style.json', // style URL
+        style: 'https://demotiles.maplibre.org/globe.json', // style URL
         center: [0, 0], // starting position [lng, lat]
-        zoom: 1 // starting zoom
+        zoom: 2 // starting zoom
     });
 </script>
 ```
@@ -56,7 +56,7 @@ import 'maplibre-gl/dist/maplibre-gl.css';
 
 const map = new maplibregl.Map({
     container: 'map', // container id
-    style: 'https://demotiles.maplibre.org/style.json', // style URL
+    style: 'https://demotiles.maplibre.org/globe.json', // style URL
     center: [0, 0], // starting position [lng, lat]
     zoom: 1 // starting zoom
 });
@@ -94,6 +94,6 @@ Note too that if the CSS isn't available by the first render, as soon as the CSS
 MapLibre GL JS is also distributed via UNPKG. Our latest version can installed by adding below tags this in the html `<head>`. Further instructions on how to select specific versions and semver ranges can be found on at [unpkg.com](https://unpkg.com).
 
 ```html
-<script src="https://unpkg.com/maplibre-gl@^5.6.1/dist/maplibre-gl.js"></script>
-<link href="https://unpkg.com/maplibre-gl@^5.6.1/dist/maplibre-gl.css" rel="stylesheet" />
+<script src="https://unpkg.com/maplibre-gl@^5.6.2/dist/maplibre-gl.js"></script>
+<link href="https://unpkg.com/maplibre-gl@^5.6.2/dist/maplibre-gl.css" rel="stylesheet" />
 ```

--- a/test/examples/display-a-globe-with-a-vector-map.html
+++ b/test/examples/display-a-globe-with-a-vector-map.html
@@ -18,8 +18,8 @@
     const map = new maplibregl.Map({
         container: 'map',
         style: 'https://demotiles.maplibre.org/style.json',
-        zoom: 0,
-        center: [137.9150899566626, 36.25956997955441],
+        zoom: 2,
+        center: [0, 0],
     });
 
     map.on('style.load', () => {


### PR DESCRIPTION
I believe over time the adaptive globe (or natural earth projection) should become the more used projection (like it is for google maps, apple maps, mapbox gl etc.), and i think the docs are useful towards normalizing, testing and stabilizing it further for a smooth transition.

At this point, the globe is quite robust for simple 2d maps, therefore this PR updates the quickstart map to the globe style. 

**Before**
<img width="1486" height="855" alt="Screenshot 2025-08-20 at 18 18 57" src="https://github.com/user-attachments/assets/75a2fda3-1a26-421c-a3ea-764f1fd5fa1a" />

**After**

<img width="1339" height="843" alt="Screenshot 2025-08-20 at 18 19 22" src="https://github.com/user-attachments/assets/11719d13-95e7-4741-9ff2-c6098fb4351d" />


## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [ ] Link to related issues.
 - [x] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [ ] Add an entry to `CHANGELOG.md` under the `## main` section.
