### PR TITLE
fix broken example for fill-pattern

### DIFF
--- a/test/examples/add-a-pattern-to-a-polygon.html
+++ b/test/examples/add-a-pattern-to-a-polygon.html
@@ -45,7 +45,7 @@
         });
 
         // Load an image to use as the pattern
-        const image = await map.loadImage('https://upload.wikimedia.org/wikipedia/commons/thumb/6/60/Cat_silhouette.svg/64px-Cat_silhouette.svg.png');
+        const image = await map.loadImage('https://upload.wikimedia.org/wikipedia/commons/thumb/6/60/Cat_silhouette.svg/60px-Cat_silhouette.svg.png');
         // Declare the image
         map.addImage('pattern', image.data);
 


### PR DESCRIPTION
Wikimedia Commons has recently started [rejecting requests for thumbails with a non-standard size](https://phabricator.wikimedia.org/T414805). This means that the example for `fill-pattern` no longer works. 

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] ~~Link to related issues.~~
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] ~~Write tests for all new functionality.~~
 - [x] ~~Document any changes to public APIs.~~
 - [x] ~~Post benchmark scores.~~
 - [x] ~~Add an entry to `CHANGELOG.md` under the `## main` section.~~
