### PR TITLE
test(terrain): make the terrain bench show a diff when using symbols

### DIFF
--- a/test/bench/benchmarks/terrain_render.ts
+++ b/test/bench/benchmarks/terrain_render.ts
@@ -14,34 +14,30 @@ export default class TerrainRender extends Benchmark {
                 height: 768,
                 center: [10.5, 46.9],
                 pitch: 60,
-                style: {
-                    version: 8,
-                    sources: {
-                        'terrain-rgb': {
-                            'type': 'raster-dem',
-                            'url': 'https://tiles.mapterhorn.com/tilejson.json'
-                        }
-                    },
-                    terrain: {
-                        source: 'terrain-rgb',
-                        exaggeration: 1
-                    },
-                    layers: [
-                        {
-                            'id': 'background',
-                            'type': 'background',
-                            'paint': {'background-color': '#f8f4f0'}
-                        }
-                    ]
-                },
+                style: 'https://tiles.openfreemap.org/styles/liberty',
                 idle: true
             });
+
+            this.map.addSource('terrain-dem', {
+                type: 'raster-dem',
+                url: 'https://tiles.mapterhorn.com/tilejson.json'
+            });
+            this.map.setTerrain({source: 'terrain-dem', exaggeration: 1.5});
+
+            // Wait for DEM tiles to load
+            await this.map.once('idle');
         } catch (error) {
             console.error(error);
         }
     }
 
+    _bearing: number = 0;
+
     bench() {
+        // Rotate the camera slightly each frame to force depth pre-pass to re-run
+        // and symbol layers to recalculate visibility against terrain depth
+        this._bearing = (this._bearing + 0.5) % 360;
+        this.map.setBearing(this._bearing);
         Benchmark.renderMap(this.map);
     }
 


### PR DESCRIPTION
currently quite naive from a bench perspective..
When I actually bearingspin this map, the symbols should change -> excercises this code path, not just the path that does not have movement.

We have a few fast-paths for "no-movements", so less of a good bench