### PR TITLE
Deprecate isUpdateableGeoJSON in favor of cleaner input validation

### DIFF
--- a/src/source/geojson_source.ts
+++ b/src/source/geojson_source.ts
@@ -3,7 +3,7 @@ import {extend, warnOnce, type ExactlyOne} from '../util/util';
 import {EXTENT} from '../data/extent';
 import {ResourceType} from '../util/request_manager';
 import {browser} from '../util/browser';
-import {applySourceDiff, isUpdateableGeoJSON, mergeSourceDiffs, toUpdateable} from './geojson_source_diff';
+import {applySourceDiff, mergeSourceDiffs, toUpdateable} from './geojson_source_diff';
 import {getGeoJSONBounds} from '../util/geojson_bounds';
 import {MessageType} from '../util/actor_messages';
 import {tileIdToLngLatBounds} from '../tile/tile_id_to_lng_lat_bounds';
@@ -464,10 +464,9 @@ export class GeoJSONSource extends Evented implements Source {
 
         // Lazily convert `this._data` to updateable if it's not already
         if (!this._data.url && !this._data.updateable) {
-            if (!isUpdateableGeoJSON(this._data.geojson, promoteId)) {
-                throw new Error(`GeoJSONSource "${this.id}": GeoJSON data is not compatible with updateData`);
-            }
-            this._data = {updateable: toUpdateable(this._data.geojson, promoteId)};
+            const updateable = toUpdateable(this._data.geojson, promoteId);
+            if (!updateable) throw new Error(`GeoJSONSource "${this.id}": GeoJSON data is not compatible with updateData`);
+            this._data = {updateable};
         }
 
         if (!this._data.updateable) {

--- a/src/source/geojson_source_diff.test.ts
+++ b/src/source/geojson_source_diff.test.ts
@@ -1,27 +1,27 @@
 import {describe, beforeEach, test, expect} from 'vitest';
 import {setPerformance} from '../util/test/util';
-import {type GeoJSONFeatureId, type GeoJSONSourceDiff, isUpdateableGeoJSON, toUpdateable, applySourceDiff, mergeSourceDiffs} from './geojson_source_diff';
+import {type GeoJSONFeatureId, type GeoJSONSourceDiff, toUpdateable, applySourceDiff, mergeSourceDiffs} from './geojson_source_diff';
 
 beforeEach(() => {
     setPerformance();
 });
 
-describe('isUpdateableGeoJSON', () => {
+describe('toUpdateable', () => {
     test('feature without id is not updateable', () => {
         // no feature id -> false
-        expect(isUpdateableGeoJSON({
+        expect(toUpdateable({
             type: 'Feature',
             geometry: {
                 type: 'Point',
                 coordinates: [0, 0]
             },
             properties: {},
-        })).toBe(false);
+        })).toBeUndefined();
     });
 
     test('feature with id is updateable', () => {
         // has a feature id -> true
-        expect(isUpdateableGeoJSON({
+        expect(toUpdateable({
             type: 'Feature',
             id: 'feature_id',
             geometry: {
@@ -29,11 +29,11 @@ describe('isUpdateableGeoJSON', () => {
                 coordinates: [0, 0]
             },
             properties: {},
-        })).toBe(true);
+        })).toBeDefined();
     });
 
     test('promoteId missing is not updateable', () => {
-        expect(isUpdateableGeoJSON({
+        expect(toUpdateable({
             type: 'Feature',
             id: 'feature_id',
             geometry: {
@@ -41,11 +41,11 @@ describe('isUpdateableGeoJSON', () => {
                 coordinates: [0, 0]
             },
             properties: {},
-        }, 'propId')).toBe(false);
+        }, 'propId')).toBeUndefined();
     });
 
     test('promoteId present is updateable', () => {
-        expect(isUpdateableGeoJSON({
+        expect(toUpdateable({
             type: 'Feature',
             geometry: {
                 type: 'Point',
@@ -54,11 +54,11 @@ describe('isUpdateableGeoJSON', () => {
             properties: {
                 propId: 'feature_id',
             },
-        }, 'propId')).toBe(true);
+        }, 'propId')).toBeDefined();
     });
 
     test('feature collection with unique ids is updateable', () => {
-        expect(isUpdateableGeoJSON({
+        expect(toUpdateable({
             type: 'FeatureCollection',
             features: [{
                 type: 'Feature',
@@ -77,11 +77,11 @@ describe('isUpdateableGeoJSON', () => {
                 },
                 properties: {},
             }]
-        })).toBe(true);
+        })).toBeDefined();
     });
 
     test('feature collection with unique promoteIds is updateable', () => {
-        expect(isUpdateableGeoJSON({
+        expect(toUpdateable({
             type: 'FeatureCollection',
             features: [{
                 type: 'Feature',
@@ -102,11 +102,11 @@ describe('isUpdateableGeoJSON', () => {
                     propId: 'feature_id_2',
                 },
             }]
-        }, 'propId')).toBe(true);
+        }, 'propId')).toBeDefined();
     });
 
     test('feature collection without unique ids is not updateable', () => {
-        expect(isUpdateableGeoJSON({
+        expect(toUpdateable({
             type: 'FeatureCollection',
             features: [{
                 type: 'Feature',
@@ -116,11 +116,11 @@ describe('isUpdateableGeoJSON', () => {
                 },
                 properties: {},
             }]
-        })).toBe(false);
+        })).toBeUndefined();
     });
 
     test('feature collection with duplicate feature ids is not updateable', () => {
-        expect(isUpdateableGeoJSON({
+        expect(toUpdateable({
             type: 'FeatureCollection',
             features: [{
                 type: 'Feature',
@@ -139,15 +139,13 @@ describe('isUpdateableGeoJSON', () => {
                 },
                 properties: {},
             }]
-        })).toBe(false);
+        })).toBeUndefined();
     });
 
     test('geometries are not updateable', () => {
-        expect(isUpdateableGeoJSON({type: 'Point', coordinates: [0, 0]})).toBe(false);
+        expect(toUpdateable({type: 'Point', coordinates: [0, 0]})).toBeUndefined();
     });
-});
 
-describe('toUpdateable', () => {
     test('works with a single feature - feature id', () => {
         const updateable = toUpdateable({
             type: 'Feature',

--- a/src/source/geojson_worker_source.ts
+++ b/src/source/geojson_worker_source.ts
@@ -9,7 +9,7 @@ import {VectorTileWorkerSource} from './vector_tile_worker_source';
 import {createExpression} from '@maplibre/maplibre-gl-style-spec';
 import {isAbortError} from '../util/abort_error';
 import {toVirtualVectorTile} from './vector_tile_overzoomed';
-import {isUpdateableGeoJSON, type GeoJSONSourceDiff, applySourceDiff, toUpdateable, type GeoJSONFeatureId} from './geojson_source_diff';
+import {type GeoJSONSourceDiff, applySourceDiff, toUpdateable, type GeoJSONFeatureId} from './geojson_source_diff';
 import type {WorkerTileParameters, WorkerTileResult} from './worker_source';
 import type {LoadVectorTileResult} from './vector_tile_worker_source';
 import type {RequestParameters} from '../util/ajax';
@@ -234,7 +234,7 @@ export class GeoJSONWorkerSource extends VectorTileWorkerSource {
      */
     async loadGeoJSONFromUrl(request: RequestParameters, promoteId: string, abortController: AbortController): Promise<GeoJSON.GeoJSON> {
         const response = await getJSON<GeoJSON.GeoJSON>(request, abortController);
-        this._dataUpdateable = isUpdateableGeoJSON(response.data, promoteId) ? toUpdateable(response.data, promoteId) : undefined;
+        this._dataUpdateable = toUpdateable(response.data, promoteId);
         return response.data;
     }
 
@@ -242,7 +242,7 @@ export class GeoJSONWorkerSource extends VectorTileWorkerSource {
      * Loads GeoJSON from a string and sets the sources updateable GeoJSON object.
      */
     _loadGeoJSONFromObject(data: GeoJSON.GeoJSON, promoteId: string): GeoJSON.GeoJSON {
-        this._dataUpdateable = isUpdateableGeoJSON(data, promoteId) ? toUpdateable(data, promoteId) : undefined;
+        this._dataUpdateable = toUpdateable(data, promoteId);
         return data;
     }
 


### PR DESCRIPTION
This PR removes the isUpdateableGeoJSON() function and consolidates validation and normalization logic into toUpdateable(). Previously, correctness depended on keeping two separate functions in sync, which risked logic drift and duplicated checks. By handling both validation and conversion in a single place, the update pipeline becomes simpler, more predictable, and easier to maintain. The caller now has a single, clear entry point: attempt to build an updateable map, and rely on undefined to signal invalid input.
