### PR TITLE
Fix symbol label density at extreme zoom overscaling

### DIFF
--- a/src/data/bucket/symbol_bucket.ts
+++ b/src/data/bucket/symbol_bucket.ts
@@ -363,7 +363,7 @@ export class SymbolBucket implements Bucket {
     constructor(options: BucketParameters<SymbolStyleLayer>) {
         this.collisionBoxArray = options.collisionBoxArray;
         this.zoom = options.zoom;
-        this.overscaling = isSafari(globalThis) ? Math.min(options.overscaling, 128) : options.overscaling;
+        this.overscaling = options.overscaling;
         this.layers = options.layers;
         this.layerIds = this.layers.map(layer => layer.id);
         this.index = options.index;

--- a/src/symbol/get_anchors.ts
+++ b/src/symbol/get_anchors.ts
@@ -97,6 +97,11 @@ function getAnchors(line: Array<Point>,
         spacing = labelLength + spacing / 4;
     }
 
+    // Apply additional spacing multiplier for high overscaling to prevent excessive label density
+    // This ensures we don't exceed MAX_GLYPHS even at extreme zoom levels
+    const overscaleFactor = Math.max(1, overscaling / 64);
+    spacing = spacing * overscaleFactor;
+
     // Offset the first anchor by:
     // Either half the label length plus a fixed extra offset if the line is not continued
     // Or half the spacing if the line is continued.


### PR DESCRIPTION
Possible alternative to: https://github.com/maplibre/maplibre-gl-js/pull/6521.

Fixed "Too many glyphs being rendered in a tile" errors at high overscaling levels by dynamically adjusting symbol spacing based on the overscaling factor. Previously attempted to clamp the overscaling value to 128, which wasn't a complete fix and didn't address all cases. The new approach scales spacing proportionally (overscaling / 64) to maintain even label distribution while preventing glyph count from exceeding the 65,535 limit.