### PR TITLE
Expose covering tiles method in map

### DIFF
--- a/src/geo/projection/covering_tiles.test.ts
+++ b/src/geo/projection/covering_tiles.test.ts
@@ -1,7 +1,7 @@
 import {beforeEach, describe, expect, test} from 'vitest';
 import {GlobeTransform} from './globe_transform';
 import {LngLat} from '../lng_lat';
-import {coveringTiles, coveringZoomLevel, createCalculateTileZoomFunction, type CoveringZoomOptions} from './covering_tiles';
+import {coveringTiles, coveringZoomLevel, createCalculateTileZoomFunction, type CoveringTilesOptions} from './covering_tiles';
 import {OverscaledTileID} from '../../source/tile_id';
 import {MercatorTransform} from './mercator_transform';
 import {globeConstants} from './vertical_perspective_projection';
@@ -676,7 +676,7 @@ describe('coveringTiles', () => {
 
 describe('coveringZoomLevel', () => {
     let transform: MercatorTransform;
-    let options: CoveringZoomOptions;
+    let options: CoveringTilesOptions;
 
     beforeEach(() => {
         transform = new MercatorTransform(0, 22, 0, 60, true);

--- a/src/geo/projection/covering_tiles.ts
+++ b/src/geo/projection/covering_tiles.ts
@@ -23,7 +23,15 @@ type CoveringTilesStackEntry = {
     fullyVisible: boolean;
 };
 
-export type CoveringZoomOptions = {
+export type CoveringTilesOptions = {
+    /**
+     * Smallest allowed tile zoom.
+     */
+    minzoom?: number;
+    /**
+     * Largest allowed tile zoom.
+     */
+    maxzoom?: number;
     /**
      * Whether to round or floor the target zoom level. If true, the value will be rounded to the closest integer. Otherwise the value will be floored.
      */
@@ -34,15 +42,7 @@ export type CoveringZoomOptions = {
     tileSize: number;
 };
 
-export type CoveringTilesOptions = CoveringZoomOptions & {
-    /**
-     * Smallest allowed tile zoom.
-     */
-    minzoom?: number;
-    /**
-     * Largest allowed tile zoom.
-     */
-    maxzoom?: number;
+export type CoveringTilesOptionsInternal = CoveringTilesOptions & {
     /**
      * `true` if tiles should be sent back to the worker for each overzoomed zoom level, `false` if not.
      * Fill this option when computing covering tiles for a source.
@@ -160,7 +160,7 @@ const defaultCalculateTileZoom = createCalculateTileZoomFunction(defaultMaxZoomL
  * @param options - The options, most importantly the source's tile size.
  * @returns An integer zoom level at which all tiles will be visible.
  */
-export function coveringZoomLevel(transform: IReadonlyTransform, options: CoveringZoomOptions): number {
+export function coveringZoomLevel(transform: IReadonlyTransform, options: CoveringTilesOptions): number {
     const z = (options.roundZoom ? Math.round : Math.floor)(
         transform.zoom + scaleZoom(transform.tileSize / options.tileSize)
     );
@@ -180,7 +180,7 @@ export function coveringZoomLevel(transform: IReadonlyTransform, options: Coveri
  * @param details - Interface to define required helper functions.
  * @returns A list of tile coordinates, ordered by ascending distance from camera.
  */
-export function coveringTiles(transform: IReadonlyTransform, options: CoveringTilesOptions): OverscaledTileID[] {
+export function coveringTiles(transform: IReadonlyTransform, options: CoveringTilesOptionsInternal): OverscaledTileID[] {
     const frustum = transform.getCameraFrustum();
     const plane = transform.getClippingPlane();
     const cameraCoord = transform.screenPointToMercatorCoordinate(transform.getCameraPoint());

--- a/src/geo/projection/covering_tiles_details_provider.ts
+++ b/src/geo/projection/covering_tiles_details_provider.ts
@@ -1,7 +1,7 @@
 import {type IBoundingVolume} from '../../util/primitives/bounding_volume';
 import {type MercatorCoordinate} from '../mercator_coordinate';
 import {type IReadonlyTransform} from '../transform_interface';
-import {type CoveringTilesOptions} from './covering_tiles';
+import {type CoveringTilesOptionsInternal} from './covering_tiles';
 
 export interface CoveringTilesDetailsProvider {
     /**
@@ -25,12 +25,12 @@ export interface CoveringTilesDetailsProvider {
      * @param elevation - camera center point elevation.
      * @param options - CoveringTilesOptions.
      */
-    getTileBoundingVolume: (tileID: {x: number; y: number; z: number}, wrap: number, elevation: number, options: CoveringTilesOptions) => IBoundingVolume;
+    getTileBoundingVolume: (tileID: {x: number; y: number; z: number}, wrap: number, elevation: number, options: CoveringTilesOptionsInternal) => IBoundingVolume;
 
     /**
      * Whether to allow variable zoom, which is used at high pitch angle to avoid loading an excessive amount of tiles.
      */
-    allowVariableZoom: (transform: IReadonlyTransform, options: CoveringTilesOptions) => boolean;
+    allowVariableZoom: (transform: IReadonlyTransform, options: CoveringTilesOptionsInternal) => boolean;
 
     /**
      * Whether to allow world copies to be rendered.

--- a/src/geo/projection/globe_covering_tiles_details_provider.ts
+++ b/src/geo/projection/globe_covering_tiles_details_provider.ts
@@ -1,7 +1,7 @@
 import {EXTENT} from '../../data/extent';
 import {projectTileCoordinatesToSphere} from './globe_utils';
 import {BoundingVolumeCache} from '../../util/primitives/bounding_volume_cache';
-import {coveringZoomLevel, type CoveringTilesOptions} from './covering_tiles';
+import {coveringZoomLevel, type CoveringTilesOptionsInternal} from './covering_tiles';
 import {vec3, type vec4} from 'gl-matrix';
 import type {IReadonlyTransform} from '../transform_interface';
 import type {MercatorCoordinate} from '../mercator_coordinate';
@@ -96,7 +96,7 @@ export class GlobeCoveringTilesDetailsProvider implements CoveringTilesDetailsPr
         return 0;
     }
     
-    allowVariableZoom(transform: IReadonlyTransform, options: CoveringTilesOptions): boolean {
+    allowVariableZoom(transform: IReadonlyTransform, options: CoveringTilesOptionsInternal): boolean {
         return coveringZoomLevel(transform, options) > 4;
     }
 
@@ -104,11 +104,11 @@ export class GlobeCoveringTilesDetailsProvider implements CoveringTilesDetailsPr
         return false;
     }
 
-    getTileBoundingVolume(tileID: { x: number; y: number; z: number }, wrap: number, elevation: number, options: CoveringTilesOptions) {
+    getTileBoundingVolume(tileID: { x: number; y: number; z: number }, wrap: number, elevation: number, options: CoveringTilesOptionsInternal) {
         return this._boundingVolumeCache.getTileBoundingVolume(tileID, wrap, elevation, options);
     }
 
-    private _computeTileBoundingVolume(tileID: {x: number; y: number; z: number}, wrap: number, elevation: number, options: CoveringTilesOptions): ConvexVolume {
+    private _computeTileBoundingVolume(tileID: {x: number; y: number; z: number}, wrap: number, elevation: number, options: CoveringTilesOptionsInternal): ConvexVolume {
         let minElevation = 0;
         let maxElevation = 0;
         if (options?.terrain) {

--- a/src/geo/projection/mercator_covering_tiles_details_provider.ts
+++ b/src/geo/projection/mercator_covering_tiles_details_provider.ts
@@ -3,7 +3,7 @@ import {Aabb} from '../../util/primitives/aabb';
 import {clamp} from '../../util/util';
 import {type MercatorCoordinate} from '../mercator_coordinate';
 import {type IReadonlyTransform} from '../transform_interface';
-import {type CoveringTilesOptions} from './covering_tiles';
+import {type CoveringTilesOptionsInternal} from './covering_tiles';
 import {type CoveringTilesDetailsProvider} from './covering_tiles_details_provider';
 
 export class MercatorCoveringTilesDetailsProvider implements CoveringTilesDetailsProvider {
@@ -25,7 +25,7 @@ export class MercatorCoveringTilesDetailsProvider implements CoveringTilesDetail
      * Returns the AABB of the specified tile.
      * @param tileID - Tile x, y and z for zoom.
      */
-    getTileBoundingVolume(tileID: {x: number; y: number; z: number}, wrap: number, elevation: number, options: CoveringTilesOptions): Aabb {
+    getTileBoundingVolume(tileID: {x: number; y: number; z: number}, wrap: number, elevation: number, options: CoveringTilesOptionsInternal): Aabb {
         let minElevation = 0;
         let maxElevation = 0;
         if (options?.terrain) {
@@ -39,7 +39,7 @@ export class MercatorCoveringTilesDetailsProvider implements CoveringTilesDetail
             [wrap + (tileID.x + 1) / numTiles, (tileID.y + 1) / numTiles, maxElevation]);
     }
     
-    allowVariableZoom(transform: IReadonlyTransform, options: CoveringTilesOptions): boolean {
+    allowVariableZoom(transform: IReadonlyTransform, options: CoveringTilesOptionsInternal): boolean {
         const zfov = transform.fov * (Math.abs(Math.cos(transform.rollInRadians)) * transform.height + Math.abs(Math.sin(transform.rollInRadians)) * transform.width) / transform.height;
         const maxConstantZoomPitch = clamp(78.5 - zfov / 2, 0.0, 60.0);
         return (!!options.terrain || transform.pitch > maxConstantZoomPitch);

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,7 +51,7 @@ import type {AnimationOptions, CameraForBoundsOptions, CameraOptions, CameraUpda
 import type {DistributiveKeys, DistributiveOmit, GeoJSONFeature, MapGeoJSONFeature} from './util/vectortile_to_geojson';
 import type {Handler, HandlerResult} from './ui/handler_manager';
 import type {Complete, RequireAtLeastOne, Subscription} from './util/util';
-import type {CalculateTileZoomFunction} from './geo/projection/covering_tiles';
+import type {CalculateTileZoomFunction, CoveringTilesOptions} from './geo/projection/covering_tiles';
 import type {StyleImage, StyleImageData, StyleImageInterface, StyleImageMetadata, TextFit} from './style/style_image';
 import type {StyleLayer} from './style/style_layer';
 import type {Tile} from './source/tile';
@@ -350,6 +350,7 @@ export {
     type MapContextEvent,
     type ErrorEvent,
     type GeoJSONFeature,
+    type CoveringTilesOptions,
     setRTLTextPlugin,
     getRTLTextPluginStatus,
     prewarm,

--- a/src/ui/map_tests/map_covering_tiles.test.ts
+++ b/src/ui/map_tests/map_covering_tiles.test.ts
@@ -1,0 +1,38 @@
+import {afterEach, beforeEach, describe, expect, test} from 'vitest';
+import {beforeMapTest, createMap} from '../../util/test/util';
+import {type Map} from '../map';
+
+let map: Map;
+
+beforeEach(async () => {
+    beforeMapTest();
+    map = createMap({
+        center: [0, 0],
+        zoom: 2,
+        style: {
+            version: 8,
+            sources: {},
+            layers: []
+        }
+    });
+    await map.once('load');
+});
+
+afterEach(() => {
+    if (map) map.remove();
+});
+
+describe('Map.coveringTiles', () => {
+    test('returns an array of tile IDs covering the viewport', () => {
+        const tiles = map.coveringTiles({tileSize: 512});
+        expect(Array.isArray(tiles)).toBe(true);
+        expect(tiles.length).toBeGreaterThan(0);
+    });
+
+    test('respects the maxzoom parameter', () => {
+        map.setZoom(5);
+        const tiles = map.coveringTiles({tileSize: 512, maxzoom: 4});
+
+        expect(tiles.every(tile => tile.canonical.z === 4)).toBeTruthy();
+    });
+});

--- a/src/util/primitives/bounding_volume_cache.ts
+++ b/src/util/primitives/bounding_volume_cache.ts
@@ -1,7 +1,7 @@
-import {type CoveringTilesOptions} from '../../geo/projection/covering_tiles';
+import {type CoveringTilesOptionsInternal} from '../../geo/projection/covering_tiles';
 import {type IBoundingVolume} from './bounding_volume';
 
-type BoundingVolumeFactory<T extends IBoundingVolume> = (tileID: {x: number; y: number; z: number}, wrap: number, elevation: number, options: CoveringTilesOptions) => T;
+type BoundingVolumeFactory<T extends IBoundingVolume> = (tileID: {x: number; y: number; z: number}, wrap: number, elevation: number, options: CoveringTilesOptionsInternal) => T;
 
 export class BoundingVolumeCache<T extends IBoundingVolume> {
     private _cachePrevious: Map<string, T> = new Map();
@@ -33,7 +33,7 @@ export class BoundingVolumeCache<T extends IBoundingVolume> {
      * Returns the bounding volume of the specified tile, fetching it from cache or creating it using the factory function if needed.
      * @param tileID - Tile x, y and z for zoom.
      */
-    getTileBoundingVolume(tileID: {x: number; y: number; z: number}, wrap: number, elevation: number, options: CoveringTilesOptions): T {
+    getTileBoundingVolume(tileID: {x: number; y: number; z: number}, wrap: number, elevation: number, options: CoveringTilesOptionsInternal): T {
         const key = `${tileID.z}_${tileID.x}_${tileID.y}_${options?.terrain ? 't' : ''}`;
         const cached = this._cache.get(key);
         if (cached) {


### PR DESCRIPTION
## Launch Checklist

- Replaces #6263
- Closes #6226

This adds the ability to get the covering tiles from the map object.

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [x] Write tests for all new functionality.
 - [x] Document any changes to public APIs.
 - [ ] Add an entry to `CHANGELOG.md` under the `## main` section.
