### PR TITLE
Fix raster flickering when using terrain 3D and optimize terrain logic.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes
+- Fix raster flickering when using terrain 3D and optimize terrain logic.
 - Fix issue where parent tiles are retained when deeper descendant tiles already cover the missing ideal tile. ([#6442](https://github.com/maplibre/maplibre-gl-js/pull/6442))
 
 ## 5.7.3


### PR DESCRIPTION
This PR fixes flickering in the raster basemap when used with 3D terrain.

Previously, tile-fade logic was applied to raster rendering. The 3D terrain implementation, which relies on a raster basemap, then attempted to undo this fading since terrain does not currently support it.

Because we can already determine whether terrain is present after creating ideal tiles for a raster basemap, there’s no need to apply fading in the first place. This change avoids applying the fading logic entirely for terrain, eliminating the need to later reverse it.

 - [X] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [X] Briefly describe the changes in this PR.
 - [X] Include before/after visuals or gifs if this PR includes visual changes.
 - [X] Add an entry to `CHANGELOG.md` under the `## main` section.

Before:
https://github.com/user-attachments/assets/1b41c21f-bab3-4f8f-805e-2fc8ab7581d7

After:
https://github.com/user-attachments/assets/c3f22429-ca46-410f-9b80-0224bc84a419
