### PR TITLE
fix: allow map communication in srcdoc iframes with null origin

### DIFF
--- a/src/util/actor.test.ts
+++ b/src/util/actor.test.ts
@@ -277,4 +277,21 @@ describe('Actor', () => {
 
         expect(spy).toHaveBeenCalled();
     });
+
+    test('should process a message when sender origin is "null" (srcdoc iframe)', async () => {
+        // Browsers assign a null origin to srcdoc iframes. When MapLibre is hosted inside
+        // such an iframe the worker's origin may differ from the iframe's 'null' origin.
+        // We must allow communication in this case, similar to file:// environments.
+        const worker = workerFactory() as any as WorkerGlobalScopeInterface & ActorTarget;
+        const actor = new Actor(worker, '1');
+
+        const spy = vi.fn().mockReturnValue(Promise.resolve({}));
+        worker.worker.actor.registerMessageHandler(MessageType.getClusterExpansionZoom, spy);
+
+        actor.target.postMessage({type: MessageType.getClusterExpansionZoom, data: {} as any, origin: 'null'});
+
+        await sleep(0);
+
+        expect(spy).toHaveBeenCalled();
+    });
 });

--- a/src/util/actor.ts
+++ b/src/util/actor.ts
@@ -147,7 +147,14 @@ export class Actor implements IActor {
     receive(message: {data: MessageData}) {
         const data = message.data;
         const id = data.id;
-        if (data.origin !== 'file://' && location.origin !== 'file://' && data.origin !== 'resource://android' && location.origin !== 'resource://android' && data.origin !== location.origin) {
+        // 'file://' and 'resource://android' are special origins used in local/embedded environments.
+        // 'null' is the opaque origin assigned by browsers to documents loaded via srcdoc iframes
+        // (or sandboxed iframes without allow-same-origin). When either side has a null origin we
+        // cannot reliably enforce the same-origin check, so we allow communication in the same way
+        // we do for file:// and Android webviews. See: https://github.com/maplibre/maplibre-gl-js/issues/7047
+        const allowedOrigin = (origin: string) =>
+            origin === 'file://' || origin === 'resource://android' || origin === 'null';
+        if (!allowedOrigin(data.origin) && !allowedOrigin(location.origin) && data.origin !== location.origin) {
             return;
         }
         if (data.targetMapId && this.mapId !== data.targetMapId) {


### PR DESCRIPTION
## Problem

When MapLibre GL JS is embedded inside an `<iframe srcdoc="...">" element, browsers assign the [opaque origin](https://html.spec.whatwg.org/multipage/origin.html#concept-origin-opaque) `'null'` (the string) to that document. The `receive()` method in `actor.ts` checks that the message sender's origin matches the receiver's origin before processing messages. This check fails when one side is a null-origin srcdoc iframe and the other is a worker created from a CDN-hosted script (which retains the CDN's real origin), causing the map to silently fail to render.

This was a regression introduced in #3233 (the actor callback→promise migration), noted in #7047.

## Root Cause

`actor.ts` line ~150:

```ts
if (data.origin !== 'file://' && location.origin !== 'file://' &&
    data.origin !== 'resource://android' && location.origin !== 'resource://android' &&
    data.origin !== location.origin) {
    return;
}
```

`file://` and `resource://android` are already exempted because those environments cannot provide a meaningful same-origin guarantee. The `'null'` opaque origin in srcdoc iframes is in exactly the same category.

## Fix

Extend the allowed-origin list with `'null'` so that maps hosted inside srcdoc iframes can communicate with their workers. The implementation extracts the check into a small helper for readability:

```ts
const allowedOrigin = (origin: string) =>
    origin === 'file://' || origin === 'resource://android' || origin === 'null';
if (!allowedOrigin(data.origin) && !allowedOrigin(location.origin) && data.origin !== location.origin) {
    return;
}
```

## Tests

Added a new unit test to `src/util/actor.test.ts`:

> **should process a message when sender origin is "null" (srcdoc iframe)**

All **16** actor unit tests pass.

## Checklist

- [x] I've read the [contribution guidelines](https://github.com/maplibre/maplibre-gl-js/blob/main/CONTRIBUTING.md)
- [x] Unit test added for the new behaviour
- [x] No backport from Mapbox proprietary code

Fixes #7047