### PR TITLE
Fix #6765: Map.setPadding no longer interrupts ongoing flyTo animations

### DIFF
--- a/src/ui/camera.test.ts
+++ b/src/ui/camera.test.ts
@@ -572,6 +572,22 @@ describe('setPadding', () => {
         expect(currentPadding.right).toBe(padding1.right);
         expect(currentPadding.bottom).toBe(padding.bottom);
     });
+
+    test('does not interrupt ongoing flyTo animation', () => {
+        const camera = createCamera();
+        
+        camera.flyTo({center: [10, 10], duration: 100});
+        expect(camera.isEasing()).toBe(true);
+        
+        // Call setPadding during the animation - should not stop it
+        camera.setPadding({left: 100, top: 50, right: 100, bottom: 50});
+        
+        // Animation should still be running (not interrupted)
+        expect(camera.isEasing()).toBe(true);
+        
+        // Padding should be applied immediately
+        expect(camera.getPadding()).toEqual({left: 100, top: 50, right: 100, bottom: 50});
+    });
 });
 
 describe('panBy', () => {

--- a/src/ui/camera.ts
+++ b/src/ui/camera.ts
@@ -648,7 +648,8 @@ export abstract class Camera extends Evented {
     /**
      * Sets the padding in pixels around the viewport.
      *
-     * Equivalent to `jumpTo({padding: padding})`.
+     * Unlike calling `jumpTo({padding})`, this method does not interrupt ongoing camera animations.
+     * If you need to stop any animation before updating the padding, call `map.stop()` first.
      *
      * Triggers the following events: `movestart` and `moveend`.
      *
@@ -661,7 +662,27 @@ export abstract class Camera extends Evented {
      * ```
      */
     setPadding(padding: PaddingOptions, eventData?: any): this {
-        this.jumpTo({padding}, eventData);
+        const tr = this._getTransformForUpdate();
+        
+        if (tr.isPaddingEqual(padding)) {
+            return this;
+        }
+        
+        const isEasing = this.isEasing();
+        
+        if (!isEasing) {
+            this.fire(new Event('movestart', eventData));
+        }
+        
+        tr.setPadding(padding);
+        this._applyUpdatedTransform(tr);
+        
+        this.fire(new Event('move', eventData));
+        
+        if (!isEasing) {
+            this.fire(new Event('moveend', eventData));
+        }
+        
         return this;
     }
 


### PR DESCRIPTION
## Description
Fixes #6765 

This PR modifies the behavior of `Map.setPadding()` to no longer interrupt ongoing camera animations like `flyTo()`.

## Changes
- Modified `Camera.setPadding()` to update padding directly on the transform without calling `jumpTo()`
- The method now checks if an animation is in progress using `isEasing()` before firing movestart/moveend events
- Padding updates are applied immediately but no longer stop ongoing animations
- Added test case to verify that flyTo animations continue when setPadding is called

## Before
When `setPadding()` was called during a `flyTo()` animation, it would call `jumpTo()`, which in turn calls `stop()`, abruptly ending the animation.

## After
`setPadding()` now applies padding changes directly without interrupting animations. The padding update is immediate, and the flyTo animation completes as expected.

## Testing
- All existing camera tests pass
- New test added to verify flyTo continues after setPadding

## Breaking Changes
None. This is a bug fix that makes behavior more intuitive. Users who want the old behavior (stopping animations) can call `map.stop()` before `map.setPadding()`.