### PR TITLE
Fix #6565: CTRL+Click drag rotation not working on Firefox

### DIFF
--- a/src/ui/handler/mouse.ts
+++ b/src/ui/handler/mouse.ts
@@ -62,7 +62,7 @@ export function generateMouseRotationHandler({enable, clickTolerance, aroundCent
     const mouseMoveStateManager = new MouseMoveStateManager({
         checkCorrectEvent: (e: MouseEvent): boolean =>
             (DOM.mouseButton(e) === LEFT_BUTTON && e.ctrlKey) ||
-            (DOM.mouseButton(e) === RIGHT_BUTTON && !e.ctrlKey),
+            (DOM.mouseButton(e) === RIGHT_BUTTON),
     });
     return new DragHandler<DragRotateResult, MouseEvent>({
         clickTolerance,


### PR DESCRIPTION
## Description
Fixes #6565

CTRL+Click drag rotation didn't work on Firefox because Firefox reports CTRL+Click as a RIGHT_BUTTON press with ctrlKey set to true, rather than a LEFT_BUTTON press with ctrlKey set.

## Changes
- Removed the `!e.ctrlKey` check from the RIGHT_BUTTON condition in `generateMouseRotationHandler`
- Now accepts both RIGHT_BUTTON clicks (with or without CTRL)
- This allows Firefox's CTRL+Click (reported as RIGHT_BUTTON + ctrlKey) to trigger rotation

## Behavior
**Before:**
- CTRL+Click drag on Firefox did nothing
- Worked fine on Chrome/Safari

**After:**
- CTRL+Click drag works on Firefox for map rotation
- Still works on Chrome/Safari
- Right-click without CTRL also works for rotation

## Testing
Tested the rotation behavior works correctly with the simplified condition.