### PR TITLE
Fix 5616

### DIFF
--- a/src/source/source_cache.test.ts
+++ b/src/source/source_cache.test.ts
@@ -965,6 +965,32 @@ describe('SourceCache._updateRetainedTiles', () => {
 
     });
 
+    test('retains overscaled loaded children with coveringZoom < maxzoom', () => {
+        const sourceCache = createSourceCache({maxzoom: 3});
+        sourceCache._source.loadTile = async (tile) => {
+            tile.state = 'errored';
+        };
+
+        const idealTile = new OverscaledTileID(3, 0, 3, 1, 2);
+        sourceCache._tiles[idealTile.key] = new Tile(idealTile, undefined);
+        sourceCache._tiles[idealTile.key].state = 'errored';
+
+        const loadedChildren = [
+            new OverscaledTileID(4, 0, 3, 1, 2)
+        ];
+
+        for (const t of loadedChildren) {
+            sourceCache._tiles[t.key] = new Tile(t, undefined);
+            sourceCache._tiles[t.key].state = 'loaded';
+        }
+
+        const retained = sourceCache._updateRetainedTiles([idealTile], 2);
+        expect(Object.keys(retained).sort()).toEqual([
+            idealTile
+        ].concat(loadedChildren).map(t => t.key).sort());
+
+    });
+
     test('adds parent tile if ideal tile errors and no child tiles are loaded', () => {
         const stateCache = {};
         const sourceCache = createSourceCache();

--- a/src/source/source_cache.ts
+++ b/src/source/source_cache.ts
@@ -751,10 +751,14 @@ export class SourceCache extends Evented {
                 // check if all 4 immediate children are loaded (i.e. the missing ideal tile is covered)
                 const children = tileID.children(this._source.maxzoom);
 
-                if (retain[children[0].key] &&
+                if (children.length === 4 &&
+                    retain[children[0].key] &&
                     retain[children[1].key] &&
                     retain[children[2].key] &&
                     retain[children[3].key]) continue; // tile is covered by children
+
+                if (children.length === 1 &&
+                    retain[children[0].key]) continue; // tile is covered by overscaled child
             }
 
             // We couldn't find child tiles that entirely cover the ideal tile; look for parents now.


### PR DESCRIPTION
This fixes #5616. It uses the fix proposed in #5630, and additionally handles the case where `children.length === 1`. A unit test has been added.

 - [X] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [X] Briefly describe the changes in this PR.
 - [X] Link to related issues.
 - [X] Write tests for all new functionality.
 - [ ] Add an entry to `CHANGELOG.md` under the `## main` section.
