### PR TITLE
Set immutableCreate to true in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,6 +120,7 @@ jobs:
           artifacts: "dist.zip"
           artifactContentType: "application/zip"
           allowUpdates: false
+          immutableCreate: true
           draft: false
           prerelease: ${{ steps.prepare_release.outputs.release_type == 'prerelease' }}
 


### PR DESCRIPTION
> `immutableCreate` [default: false]
> 
> Indicates if immutable release creation should be used. When enabled, the action will first create a draft, upload artifacts, then publish the release.

We should set this to true 🤦🏻‍♂️

Shoud solve `dist.zip` being uploaded for FUTURE releases.
Due to the past being immutable, we cannot change past mistakes.
So be it, they are on npm if someone needs them.

Resolves #6632