### PR TITLE
Context7 validation

### DIFF
--- a/context7.json
+++ b/context7.json
@@ -1,0 +1,4 @@
+{
+  "url": "https://context7.com/maplibre/maplibre-gl-js",
+  "public_key": "pk_V2bWQi3x0U7HfMJSkoqQG"
+}


### PR DESCRIPTION
One of the most prominent Docs-For-LLM sites are Context7, which has MapLibre GL JS indexed at:

https://context7.com/maplibre/maplibre-gl-js

By verifying we get some more handles to improve the content that the LLMs will see. It's e.g. mentioning that there [isn't docs for the setStyle()](https://context7.com/maplibre/maplibre-gl-js?tab=benchmark) method, which [there are.](https://maplibre.org/maplibre-gl-js/docs/API/classes/Map/#setstyle)