### PR TITLE
Fix 6111

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### 🐞 Bug fixes
 - Fix accuracy circle on locate user control ([#5432](https://github.com/maplibre/maplibre-gl-js/issues/5432))
 - Fix evaluating `global-state` in paint `...-pattern` properties ([6301](https://github.com/maplibre/maplibre-gl-js/pull/6301))
+- Fix pan moving in the wrong direction when map is pitched ([#6111](https://github.com/maplibre/maplibre-gl-js/issues/6111))
 - _...Add new stuff here..._
 
 ## 5.7.0

--- a/src/ui/camera.test.ts
+++ b/src/ui/camera.test.ts
@@ -908,6 +908,25 @@ describe('easeTo', () => {
         expect(fixedLngLat(camera.getCenter())).toEqual({lng: 170.3125, lat: 0});
     });
 
+    test('pans with offset with camera pitch', () => {
+        const camera = createCamera({pitch: 85});
+        camera.easeTo({center: [0, 0], offset: [0, -100], noMoveStart: true, duration: 0});
+        expect(fixedLngLat(camera.getCenter()).lat).toBeLessThan(0);
+    });
+
+    test('pans with large offset with camera pitch', () => {
+        const camera = createCamera({pitch: 85});
+        camera.easeTo({center: [0, 0], offset: [0, -500], noMoveStart: true, duration: 0});
+        expect(fixedLngLat(camera.getCenter()).lat).toBeLessThan(0);
+    });
+
+    test('pans with large offset with camera pitch and bearing', () => {
+        const camera = createCamera({pitch: 85, bearing: 135});
+        camera.easeTo({center: [0, 0], offset: [0, -500], noMoveStart: true, duration: 0});
+        expect(fixedLngLat(camera.getCenter()).lat).toBeGreaterThan(0);
+        expect(fixedLngLat(camera.getCenter()).lng).toBeLessThan(0);
+    });
+
     test('zooms with specified offset', () => {
         const camera = createCamera();
         camera.easeTo({zoom: 3.2, offset: [100, 0], duration: 0});
@@ -2915,6 +2934,25 @@ describe('easeTo globe projection', () => {
             const camera = createCameraGlobe({bearing: 180});
             camera.easeTo({center: [100, 0], offset: [100, 0], duration: 0});
             expect(fixedLngLat(camera.getCenter())).toEqual({lng: -175.50457909, lat: 0});
+        });
+
+        test('pans with offset with camera pitch', () => {
+            const camera = createCameraGlobe({pitch: 85});
+            camera.easeTo({center: [0, 0], offset: [0, -100], noMoveStart: true, duration: 0});
+            expect(fixedLngLat(camera.getCenter()).lat).toBeLessThan(0);
+        });
+
+        test('pans with large offset with camera pitch', () => {
+            const camera = createCameraGlobe({pitch: 85});
+            camera.easeTo({center: [0, 0], offset: [0, -500], noMoveStart: true, duration: 0});
+            expect(fixedLngLat(camera.getCenter()).lat).toBeLessThan(0);
+        });
+
+        test('pans with large offset with camera pitch and bearing', () => {
+            const camera = createCameraGlobe({pitch: 85, bearing: 135});
+            camera.easeTo({center: [0, 0], offset: [0, -500], noMoveStart: true, duration: 0});
+            expect(fixedLngLat(camera.getCenter()).lat).toBeGreaterThan(0);
+            expect(fixedLngLat(camera.getCenter()).lng).toBeLessThan(0);
         });
 
         test('zooms with specified offset', () => {

--- a/src/ui/camera.test.ts
+++ b/src/ui/camera.test.ts
@@ -909,19 +909,19 @@ describe('easeTo', () => {
     });
 
     test('pans with offset with camera pitch', () => {
-        const camera = createCamera({pitch: 85});
+        const camera = createCamera({pitch: 85, zoom: 10});
         camera.easeTo({center: [0, 0], offset: [0, -100], noMoveStart: true, duration: 0});
         expect(fixedLngLat(camera.getCenter()).lat).toBeLessThan(0);
     });
 
     test('pans with large offset with camera pitch', () => {
-        const camera = createCamera({pitch: 85});
+        const camera = createCamera({pitch: 85, zoom: 10});
         camera.easeTo({center: [0, 0], offset: [0, -500], noMoveStart: true, duration: 0});
         expect(fixedLngLat(camera.getCenter()).lat).toBeLessThan(0);
     });
 
     test('pans with large offset with camera pitch and bearing', () => {
-        const camera = createCamera({pitch: 85, bearing: 135});
+        const camera = createCamera({pitch: 85, bearing: 135, zoom: 10});
         camera.easeTo({center: [0, 0], offset: [0, -500], noMoveStart: true, duration: 0});
         expect(fixedLngLat(camera.getCenter()).lat).toBeGreaterThan(0);
         expect(fixedLngLat(camera.getCenter()).lng).toBeLessThan(0);


### PR DESCRIPTION
This PR fixes #6111.

The fundamental issue is that the pan inertia is calculated in screen pixels. At high pitch angles, the calculated pan motion sometimes crosses the horizon. When it does the calculated map point is behind the camera instead of in front, causing the motion to be backwards.

This PR fixes the issue by reducing the pan offset so that it never crosses the horizon. The exact logic I used is:

- Clip the pan offset to half the distance to horizon.

There is nothing special about this exact choice, the important thing is that the pan offset does not cross the horizon.

 - [X] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [X] Briefly describe the changes in this PR.
 - [X] Link to related issues.
 - [X] Write tests for all new functionality.
 - [X] Add an entry to `CHANGELOG.md` under the `## main` section.
