### PR TITLE
Fix #5430 - when TileJSON fails to load ignore source but trigger load and idle events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### 🐞 Bug fixes
 - Fix `_updateRetainedTiles` checking for children when children length is 1 overscaled tile "child" ([#6388](https://github.com/maplibre/maplibre-gl-js/pull/6388))
 - Fix evaluating `global-state` for layers added after loading style ([#6361](https://github.com/maplibre/maplibre-gl-js/issues/6361))
+- Fix triggering `load` and `idle` events when source TileJSON fails to load ([#5430](https://github.com/maplibre/maplibre-gl-js/issues/5430))
 - _...Add new stuff here..._
 
 ## 5.7.1

--- a/src/source/raster_tile_source.test.ts
+++ b/src/source/raster_tile_source.test.ts
@@ -52,6 +52,17 @@ describe('RasterTileSource', () => {
         expect(transformSpy.mock.calls[0][1]).toBe('Source');
     });
 
+    test('fires "error" event if TileJSON request fails', async () => {
+        server.respondWith('/source.json', [404, {}, '']);
+
+        const source = createSource({url: '/source.json'});
+        const errorEvent = waitForEvent(source, 'error', (e) => e.error.status === 404);
+        server.respond();
+
+        await expect(errorEvent).resolves.toBeDefined();
+        expect(source.loaded()).toBe(true);
+    });
+
     test('respects TileJSON.bounds', async () => {
         const source = createSource({
             minzoom: 0,
@@ -78,7 +89,7 @@ describe('RasterTileSource', () => {
 
         await waitForEvent(source, 'data', (e: MapSourceDataEvent) => e.sourceDataType === 'metadata');
 
-        expect(source.tileBounds.bounds).toEqual({_sw: {lng: -47, lat: -7}, _ne: {lng: -45, lat: 90}});  
+        expect(source.tileBounds.bounds).toEqual({_sw: {lng: -47, lat: -7}, _ne: {lng: -45, lat: 90}});
     });
 
     test('respects TileJSON.bounds when loaded from TileJSON', async () => {
@@ -200,7 +211,7 @@ describe('RasterTileSource', () => {
             tiles: ['http://example.com/{z}/{x}/{y}.png'],
             bounds: [-47, -7, -45, -5]
         }));
-        server.respondWith('http://example.com/10/5/5.png', 
+        server.respondWith('http://example.com/10/5/5.png',
             [200, {'Content-Type': 'image/png', 'Content-Length': 1, 'Cache-Control': 'max-age=100'}, '0']
         );
         const source = createSource({url: '/source.json'});
@@ -231,7 +242,7 @@ describe('RasterTileSource', () => {
             tiles: ['http://example.com/{z}/{x}/{y}.png'],
             bounds: [-47, -7, -45, -5]
         }));
-        server.respondWith('http://example.com/10/5/5.png', 
+        server.respondWith('http://example.com/10/5/5.png',
             [200, {'Content-Type': 'image/png', 'Content-Length': 1, 'Expires': 'Wed, 21 Oct 2015 07:28:00 GMT'}, '0']
         );
         const source = createSource({url: '/source.json'});
@@ -262,7 +273,7 @@ describe('RasterTileSource', () => {
             tiles: ['http://example.com/{z}/{x}/{y}.png'],
             bounds: [-47, -7, -45, -5]
         }));
-        server.respondWith('http://example.com/10/5/5.png', 
+        server.respondWith('http://example.com/10/5/5.png',
             [200, {'Content-Type': 'image/png', 'Content-Length': 1, 'Cache-Control': '', 'Expires': 'Wed, 21 Oct 2015 07:28:00 GMT'}, '0']
         );
         const source = createSource({url: '/source.json'});

--- a/src/source/raster_tile_source.ts
+++ b/src/source/raster_tile_source.ts
@@ -107,6 +107,7 @@ export class RasterTileSource extends Evented implements Source {
             }
         } catch (err) {
             this._tileJSONRequest = null;
+            this._loaded = true; // let's pretend it's loaded so the source will be ignored
             this.fire(new ErrorEvent(err));
         }
     }

--- a/src/source/vector_tile_source.test.ts
+++ b/src/source/vector_tile_source.test.ts
@@ -111,6 +111,17 @@ describe('VectorTileSource', () => {
         expect(dataloadingFired).toBeTruthy();
     });
 
+    test('fires "error" event if TileJSON request fails', async () => {
+        server.respondWith('/source.json', [404, {}, '']);
+
+        const source = createSource({url: '/source.json'});
+        const errorEvent = waitForEvent(source, 'error', (e) => e.error.status === 404);
+        server.respond();
+
+        await expect(errorEvent).resolves.toBeDefined();
+        expect(source.loaded()).toBe(true);
+    });
+
     test('serialize URL', () => {
         const source = createSource({
             url: 'http://localhost:2900/source.json'

--- a/src/source/vector_tile_source.ts
+++ b/src/source/vector_tile_source.ts
@@ -123,6 +123,7 @@ export class VectorTileSource extends Evented implements Source {
             }
         } catch (err) {
             this._tileJSONRequest = null;
+            this._loaded = true; // let's pretend it's loaded so the source will be ignored
             this.fire(new ErrorEvent(err));
         }
     }

--- a/src/ui/map_tests/map_events.test.ts
+++ b/src/ui/map_tests/map_events.test.ts
@@ -1090,8 +1090,36 @@ describe('map events', () => {
             await sleep(100);
 
             expect(errorHandler).toHaveBeenCalledTimes(1);
-          
+
         });
+    });
+
+    test('emits load event when source TileJSON fails to load', async () => {
+        const style: StyleSpecification = {
+            ...createStyle(),
+            sources: {
+                'source': {
+                    type: 'vector',
+                    url: 'maplibre://nonexistent'
+                }
+            },
+            layers: [
+                {
+                    id: 'layer',
+                    source: 'source',
+                    type: 'fill',
+                    'source-layer': 'test'
+                }
+            ]
+        };
+        const map = createMap();
+        map.setStyle(style);
+
+        await map.once('load');
+        expect(map.isStyleLoaded()).toBe(true);
+
+        map.triggerRepaint();
+        await map.once('idle');
     });
 
     describe('projectiontransition event', () => {


### PR DESCRIPTION
- Fixes #5430

When source TileJSON fails to load it is already ignored. However the source is treated as not loaded yet which causes events `load` and `idle` to be withheld.

The `load` event is used to signal that the map is ready. Specifically it means that map style can be modified. This condition is met after TileJSON fails to load, so the `load` event can be triggered in that case. Similarly the `idle` event means that there are no outstanding repaints, which again is true after TileJSON fails to load and map is fully repainted.

This PR marks sources with TileJSON that failed to load as loaded, enabling `load` and `idle` events to trigger. 

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [x] Write tests for all new functionality.
 - [x] Add an entry to `CHANGELOG.md` under the `## main` section.
