### PR TITLE
Fix broken image link in README for example 'Animate a series of images'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@
 - Contextmenu events not blocked by scrolling ([#5683](https://github.com/maplibre/maplibre-gl-js/issues/5683)
 - Mousemove events are not blocked by scrolling ([#6302](https://github.com/maplibre/maplibre-gl-js/issues/6302))
 - Dashed lines have blurry rounded caps ([#6554](https://github.com/maplibre/maplibre-gl-js/pull/6554))
-- Fix broken image link in README for example 'Animate a series of images'
 
 ## 5.9.0
 


### PR DESCRIPTION
## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->
Current README image for 'Animate a series of images' points to the old title for the example ('animate-images'). This changes it to the correct link.

|Before|After|
|-|-|
|<img width="839" height="535" alt="image" src="https://github.com/user-attachments/assets/2417c19a-ed49-4578-a8c4-02bc09511b83" />|<img width="871" height="556" alt="image" src="https://github.com/user-attachments/assets/e9906962-5bee-463d-89f2-e5d381eeeddb" />|

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
