### PR TITLE
Adding role to marker to satisfy aria-label accessibility issue (fix: #6435)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - Improve fading - dynamic bi-directional raster cross-fading and self fading ([#6469](https://github.com/maplibre/maplibre-gl-js/pull/6469))
 
 ### 🐞 Bug fixes
-- _...Add new stuff here..._
+- Added `button` role to marker div to fix accessibility issues with the `aria-label` ([#6435](https://github.com/maplibre/maplibre-gl-js/issues/6435))
 
 ## 5.8.0
 

--- a/src/ui/marker.test.ts
+++ b/src/ui/marker.test.ts
@@ -290,6 +290,13 @@ describe('marker', () => {
         expect(markerWithHtmlElement.getElement().getAttribute('aria-label')).toBe('custom aria label');
     });
 
+    test('Marker should have a role attribute to satisfy accessibility requirements for the aria-label', () => {
+        const map = createMap({locale: {'Marker.Title': 'alt title'}});
+        const marker = new Marker().setLngLat([0, 0]).addTo(map);
+
+        expect(marker.getElement().getAttribute('role')).toBe('button');
+    });
+
     test('Marker anchor defaults to center', () => {
         const map = createMap();
         const marker = new Marker()

--- a/src/ui/marker.ts
+++ b/src/ui/marker.ts
@@ -320,6 +320,10 @@ export class Marker extends Evented {
             this._element.setAttribute('aria-label', map._getUIString('Marker.Title'));
         }
 
+        // aria-label is set either by user or above default, so set role
+        // since div is interactive and cannot have aria-label without a role
+        this._element.setAttribute('role', 'button');
+
         map.getCanvasContainer().appendChild(this._element);
         map.on('move', this._update);
         map.on('moveend', this._update);

--- a/src/ui/marker.ts
+++ b/src/ui/marker.ts
@@ -322,7 +322,9 @@ export class Marker extends Evented {
 
         // aria-label is set either by user or above default, so set role
         // since div is interactive and cannot have aria-label without a role
-        this._element.setAttribute('role', 'button');
+        if (!this._element.hasAttribute('role')) {
+            this._element.setAttribute('role', 'button');
+        }
 
         map.getCanvasContainer().appendChild(this._element);
         map.on('move', this._update);


### PR DESCRIPTION
## Launch Checklist

In March of 2025, `aria-label` was added by default to markers even if not set when implementing. Since the marker is a `div` which has no role by default, this causes accessibility audits to pick it up as an issue.

Instead of removing the `aria-label` since it should likely be there, I'm adding a role of button to the marker.

Related issue: https://github.com/maplibre/maplibre-gl-js/issues/6435

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [x] Add an entry to `CHANGELOG.md` under the `## main` section.
