### PR TITLE
Test mousemove events not blocked by scrollzoom

### DIFF
--- a/test/integration/browser/browser.test.ts
+++ b/test/integration/browser/browser.test.ts
@@ -64,10 +64,10 @@ describe('Browser tests', () => {
     test('Mousemove events are fired during scrollzoom', {retry: 3, timeout: 20000}, async () => {
         const mouseMoveFired = await page.evaluate(() => {
             return new Promise<Array<number>>((resolve, _reject) => {
-                let mouseMoveCount = 0
-                let wheelCount = 0
+                let mouseMoveCount = 0;
+                let wheelCount = 0;
                 map.on('mousemove', () => {mouseMoveCount++;});
-                map.on('wheel', () => {wheelCount++})
+                map.on('wheel', () => {wheelCount++;});
                 map.getCanvas().dispatchEvent(new WheelEvent('wheel', {deltaY: 120, bubbles: true}));
                 map.getCanvas().dispatchEvent(new WheelEvent('wheel', {deltaY: 120, bubbles: true}));
                 map.getCanvas().dispatchEvent(new MouseEvent('mousemove', {bubbles: true}));
@@ -76,9 +76,9 @@ describe('Browser tests', () => {
                 map.getCanvas().dispatchEvent(new MouseEvent('mousemove', {bubbles: true}));
                 map.getCanvas().dispatchEvent(new WheelEvent('wheel', {deltaY: 120, bubbles: true}));
                 map.getCanvas().dispatchEvent(new MouseEvent('mousemove', {bubbles: true}));
-                resolve([mouseMoveCount, wheelCount])
-            })   
+                resolve([mouseMoveCount, wheelCount]);
             });
+        });
         expect(mouseMoveFired[0]).toBe(4);
         expect(mouseMoveFired[1]).toBe(4);
     });


### PR DESCRIPTION
This PR adds a test to confirm that mousemove events are triggered while scrolling. See bug issue #6302 

Waiting for https://github.com/maplibre/maplibre-gl-js/pull/6529 

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [x] Write tests for all new functionality.
