### PR TITLE
Remove unused import 'vi' from raster_style_layer test

### DIFF
--- a/src/style/style_layer/raster_style_layer.test.ts
+++ b/src/style/style_layer/raster_style_layer.test.ts
@@ -1,4 +1,4 @@
-import {describe, test, expect, vi} from 'vitest';
+import {describe, test, expect} from 'vitest';
 import {type LayerSpecification} from '@maplibre/maplibre-gl-style-spec';
 import {createStyleLayer} from '../create_style_layer';
 import {extend} from '../../util/util';


### PR DESCRIPTION
## Launch Checklist

See title, this fixes a lint warning.


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!

