### PR TITLE
feat: add MapLibreMap as alias for Map class

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -201,6 +201,7 @@ function importScriptInWorkers(workerUrl: string) { return getGlobalDispatcher()
 
 export {
     Map,
+    Map as MapLibreMap,
     NavigationControl,
     GeolocateControl,
     AttributionControl,


### PR DESCRIPTION
## Summary
Add `MapLibreMap` as an alias for the `Map` class to avoid conflicts with JavaScript's built-in `Map` object.

This is similar to what Leaflet 2.0 did (https://leafletjs.com/2025/05/18/leaflet-2.0-alpha.html)

Closes #7155