### PR TITLE
Update upload-benchmarks.yml

### DIFF
--- a/.github/workflows/upload-benchmarks.yml
+++ b/.github/workflows/upload-benchmarks.yml
@@ -57,5 +57,5 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: tmp
           destination_dir: benchmarks/${{ inputs.tag || 'main' }}
-          commit_message: 'deploy: ${{ inputs.tag || github.sha }}'
+          commit_message: 'deploy: ${{ inputs.tag }}'
 


### PR DESCRIPTION
Fixes the label which is currently the following:

<img width="1619" height="72" alt="image" src="https://github.com/user-attachments/assets/3874d66e-1fde-499f-ac44-80a040a22fb3" />
