### PR TITLE
Clear both TinySDF instances together

### DIFF
--- a/src/render/glyph_manager.ts
+++ b/src/render/glyph_manager.ts
@@ -290,6 +290,9 @@ export class GlyphManager {
             if (entry.tinySDF) {
                 entry.tinySDF = null;
             }
+            if (entry.ideographTinySDF) {
+                entry.ideographTinySDF = null;
+            }
             entry.glyphs = {};
             entry.requests = {};
             entry.ranges = {};


### PR DESCRIPTION
#6398 introduced `GlyphManager.destroy` and #4564 introduced `GlyphManager.ideographTinySDF` independently of each other. Both TinySDF instances need to be cleared together. This was effectively a merge conflict, but Git was unable to catch it.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [ ] Add an entry to `CHANGELOG.md` under the `## main` section.
