### PR TITLE
fix: add exports field for modern bundler compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,15 @@
   "description": "BSD licensed community fork of mapbox-gl, a WebGL interactive maps library",
   "version": "5.22.0",
   "main": "dist/maplibre-gl.js",
+  "exports": {
+    ".": {
+      "import": "./dist/maplibre-gl-csp.js",
+      "require": "./dist/maplibre-gl.js",
+      "default": "./dist/maplibre-gl.js"
+    },
+    "./dist/*": "./dist/*",
+    "./package.json": "./package.json"
+  },
   "style": "dist/maplibre-gl.css",
   "license": "BSD-3-Clause",
   "homepage": "https://maplibre.org/",


### PR DESCRIPTION
## Problem

Modern bundlers like Turbopack (Next.js) process the UMD dist (`dist/maplibre-gl.js`) by re-scoping its internal AMD module factories into a single chunk. The dist uses a custom `define()` loader with 3 internal modules (`shared`, `worker`, `index`), and Terser mangles variable names independently within each module scope. When a bundler flattens these scopes, minified names can collide — e.g., `function C()` (mat2.create in `shared`) vs `var C = ...` (isTileVisible in `index`). The `var` hoists and overwrites the function, causing `TypeError: C is not a function` at runtime.

This surfaced in v5.22.0 because the TypeScript 6 upgrade and new features changed the variable count/order, shifting Terser's name assignments into a collision. But the underlying issue — no `exports` field to direct modern bundlers away from the UMD — exists in all versions.

## Fix

Add an `exports` field to `package.json` that maps `import` to the CSP build (`dist/maplibre-gl-csp.js`), which uses a flat module structure without the custom AMD loader. Modern bundlers (Turbopack, Vite, esbuild) resolve via `import` and get the flat build. Node/legacy bundlers resolve via `require` and get the existing UMD.

\`\`\`json
"exports": {
  ".": {
    "import": "./dist/maplibre-gl-csp.js",
    "require": "./dist/maplibre-gl.js",
    "default": "./dist/maplibre-gl.js"
  },
  "./dist/*": "./dist/*",
  "./package.json": "./package.json"
}
\`\`\`

## Impact

- Fixes \`TypeError: C is not a function\` in Next.js 16 (Turbopack) with maplibre-gl 5.22.0
- Zero breaking changes — \`require()\` consumers unaffected
- Consumers using \`import\` get the CSP build, which requires calling \`setWorkerUrl()\` to point to the CSP worker file — this is already standard practice for CSP environments

## Workaround

Until this ships, consumers can add a resolve alias:

\`\`\`js
// next.config.ts (Turbopack)
turbopack: {
  resolveAlias: {
    "maplibre-gl": "maplibre-gl/dist/maplibre-gl-csp.js",
  }
}
\`\`\`