### PR TITLE
Fix #6744: Prevent padding accumulation between flyTo and fitBounds

### DIFF
--- a/src/geo/projection/camera_helper.ts
+++ b/src/geo/projection/camera_helper.ts
@@ -154,8 +154,6 @@ export function updateRotation(args: UpdateRotationArgs) {
 }
 
 export function cameraForBoxAndBearing(options: CameraForBoundsOptions, padding: PaddingOptions, bounds: LngLatBounds, bearing: number, tr: IReadonlyTransform): CameraForBoxAndBearingHandlerResult {
-    const edgePadding = tr.padding;
-
     // Consider all corners of the rotated bounding box derived from the given points
     // when find the camera position that fits the given points.
 
@@ -184,8 +182,8 @@ export function cameraForBoxAndBearing(options: CameraForBoundsOptions, padding:
     // Calculate zoom: consider the original bbox and padding.
     const size = upperRight.sub(lowerLeft);
 
-    const availableWidth = (tr.width - (edgePadding.left + edgePadding.right + padding.left + padding.right));
-    const availableHeight = (tr.height - (edgePadding.top + edgePadding.bottom + padding.top + padding.bottom));
+    const availableWidth = (tr.width - (padding.left + padding.right));
+    const availableHeight = (tr.height - (padding.top + padding.bottom));
     const scaleX = availableWidth / size.x;
     const scaleY = availableHeight / size.y;
 

--- a/src/ui/camera.test.ts
+++ b/src/ui/camera.test.ts
@@ -2434,6 +2434,32 @@ describe('fitBounds', () => {
         expect(fixedNum(camera.getZoom(), 3)).toBe(4.163);
     });
 
+    test('padding from flyTo does not accumulate with fitBounds padding (issue #6744)', () => {
+        const camera = createCamera();
+        
+        // First, flyTo with padding
+        camera.flyTo({
+            center: [0, 0],
+            padding: {top: 50, bottom: 0, left: 100, right: 0},
+            duration: 0
+        });
+        
+        // Verify the padding from flyTo is set on the transform
+        expect(camera.transform.padding).toEqual({top: 50, bottom: 0, left: 100, right: 0});
+        
+        // Now call fitBounds with its own padding
+        const bb = [[-10, -10], [10, 10]] as [LngLatLike, LngLatLike];
+        camera.fitBounds(bb, {padding: 20, duration: 0});
+        
+        // The result should be the same as fitBounds with padding 20 on a fresh camera
+        // (i.e., the flyTo padding should not be summed with the fitBounds padding)
+        const freshCamera = createCamera();
+        freshCamera.fitBounds(bb, {padding: 20, duration: 0});
+        
+        expect(fixedLngLat(camera.getCenter(), 4)).toEqual(fixedLngLat(freshCamera.getCenter(), 4));
+        expect(fixedNum(camera.getZoom(), 3)).toBe(fixedNum(freshCamera.getZoom(), 3));
+    });
+
 });
 
 describe('fitScreenCoordinates', () => {


### PR DESCRIPTION
## Description
Fixes #6744

This PR fixes a bug where padding from `flyTo()` would persist and be added to the padding specified in subsequent `fitBounds()` calls, causing incorrect zoom calculations.

## Problem
When calling `flyTo()` with padding, that padding is set on the transform and persists. When `fitBounds()` is then called with its own padding, the `cameraForBoxAndBearing` function was summing both paddings together:

```typescript
const edgePadding = tr.padding;  // Old padding from flyTo
const availableWidth = (tr.width - (edgePadding.left + edgePadding.right + padding.left + padding.right));
const availableHeight = (tr.height - (edgePadding.top + edgePadding.bottom + padding.top + padding.bottom));
```

This resulted in incorrect camera calculations and broken UI behavior.

## Solution
Removed the addition of `edgePadding` (the transform's current padding) in the `cameraForBoxAndBearing` calculation. Now only the explicitly requested padding parameter is used:

```typescript
const availableWidth = (tr.width - (padding.left + padding.right));
const availableHeight = (tr.height - (padding.top + padding.bottom));
```

## Changes
- Modified `cameraForBoxAndBearing()` in `src/geo/projection/camera_helper.ts`
- Removed the `edgePadding` variable and its usage in width/height calculations
- Added comprehensive test to verify padding is not accumulated between animations

## Testing
- All existing camera and fitBounds tests pass
- New test verifies that fitBounds produces the same result regardless of previous flyTo padding

## Breaking Changes
None. This is a bug fix that restores the expected behavior.
