### PR TITLE
fix: prevent crash on mismatched array interpolation (Fixes #6606)

### DIFF
--- a/src/style/properties.test.ts
+++ b/src/style/properties.test.ts
@@ -1,5 +1,5 @@
 import {describe, test, expect} from 'vitest';
-import {Layout, PropertyValue} from './properties';
+import {Layout, PropertyValue, DataConstantProperty} from './properties';
 import symbolProperties from './style_layer/symbol_style_layer_properties.g';
 import {type EvaluationParameters} from './evaluation_parameters';
 
@@ -18,5 +18,18 @@ describe('Layout', () => {
         const _layout = layout.possiblyEvaluate({} as EvaluationParameters);
         expect(_layout.get('text-size').evaluate()).toBe(15);
         expect(_layout.get('text-transform').evaluate()).toBe('uppercase');
+    });
+});
+
+describe('DataConstantProperty', () => {
+    test('interpolate skips interpolation on array length mismatch', () => {
+        const prop = new DataConstantProperty({type: 'color', value: 'color'} as any);
+        const a = [0, 0, 0, 1];
+        const b = [0, 0, 0];
+        
+        // standard color array interpolation would crash here if passed to style-spec
+        // With fix, it should return a or b depending on t
+        expect(prop.interpolate(a, b, 0.4)).toBe(a);
+        expect(prop.interpolate(a, b, 0.6)).toBe(b);
     });
 });

--- a/src/style/properties.ts
+++ b/src/style/properties.ts
@@ -467,6 +467,9 @@ export class DataConstantProperty<T> implements Property<T, T> {
     }
 
     interpolate(a: T, b: T, t: number): T {
+        if (Array.isArray(a) && Array.isArray(b) && a.length !== b.length) {
+            return t < 0.5 ? a : b;
+        }
         const interpolationType = this.specification.type as keyof typeof interpolates;
         const interpolationFn = interpolates[interpolationType] as ((from: T, to: T, t: number) => T) | undefined;
         if (interpolationFn) {


### PR DESCRIPTION
This PR fixes a crash (Arrays have mismatched length) that occurs when updating multidirectional hillshade light arrays with different lengths.

Fix: Updated DataConstantProperty.interpolate to detect mismatched array lengths. Instead of crashing, it now skips interpolation (returning a discrete step).