### PR TITLE
Fix timeout for render tests

### DIFF
--- a/test/integration/render/tests/high-pitch/pitch95-roll135/style.json
+++ b/test/integration/render/tests/high-pitch/pitch95-roll135/style.json
@@ -2,9 +2,9 @@
     "version": 8,
     "sprite": "local://sprites/sprite",
     "glyphs": "local://glyphs/{fontstack}/{range}.pbf",
-    "timeout": 60000,
     "metadata": {
         "test": {
+            "timeout": 60000,
             "height": 512,
             "width": 512,
             "maxPitch": 95,

--- a/test/integration/render/tests/high-pitch/pitch95/style.json
+++ b/test/integration/render/tests/high-pitch/pitch95/style.json
@@ -2,9 +2,9 @@
     "version": 8,
     "sprite": "local://sprites/sprite",
     "glyphs": "local://glyphs/{fontstack}/{range}.pbf",
-    "timeout": 60000,
     "metadata": {
         "test": {
+            "timeout": 60000,
             "height": 512,
             "width": 512,
             "maxPitch": 95,

--- a/test/integration/render/tests/sky/basic/style.json
+++ b/test/integration/render/tests/sky/basic/style.json
@@ -2,9 +2,9 @@
     "version": 8,
     "sprite": "local://sprites/sprite",
     "glyphs": "local://glyphs/{fontstack}/{range}.pbf",
-    "timeout": 60000,
     "metadata": {
         "test": {
+            "timeout": 60000,
             "height": 512,
             "width": 512,
             "maxPitch": 85,

--- a/test/integration/render/tests/sky/roll10/style.json
+++ b/test/integration/render/tests/sky/roll10/style.json
@@ -2,9 +2,9 @@
     "version": 8,
     "sprite": "local://sprites/sprite",
     "glyphs": "local://glyphs/{fontstack}/{range}.pbf",
-    "timeout": 60000,
     "metadata": {
         "test": {
+            "timeout": 60000,
             "height": 512,
             "width": 512,
             "maxPitch": 85,

--- a/test/integration/render/tests/sky/roll180/style.json
+++ b/test/integration/render/tests/sky/roll180/style.json
@@ -2,9 +2,9 @@
     "version": 8,
     "sprite": "local://sprites/sprite",
     "glyphs": "local://glyphs/{fontstack}/{range}.pbf",
-    "timeout": 60000,
     "metadata": {
         "test": {
+            "timeout": 60000,
             "height": 512,
             "width": 512,
             "maxPitch": 85,

--- a/test/integration/render/tests/sky/roll45-with-text/style.json
+++ b/test/integration/render/tests/sky/roll45-with-text/style.json
@@ -2,9 +2,9 @@
     "version": 8,
     "sprite": "local://sprites/sprite",
     "glyphs": "local://glyphs/{fontstack}/{range}.pbf",
-    "timeout": 60000,
     "metadata": {
         "test": {
+            "timeout": 60000,
             "height": 512,
             "width": 512,
             "maxPitch": 85,

--- a/test/integration/render/tests/sky/roll90/style.json
+++ b/test/integration/render/tests/sky/roll90/style.json
@@ -2,9 +2,9 @@
     "version": 8,
     "sprite": "local://sprites/sprite",
     "glyphs": "local://glyphs/{fontstack}/{range}.pbf",
-    "timeout": 60000,
     "metadata": {
         "test": {
+            "timeout": 60000,
             "height": 512,
             "width": 512,
             "maxPitch": 85,

--- a/test/integration/render/tests/terrain/fog-no-sky-blend-roll/style.json
+++ b/test/integration/render/tests/terrain/fog-no-sky-blend-roll/style.json
@@ -2,9 +2,9 @@
     "version": 8,
     "sprite": "local://sprites/sprite",
     "glyphs": "local://glyphs/{fontstack}/{range}.pbf",
-    "timeout": 60000,
     "metadata": {
         "test": {
+            "timeout": 60000,
             "height": 512,
             "width": 512,
             "maxPitch": 85,

--- a/test/integration/render/tests/terrain/fog-no-sky-blend/style.json
+++ b/test/integration/render/tests/terrain/fog-no-sky-blend/style.json
@@ -2,9 +2,9 @@
     "version": 8,
     "sprite": "local://sprites/sprite",
     "glyphs": "local://glyphs/{fontstack}/{range}.pbf",
-    "timeout": 60000,
     "metadata": {
         "test": {
+            "timeout": 60000,
             "height": 512,
             "width": 512,
             "maxPitch": 85,

--- a/test/integration/render/tests/terrain/fog-sky-blend-globe/style.json
+++ b/test/integration/render/tests/terrain/fog-sky-blend-globe/style.json
@@ -2,6 +2,7 @@
     "version": 8,
     "metadata": {
         "test": {
+            "timeout": 60000,
             "height": 256,
             "width": 256,
             "maxPitch": 120,
@@ -10,7 +11,6 @@
             ]
         }
     },
-    "timeout": 60000,
     "center": [11.52517, 47.34487],
     "zoom": 13,
     "pitch": 80,

--- a/test/integration/render/tests/terrain/fog-sky-blend-roll/style.json
+++ b/test/integration/render/tests/terrain/fog-sky-blend-roll/style.json
@@ -2,9 +2,9 @@
     "version": 8,
     "sprite": "local://sprites/sprite",
     "glyphs": "local://glyphs/{fontstack}/{range}.pbf",
-    "timeout": 60000,
     "metadata": {
         "test": {
+            "timeout": 60000,
             "height": 512,
             "width": 512,
             "maxPitch": 85,

--- a/test/integration/render/tests/terrain/fog-sky-blend/style.json
+++ b/test/integration/render/tests/terrain/fog-sky-blend/style.json
@@ -2,9 +2,9 @@
     "version": 8,
     "sprite": "local://sprites/sprite",
     "glyphs": "local://glyphs/{fontstack}/{range}.pbf",
-    "timeout": 60000,
     "metadata": {
         "test": {
+            "timeout": 60000,
             "height": 512,
             "width": 512,
             "maxPitch": 85,

--- a/test/integration/render/tests/terrain/fog/style.json
+++ b/test/integration/render/tests/terrain/fog/style.json
@@ -2,9 +2,9 @@
     "version": 8,
     "sprite": "local://sprites/sprite",
     "glyphs": "local://glyphs/{fontstack}/{range}.pbf",
-    "timeout": 60000,
     "metadata": {
         "test": {
+            "timeout": 60000,
             "height": 512,
             "width": 512,
             "maxPitch": 85,

--- a/test/integration/render/tests/terrain/symbol-add-terrain/style.json
+++ b/test/integration/render/tests/terrain/symbol-add-terrain/style.json
@@ -2,9 +2,9 @@
     "version": 8,
     "sprite": "local://sprites/sprite",
     "glyphs": "local://glyphs/{fontstack}/{range}.pbf",
-    "timeout": 60000,
     "metadata": {
         "test": {
+            "timeout": 60000,
             "height": 512,
             "width": 512,
             "operations": [


### PR DESCRIPTION
`timeout` needs to be under `metadata > test` to be effective. Otherwise it defaults to [40 seconds](https://github.com/maplibre/maplibre-gl-js/blob/22bdc59aa3434e1857db22ea518bc373069b6c86/test/integration/render/run_render_tests.ts#L715) which seems to be too little for some tests (i.e. [terrain/fog](https://github.com/maplibre/maplibre-gl-js/blob/main/test/integration/render/tests/terrain/fog/style.json)) when executed on `github`.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
