### PR TITLE
Update NavigationControl.ResetBearing message

### DIFF
--- a/src/ui/default_locale.ts
+++ b/src/ui/default_locale.ts
@@ -8,7 +8,7 @@ export const defaultLocale = {
     'LogoControl.Title': 'MapLibre logo',
     'Map.Title': 'Map',
     'Marker.Title': 'Map marker',
-    'NavigationControl.ResetBearing': 'Reset bearing to north',
+    'NavigationControl.ResetBearing': 'Drag to rotate map. Click to reset.',
     'NavigationControl.ZoomIn': 'Zoom in',
     'NavigationControl.ZoomOut': 'Zoom out',
     'Popup.Close': 'Close popup',


### PR DESCRIPTION
For #6716. Else users will never guess they are able to rotate the map! They would think all they can do is reset rotated maps only.

