### PR TITLE
Add source id to error message

### DIFF
--- a/src/style/style.ts
+++ b/src/style/style.ts
@@ -1035,7 +1035,7 @@ export class Style extends Evented {
         this._checkLoaded();
 
         if (this.tileManagers[id] === undefined) {
-            throw new Error('There is no source with this ID');
+            throw new Error(`There is no source with this ID=${id}`);
         }
         for (const layerId in this._layers) {
             if (this._layers[layerId].source === id) {


### PR DESCRIPTION
## Launch Checklist

When removing a non-existing source the error message will now let the user know which id was attempted to be removed without success.

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
