### PR TITLE
Hide control characters in formatted string expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### 🐞 Bug fixes
 
 - Fix setting visibility on custom layer ([#6883](https://github.com/maplibre/maplibre-gl-js/issues/6883) (by [melitele](https://github.com/melitele))
+- Hide leading and trailing control characters in `format` expressions ([#6907](https://github.com/maplibre/maplibre-gl-js/pull/6907) by [1ec5](https://github.com/1ec5))
 - _...Add new stuff here..._
 
 ## 5.15.0

--- a/src/render/glyph_manager.ts
+++ b/src/render/glyph_manager.ts
@@ -191,15 +191,18 @@ export class GlyphManager {
 
         const leftAdjustment = 0.5;
 
+        // By definition, control characters are invisible and nonspacing.
+        const isControl = /^\p{gc=Cf}+$/u.test(String.fromCodePoint(id));
+
         return {
             id,
             bitmap: new AlphaImage({width: char.width || 30 * textureScale, height: char.height || 30 * textureScale}, char.data),
             metrics: {
-                width: char.glyphWidth / textureScale || 24,
+                width: isControl ? 0 : (char.glyphWidth / textureScale || 24),
                 height: char.glyphHeight / textureScale || 24,
                 left: (char.glyphLeft / textureScale + leftAdjustment) || 0,
                 top: char.glyphTop / textureScale - topAdjustment || -8,
-                advance: char.glyphAdvance / textureScale || 24,
+                advance: isControl ? 0 : (char.glyphAdvance / textureScale || 24),
                 isDoubleResolution: true
             }
         };


### PR DESCRIPTION
A control character that occurs at the beginning or end of an in put to a formatted string expression (`format`) is by definition invisible and nonspacing, so zero out its horizontal metrics. Along the way, I realized we weren’t actually testing glyph manager when leaving `glyphs` unset, so we have a basic test of that now.

Before | After
----|----
<img width="3456" height="1934" alt="Spaced parentheses" src="https://github.com/user-attachments/assets/17adc839-e2d6-4a76-bb76-d3b08d54eec6" /> | <img width="3456" height="1934" alt="Unspaced parentheses" src="https://github.com/user-attachments/assets/dcbd879a-c0ab-4372-9ec0-f01de45621c8" />

Fixes #6903.

## Launch Checklist

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [x] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [x] Add an entry to `CHANGELOG.md` under the `## main` section.
