### PR TITLE
refactor: replace deprecated substr() with startsWith()

### DIFF
--- a/src/data/program_configuration.ts
+++ b/src/data/program_configuration.ts
@@ -187,7 +187,7 @@ class CrossFadedConstantBinder implements UniformBinder {
     }
 
     getBinding(context: Context, location: WebGLUniformLocation, name: string): Partial<Uniform<any>> {
-        return (name.substr(0, 9) === 'u_pattern' || name.substr(0, 12) === 'u_dasharray_') ?
+        return (name.startsWith('u_pattern') || name.startsWith('u_dasharray_')) ?
             new Uniform4f(context, location) :
             new Uniform1f(context, location);
     }


### PR DESCRIPTION
Replace `String.substr()` with `String.startsWith()` in `program_configuration.ts`.

`substr()` is [deprecated](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) and `startsWith()` is more readable and semantic for prefix checking.

**Before:**
```ts
name.substr(0, 9) === 'u_pattern' || name.substr(0, 12) === 'u_dasharray_'
```

**After:**
```ts
name.startsWith('u_pattern') || name.startsWith('u_dasharray_')
```