### PR TITLE
chore(deps): add a cooldown setting to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,7 +15,23 @@ updates:
       vitest:
         patterns:
           - "*vitest*"
+    cooldown:
+      default-days: 5
+      semver-major-days: 5
+      semver-minor-days: 3
+      semver-patch-days: 3
+      include:
+        - "*"
+      exclude:
+        - "@maplibre/*"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 5
+      semver-major-days: 5
+      semver-minor-days: 3
+      semver-patch-days: 3
+      include:
+        - "*"


### PR DESCRIPTION
This PR enables Dependabot cooldown feature.
This potentially allows our tooling to spot security issues instead of noticing them after the merge.

Related to: 
- https://github.com/maplibre/maplibre-gl-js/pull/6421

## Launch Checklist

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 