### PR TITLE
feat:export-imagerequest-texture

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -45,6 +45,8 @@ import {KeyboardHandler} from './ui/handler/keyboard';
 import {TwoFingersTouchPitchHandler, TwoFingersTouchRotateHandler, TwoFingersTouchZoomHandler, type AroundCenterOptions} from './ui/handler/two_fingers_touch';
 import {MessageType, type ActorMessage, type RequestResponseMessageMap} from './util/actor_messages';
 import {createTileMesh, type CreateTileMeshOptions, type IndicesType, type TileMesh} from './util/create_tile_mesh';
+import {ImageRequest} from './util/image_request';
+import {Texture} from './render/texture';
 import type {ControlPosition, IControl} from './ui/control/control';
 import type {CustomRenderMethod, CustomLayerInterface, CustomRenderMethodInput} from './style/style_layer/custom_style_layer';
 import type {AnimationOptions, CameraForBoundsOptions, CameraOptions, CameraUpdateTransformFunction, CenterZoomBearing, EaseToOptions, FitBoundsOptions, FlyToOptions, JumpToOptions, PointLike} from './ui/camera';
@@ -239,6 +241,8 @@ export {
     MapWheelEvent,
     MapTouchEvent,
     MapMouseEvent,
+    ImageRequest,
+    Texture,
     type Handler,
     type RequireAtLeastOne,
     type CameraUpdateTransformFunction,


### PR DESCRIPTION
## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Export internal ImageRequest and Texture classes via index.ts, enabling the loading of tile slices with custom rules. This supports integration with libraries such as maptalks.tileclip; see the [demo](https://maptalks.org/maptalks.tileclip/demo/maplibre.html).
 - [ ] Link to related issues.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [x] Export ImageRequest and Texture classes to support external usage (e.g., maptalks.tileclip).
