### PR TITLE
Use built-in method for absolute path in tests

### DIFF
--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -196,10 +196,7 @@ jobs:
 
       - name: Merge Coverage reports
         shell: bash
-        run: | 
-          find ./downloaded -type f -exec perl -pi -e 's|maplibre-gl-js/maplibre-gl-js/|maplibre-gl-js/|g' {} \;
-          find ./downloaded -type f -exec perl -pi -e 's|"/[A-Za-z/]*/maplibre-gl-js/|"|g' {} \;
-          npx nyc report -t ${{ github.workspace }}/downloaded --reporter lcov --reporter json --report-dir coverage-merged
+        run: npx nyc report -t ${{ github.workspace }}/downloaded --reporter lcov --reporter json --report-dir coverage-merged
 
       - name: Upload merged coverage report
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4

--- a/package-lock.json
+++ b/package-lock.json
@@ -90,7 +90,7 @@
         "junit-report-builder": "^5.1.1",
         "minimist": "^1.2.8",
         "mock-geolocation": "^1.0.11",
-        "monocart-coverage-reports": "^2.12.6",
+        "monocart-coverage-reports": "^2.12.7",
         "nise": "^6.1.1",
         "npm-font-open-sans": "^1.1.0",
         "npm-run-all": "^4.1.5",
@@ -4597,13 +4597,13 @@
       }
     },
     "node_modules/acorn-loose": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/acorn-loose/-/acorn-loose-8.5.0.tgz",
-      "integrity": "sha512-ppga7pybjwX2HSJv5ayHe6QG4wmNS1RQ2wjBMFTVnOj0h8Rxsmtc6fnVzINqHSSRz23sTe9IL3UAt/PU9gc4FA==",
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/acorn-loose/-/acorn-loose-8.5.2.tgz",
+      "integrity": "sha512-PPvV6g8UGMGgjrMu+n/f9E/tCSkNQ2Y97eFvuVdJfG11+xdIeDcLyNdC8SHcrHbRqkfwLASdplyR6B6sKM1U4A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "acorn": "^8.14.0"
+        "acorn": "^8.15.0"
       },
       "engines": {
         "node": ">=0.4.0"
@@ -5812,13 +5812,13 @@
       }
     },
     "node_modules/commander": {
-      "version": "13.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
-      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.0.tgz",
+      "integrity": "sha512-2uM9rYjPvyq39NwLRqaiLtWHyDC1FvryJDa2ATTVims5YAS4PupsEQsDvP14FqhFr0P49CYDugi59xaxJlTXRA==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/comment-json": {
@@ -6104,16 +6104,6 @@
         "@cspell/cspell-types": "9.2.1",
         "gensequence": "^7.0.0"
       },
-      "engines": {
-        "node": ">=20"
-      }
-    },
-    "node_modules/cspell/node_modules/commander": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.0.tgz",
-      "integrity": "sha512-2uM9rYjPvyq39NwLRqaiLtWHyDC1FvryJDa2ATTVims5YAS4PupsEQsDvP14FqhFr0P49CYDugi59xaxJlTXRA==",
-      "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=20"
       }
@@ -9748,9 +9738,9 @@
       }
     },
     "node_modules/istanbul-reports": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.7.tgz",
-      "integrity": "sha512-BewmUXImeuRk2YY0PVbxgKAysvhRPUQE0h5QRM++nVWyubKGV0l8qQ5op8+B2DOmwSe63Jivj0BjkPQVf8fP5g==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -10763,22 +10753,22 @@
       "license": "MIT"
     },
     "node_modules/monocart-coverage-reports": {
-      "version": "2.12.6",
-      "resolved": "https://registry.npmjs.org/monocart-coverage-reports/-/monocart-coverage-reports-2.12.6.tgz",
-      "integrity": "sha512-96CMC4B+Rw5Yi8OH2Aot+aMYIw84fK3PNJs7nP9Yw07I0+k0lY1GGiPOJTt123GMDdSpS32lPUIMu/OyqOfBCA==",
+      "version": "2.12.7",
+      "resolved": "https://registry.npmjs.org/monocart-coverage-reports/-/monocart-coverage-reports-2.12.7.tgz",
+      "integrity": "sha512-Gf+6mSsrbDSvjfzIr6Uer/soOC/j8mLrcnvA5bRGqJJsG3AYjqg/eaNTclqRZfFSLFKqOKkzkGwLhM1gHdmp8w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "acorn": "^8.14.1",
-        "acorn-loose": "^8.5.0",
+        "acorn": "^8.15.0",
+        "acorn-loose": "^8.5.2",
         "acorn-walk": "^8.3.4",
-        "commander": "^13.1.0",
+        "commander": "^14.0.0",
         "console-grid": "^2.2.3",
         "eight-colors": "^1.3.1",
         "foreground-child": "^3.3.1",
         "istanbul-lib-coverage": "^3.2.2",
         "istanbul-lib-report": "^3.0.1",
-        "istanbul-reports": "^3.1.7",
+        "istanbul-reports": "^3.2.0",
         "lz-utils": "^2.1.0",
         "monocart-locator": "^1.0.2"
       },

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "junit-report-builder": "^5.1.1",
     "minimist": "^1.2.8",
     "mock-geolocation": "^1.0.11",
-    "monocart-coverage-reports": "^2.12.6",
+    "monocart-coverage-reports": "^2.12.7",
     "nise": "^6.1.1",
     "npm-font-open-sans": "^1.1.0",
     "npm-run-all": "^4.1.5",

--- a/test/integration/query/query.test.ts
+++ b/test/integration/query/query.test.ts
@@ -142,7 +142,10 @@ describe('query tests', () => {
         const coverageReport = new CoverageReport({
             name: 'MapLibre Coverage Report',
             outputDir: './coverage/query',
-            reports: [['v8'], ['json']]
+            reports: [['v8'], ['json']],
+            sourcePath: (relativePath)=> {
+                return path.resolve(relativePath);
+            }
         });
         coverageReport.cleanCache();
         

--- a/test/integration/render/run_render_tests.ts
+++ b/test/integration/render/run_render_tests.ts
@@ -946,7 +946,10 @@ async function closePageAndFinish(page: Page, reportCoverage: boolean) {
     const coverageReport = new CoverageReport({
         name: 'MapLibre Coverage Report',
         outputDir: './coverage/render',
-        reports: [['v8'], ['json']]
+        reports: [['v8'], ['json']],
+        sourcePath: (relativePath)=> {
+            return path.resolve(relativePath);
+        }
     });
     coverageReport.cleanCache();
 


### PR DESCRIPTION
## Launch Checklist

- This is a left over from #6338 
- Which needed the following fix: https://github.com/cenfun/monocart-coverage-reports/issues/118

It is using the correct method that was fixed in last build of monocart coverage report.

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.