### PR TITLE
fix(geojson): skip clearLoaded on dataDiff updates

### DIFF
--- a/src/source/geojson_worker_source.test.ts
+++ b/src/source/geojson_worker_source.test.ts
@@ -502,10 +502,6 @@ describe('loadData', () => {
         await expect(worker.loadData({source: 'source1', dataDiff: {removeAll: true}, geojsonVtOptions: {}} as LoadGeoJSONParameters)).resolves.toBeDefined();
     });
 
-    // Regression test for issue #7443:
-    // loadData with dataDiff must NOT clear loaded tiles, so that tiles evicted
-    // mid-update (e.g. during a pan) can be re-parsed against the updated index
-    // when reloadTile is called. Clearing on full data reset is still required.
     test('loadData with dataDiff preserves loaded tile state; loadData with data clears it', async () => {
         const worker = new GeoJSONWorkerSource(actor, layerIndex, []);
         const fakeLoadedTile = {status: 'done'} as any as WorkerTile;

--- a/src/source/geojson_worker_source.test.ts
+++ b/src/source/geojson_worker_source.test.ts
@@ -502,6 +502,30 @@ describe('loadData', () => {
         await expect(worker.loadData({source: 'source1', dataDiff: {removeAll: true}, geojsonVtOptions: {}} as LoadGeoJSONParameters)).resolves.toBeDefined();
     });
 
+    // Regression test for issue #7443:
+    // loadData with dataDiff must NOT clear loaded tiles, so that tiles evicted
+    // mid-update (e.g. during a pan) can be re-parsed against the updated index
+    // when reloadTile is called. Clearing on full data reset is still required.
+    test('loadData with dataDiff preserves loaded tile state; loadData with data clears it', async () => {
+        const worker = new GeoJSONWorkerSource(actor, layerIndex, []);
+        const fakeLoadedTile = {status: 'done'} as any as WorkerTile;
+
+        // Initial full load.
+        await worker.loadData({source: 'source1', data: updateableGeoJson, geojsonVtOptions: {}} as LoadGeoJSONParameters);
+
+        // Simulate a tile that was loaded and cached.
+        worker.tileState.loaded = {'42': fakeLoadedTile};
+
+        // A dataDiff update must NOT clear the loaded tile cache (fix for #7443).
+        await worker.loadData({source: 'source1', dataDiff: {add: []}, geojsonVtOptions: {}} as LoadGeoJSONParameters);
+        expect(worker.tileState.loaded).toHaveProperty('42');
+
+        // A full data update (params.data) MUST clear the loaded tile cache.
+        worker.tileState.loaded = {'42': fakeLoadedTile};
+        await worker.loadData({source: 'source1', data: updateableGeoJson, geojsonVtOptions: {}} as LoadGeoJSONParameters);
+        expect(worker.tileState.loaded).not.toHaveProperty('42');
+    });
+
     test('loadData with geojson network call creates an updateable source', async () => {
         const worker = new GeoJSONWorkerSource(actor, layerIndex, []);
 

--- a/src/source/geojson_worker_source.ts
+++ b/src/source/geojson_worker_source.ts
@@ -193,7 +193,16 @@ export class GeoJSONWorkerSource implements WorkerSource {
         try {
             await this.loadAndProcessGeoJSON(params, this._pendingRequest);
             delete this._pendingRequest;
-            this.tileState.clearLoaded();
+            // For a full data reset (`data` or `request`), all cached tiles are stale — clear them
+            // so reloadTile triggers fresh loads against the new index.
+            // For a diff update (`dataDiff`), the index is patched in-place: cached tiles that
+            // were in-flight or evicted mid-update must remain in tileState so that reloadTile
+            // can re-parse them from the updated index when the main thread requests them.
+            // Clearing all tiles on a diff causes features added near the viewport boundary to
+            // silently disappear from evicted tiles (regression since 5.19 — issue #7443).
+            if (!params.dataDiff) {
+                this.tileState.clearLoaded();
+            }
 
             // Sending a large GeoJSON payload from the worker to the main thread is slow so only do if necessary.
             // Send data only if it was loaded from a URL, otherwise the main thread already has a copy of this data.

--- a/src/source/geojson_worker_source.ts
+++ b/src/source/geojson_worker_source.ts
@@ -193,13 +193,8 @@ export class GeoJSONWorkerSource implements WorkerSource {
         try {
             await this.loadAndProcessGeoJSON(params, this._pendingRequest);
             delete this._pendingRequest;
-            // For a full data reset (`data` or `request`), all cached tiles are stale — clear them
-            // so reloadTile triggers fresh loads against the new index.
-            // For a diff update (`dataDiff`), the index is patched in-place: cached tiles that
-            // were in-flight or evicted mid-update must remain in tileState so that reloadTile
-            // can re-parse them from the updated index when the main thread requests them.
-            // Clearing all tiles on a diff causes features added near the viewport boundary to
-            // silently disappear from evicted tiles (regression since 5.19 — issue #7443).
+            // Skip clearLoaded on diff updates: the index is patched in-place and cached tiles
+            // must remain available so reloadTile can re-parse them against the updated index.
             if (!params.dataDiff) {
                 this.tileState.clearLoaded();
             }


### PR DESCRIPTION
## Summary

`loadData()` called `this.tileState.clearLoaded()` unconditionally after every update, including incremental diff updates (`dataDiff`). For diff updates the GeoJSON index is patched in-place — clearing all cached tiles meant that tiles evicted mid-update (e.g. during a pan) never re-entered `tileState.loaded`, so `reloadTile` fell through to `loadTile` and the main thread received no prompt to re-request them. Features added near the viewport boundary silently disappeared.

Fixes maplibre/geojson-vt#97

## Fix

Wrapped `clearLoaded()` in `if (!params.dataDiff)` — only full data resets (`params.data` or `params.request`) should clear the tile cache. For diff updates, cached tiles remain valid entries for `reloadTile` to find and re-parse against the updated index.

```typescript
// Only clear on full data reset, not on incremental diff (issue maplibre/geojson-vt#97)
if (!params.dataDiff) {
    this.tileState.clearLoaded();
}
```

## Existing behavior audit (OPS-RULE-016)

- `geojson_worker_source.ts:196` — `this.tileState.clearLoaded()` called unconditionally after every `loadAndProcessGeoJSON` call, regardless of whether `params.dataDiff` was used
- `worker_tile_state.ts:59` — `clearLoaded()` replaces `this.loaded` with an empty object
- `geojson_worker_source.ts:235` — `reloadTile()` falls through to `loadTile()` when tile is not found in `loaded`; `loadTile` is only triggered by an explicit main-thread tile request
- `geojson_source.ts:470` — main thread correctly computes `affectedBounds` for diff updates and fires `shouldReloadTileOptions` events; these events are not sent for tiles that have scrolled off-screen

## Scope classification (OPS-RULE-017)

**(a) Bug fix** — regression since 5.19.0; `updateData({add: [...]})` near viewport boundary causes silent feature loss.

## Prior art consulted (OPS-RULE-018)

1. Issue [#7443](https://github.com/maplibre/geojson-vt/issues/97) — bug report with regression window 5.19.0 → 5.22.0 and steps to reproduce
2. `geojson_source_diff.ts` — diff machinery: `updateData` / `add` / `remove` — index is updated in-place via `_geoJSONIndex.updateData()`
3. `geojson_worker_source.test.ts` existing tests — `clearLoaded` behavior was implicitly tested; the new regression test explicitly covers the diff-vs-full-reset distinction

## Test evidence

Added regression test in `geojson_worker_source.test.ts`:
- Asserts that after a `dataDiff` loadData call, a previously loaded tile **remains** in `tileState.loaded`
- Asserts that after a full `data` loadData call, the tile **is cleared**

Note: local test execution requires Node ≥ 20. Tests were verified to be structurally correct against the existing test suite patterns.

*AI-assisted — authored with Claude, reviewed by Komada.*