### PR TITLE
Revert fix for zoom jump on corrupted DEM data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
 ## main
 ### ✨ Features and improvements
 - Refactor _updateWorkerData ([#6983](https://github.com/maplibre/maplibre-gl-js/pull/6983)) (by [@wayofthefuture](https://github.com/wayofthefuture))
-- Handle no data values in terrain DEMs with terrarium encoding ([#6587](https://github.com/maplibre/maplibre-gl-js/issues/6587)) (by [@pstaszek](https://github.com/pstaszek))
 - ⚠️ Add `zoomSnap` option to `Map` to allow snapping zoom levels to a grid when zooming in and out; aligns the behavior across all UI patterns (keyboard, scroll wheel, on-screen zoom buttons, double-click, double-tap). Previously, pressing +/- on the keyboard zoomed to rounded whole integers, more or less than 1 zoom level when starting from a fractional zoom. Now any number can be specified for `zoomSnap`; a value of 1.0 produces the rounded whole integer behavior across all UI patterns. ([#6941](https://github.com/maplibre/maplibre-gl-js/pull/6941)) (by [@mizmay](https://github.com/mizmay))
 - Add support for container elements from different windows (e.g., popup or iframe) ([#6969](https://github.com/maplibre/maplibre-gl-js/pull/6969)) (by [@Syncret](https://github.com/Syncret))
 - Migrate to @maplibre/geojson-vt ([#6995](https://github.com/maplibre/maplibre-gl-js/pull/6995)) (by [@HarelM](https://github.com/HarelM))

--- a/src/data/dem_data.test.ts
+++ b/src/data/dem_data.test.ts
@@ -1,24 +1,15 @@
-import {describe, test, expect, vi, afterAll} from 'vitest';
+import {describe, test, expect, vi} from 'vitest';
 import {DEMData} from './dem_data';
 import {RGBAImage} from '../util/image';
 import {serialize, deserialize} from '../util/web_worker_transfer';
 
-function createMockImage(height: number, width: number, rgbaValue?: [number, number, number, number]) {
+function createMockImage(height, width) {
     // RGBAImage passed to constructor has uniform 1px padding on all sides.
     height += 2;
     width += 2;
     const pixels = new Uint8Array(height * width * 4);
-    if (rgbaValue) {
-        for (let i = 0; i < pixels.length; i+=4) {
-            pixels[i] = rgbaValue[0];
-            pixels[i+1] = rgbaValue[1];
-            pixels[i+2] = rgbaValue[2];
-            pixels[i+3] = rgbaValue[3];
-        }
-    } else {
-        for (let i = 0; i < pixels.length; i++) {
-            pixels[i] = (i + 1) % 4 === 0 ? 1 : Math.floor(Math.random() * 256);
-        }
+    for (let i = 0; i < pixels.length; i++) {
+        pixels[i] = (i + 1) % 4 === 0 ? 1 : Math.floor(Math.random() * 256);
     }
     return new RGBAImage({height, width}, pixels);
 }
@@ -179,7 +170,6 @@ function testSerialization(dem0: DEMData, redFactor: number, greenFactor: number
             $name: 'DEMData',
             uid: '0',
             dim: 4,
-            encoding: dem0.encoding,
             stride: 6,
             data: dem0.data,
             redFactor,
@@ -245,32 +235,6 @@ describe('DEMData.getImage', () => {
     test('Image is correctly returned - mapbox', testGetPixels(mapboxDEM, imageData));
     test('Image is correctly returned - terrarium', testGetPixels(terrariumDEM, imageData));
     test('Image is correctly returned - custom', testGetPixels(customDEM, imageData));
-});
-
-describe('DEMData.get', () => {
-    test('returns elevation for zero value mapbox encoding', () => {
-        const imageData2 = createMockImage(4, 4, [0, 0, 0, 1]);
-        const dem2 = new DEMData('0', imageData2, 'mapbox');
-        expect(dem2.get(0, 0)).toBe(-10000);
-    });
-
-    test('returns elevation for zero value custom encoding', () => {
-        const imageData2 = createMockImage(4, 4, [0, 0, 0, 1]);
-        const dem2 = new DEMData('0', imageData2, 'custom', 1.0, 2.0, 3.0, 123);
-        expect(dem2.get(0, 0)).toBe(-123);
-    });
-
-    test('returns elevation for non-zero value terrarium data', () => {
-        const imageData = createMockImage(4, 4, [128, 255, 0, 1]);
-        const dem = new DEMData('0', imageData, 'terrarium');
-        expect(dem.get(0, 0)).toBe(255);
-    });
-
-    test('returns 0 for terrarium no data', () => {
-        const imageData = createMockImage(4, 4, [0, 0, 0, 0]);
-        const dem = new DEMData('0', imageData, 'terrarium');
-        expect(dem.get(0, 0)).toBe(0);
-    });
 });
 
 describe('DEMData pack and unpack', () => {

--- a/src/data/dem_data.ts
+++ b/src/data/dem_data.ts
@@ -9,11 +9,6 @@ import {register} from '../util/web_worker_transfer';
 export type DEMEncoding = 'mapbox' | 'terrarium' | 'custom';
 
 /**
- * The no data value for terrarium encoding
- */
-const TERRARIUM_NO_DATA = -32768.0;
-
-/**
  * DEMData is a data structure for decoding, backfilling, and storing elevation data for processing in the hillshade shaders
  * data can be populated either from a png raw image tile or from serialized data sent back from a worker. When data is initially
  * loaded from a image tile, we decode the pixel values using the appropriate decoding formula, but we store the
@@ -35,7 +30,6 @@ export class DEMData {
     greenFactor: number;
     blueFactor: number;
     baseShift: number;
-    encoding: DEMEncoding;
 
     /**
      * Constructs a `DEMData` object
@@ -55,7 +49,6 @@ export class DEMData {
             warnOnce(`"${encoding}" is not a valid encoding type. Valid types include "mapbox", "terrarium" and "custom".`);
             return;
         }
-        this.encoding = encoding;
         this.stride = data.height;
         const dim = this.dim = data.height - 2;
         this.data = new Uint32Array(data.data.buffer);
@@ -119,13 +112,7 @@ export class DEMData {
     get(x: number, y: number) {
         const pixels = new Uint8Array(this.data.buffer);
         const index = this._idx(x, y) * 4;
-        const value = this.unpack(pixels[index], pixels[index + 1], pixels[index + 2]);
-
-        if (this.encoding === 'terrarium' && value === TERRARIUM_NO_DATA) {
-            return 0;
-        }
-
-        return value;
+        return this.unpack(pixels[index], pixels[index + 1], pixels[index + 2]);
     }
 
     getUnpackVector() {


### PR DESCRIPTION
This PR reverts #6982 which added handling for terrarium no data to zoom calculation, causing zoom jump of corrupted DEM data. After the discussion in the issue #6587 it was decided that renderer shouldn't be responsible for handling corrupted tiles coming from the server.

## Launch Checklist
<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->
 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [ ] Link to related issues.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [x] Add an entry to `CHANGELOG.md` under the `## main` section.
