### PR TITLE
Clamp mercator horizon for high pitch angles

### DIFF
--- a/src/geo/projection/mercator_utils.test.ts
+++ b/src/geo/projection/mercator_utils.test.ts
@@ -36,7 +36,7 @@ describe('mercator utils', () => {
         transform.setPitch(90);
         const horizon = getMercatorHorizon(transform);
 
-        expect(horizon).toBeCloseTo(-9.818037813626313, 10);
+        expect(horizon).toBe(0);
     });
 
     test('getMercatorHorizon95', () => {
@@ -45,7 +45,7 @@ describe('mercator utils', () => {
         transform.setPitch(95);
         const horizon = getMercatorHorizon(transform);
 
-        expect(horizon).toBeCloseTo(-75.52102888757743, 10);
+        expect(horizon).toBe(0);
     });
     describe('getProjectionData', () => {
         test('return identity matrix when not passing overscaledTileID', () => {

--- a/src/geo/projection/mercator_utils.ts
+++ b/src/geo/projection/mercator_utils.ts
@@ -69,8 +69,9 @@ export function unprojectFromWorldCoordinates(worldSize: number, point: Point): 
  * @returns Horizon above center in pixels.
  */
 export function getMercatorHorizon(transform: {pitch: number; cameraToCenterDistance: number}): number {
-    return transform.cameraToCenterDistance * Math.min(Math.tan(degreesToRadians(90 - transform.pitch)) * 0.85,
-        Math.tan(degreesToRadians(maxMercatorHorizonAngle - transform.pitch)));
+    const clampedPitch = Math.min(transform.pitch, maxMercatorHorizonAngle);
+    return transform.cameraToCenterDistance * Math.min(Math.tan(degreesToRadians(90 - clampedPitch)) * 0.85,
+        Math.tan(degreesToRadians(maxMercatorHorizonAngle - clampedPitch)));
 }
 
 export function calculateTileMatrix(unwrappedTileID: UnwrappedTileIDType, worldSize: number): mat4 {


### PR DESCRIPTION
### Motivation
- Prevent negative horizon values and ground disappearance when the camera pitch exceeds about 89 degrees in Mercator mode.
- This surfaced in downstream testing in a web game that uses MapLibre for a near-ground missile-tracking camera, where high pitch angles caused the ground to disappear.

### Description
- Clamp the pitch to `maxMercatorHorizonAngle` inside `getMercatorHorizon()` in `src/geo/projection/mercator_utils.ts` before computing tangents.
- Update `src/geo/projection/mercator_utils.test.ts` so 90 degree and 95 degree pitch cases expect a horizon of `0`.
- No public API or style-spec changes are included.

### Testing
- `npm run test-unit -- src/geo/projection/mercator_utils.test.ts`
- Downstream manual validation in the web game: high-pitch ground view no longer loses the ground plane once the fix is applied.

### Notes
- This is a small Mercator projection bug fix, so I am opening it directly as a PR rather than starting with a separate issue.