### PR TITLE
Improve ability to import scripts in workers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ### ✨ Features and improvements
 - _...Add new stuff here..._
 - Add `touchZoomRotate.setZoomRate()` and `touchZoomRotate.setZoomThreshold()` to customize touch zoom speed and pinch sensitivity ([#7271](https://github.com/maplibre/maplibre-gl-js/issues/7271))
+- Improve ability to communicate with imported scripts in workers and use `makeRequest` in workres as well ([#7451](https://github.com/maplibre/maplibre-gl-js/issues/7451)) (by [@HarelM](https://github.com/HarelM))
 
 ### 🐞 Bug fixes
 - Fix polygon text label placement drifting far from center for convex polygons at high zoom due to coordinate rounding in geojson-vt ([#7380](https://github.com/maplibre/maplibre-gl-js/pull/7380)) (by [@CommanderStorm](https://github.com/CommanderStorm))

--- a/src/index.ts
+++ b/src/index.ts
@@ -384,5 +384,6 @@ export {
     setNow,
     restoreNow,
     isTimeFrozen,
+    getGlobalDispatcher,
     EXTENT
 };

--- a/src/source/worker.ts
+++ b/src/source/worker.ts
@@ -6,6 +6,8 @@ import {rtlWorkerPlugin, type RTLTextPlugin} from './rtl_text_plugin_worker';
 import {GeoJSONWorkerSource, type LoadGeoJSONParameters} from './geojson_worker_source';
 import {isWorker} from '../util/util';
 import {addProtocol, removeProtocol} from './protocol_crud';
+import {makeRequest} from '../util/ajax';
+
 import {type PluginState} from './rtl_text_plugin_status';
 import type {
     WorkerSource,
@@ -14,7 +16,6 @@ import type {
     WorkerDEMTileParameters,
     TileParameters
 } from '../source/worker_source';
-
 import type {WorkerGlobalScopeInterface} from '../util/web_worker';
 import type {LayerSpecification} from '@maplibre/maplibre-gl-style-spec';
 import {
@@ -86,9 +87,10 @@ export default class Worker {
 
         // This is invoked by the RTL text plugin when the download via the `importScripts` call has finished, and the code has been parsed.
         this.self.registerRTLTextPlugin = (rtlTextPlugin: RTLTextPlugin) => {
-
             rtlWorkerPlugin.setMethods(rtlTextPlugin);
         };
+
+        this.self.makeRequest = makeRequest;
 
         this.actor.registerMessageHandler(MessageType.loadDEMTile, (mapId: string, params: WorkerDEMTileParameters) => {
             return this._getDEMWorkerSource(mapId, params.source).loadTile(params);

--- a/src/util/dispatcher.ts
+++ b/src/util/dispatcher.ts
@@ -74,10 +74,10 @@ export class Dispatcher {
 let globalDispatcher: Dispatcher;
 
 /**
- * This method is used to get the global dispatcher that is shared across all maps instances.
+ * This function is used to get the global dispatcher that is shared across all maps instances.
  * It is used by the main thread to send messages to the workers, and by the workers to send messages back to the main thread.
  * If you import a script into the worker and need to send a message to the workers to pass some parameters for example, 
- * you can use this method to get the global dispatcher and send a message to the workers.
+ * you can use this function to get the global dispatcher and send a message to the workers.
  * @returns The global dispatcher instance.
  */
 export function getGlobalDispatcher(): Dispatcher {

--- a/src/util/dispatcher.ts
+++ b/src/util/dispatcher.ts
@@ -73,6 +73,13 @@ export class Dispatcher {
 
 let globalDispatcher: Dispatcher;
 
+/**
+ * This method is used to get the global dispatcher that is shared across all maps instances.
+ * It is used by the main thread to send messages to the workers, and by the workers to send messages back to the main thread.
+ * If you import a script into the worker and need to send a message to the workers to pass some parameters for example, 
+ * you can use this method to get the global dispatcher and send a message to the workers.
+ * @returns The global dispatcher instance.
+ */
 export function getGlobalDispatcher(): Dispatcher {
     if (!globalDispatcher) {
         globalDispatcher = new Dispatcher(getGlobalWorkerPool(), GLOBAL_DISPATCHER_ID);

--- a/src/util/web_worker.ts
+++ b/src/util/web_worker.ts
@@ -1,6 +1,7 @@
 import {type AddProtocolAction, config} from './config';
 import type {default as MaplibreWorker} from '../source/worker';
 import type {WorkerSourceConstructor} from '../source/worker_source';
+import type {GetResourceResponse, RequestParameters} from './ajax';
 
 export interface WorkerGlobalScopeInterface {
     importScripts(...urls: string[]): void;
@@ -8,6 +9,7 @@ export interface WorkerGlobalScopeInterface {
     registerRTLTextPlugin: (_: any) => void;
     addProtocol: (customProtocol: string, loadFn: AddProtocolAction) => void;
     removeProtocol: (customProtocol: string) => void;
+    makeRequest: (request: RequestParameters, abortController: AbortController) => Promise<GetResourceResponse<any>>;
     worker: MaplibreWorker;
 }
 

--- a/test/unit/lib/web_worker_mock.ts
+++ b/test/unit/lib/web_worker_mock.ts
@@ -11,6 +11,7 @@ export class MessageBus implements WorkerGlobalScopeInterface, ActorTarget {
     registerRTLTextPlugin: any;
     addProtocol: any;
     removeProtocol: any;
+    makeRequest: any;
     worker: any;
 
     constructor(addListeners: EventListener[], postListeners: EventListener[]) {


### PR DESCRIPTION
## Launch Checklist

I wanted to improve the situation with maplibre-contours since I needed it to be able to support other protocols.
In order to do that I decided to try and use the `importScriptInWorkers` API.
I was able to achieve what I wanted but found out there are two missing things that will improve ergonomics:
1. Add ability to send message to the workers. This is important since loading the script is only allowing "hardcoded" initialization, but if there are parameters that need to be passed to the worker there's no easy way to do it. global dispacher is the way to do it, this is how it's done with RTL plugin and in general the way to communicate with the workers.
2. Add `makeRequest` available in the worker. When you use `addProtocol` in one plugin but need to use this in anther plugin the `makeRequest` is the way to activate this. So this is also needed in the worker context.

Here's my process around this issue:
- https://github.com/IsraelHikingMap/Site/issues/2454

I did think about implementing the contour source in maplibre, but decided to avoid this at this point in time. 

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [ ] ~Write tests for all new functionality.~ only public APIs updated.
 - [x] Document any changes to public APIs.
 - [x] Add an entry to `CHANGELOG.md` under the `## main` section.
