### PR TITLE
Remove upload of test failures.

### DIFF
--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -64,11 +64,6 @@ jobs:
           name: coverage-reports-unit-tests
           path: ${{ github.workspace }}/coverage/vitest/unit/coverage-final.json
           retention-days: 1
-      - name: Upload test results to Codecov
-        if: '!cancelled()'
-        uses: codecov/test-results-action@47f89e9acb64b76debcd5ea40642d25a4adced9f # v1.1.1
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
 
   integration-tests:
     name: Integration tests
@@ -158,11 +153,6 @@ jobs:
           name: coverage-reports-render-tests-${{ matrix.split }}
           path: ${{ github.workspace }}/upload/coverage-final-render-${{ matrix.split }}.json
           retention-days: 1
-      - name: Upload test results to Codecov
-        if: '!cancelled()'
-        uses: codecov/test-results-action@47f89e9acb64b76debcd5ea40642d25a4adced9f # v1.1.1
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
       - name: Upload render test failure
         if: failure()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2


### PR DESCRIPTION
## Launch Checklist

According to this issue:
- https://github.com/codecov/codecov-action/issues/1825

The test report is what is preventing codecov from being able to add a PR comment for code coverage to a PR made from a fork.
Since uploading tests results (this is not code coverage, just which tests failed etc) do not have a significant value as CI simply tells us if tests failed or not, removing it is the easiest solution. 
If we will ever need it, we can add it back in the future.

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
