### PR TITLE
Allow raster sources to disable alpha premultiplication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### 🐞 Bug fixes
 - _...Add new stuff here..._
+- Add `RasterTileSource#setPremultiplyAlpha(false)` to preserve raw RGBA tile values when alpha is used for data instead of opacity ([#7235](https://github.com/maplibre/maplibre-gl-js/pull/7235)) (by [@plantain](https://github.com/plantain)).
 
 ## 6.0.0-20
 

--- a/src/source/raster_tile_source.test.ts
+++ b/src/source/raster_tile_source.test.ts
@@ -7,6 +7,7 @@ import {fakeServer, type FakeServer} from 'nise';
 import {type Tile} from '../tile/tile.ts';
 import {sleep, stubAjaxGetImage, waitForEvent} from '../util/test/util.ts';
 import {type MapSourceDataEvent} from '../ui/events.ts';
+import {ImageRequest} from '../util/image_request.ts';
 
 function createSource(options, transformCallback?) {
     const source = new RasterTileSource('id', options, {send() {}} as any as Dispatcher, options.eventedParent);
@@ -30,6 +31,7 @@ describe('RasterTileSource', () => {
     });
 
     afterEach(() => {
+        vi.restoreAllMocks();
         server.restore();
     });
 
@@ -269,12 +271,73 @@ describe('RasterTileSource', () => {
             minzoom: 2,
             maxzoom: 10
         });
+
         expect(source.serialize()).toStrictEqual({
             type: 'raster',
             tiles: ['http://localhost:2900/raster/{z}/{x}/{y}.png'],
             minzoom: 2,
             maxzoom: 10
         });
+    });
+
+    test('does not serialize runtime premultiplyAlpha setting', () => {
+        const source = createSource({
+            tiles: ['http://localhost:2900/raster/{z}/{x}/{y}.png']
+        });
+        source.setPremultiplyAlpha(false);
+
+        expect(source.serialize()).toStrictEqual({
+            type: 'raster',
+            tiles: ['http://localhost:2900/raster/{z}/{x}/{y}.png']
+        });
+    });
+
+    test('setPremultiplyAlpha reloads source content when changed', async () => {
+        const source = createSource({
+            tiles: ['http://example.com/{z}/{x}/{y}.png']
+        });
+        const initialDataEvent: MapSourceDataEvent = await waitForEvent(source, 'data', (e: MapSourceDataEvent) => e.sourceDataType === 'content');
+        expect(initialDataEvent.sourceDataChanged).toBe(false);
+
+        const dataEvent = waitForEvent(source, 'data', (e: MapSourceDataEvent) => e.sourceDataType === 'content' && e.sourceDataChanged === true);
+
+        expect(source.setPremultiplyAlpha(false)).toBe(source);
+
+        await expect(dataEvent).resolves.toBeDefined();
+    });
+
+    test('loadTile uploads raster data without premultiplication after setPremultiplyAlpha(false)', async () => {
+        const source = createSource({
+            tiles: ['http://example.com/{z}/{x}/{y}.png']
+        });
+        source.setPremultiplyAlpha(false);
+        source.tiles = ['http://example.com/{z}/{x}/{y}.png'];
+        source.map._refreshExpiredTiles = false;
+
+        const image = {width: 256, height: 256} as ImageBitmap;
+        const getImageSpy = vi.spyOn(ImageRequest, 'getImage').mockResolvedValue({data: image});
+        const update = vi.fn();
+        source.map.painter = {
+            context: {gl: {}},
+            getTileTexture: () => ({update})
+        } as any;
+
+        const tile = {
+            tileID: new OverscaledTileID(10, 0, 10, 5, 5),
+            state: 'loading',
+            setExpiryData() {}
+        } as any as Tile;
+
+        await source.loadTile(tile);
+
+        expect(getImageSpy).toHaveBeenCalledWith(
+            expect.anything(),
+            expect.any(AbortController),
+            false,
+            {premultiplyAlpha: 'none'}
+        );
+        expect(update).toHaveBeenCalledWith(image, {useMipmap: true, premultiply: false});
+        expect(tile.state).toBe('loaded');
     });
 
     test('Tile expiry data is set when "Cache-Control" is set but not "Expires"', async () => {

--- a/src/source/raster_tile_source.ts
+++ b/src/source/raster_tile_source.ts
@@ -69,6 +69,7 @@ export class RasterTileSource extends Evented<SourceEventType> implements Source
 
     _loaded: boolean;
     _options: RasterSourceSpecification | RasterDEMSourceSpecification;
+    _premultiplyAlpha: boolean;
     _tileJSONRequest: AbortController;
 
     constructor(id: string, options: RasterSourceSpecification | RasterDEMSourceSpecification, dispatcher: Dispatcher, eventedParent: Evented) {
@@ -84,6 +85,7 @@ export class RasterTileSource extends Evented<SourceEventType> implements Source
         this.scheme = 'xyz';
         this.tileSize = 512;
         this._loaded = false;
+        this._premultiplyAlpha = true;
 
         this._options = extend({type: 'raster'}, options);
         extend(this, pick(options, ['url', 'scheme', 'tileSize']));
@@ -176,15 +178,42 @@ export class RasterTileSource extends Evented<SourceEventType> implements Source
         return extend({}, this._options);
     }
 
+    /**
+     * Sets whether alpha premultiplication is applied to raster tile images.
+     * Set to `false` to preserve exact RGBA byte values when alpha carries data instead of opacity.
+     *
+     * @param premultiplyAlpha - If `false`, disables alpha premultiplication for raster tile image decode and texture upload.
+     * @example
+     * ```ts
+     * map.getSource<RasterTileSource>('raster-source').setPremultiplyAlpha(false);
+     * ```
+     */
+    setPremultiplyAlpha(premultiplyAlpha: boolean): this {
+        if (this._premultiplyAlpha === premultiplyAlpha) return this;
+
+        this.setSourceProperty(() => {
+            this._premultiplyAlpha = premultiplyAlpha;
+        });
+
+        return this;
+    }
+
     hasTile(tileID: OverscaledTileID): boolean {
         return !this.tileBounds || this.tileBounds.contains(tileID.canonical);
     }
 
     async loadTile(tile: Tile): Promise<void> {
         const url = tile.tileID.canonical.url(this.tiles, this.map.getPixelRatio(), this.scheme);
+        const premultiply = this._premultiplyAlpha;
+        const imageBitmapOptions = premultiply ? undefined : {premultiplyAlpha: 'none'} as const;
         tile.abortController = new AbortController();
         try {
-            const response = await ImageRequest.getImage(await this.map._requestManager.transformRequest(url, ResourceType.Tile), tile.abortController, this.map._refreshExpiredTiles);
+            const response = await ImageRequest.getImage(
+                await this.map._requestManager.transformRequest(url, ResourceType.Tile),
+                tile.abortController,
+                this.map._refreshExpiredTiles,
+                imageBitmapOptions
+            );
             delete tile.abortController;
             if (tile.aborted) {
                 tile.state = 'unloaded';
@@ -199,9 +228,9 @@ export class RasterTileSource extends Evented<SourceEventType> implements Source
                 const img = response.data;
                 tile.texture = this.map.painter.getTileTexture(img.width);
                 if (tile.texture) {
-                    tile.texture.update(img, {useMipmap: true});
+                    tile.texture.update(img, {useMipmap: true, premultiply});
                 } else {
-                    tile.texture = new Texture(context, img, gl.RGBA, {useMipmap: true});
+                    tile.texture = new Texture(context, img, gl.RGBA, {useMipmap: true, premultiply});
                     tile.texture.bind(gl.LINEAR, gl.CLAMP_TO_EDGE, gl.LINEAR_MIPMAP_NEAREST);
                 }
                 tile.state = 'loaded';

--- a/src/util/image_request.test.ts
+++ b/src/util/image_request.test.ts
@@ -113,10 +113,12 @@ describe('ImageRequest', () => {
     test('getImage uses createImageBitmap when supported', async () => {
         server.respondWith(request => { request.respond(200, {'Content-Type': 'image/png',
             'Cache-Control': 'cache',
-            'Expires': 'expires'}, ''); });
+            'Expires': 'expires'}, '0'); });
 
-        stubAjaxGetImage(() => Promise.resolve(new ImageBitmap()));
-        const promise = ImageRequest.getImage({url: ''}, new AbortController());
+        const createImageBitmapSpy = vi.fn().mockResolvedValue(new ImageBitmap());
+        stubAjaxGetImage(createImageBitmapSpy);
+        const options = {premultiplyAlpha: 'none'} as const;
+        const promise = ImageRequest.getImage({url: ''}, new AbortController(), true, options);
         server.respond();
 
         const response = await promise;
@@ -124,6 +126,7 @@ describe('ImageRequest', () => {
         expect(response.data).toBeInstanceOf(ImageBitmap);
         expect(response.cacheControl).toBe('cache');
         expect(response.expires).toBe('expires');
+        expect(createImageBitmapSpy).toHaveBeenCalledWith(expect.any(Blob), options);
     });
 
     test('getImage using createImageBitmap throws exception', async () => {
@@ -202,6 +205,17 @@ describe('ImageRequest', () => {
 
         expect(makeRequestSky).toHaveBeenCalledTimes(1);
         makeRequestSky.mockClear();
+    });
+
+    test('getImage uses makeRequest when imageBitmapOptions are set', async () => {
+        const makeRequestSky = vi.spyOn(ajax, 'makeRequest');
+        server.respondWith(request => request.respond(200, {'Content-Type': 'image/png'}, '0'));
+
+        const promise = ImageRequest.getImage({url: ''}, new AbortController(), false, {premultiplyAlpha: 'none'});
+
+        expect(makeRequestSky).toHaveBeenCalledTimes(1);
+        server.respond();
+        await expect(promise).resolves.toBeDefined();
     });
 
     test('getImage request returned 404 response for fetch request', async () => {

--- a/src/util/image_request.ts
+++ b/src/util/image_request.ts
@@ -9,6 +9,7 @@ type ImageQueueThrottleControlCallback = () => boolean;
 export type ImageRequestQueueItem  = {
     requestParameters: RequestParameters;
     supportImageRefresh: boolean;
+    imageBitmapOptions?: ImageBitmapOptions;
     state: 'queued' | 'running' | 'completed';
     abortController: AbortController;
     onError: (error: Error) => void;
@@ -103,7 +104,12 @@ export namespace ImageRequest {
      * @param supportImageRefresh - `true`, if the image request need to support refresh based on cache headers.
      * @returns - A promise resolved when the image is loaded.
      */
-    export const getImage = (requestParameters: RequestParameters, abortController: AbortController, supportImageRefresh: boolean = true): Promise<GetResourceResponse<HTMLImageElement | ImageBitmap | null>> => {
+    export const getImage = (
+        requestParameters: RequestParameters,
+        abortController: AbortController,
+        supportImageRefresh: boolean = true,
+        imageBitmapOptions?: ImageBitmapOptions
+    ): Promise<GetResourceResponse<HTMLImageElement | ImageBitmap | null>> => {
         return new Promise<GetResourceResponse<HTMLImageElement | ImageBitmap | null>>((resolve, reject) => {
             requestParameters.headers ||= {};
             requestParameters.headers.accept = 'image/webp,*/*';
@@ -112,6 +118,7 @@ export namespace ImageRequest {
                 abortController,
                 requestParameters,
                 supportImageRefresh,
+                imageBitmapOptions,
                 state: 'queued',
                 onError: (error: Error) => {
                     reject(error);
@@ -126,10 +133,10 @@ export namespace ImageRequest {
         });
     };
 
-    const arrayBufferToCanvasImageSource = (data: ArrayBuffer): Promise<HTMLImageElement | ImageBitmap | null> => {
+    const arrayBufferToCanvasImageSource = (data: ArrayBuffer, imageBitmapOptions?: ImageBitmapOptions): Promise<HTMLImageElement | ImageBitmap | null> => {
         const imageBitmapSupported = typeof createImageBitmap === 'function';
         if (imageBitmapSupported) {
-            return arrayBufferToImageBitmap(data);
+            return arrayBufferToImageBitmap(data, imageBitmapOptions);
         } else {
             return arrayBufferToImage(data);
         }
@@ -137,7 +144,7 @@ export namespace ImageRequest {
 
     const doImageRequest = async (itemInQueue: ImageRequestQueueItem) => {
         itemInQueue.state = 'running';
-        const {requestParameters, supportImageRefresh, onError, onSuccess, abortController} = itemInQueue;
+        const {requestParameters, supportImageRefresh, imageBitmapOptions, onError, onSuccess, abortController} = itemInQueue;
         // - If refreshExpiredTiles is false, then we can use HTMLImageElement to download raster images.
         // - Fetch/XHR (via MakeRequest API) will be used to download images for following scenarios:
         //      1. Style image sprite will had a issue with HTMLImageElement as described
@@ -148,6 +155,7 @@ export namespace ImageRequest {
         //      let makeRequest handle it.
         // - HtmlImageElement request automatically adds accept header for all the browser supported images
         const canUseHTMLImageElement = supportImageRefresh === false &&
+            !imageBitmapOptions &&
             !isWorker(self) &&
             !getProtocol(requestParameters.url) &&
             (!requestParameters.headers ||
@@ -168,7 +176,7 @@ export namespace ImageRequest {
                 // If HtmlImageElement is used to get image then response type will be HTMLImageElement
                 onSuccess(response);
             } else if (response.data) {
-                const img = await arrayBufferToCanvasImageSource(response.data);
+                const img = await arrayBufferToCanvasImageSource(response.data, imageBitmapOptions);
                 onSuccess({data: img, cacheControl: response.cacheControl, expires: response.expires});
             }
         } catch (err) {

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -781,13 +781,13 @@ export function isImageBitmap(image: any): image is ImageBitmap {
  * @param data - Data to convert
  * @returns - A  promise resolved when the conversion is finished
  */
-export const arrayBufferToImageBitmap = async (data: ArrayBuffer): Promise<ImageBitmap> => {
+export const arrayBufferToImageBitmap = async (data: ArrayBuffer, options?: ImageBitmapOptions): Promise<ImageBitmap> => {
     if (data.byteLength === 0) {
-        return createImageBitmap(new ImageData(1, 1));
+        return createImageBitmap(new ImageData(1, 1), options);
     }
     const blob: Blob = new Blob([new Uint8Array(data)], {type: 'image/png'});
     try {
-        return createImageBitmap(blob);
+        return createImageBitmap(blob, options);
     } catch (e) {
         throw new Error(`Could not load image because of ${ensureError(e).message}. Please make sure to use a supported image type such as PNG or JPEG. Note that SVGs are not supported.`);
     }


### PR DESCRIPTION
Add a raster source option that controls whether raster tiles should be alpha-premultiplied during decode and texture upload.

Implementation of https://github.com/maplibre/maplibre-style-spec/issues/1542

## Launch Checklist

 - [X] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [X] Briefly describe the changes in this PR.
 - [X] Link to related issues.
 - [X] Write tests for all new functionality.
 - [X] Document any changes to public APIs.
 - [X] Add an entry to `CHANGELOG.md` under the `## main` section.
