### PR TITLE
Remove tilesize from Mapterhorn examples

### DIFF
--- a/test/examples/3d-terrain.html
+++ b/test/examples/3d-terrain.html
@@ -34,13 +34,11 @@
                 // Use a different source for terrain and hillshade layers, to improve render quality
                 terrainSource: {
                     type: 'raster-dem',
-                    url: 'https://tiles.mapterhorn.com/tilejson.json',
-                    tileSize: 256
+                    url: 'https://tiles.mapterhorn.com/tilejson.json'
                 },
                 hillshadeSource: {
                     type: 'raster-dem',
-                    url: 'https://tiles.mapterhorn.com/tilejson.json',
-                    tileSize: 256
+                    url: 'https://tiles.mapterhorn.com/tilejson.json'
                 }
             },
             layers: [

--- a/test/examples/adding-3d-models-using-threejs-on-terrain.html
+++ b/test/examples/adding-3d-models-using-threejs-on-terrain.html
@@ -77,13 +77,11 @@
                     sources: {
                         terrainSource: {
                             type: 'raster-dem',
-                            url: 'https://tiles.mapterhorn.com/tilejson.json',
-                            tileSize: 256
+                            url: 'https://tiles.mapterhorn.com/tilejson.json'
                         },
                         hillshadeSource: {
                             type: 'raster-dem',
-                            url: 'https://tiles.mapterhorn.com/tilejson.json',
-                            tileSize: 256
+                            url: 'https://tiles.mapterhorn.com/tilejson.json'
                         }
                     },
                 }

--- a/test/examples/create-a-heatmap-layer-on-a-globe-with-terrain-elevation.html
+++ b/test/examples/create-a-heatmap-layer-on-a-globe-with-terrain-elevation.html
@@ -44,13 +44,11 @@
                 nextStyle.sources = {
                     ...nextStyle.sources, terrainSource: {
                         type: 'raster-dem',
-                        url: 'https://tiles.mapterhorn.com/tilejson.json',
-                        tileSize: 256
+                        url: 'https://tiles.mapterhorn.com/tilejson.json'
                     },
                     hillshadeSource: {
                         type: 'raster-dem',
-                        url: 'https://tiles.mapterhorn.com/tilejson.json',
-                        tileSize: 256
+                        url: 'https://tiles.mapterhorn.com/tilejson.json'
                     }
                 }
                 nextStyle.terrain = {

--- a/test/examples/display-a-hybrid-satellite-map-with-terrain-elevation.html
+++ b/test/examples/display-a-hybrid-satellite-map-with-terrain-elevation.html
@@ -37,13 +37,11 @@
                     },
                     terrainSource: {
                         type: 'raster-dem',
-                        url: 'https://tiles.mapterhorn.com/tilejson.json',
-                        tileSize: 256
+                        url: 'https://tiles.mapterhorn.com/tilejson.json'
                     },
                     hillshadeSource: {
                         type: 'raster-dem',
-                        url: 'https://tiles.mapterhorn.com/tilejson.json',
-                        tileSize: 256
+                        url: 'https://tiles.mapterhorn.com/tilejson.json'
                     }
                 }
                 nextStyle.terrain = {

--- a/test/examples/sky-fog-terrain.html
+++ b/test/examples/sky-fog-terrain.html
@@ -68,13 +68,11 @@
                 // Use a different source for terrain and hillshade layers, to improve render quality
                 terrainSource: {
                     type: 'raster-dem',
-                    url: 'https://tiles.mapterhorn.com/tilejson.json',
-                    tileSize: 256
+                    url: 'https://tiles.mapterhorn.com/tilejson.json'
                 },
                 hillshadeSource: {
                     type: 'raster-dem',
-                    url: 'https://tiles.mapterhorn.com/tilejson.json',
-                    tileSize: 256
+                    url: 'https://tiles.mapterhorn.com/tilejson.json'
                 }
             },
             layers: [


### PR DESCRIPTION
## Launch Checklist

The tiles are 512 pixels wide, see tilejson.json.


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [ ] Briefly describe the changes in this PR.
 - [ ] Link to related issues.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [ ] Add an entry to `CHANGELOG.md` under the `## main` section.
