### PR TITLE
fix: mapbox draw example needs maplibre specific CSS classes to work

### DIFF
--- a/test/examples/draw-polygon-with-mapbox-gl-draw.html
+++ b/test/examples/draw-polygon-with-mapbox-gl-draw.html
@@ -42,9 +42,39 @@
         <div id="calculated-area"></div>
     </div>
 
+    <!-- Fix Mapbox Draw cursors: CSS classes to point to MapLibre GL classes -->
+    <style>
+        .maplibregl-map.mouse-pointer .maplibregl-canvas-container.maplibregl-interactive {
+            cursor: pointer;
+        }
+        .maplibregl-map.mouse-move .maplibregl-canvas-container.maplibregl-interactive {
+            cursor: move;
+        }
+        .maplibregl-map.mouse-add .maplibregl-canvas-container.maplibregl-interactive {
+            cursor: crosshair;
+        }
+        .maplibregl-map.mouse-move.mode-direct_select .maplibregl-canvas-container.maplibregl-interactive {
+            cursor: grab;
+            cursor: -moz-grab;
+            cursor: -webkit-grab;
+        }
+        .maplibregl-map.mode-direct_select.feature-vertex.mouse-move .maplibregl-canvas-container.maplibregl-interactive {
+            cursor: move;
+        }
+        .maplibregl-map.mode-direct_select.feature-midpoint.mouse-pointer .maplibregl-canvas-container.maplibregl-interactive {
+            cursor: cell;
+        }
+        .maplibregl-map.mode-direct_select.feature-feature.mouse-move .maplibregl-canvas-container.maplibregl-interactive {
+            cursor: move;
+        }
+        .maplibregl-map.mode-static.mouse-pointer  .maplibregl-canvas-container.maplibregl-interactive {
+            cursor: grab;
+            cursor: -moz-grab;
+            cursor: -webkit-grab;
+        }
+    </style>
+
     <script type="module">
-
-
     import * as turf from 'https://esm.sh/@turf/turf@7.1.0';
 
     MapboxDraw.constants.classes.CANVAS  = 'maplibregl-canvas';
@@ -95,6 +125,6 @@
                 alert('Use the draw tools to draw a polygon!');
         }
     }
-</script>
+    </script>
 </body>
 </html>


### PR DESCRIPTION
Mapbox Draw plugin which works with Maplibre references Mapbox specific CSS classes for CSS cursor changes.

In the example of how to use Mapbox Draw plugin there was already one fix that showed how `styles` (internal) needed to be changed to work with Maplibre, so I added the required CSS with changed class names as well so others know how to use "correctly".