### PR TITLE
fix: recover from task callback errors to prevent map freeze

### DIFF
--- a/src/util/task_queue.test.ts
+++ b/src/util/task_queue.test.ts
@@ -100,6 +100,17 @@ describe('TaskQueue', () => {
         expect(after).toHaveBeenCalledTimes(1);
     });
 
+    test('Recovers from task callback errors and allows subsequent run()', () => {
+        const q = new TaskQueue();
+        q.add(() => { throw new Error('task error'); });
+        expect(() => q.run()).toThrow('task error');
+        // Queue should be recoverable — not stuck in "already running" state
+        const cb = vi.fn();
+        q.add(cb);
+        q.run();
+        expect(cb).toHaveBeenCalledTimes(1);
+    });
+
     test('TaskQueue.clear() interrupts currently-running queue', () => {
         const q = new TaskQueue();
         const before = vi.fn();

--- a/src/util/task_queue.ts
+++ b/src/util/task_queue.ts
@@ -45,14 +45,16 @@ export class TaskQueue {
         // on the next run, not the current run.
         this._queue = [];
 
-        for (const task of queue) {
-            if (task.cancelled) continue;
-            task.callback(timeStamp);
-            if (this._cleared) break;
+        try {
+            for (const task of queue) {
+                if (task.cancelled) continue;
+                task.callback(timeStamp);
+                if (this._cleared) break;
+            }
+        } finally {
+            this._cleared = false;
+            this._currentlyRunning = false;
         }
-
-        this._cleared = false;
-        this._currentlyRunning = false;
     }
 
     clear() {


### PR DESCRIPTION
## Summary

Wrap the task execution loop in `TaskQueue.run()` with `try/finally` to ensure `_currentlyRunning` is always reset, even when a task callback throws.

Fixes #6093

## Problem

When a task callback throws an error (e.g., during globe↔mercator projection transitions where `getRayDirectionFromPixel` throws "not implemented yet"), the `_currentlyRunning` flag is never reset to `false`. This causes every subsequent `run()` call to throw:

> Attempting to run(), but is already running.

This permanently freezes the map — no further interactions or renders are possible.

## Fix

Move the cleanup code (`_cleared = false`, `_currentlyRunning = false`) into a `finally` block so it executes regardless of whether a task throws. The error still propagates to the caller, but the queue recovers and can be used again.

## Test

Added a test verifying that after a task throws, the queue accepts and runs new tasks normally.