### PR TITLE
Send GeoJSON data from worker to main if loaded from a URL

### DIFF
--- a/src/source/geojson_source.test.ts
+++ b/src/source/geojson_source.test.ts
@@ -506,7 +506,7 @@ describe('GeoJSONSource.update', () => {
         source.load();
         await promise;
 
-        expect((source as any)._data.geojson).toStrictEqual(hawkHill);
+        expect(source.serialize()).toStrictEqual({type: 'geojson', data: hawkHill});
     });
 
     test('fires event when metadata loads', async () =>  {

--- a/src/source/geojson_source.test.ts
+++ b/src/source/geojson_source.test.ts
@@ -497,34 +497,18 @@ describe('GeoJSONSource.update', () => {
     });
 
     test('updates _data.geojson when worker returns data from URL load', async () => {
-        const returnedData = {
-            type: 'FeatureCollection',
-            features: [{type: 'Feature', properties: {}, geometry: {type: 'Point', coordinates: [0, 0]}}]
-        } as GeoJSON.GeoJSON;
-
-        const mockDispatcher = wrapDispatcher({
-            sendAsync(_message: ActorMessage<MessageType>) {
-                return new Promise((resolve) => {
-                    setTimeout(() => resolve({data: returnedData}), 0);
-                });
-            }
-        });
-
-        const mapStub = {
-            _requestManager: {
-                transformRequest: (url) => ({url})
-            }
-        } as any;
-
-        const source = new GeoJSONSource('id', {data: 'https://example.com/data.geojson'} as GeoJSONSourceOptions, mockDispatcher, undefined);
-        source.map = mapStub;
+        const source = new GeoJSONSource('id', {data: 'https://example.com/data.geojson'} as GeoJSONSourceOptions, wrapDispatcher({
+            sendAsync() { return Promise.resolve({data: hawkHill}); }
+        }), undefined);
+        source.map = {_requestManager: {transformRequest: (url) => ({url})}} as any;
 
         const promise = waitForEvent(source, 'data', (e: MapSourceDataEvent) => e.sourceDataType === 'metadata');
         source.load();
         await promise;
 
-        expect((source as any)._data.geojson).toStrictEqual(returnedData);
+        expect((source as any)._data.geojson).toStrictEqual(hawkHill);
     });
+
     test('fires event when metadata loads', async () =>  {
         const mockDispatcher = wrapDispatcher({
             sendAsync(_message: ActorMessage<MessageType>) {

--- a/src/source/geojson_source.test.ts
+++ b/src/source/geojson_source.test.ts
@@ -495,6 +495,36 @@ describe('GeoJSONSource.update', () => {
         expect(transformSpy).toHaveBeenCalledTimes(1);
         expect(transformSpy.mock.calls[0][0]).toBe('https://example.com/data.geojson');
     });
+
+    test('updates _data.geojson when worker returns data from URL load', async () => {
+        const returnedData = {
+            type: 'FeatureCollection',
+            features: [{type: 'Feature', properties: {}, geometry: {type: 'Point', coordinates: [0, 0]}}]
+        } as GeoJSON.GeoJSON;
+
+        const mockDispatcher = wrapDispatcher({
+            sendAsync(_message: ActorMessage<MessageType>) {
+                return new Promise((resolve) => {
+                    setTimeout(() => resolve({data: returnedData}), 0);
+                });
+            }
+        });
+
+        const mapStub = {
+            _requestManager: {
+                transformRequest: (url) => ({url})
+            }
+        } as any;
+
+        const source = new GeoJSONSource('id', {data: 'https://example.com/data.geojson'} as GeoJSONSourceOptions, mockDispatcher, undefined);
+        source.map = mapStub;
+
+        const promise = waitForEvent(source, 'data', (e: MapSourceDataEvent) => e.sourceDataType === 'metadata');
+        source.load();
+        await promise;
+
+        expect((source as any)._data.geojson).toStrictEqual(returnedData);
+    });
     test('fires event when metadata loads', async () =>  {
         const mockDispatcher = wrapDispatcher({
             sendAsync(_message: ActorMessage<MessageType>) {

--- a/src/source/geojson_source.ts
+++ b/src/source/geojson_source.ts
@@ -424,7 +424,8 @@ export class GeoJSONSource extends Evented implements Source {
                 return;
             }
 
-            if (diff) this._applyDiff(diff);
+            if (result.data) this._data.geojson = result.data;
+            else if (diff) this._applyDiff(diff);
 
             let resourceTiming: PerformanceResourceTiming[] = null;
             if (result.resourceTiming && result.resourceTiming[this.id]) {

--- a/src/source/geojson_source.ts
+++ b/src/source/geojson_source.ts
@@ -424,7 +424,7 @@ export class GeoJSONSource extends Evented implements Source {
                 return;
             }
 
-            if (result.data) this._data.geojson = result.data;
+            if (result.data) this._data = {geojson: result.data};
             else if (diff) this._applyDiff(diff);
 
             let resourceTiming: PerformanceResourceTiming[] = null;

--- a/src/source/geojson_worker_source.test.ts
+++ b/src/source/geojson_worker_source.test.ts
@@ -157,6 +157,7 @@ describe('resourceTiming', () => {
 
         const result = await source.loadData({source: 'testSource', data: geoJson} as LoadGeoJSONParameters);
         expect(result.resourceTiming).toBeUndefined();
+        expect(result.data).toBeUndefined();
     });
 
 });
@@ -296,7 +297,8 @@ describe('loadData', () => {
         const load1Promise = worker.loadData({source: 'source1', request: {url: ''}} as LoadGeoJSONParameters);
         server.respond();
 
-        await load1Promise;
+        const result = await load1Promise;
+        expect(result.data).toStrictEqual(updateableGeoJson);
         await expect(worker.loadData({source: 'source1', dataDiff: {removeAll: true}} as LoadGeoJSONParameters)).resolves.toBeDefined();
     });
 
@@ -320,14 +322,16 @@ describe('loadData', () => {
         const worker = new GeoJSONWorkerSource(actor, layerIndex, []);
 
         await worker.loadData({source: 'source1', data: updateableGeoJson} as LoadGeoJSONParameters);
-        await expect(worker.loadData({source: 'source1', dataDiff: {
+        const result = await worker.loadData({source: 'source1', dataDiff: {
             add: [{
                 type: 'Feature',
                 id: 'update_point',
                 geometry: {type: 'Point', coordinates: [0, 0]},
                 properties: {}
             }]
-        }} as LoadGeoJSONParameters)).resolves.toBeDefined();
+        }} as LoadGeoJSONParameters);
+        expect(result).toBeDefined();
+        expect(result.data).toBeUndefined();
     });
 
     test('loadData should reject as first call with no data', async () => {

--- a/src/source/geojson_worker_source.ts
+++ b/src/source/geojson_worker_source.ts
@@ -129,6 +129,7 @@ export class GeoJSONWorkerSource extends VectorTileWorkerSource {
             this.loaded = {};
 
             const result: GeoJSONWorkerSourceLoadDataResult = {};
+            if (para)
 
             this._finishPerformance(perf, params, result);
             return result;

--- a/src/source/geojson_worker_source.ts
+++ b/src/source/geojson_worker_source.ts
@@ -129,7 +129,12 @@ export class GeoJSONWorkerSource extends VectorTileWorkerSource {
             this.loaded = {};
 
             const result: GeoJSONWorkerSourceLoadDataResult = {};
-            if (para)
+
+            // Sending a large GeoJSON payload from the worker thread to the main thread
+            // is SLOW so we only do it if absolutely nescessary.
+            // The main thread already has a copy of this data UNLESS it was loaded
+            // from a URL.
+            if (params.request) result.data = data;
 
             this._finishPerformance(perf, params, result);
             return result;

--- a/src/util/actor_messages.ts
+++ b/src/util/actor_messages.ts
@@ -29,10 +29,7 @@ export type GetClusterLeavesParams = ClusterIDAndSource & { limit: number; offse
 export type GeoJSONWorkerSourceLoadDataResult = {
     resourceTiming?: {[_: string]: Array<PerformanceResourceTiming>};
     abandoned?: boolean;
-
-    // This is used ONLY when the GeoJSON is loaded from a URL and therefore
-    // the main thread doesn't have a copy of the data at all.
-    data?: GeoJSON.FeatureCollection;
+    data?: GeoJSON.GeoJSON;
 };
 
 /**

--- a/src/util/actor_messages.ts
+++ b/src/util/actor_messages.ts
@@ -29,6 +29,10 @@ export type GetClusterLeavesParams = ClusterIDAndSource & { limit: number; offse
 export type GeoJSONWorkerSourceLoadDataResult = {
     resourceTiming?: {[_: string]: Array<PerformanceResourceTiming>};
     abandoned?: boolean;
+
+    // This is used ONLY when the GeoJSON is loaded from a URL and therefore
+    // the main thread doesn't have a copy of the data at all.
+    data?: GeoJSON.FeatureCollection;
 };
 
 /**


### PR DESCRIPTION
## Summary

Part of https://github.com/maplibre/maplibre-gl-js/issues/4364

This PR carves out an exception from the optimization added in #6668. When GeoJSON data is loaded from a URL, we now send it back to the main thread so that it can be:
- Returned from `map.getStyle()`
- Used in `GeoJSONSource#_getShouldReloadTileOptions` for faster `GeoJSONSource#updateData` operations (ref #6800)
- (Maybe someday) used in `queryRenderedFeatures` to return original feature properties (ref #6803)

When GeoJSON is provided inline or via diff updates, the main thread already has the data, so we skip sending it back (preserving the #6668 optimization).

This will make `GeoJSONSource#updateData` much faster when the GeoJSON data was loaded from a URL.

## Benchmarks

```
$ npm run benchmark -- GeoJSONSourceUpdateData && npm run benchmark -- GeoJSONSourceSetData 

> maplibre-gl@5.14.0 benchmark
> node --no-warnings --loader ts-node/esm test/bench/run-benchmarks.ts GeoJSONSourceUpdateData

Starting headless chrome at: http://localhost:9966/test/bench/versions/index.html
                                      v5.14.0                  main  set-data-url 85c1f56 
 GeoJSONSourceUpdateData                                92.3814 ms            92.6344 ms 

> maplibre-gl@5.14.0 benchmark
> node --no-warnings --loader ts-node/esm test/bench/run-benchmarks.ts GeoJSONSourceSetData

Starting headless chrome at: http://localhost:9966/test/bench/versions/index.html
                                   v5.14.0                  main  set-data-url 85c1f56 
 GeoJSONSourceSetData                               279.7234 ms           284.3850 ms 
```

## Launch Checklist

- [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license)
- [x] Briefly describe the changes in this PR.
- [x] Link to related issues.
- [ ] Include before/after visuals or gifs if this PR includes visual changes.
- [x] Write tests for all new functionality.
- [ ] Document any changes to public APIs.
- [x] Post benchmark scores.
- [ ] Add an entry to `CHANGELOG.md` under the `## main` section.