### PR TITLE
fix: guard against null style in _contextRestored

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### 🐞 Bug fixes
 - Fix polygon text label placement drifting far from center for convex polygons at high zoom due to coordinate rounding in geojson-vt ([#7380](https://github.com/maplibre/maplibre-gl-js/pull/7380)) (by [@CommanderStorm](https://github.com/CommanderStorm))
 - Ensure that a successful ArrayBuffer response from a custom protocol that is null/undefined is set to an empty ArrayBuffer ([#7427](https://github.com/maplibre/maplibre-gl-js/pull/7427)) (by [@neodescis](https://github.com/neodescis))
+- Fix error in `_contextRestored` when map was initialized without a style ([#7432](https://github.com/maplibre/maplibre-gl-js/issues/7432))
 - _...Add new stuff here..._
 
 ## 5.22.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 ### 🐞 Bug fixes
 - Fix polygon text label placement drifting far from center for convex polygons at high zoom due to coordinate rounding in geojson-vt ([#7380](https://github.com/maplibre/maplibre-gl-js/pull/7380)) (by [@CommanderStorm](https://github.com/CommanderStorm))
 - Ensure that a successful ArrayBuffer response from a custom protocol that is null/undefined is set to an empty ArrayBuffer ([#7427](https://github.com/maplibre/maplibre-gl-js/pull/7427)) (by [@neodescis](https://github.com/neodescis))
-- Fix error in `_contextRestored` when map was initialized without a style ([#7432](https://github.com/maplibre/maplibre-gl-js/issues/7432))
+- Fix error in `_contextRestored` when map was initialized without a style ([#7432](https://github.com/maplibre/maplibre-gl-js/issues/7432)) (by [@mvanhorn](https://github.com/mvanhorn))
 - Fix issue with the cache used for zoomLevelsToOverscale feature ([#7450](https://github.com/maplibre/maplibre-gl-js/issues/7450)) (by [@HarelM](https://github.com/HarelM))
 - _...Add new stuff here..._
 

--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -3532,7 +3532,7 @@ export class Map extends Camera {
             this.setStyle(this._lostContextStyle.style, {diff: false});
         }
 
-        if (this._lostContextStyle.images) {
+        if (this._lostContextStyle.images && this.style) {
             this.style.imageManager.images = this._lostContextStyle.images;
         }
 

--- a/src/ui/map_tests/map_webgl.test.ts
+++ b/src/ui/map_tests/map_webgl.test.ts
@@ -41,6 +41,22 @@ test('handles "webglcontextlost" when map is created without style', () => {
     map.remove();
 });
 
+test('handles "webglcontextrestored" when map is created without style', async () => {
+    // This test verifies fix for #7432 - map should not throw when WebGL context
+    // is restored but this.style is null (map initialized without style)
+    const map = createMap({deleteStyle: true});
+    const canvas = map.getCanvas();
+
+    const contextLostPromise = map.once('webglcontextlost');
+    canvas.dispatchEvent(new window.Event('webglcontextlost'));
+    await contextLostPromise;
+
+    expect(() => {
+        canvas.dispatchEvent(new window.Event('webglcontextrestored'));
+    }).not.toThrow();
+    map.remove();
+});
+
 test('does not fire "webglcontextrestored" after remove has been called', async () => {
     const map = createMap();
     const canvas = map.getCanvas();

--- a/src/ui/map_tests/map_webgl.test.ts
+++ b/src/ui/map_tests/map_webgl.test.ts
@@ -42,8 +42,6 @@ test('handles "webglcontextlost" when map is created without style', () => {
 });
 
 test('handles "webglcontextrestored" when map is created without style', async () => {
-    // This test verifies fix for #7432 - map should not throw when WebGL context
-    // is restored but this.style is null (map initialized without style)
     const map = createMap({deleteStyle: true});
     const canvas = map.getCanvas();
 


### PR DESCRIPTION
## Launch Checklist

- [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license)
- [x] Briefly describe the changes in this PR.
- [x] Link to related issues.
- [x] Write tests for all new functionality.
- [x] Add an entry to `CHANGELOG.md` under the `## main` section.

## Description

When a map is initialized without a style (which is valid per the TypeScript typings), `_contextLost` sets `this.style = null`. On context restore, `_contextRestored` skips the `setStyle` call (since `_lostContextStyle.style` is null) but still tries to access `this.style.imageManager.images`, which throws.

The fix adds a null check on `this.style` before restoring cached images. If there's no style, there are no images to restore.

### Test

Added a test that creates a map without a style, triggers context loss then context restore, and verifies no error is thrown.

Fixes #7432