### PR TITLE
Add mguide to cspell dictionary

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -113,6 +113,7 @@
     "mediump",
     "Merc",
     "merp",
+    "mguide",
     "MIERUNE",
     "mihalyi",
     "Mincho",


### PR DESCRIPTION
Adds "mguide" to the cspell dictionary to support the awesome-maplibre PR (#141) which adds MGuide to the Users section.