### PR TITLE
Update PR template to include AI policy confirmation

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,6 +4,7 @@
 
 
  - [ ] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
+ - [ ] Confirm you have read our AI policy [here](https://github.com/maplibre/maplibre/blob/main/AI_POLICY.md).
  - [ ] Briefly describe the changes in this PR.
  - [ ] Link to related issues.
  - [ ] Include before/after visuals or gifs if this PR includes visual changes.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,3 +12,7 @@
  - [ ] Document any changes to public APIs.
  - [ ] Post benchmark scores.
  - [ ] Add an entry to `CHANGELOG.md` under the `## main` section.
+ - [ ] Confirm you have read our AI policy [here](https://github.com/maplibre/maplibre/blob/main/AI_POLICY.md).
+<!--
+  Add one of:    Assisted-By: | Generated-By:     and the model/version
+-->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,6 @@
 
 
  - [ ] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
- - [ ] Confirm you have read our AI policy [here](https://github.com/maplibre/maplibre/blob/main/AI_POLICY.md).
  - [ ] Briefly describe the changes in this PR.
  - [ ] Link to related issues.
  - [ ] Include before/after visuals or gifs if this PR includes visual changes.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 ## Launch Checklist
 
-<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->
+<!-- Thanks for the PR! Feel free to add or remove items that are not relevant. -->
 
 
  - [ ] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!


### PR DESCRIPTION
Added confirmation checkbox for AI policy acknowledgment.

AI policy update is handled here:
- https://github.com/maplibre/maplibre/pull/494

## Launch Checklist

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.