### PR TITLE
fix: console in warnOnce might be undefined after minifying

### DIFF
--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -580,7 +580,9 @@ const warnOnceHistory: {[key: string]: boolean} = {};
 export function warnOnce(message: string): void {
     if (!warnOnceHistory[message]) {
         // console isn't defined in some WebWorkers, see #2558
-        if (typeof console !== 'undefined') console.warn(message);
+        // use a local reference to console so that minifiers cannot break it
+        const _console = typeof console !== 'undefined' ? console : undefined;
+        _console?.warn(message);
         warnOnceHistory[message] = true;
     }
 }


### PR DESCRIPTION
## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->
We ran into a situation were terser minified this function, sometimes renaming the reference to console (e.g. to 'n'). This then broke in production (e.g. could not parse tiles with geometries exceeding the allowed content rather then only showing the log message: "Geometry exceeds allowed extent, reduce your vector tile buffer size") as 'n' is undefined.
<img width="523" height="79" alt="maplibre_minified" src="https://github.com/user-attachments/assets/028e576c-ca44-4d94-a5be-449df8fbfbda" />

Maybe there's a better solution. So feel free to comment.

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [ ] Link to related issues.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [ ] Add an entry to `CHANGELOG.md` under the `## main` section.
