### PR TITLE
Fix zoom issue with globe + terrain when dragging to poles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Fix raster flickering when using terrain 3D and optimize terrain logic.
 - Fix issue where parent tiles are retained when deeper descendant tiles already cover the missing ideal tile. ([#6442](https://github.com/maplibre/maplibre-gl-js/pull/6442))
 - Fix an issue when GeolocateControl fires outofmaxbounds event with trackUserLocation disabled ([#6464](https://github.com/maplibre/maplibre-gl-js/pull/6464))
+- Fix an issue with globe+terrain "zooming" in when dragging towards the poles ([#6470](https://github.com/maplibre/maplibre-gl-js/pull/6470))
 
 ## 5.7.3
 

--- a/src/ui/handler_manager.test.ts
+++ b/src/ui/handler_manager.test.ts
@@ -1,0 +1,203 @@
+import {describe, it, expect, vi} from 'vitest';
+import Point from '@mapbox/point-geometry';
+
+import {HandlerManager} from './handler_manager';
+import type {TerrainScenarioOptions, EventsInProgress} from './handler_manager';
+import type {Map} from './map';
+import {LngLat} from '../geo/lng_lat';
+import type {ICameraHelper, MapControlsDeltas} from '../geo/projection/camera_helper';
+import type {Terrain} from '../render/terrain';
+import type {ITransform} from '../geo/transform_interface';
+
+type ManagerWithInternals = HandlerManager & Record<string, unknown>;
+
+type CameraHelperStub = Pick<ICameraHelper, 'handleMapControlsRollPitchBearingZoom' | 'handleMapControlsPan'> & {
+    useGlobeControls: boolean;
+};
+
+const createManager = (useGlobeControls = false) => {
+    const manager = Object.create(HandlerManager.prototype) as ManagerWithInternals;
+    const handleZoom = vi.fn<(deltas: MapControlsDeltas, tr: ITransform) => void>();
+    const handlePan = vi.fn<(deltas: MapControlsDeltas, tr: ITransform, preZoomAroundLoc: LngLat) => void>();
+
+    const cameraHelper: CameraHelperStub = {
+        handleMapControlsRollPitchBearingZoom: handleZoom,
+        handleMapControlsPan: handlePan,
+        useGlobeControls,
+    };
+
+    const mapStub: Pick<Map, 'cameraHelper' | '_elevationFreeze'> = {
+        cameraHelper: cameraHelper as unknown as ICameraHelper,
+        _elevationFreeze: false,
+    };
+
+    manager._map = mapStub as Map;
+    manager._terrainMovement = false;
+
+    return {manager, handleZoom, handlePan};
+};
+
+type TerrainOptionsParams = {
+    terrain?: Terrain | null;
+    combinedEventsInProgress?: EventsInProgress;
+    panDelta?: Point;
+    centerPoint?: Point;
+    screenPointToLocationResult?: LngLat;
+};
+
+const createTerrainOptions = (params: TerrainOptionsParams = {}): {
+    options: TerrainScenarioOptions;
+    screenPointToLocationMock: ReturnType<typeof vi.fn>;
+    setCenterMock: ReturnType<typeof vi.fn>;
+} => {
+    const panDelta = params.panDelta;
+    const terrain = Object.prototype.hasOwnProperty.call(params, 'terrain') ? params.terrain : ({} as Terrain);
+    const combinedEventsInProgress = Object.prototype.hasOwnProperty.call(params, 'combinedEventsInProgress') ?
+        params.combinedEventsInProgress : {};
+    const screenPointToLocationMock = vi.fn<(point: Point) => LngLat>(() => params.screenPointToLocationResult ?? new LngLat(1, 1));
+    const setCenterMock = vi.fn<(center: LngLat) => void>();
+
+    const transformStub = {
+        centerPoint: params.centerPoint ?? new Point(0, 0),
+        center: new LngLat(0, 0),
+        screenPointToLocation: screenPointToLocationMock,
+        setCenter: setCenterMock,
+    } satisfies Pick<ITransform, 'centerPoint' | 'center' | 'screenPointToLocation' | 'setCenter'>;
+
+    const deltasForHelper: MapControlsDeltas = {
+        panDelta: panDelta ?? new Point(0, 0),
+        zoomDelta: 0,
+        rollDelta: 0,
+        pitchDelta: 0,
+        bearingDelta: 0,
+        around: new Point(0, 0),
+    };
+
+    const options: TerrainScenarioOptions = {
+        terrain,
+        tr: transformStub as unknown as ITransform,
+        deltasForHelper,
+        preZoomAroundLoc: new LngLat(0, 0),
+        combinedEventsInProgress,
+        panDelta,
+    };
+
+    return {
+        options,
+        screenPointToLocationMock,
+        setCenterMock,
+    };
+};
+
+describe('HandlerManager terrain scenarios', () => {
+    describe('_applyTerrainScenario', () => {
+        it('delegates to no-terrain scenario when terrain is missing', () => {
+            const {manager} = createManager();
+            const noTerrain = vi.spyOn(manager, '_applyNoTerrainScenario');
+            const globeTerrain = vi.spyOn(manager, '_applyGlobeTerrainScenario');
+            const mercatorTerrain = vi.spyOn(manager, '_applyMercatorTerrainScenario');
+            const {options} = createTerrainOptions({terrain: undefined});
+
+            manager._applyTerrainScenario(options);
+
+            expect(noTerrain).toHaveBeenCalledWith(options);
+            expect(globeTerrain).not.toHaveBeenCalled();
+            expect(mercatorTerrain).not.toHaveBeenCalled();
+        });
+
+        it('delegates to globe terrain scenario when globe controls are active', () => {
+            const {manager} = createManager(true);
+            const globeTerrain = vi.spyOn(manager, '_applyGlobeTerrainScenario');
+            const mercatorTerrain = vi.spyOn(manager, '_applyMercatorTerrainScenario');
+            const {options} = createTerrainOptions();
+
+            manager._applyTerrainScenario(options);
+
+            expect(globeTerrain).toHaveBeenCalledWith(options);
+            expect(mercatorTerrain).not.toHaveBeenCalled();
+        });
+
+        it('delegates to mercator terrain scenario when globe controls are inactive', () => {
+            const {manager} = createManager(false);
+            const globeTerrain = vi.spyOn(manager, '_applyGlobeTerrainScenario');
+            const mercatorTerrain = vi.spyOn(manager, '_applyMercatorTerrainScenario');
+            const {options} = createTerrainOptions();
+
+            manager._map.cameraHelper.useGlobeControls = false;
+            manager._applyTerrainScenario(options);
+
+            expect(mercatorTerrain).toHaveBeenCalledWith(options);
+            expect(globeTerrain).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('_applyGlobeTerrainScenario', () => {
+        it('enables terrain movement and freezes elevation on new drag or zoom', () => {
+            const {manager, handleZoom, handlePan} = createManager(true);
+            const {options} = createTerrainOptions({combinedEventsInProgress: {drag: {}}});
+
+            manager._applyGlobeTerrainScenario(options);
+
+            expect(handleZoom).toHaveBeenCalledWith(options.deltasForHelper, options.tr);
+            expect(handlePan).toHaveBeenCalledWith(options.deltasForHelper, options.tr, options.preZoomAroundLoc);
+            expect(manager._terrainMovement).toBe(true);
+            expect(manager._map._elevationFreeze).toBe(true);
+        });
+
+        it('keeps terrain movement state when already active', () => {
+            const {manager, handlePan} = createManager(true);
+            const {options} = createTerrainOptions();
+
+            manager._terrainMovement = true;
+            manager._map._elevationFreeze = true;
+            manager._applyGlobeTerrainScenario(options);
+
+            expect(manager._terrainMovement).toBe(true);
+            expect(manager._map._elevationFreeze).toBe(true);
+            expect(handlePan).toHaveBeenCalled();
+        });
+    });
+
+    describe('_applyMercatorTerrainScenario', () => {
+        it('activates terrain movement on first drag or zoom', () => {
+            const {manager, handlePan} = createManager(false);
+            const {options, setCenterMock} = createTerrainOptions({combinedEventsInProgress: {drag: {}}});
+
+            manager._applyMercatorTerrainScenario(options);
+
+            expect(manager._terrainMovement).toBe(true);
+            expect(manager._map._elevationFreeze).toBe(true);
+            expect(handlePan).toHaveBeenCalledTimes(1);
+            expect(setCenterMock).not.toHaveBeenCalled();
+        });
+
+        it('drags map using transform when already in terrain movement', () => {
+            const {manager, handlePan} = createManager(false);
+            const panDelta = new Point(2, 3);
+            const screenPointToLocationResult = new LngLat(7, 7);
+            const {options, screenPointToLocationMock, setCenterMock} = createTerrainOptions({
+                combinedEventsInProgress: {drag: {}},
+                panDelta,
+                centerPoint: new Point(5, 5),
+                screenPointToLocationResult,
+            });
+
+            manager._terrainMovement = true;
+            manager._applyMercatorTerrainScenario(options);
+
+            expect(screenPointToLocationMock).toHaveBeenCalled();
+            expect(setCenterMock).toHaveBeenCalledWith(screenPointToLocationResult);
+            expect(handlePan).not.toHaveBeenCalled();
+        });
+
+        it('falls back to helper panning when not dragging', () => {
+            const {manager, handlePan} = createManager(false);
+            const {options} = createTerrainOptions({combinedEventsInProgress: {}});
+
+            manager._terrainMovement = true;
+            manager._applyMercatorTerrainScenario(options);
+
+            expect(handlePan).toHaveBeenCalledWith(options.deltasForHelper, options.tr, options.preZoomAroundLoc);
+        });
+    });
+});

--- a/src/ui/handler_manager.test.ts
+++ b/src/ui/handler_manager.test.ts
@@ -2,7 +2,7 @@ import {describe, it, expect, vi} from 'vitest';
 import Point from '@mapbox/point-geometry';
 
 import {HandlerManager} from './handler_manager';
-import type {TerrainScenarioOptions, EventsInProgress, EventInProgress} from './handler_manager';
+import type {MapControlsScenarioOptions, EventsInProgress, EventInProgress} from './handler_manager';
 import type {Map} from './map';
 import {LngLat} from '../geo/lng_lat';
 import type {ICameraHelper, MapControlsDeltas} from '../geo/projection/camera_helper';
@@ -47,7 +47,7 @@ type TerrainOptionsParams = {
 };
 
 const createTerrainOptions = (params: TerrainOptionsParams = {}): {
-    options: TerrainScenarioOptions;
+    options: MapControlsScenarioOptions;
     screenPointToLocationMock: ReturnType<typeof vi.fn>;
     setCenterMock: ReturnType<typeof vi.fn>;
 } => {
@@ -73,7 +73,7 @@ const createTerrainOptions = (params: TerrainOptionsParams = {}): {
         around: new Point(0, 0),
     };
 
-    const options: TerrainScenarioOptions = {
+    const options: MapControlsScenarioOptions = {
         terrain,
         tr: transformStub as unknown as ITransform,
         deltasForHelper,
@@ -106,7 +106,7 @@ function createEventInProgress(name: keyof EventsInProgress): EventInProgress {
 }
 
 describe('HandlerManager terrain scenarios', () => {
-    describe('_applyTerrainScenario', () => {
+    describe('_handleMapControls', () => {
         it('delegates to no-terrain scenario when terrain is missing', () => {
             const {manager} = createManager();
             const noTerrain = vi.spyOn(manager, '_applyNoTerrainScenario');
@@ -114,7 +114,7 @@ describe('HandlerManager terrain scenarios', () => {
             const mercatorTerrain = vi.spyOn(manager, '_applyMercatorTerrainScenario');
             const {options} = createTerrainOptions({terrain: undefined});
 
-            manager._applyTerrainScenario(options);
+            manager._handleMapControls(options);
 
             expect(noTerrain).toHaveBeenCalledWith(options);
             expect(globeTerrain).not.toHaveBeenCalled();
@@ -127,7 +127,7 @@ describe('HandlerManager terrain scenarios', () => {
             const mercatorTerrain = vi.spyOn(manager, '_applyMercatorTerrainScenario');
             const {options} = createTerrainOptions();
 
-            manager._applyTerrainScenario(options);
+            manager._handleMapControls(options);
 
             expect(globeTerrain).toHaveBeenCalledWith(options);
             expect(mercatorTerrain).not.toHaveBeenCalled();
@@ -139,7 +139,7 @@ describe('HandlerManager terrain scenarios', () => {
             const mercatorTerrain = vi.spyOn(manager, '_applyMercatorTerrainScenario');
             const {options} = createTerrainOptions();
 
-            manager._applyTerrainScenario(options);
+            manager._handleMapControls(options);
 
             expect(mercatorTerrain).toHaveBeenCalledWith(options);
             expect(globeTerrain).not.toHaveBeenCalled();

--- a/src/ui/handler_manager.ts
+++ b/src/ui/handler_manager.ts
@@ -127,7 +127,7 @@ export type EventsInProgress = {
     drag?: EventInProgress;
 };
 
-export type TerrainScenarioOptions = {
+export type MapControlsScenarioOptions = {
     terrain?: Terrain | null;
     tr: ITransform;
     deltasForHelper: MapControlsDeltas;
@@ -549,7 +549,7 @@ export class HandlerManager {
             tr.center :
             tr.screenPointToLocation(panDelta ? around.sub(panDelta) : around);
 
-        this._applyTerrainScenario({
+        this._handleMapControls({
             terrain,
             tr,
             deltasForHelper,
@@ -566,7 +566,7 @@ export class HandlerManager {
 
     }
 
-    _applyTerrainScenario(options: TerrainScenarioOptions) {
+    _handleMapControls(options: MapControlsScenarioOptions) {
         if (!options.terrain) {
             this._applyNoTerrainScenario(options);
             return;
@@ -580,12 +580,12 @@ export class HandlerManager {
         this._applyMercatorTerrainScenario(options);
     }
 
-    _applyNoTerrainScenario({deltasForHelper, tr, preZoomAroundLoc}: TerrainScenarioOptions) {
+    _applyNoTerrainScenario({deltasForHelper, tr, preZoomAroundLoc}: MapControlsScenarioOptions) {
         this._map.cameraHelper.handleMapControlsRollPitchBearingZoom(deltasForHelper, tr);
         this._map.cameraHelper.handleMapControlsPan(deltasForHelper, tr, preZoomAroundLoc);
     }
 
-    _applyGlobeTerrainScenario({deltasForHelper, tr, preZoomAroundLoc, combinedEventsInProgress}: TerrainScenarioOptions) {
+    _applyGlobeTerrainScenario({deltasForHelper, tr, preZoomAroundLoc, combinedEventsInProgress}: MapControlsScenarioOptions) {
         this._map.cameraHelper.handleMapControlsRollPitchBearingZoom(deltasForHelper, tr);
 
         if (!this._terrainMovement && (combinedEventsInProgress.drag || combinedEventsInProgress.zoom)) {
@@ -596,7 +596,7 @@ export class HandlerManager {
         this._map.cameraHelper.handleMapControlsPan(deltasForHelper, tr, preZoomAroundLoc);
     }
 
-    _applyMercatorTerrainScenario({deltasForHelper, tr, preZoomAroundLoc, combinedEventsInProgress, panDelta}: TerrainScenarioOptions) {
+    _applyMercatorTerrainScenario({deltasForHelper, tr, preZoomAroundLoc, combinedEventsInProgress, panDelta}: MapControlsScenarioOptions) {
         this._map.cameraHelper.handleMapControlsRollPitchBearingZoom(deltasForHelper, tr);
 
         if (!this._terrainMovement && (combinedEventsInProgress.drag || combinedEventsInProgress.zoom)) {

--- a/src/ui/handler_manager.ts
+++ b/src/ui/handler_manager.ts
@@ -566,43 +566,36 @@ export class HandlerManager {
 
     }
 
-    _handleMapControls(options: MapControlsScenarioOptions) {
-        if (!options.terrain) {
-            this._applyNoTerrainScenario(options);
+    _handleMapControls({
+        terrain,
+        tr,
+        deltasForHelper,
+        preZoomAroundLoc,
+        combinedEventsInProgress,
+        panDelta}: MapControlsScenarioOptions) {
+
+        const cameraHelper = this._map.cameraHelper;
+
+        cameraHelper.handleMapControlsRollPitchBearingZoom(deltasForHelper, tr);
+
+        if (!terrain) {
+            cameraHelper.handleMapControlsPan(deltasForHelper, tr, preZoomAroundLoc);
             return;
         }
 
-        if (this._map.cameraHelper.useGlobeControls) {
-            this._applyGlobeTerrainScenario(options);
+        if (cameraHelper.useGlobeControls) {
+            if (!this._terrainMovement && (combinedEventsInProgress.drag || combinedEventsInProgress.zoom)) {
+                this._terrainMovement = true;
+                this._map._elevationFreeze = true;
+            }
+            cameraHelper.handleMapControlsPan(deltasForHelper, tr, preZoomAroundLoc);
             return;
         }
-
-        this._applyMercatorTerrainScenario(options);
-    }
-
-    _applyNoTerrainScenario({deltasForHelper, tr, preZoomAroundLoc}: MapControlsScenarioOptions) {
-        this._map.cameraHelper.handleMapControlsRollPitchBearingZoom(deltasForHelper, tr);
-        this._map.cameraHelper.handleMapControlsPan(deltasForHelper, tr, preZoomAroundLoc);
-    }
-
-    _applyGlobeTerrainScenario({deltasForHelper, tr, preZoomAroundLoc, combinedEventsInProgress}: MapControlsScenarioOptions) {
-        this._map.cameraHelper.handleMapControlsRollPitchBearingZoom(deltasForHelper, tr);
 
         if (!this._terrainMovement && (combinedEventsInProgress.drag || combinedEventsInProgress.zoom)) {
             this._terrainMovement = true;
             this._map._elevationFreeze = true;
-        }
-
-        this._map.cameraHelper.handleMapControlsPan(deltasForHelper, tr, preZoomAroundLoc);
-    }
-
-    _applyMercatorTerrainScenario({deltasForHelper, tr, preZoomAroundLoc, combinedEventsInProgress, panDelta}: MapControlsScenarioOptions) {
-        this._map.cameraHelper.handleMapControlsRollPitchBearingZoom(deltasForHelper, tr);
-
-        if (!this._terrainMovement && (combinedEventsInProgress.drag || combinedEventsInProgress.zoom)) {
-            this._terrainMovement = true;
-            this._map._elevationFreeze = true;
-            this._map.cameraHelper.handleMapControlsPan(deltasForHelper, tr, preZoomAroundLoc);
+            cameraHelper.handleMapControlsPan(deltasForHelper, tr, preZoomAroundLoc);
             return;
         }
 
@@ -611,7 +604,7 @@ export class HandlerManager {
             return;
         }
 
-        this._map.cameraHelper.handleMapControlsPan(deltasForHelper, tr, preZoomAroundLoc);
+        cameraHelper.handleMapControlsPan(deltasForHelper, tr, preZoomAroundLoc);
     }
 
     _fireEvents(newEventsInProgress: EventsInProgress, deactivatedHandlers: {[handlerName: string]: Event}, allowEndAnimation: boolean) {

--- a/src/ui/handler_manager.ts
+++ b/src/ui/handler_manager.ts
@@ -21,9 +21,9 @@ import {extend, isPointableEvent, isTouchableEvent, isTouchableOrPointableType} 
 import {browser} from '../util/browser';
 import Point from '@mapbox/point-geometry';
 import {type MapControlsDeltas} from '../geo/projection/camera_helper';
-import { LngLat } from '../geo/lng_lat';
-import { ITransform } from '../geo/transform_interface';
-import { Terrain } from '../render/terrain';
+import type {LngLat} from '../geo/lng_lat';
+import type {ITransform} from '../geo/transform_interface';
+import type {Terrain} from '../render/terrain';
 
 const isMoving = (p: EventsInProgress) => p.zoom || p.drag || p.roll || p.pitch || p.rotate;
 
@@ -127,8 +127,8 @@ export type EventsInProgress = {
     drag?: EventInProgress;
 };
 
-type TerrainScenarioOptions = {
-    terrain: Terrain;
+export type TerrainScenarioOptions = {
+    terrain?: Terrain | null;
     tr: ITransform;
     deltasForHelper: MapControlsDeltas;
     preZoomAroundLoc: LngLat;


### PR DESCRIPTION
Closes #5839
- #5839

Closes https://github.com/maplibre/maplibre-gl-js/issues/5026
- https://github.com/maplibre/maplibre-gl-js/issues/5026

Rotating a globe with terrain enabled used to “zoom toward the poles” because the mercator-specific terrain pan logic bypassed the globe helper’s zoom compensation.

This PR redirects all globe+terrain drags through the globe pan helper so the apparent radius stays constant, while keeping the old pixel-delta path for mercator terrain users.

Before

https://github.com/user-attachments/assets/5611978c-8eec-43bb-af5b-5d0578c37d06


After


https://github.com/user-attachments/assets/5dfbbe04-29d5-4b51-a7f5-46fcc98fa89e



## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [X] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [X] Briefly describe the changes in this PR.
 - [X] Link to related issues.
 - [x] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality. 
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [x] Add an entry to `CHANGELOG.md` under the `## main` section.
