### PR TITLE
Fix #7082: Prevent popup close button from receiving automatic keyboard focus

### DIFF
--- a/src/ui/popup.test.ts
+++ b/src/ui/popup.test.ts
@@ -729,7 +729,7 @@ describe('popup', () => {
         expect(window.document.activeElement).toBe(dummyFocusedEl);
     });
 
-    test('Close button is focused if it is the only focusable element', () => {
+    test('Close button is not automatically focused when popup opens', () => {
         const dummyFocusedEl = window.document.createElement('button');
         window.document.body.appendChild(dummyFocusedEl);
         dummyFocusedEl.focus();
@@ -743,10 +743,12 @@ describe('popup', () => {
                 }
             }));
 
-        // Suboptimal because the string matching is case-sensitive
+        // Close button has tabindex="-1" so it should not receive automatic focus
+        expect(window.document.activeElement).toBe(dummyFocusedEl);
+        
+        // Verify close button has tabindex="-1"
         const closeButton = popup._container.querySelector('[aria-label^=\'Alt close label\']');
-
-        expect(window.document.activeElement).toBe(closeButton);
+        expect(closeButton.getAttribute('tabindex')).toBe('-1');
     });
 
     test('If popup content contains a focusable element it is focused', () => {
@@ -761,16 +763,20 @@ describe('popup', () => {
     });
 
     test('Element with tabindex="-1" is not focused', () => {
+        const dummyFocusedEl = window.document.createElement('button');
+        window.document.body.appendChild(dummyFocusedEl);
+        dummyFocusedEl.focus();
+
         const popup = new Popup({closeButton: true})
             .setHTML('<span tabindex="-1" data-testid="abc">Test</span>')
             .setLngLat([0, 0])
             .addTo(createMap());
 
         const nonFocusableEl = popup._container.querySelector('[data-testid=\'abc\']');
-        const closeButton = popup._container.querySelector('button[aria-label=\'Close popup\']');
 
+        // Neither the element with tabindex="-1" nor the close button should be focused
         expect(window.document.activeElement).not.toBe(nonFocusableEl);
-        expect(window.document.activeElement).toBe(closeButton);
+        expect(window.document.activeElement).toBe(dummyFocusedEl);
     });
 
     test('If popup contains a disabled button and a focusable element then the latter is focused', () => {

--- a/src/ui/popup.ts
+++ b/src/ui/popup.ts
@@ -110,7 +110,7 @@ const focusQuerySelector = [
     'a[href]',
     '[tabindex]:not([tabindex=\'-1\'])',
     '[contenteditable]:not([contenteditable=\'false\'])',
-    'button:not([disabled])',
+    'button:not([disabled]):not([tabindex=\'-1\'])',
     'input:not([disabled])',
     'select:not([disabled])',
     'textarea:not([disabled])',
@@ -594,6 +594,7 @@ export class Popup extends Evented {
         if (this.options.closeButton) {
             this._closeButton = DOM.create('button', 'maplibregl-popup-close-button', this._content);
             this._closeButton.type = 'button';
+            this._closeButton.setAttribute('tabindex', '-1');
             this._closeButton.innerHTML = '&#215;';
             this._closeButton.addEventListener('click', this._onClose);
         }


### PR DESCRIPTION
## Description
Fixes #7082

When a popup auto-opens (e.g., via marker click), the close button was receiving automatic keyboard focus, creating unexpected keyboard navigation behavior.

## Changes
- Added `tabindex="-1"` to the popup close button to exclude it from automatic focus
- Updated `focusQuerySelector` to exclude buttons with `tabindex="-1"`
- Updated tests to reflect the new behavior

## Behavior
**Before:**
- Close button received focus when popup opened with no other focusable content
- Pressing Tab would immediately focus the close button

**After:**
- Close button does not receive automatic focus
- Close button remains clickable and accessible via mouse
- Keyboard focus stays on previously focused element or first focusable content element
- Close button is still accessible but not in the automatic tab order

## Testing
All existing popup tests pass with updated expectations.