### PR TITLE
fix(double click zoom): makes it possible to disable double click zoom

### DIFF
--- a/src/ui/handler/click_zoom.ts
+++ b/src/ui/handler/click_zoom.ts
@@ -25,6 +25,9 @@ export class ClickZoomHandler implements Handler {
     }
 
     dblclick(e: MouseEvent, point: Point) {
+        if (!this._enabled) {
+            return;
+        }
         e.preventDefault();
         return {
             cameraAnimation: (map: Map) => {

--- a/src/ui/handler/shim/dblclick_zoom.ts
+++ b/src/ui/handler/shim/dblclick_zoom.ts
@@ -50,7 +50,7 @@ export class DoubleClickZoomHandler {
      * @returns `true` if the "double click to zoom" interaction is enabled.
      */
     isEnabled() {
-        return this._clickZoom.isEnabled() && this._tapZoom.isEnabled();
+        return !!(this._clickZoom.isEnabled() && this._tapZoom.isEnabled());
     }
 
     /**
@@ -59,6 +59,6 @@ export class DoubleClickZoomHandler {
      * @returns `true` if the "double click to zoom" interaction is active.
      */
     isActive() {
-        return this._clickZoom.isActive() || this._tapZoom.isActive();
+        return !!(this._clickZoom.isActive() || this._tapZoom.isActive());
     }
 }

--- a/src/ui/handler/tap_zoom.ts
+++ b/src/ui/handler/tap_zoom.ts
@@ -47,6 +47,10 @@ export class TapZoomHandler implements Handler {
     }
 
     touchend(e: TouchEvent, points: Array<Point>, mapTouches: Array<Touch>) {
+        if (!this._enabled) {
+            return;
+        }
+
         const zoomInPoint = this._zoomIn.touchend(e, points, mapTouches);
         const zoomOutPoint = this._zoomOut.touchend(e, points, mapTouches);
         const tr = this._tr;


### PR DESCRIPTION
I noticed one can't disable double-click zoom really - and that's for two reasons.

First, the click and tap handlers ignore their enabled state.

Second, the double-click shim handler reports its own enabled state as `undefined` by default (no defaults set on its dependencies), which is treated as `true` down the line.

This fixes both issues.