### PR TITLE
Clarify queryRenderedFeatures docs

### DIFF
--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -1770,7 +1770,7 @@ export class Map extends Camera {
      * representing visible features that satisfy the query parameters.
      *
      * @param geometryOrOptions - (optional) The geometry of the query region in pixel points within the map viewport:
-     * Either a single pixel point or a pair of top-left and bottom-right pixel points describing a bounding box.
+     * either a single pixel point or a pair of top-left and bottom-right pixel points describing a bounding box.
      * The origin of the pixel points is at the top-left of the map viewport.
      * Omitting this parameter (i.e. calling {@link Map.queryRenderedFeatures} with zero arguments,
      * or with only a `options` argument) is equivalent to passing a bounding box encompassing the entire


### PR DESCRIPTION
The docs of `queryRenderedFeatures` are misleading. The wording of `geometry` in conjunction with `southwest` and `northeast` suggest to pass geographic coordinates. Also it denotes a wrong order. When looking at the implementation and examples it's clear top-left and bottom-right should be passed:

https://github.com/maplibre/maplibre-gl-js/blob/8d04baafb3300d83829fae6870ba16df7214ffac/src/ui/map.ts#L1859-L1861

- `tl`: top-left
- `br`: bottom-right.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [ ] Link to related issues.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [ ] Add an entry to `CHANGELOG.md` under the `## main` section.
