### PR TITLE
docs: Improve documentation for MapOptions hash parameter

### DIFF
--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -79,10 +79,11 @@ export type WebGLContextAttributesWithType = WebGLContextAttributes & {contextTy
 export type MapOptions = {
     /**
      * If `true`, the map's position (zoom, center latitude, center longitude, bearing, and pitch) will be synced with the hash fragment of the page's URL.
-     * For example, `http://path/to/my/page.html#2.59/39.26/53.07/-24.1/60`.
-     * An additional string may optionally be provided to indicate a parameter-styled hash,
-     * e.g. http://path/to/my/page.html#map=2.59/39.26/53.07/-24.1/60&foo=bar, where foo
-     * is a custom parameter and bar is an arbitrary hash distinct from the map hash.
+     * For example, `https://example.com#2.59/39.26/53.07/-24.1/60`.
+     * 
+     * An additional string may optionally be provided as an alternative to indicate a parameter-styled hash.
+     * For example, passing `hash: "foo"` can be used to `https://example.com#foo=2.59/39.26/53.07/-24.1/60`.
+     * This is usefull for allowing multiple maps or other state.
      * @defaultValue false
      */
     hash?: boolean | string;

--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -82,7 +82,7 @@ export type MapOptions = {
      * For example, `https://example.com#2.59/39.26/53.07/-24.1/60`.
      * 
      * An additional string may optionally be provided as an alternative to indicate a parameter-styled hash.
-     * For example, passing `hash: "foo"` can be used to `https://example.com#foo=2.59/39.26/53.07/-24.1/60`.
+     * For example, passing `hash: "foo"` will produce a hash like `https://example.com#foo=2.59/39.26/53.07/-24.1/60`.
      * This is usefull for allowing multiple maps or other state.
      * @defaultValue false
      */


### PR DESCRIPTION
I think we explain this in a fairly convoluted way