### PR TITLE
fix: guard Style._load against removed map

### DIFF
--- a/src/style/style.ts
+++ b/src/style/style.ts
@@ -458,6 +458,12 @@ export class Style extends Evented {
     }
 
     _load(json: StyleSpecification, options: StyleSwapOptions & StyleSetterOptions, previousStyle?: StyleSpecification) {
+        // Bail out if the map was removed while the async style load was in flight.
+        // This happens in React StrictMode which double-invokes effects: the first
+        // map is created and immediately removed, but its style fetch resolves after
+        // removal and accesses destroyed state (this.map.style.projection, etc.).
+        if (this.map._removed) return;
+
         let nextState = options.transformStyle ? options.transformStyle(previousStyle, json) : json;
         if (options.validate && emitValidationErrors(this, validateStyle(nextState))) {
             return;


### PR DESCRIPTION
## Problem

When a `Map` is created and immediately removed via `map.remove()` before the async style load completes, the `_load` callback fires on the destroyed map and accesses nullified internal state:

```
TypeError: Cannot read properties of undefined (reading 'projection')
    at Style.migrateProjection
    at Style._setProjectionInternal
    at Style._load
```

This happens reliably in **React 18+ with StrictMode**, which double-invokes effects in development:

1. Effect mounts → `new Map({ style: "..." })` → async style fetch begins
2. Effect cleanup → `map.remove()` → internal state destroyed
3. Effect remounts → new Map created (works fine)
4. Step 1's async `_load` resolves → accesses `this.map.style.projection` → **TypeError**

## Fix

Add an early return in `Style._load` when `this.map._removed` is `true`. This matches the existing pattern used in `_render` (line 3604) and the `ResizeObserver` callback (line 3347).

## Reproduction

```tsx
import { useEffect, useRef } from "react";
import maplibregl from "maplibre-gl";

function MapComponent() {
  const ref = useRef<HTMLDivElement>(null);
  useEffect(() => {
    const map = new maplibregl.Map({
      container: ref.current!,
      style: "https://demotiles.maplibre.org/style.json",
      center: [0, 0],
      zoom: 2,
    });
    return () => map.remove();
  }, []);
  return <div ref={ref} style={{ width: "100%", height: 400 }} />;
}

// StrictMode triggers mount → cleanup → remount in dev:
<React.StrictMode><MapComponent /></React.StrictMode>
```

**Steps:** Run in dev mode → navigate to page with map → observe TypeError in console.

## Environment

- maplibre-gl: 5.21.1
- React 18/19 with StrictMode
- Tested in Next.js 16 (Turbopack) and reproducible with any React framework