### PR TITLE
Additional links and reference to revised AI Policy

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -8,7 +8,7 @@ about: Report a bug
 Hello! Thanks for contributing.  For the fastest response and resolution, please:
 
  - Make the issue title a succinct but specific description of the unexpected behavior.
-   Bad: "Map rotation is broken". 
+   Bad: "Map rotation is broken".
    Good: "map.setBearing(...) throws a TypeError for negative values"
 
  - Include a link to a minimal demonstration of the bug – more below …
@@ -16,6 +16,9 @@ Hello! Thanks for contributing.  For the fastest response and resolution, please
  - Ensure you can reproduce the bug using the latest release.
 
  - Check the console for relevant errors and warnings
+
+- If an AI tool helped you write or research this report, note it briefly.
+This helps maintainers ask better follow-up questions.
 
  - Only post to report a bug. For feature requests, please use https://github.com/maplibre/maplibre-gl-js/issues/new?template=Feature_request.md instead.  Direct all other questions to https://stackoverflow.com/questions/tagged/maplibre-gl-js
 
@@ -34,11 +37,11 @@ Hello! Thanks for contributing.  For the fastest response and resolution, please
 ### Link to Demonstration
 
 <!--
-Providing a minimal, complete, verifiable demonstration *dramatically* improves maintainers' and other community members' ability to understand and address the problem you're reporting. 
+Providing a minimal, complete, verifiable demonstration *dramatically* improves maintainers' and other community members' ability to understand and address the problem you're reporting.
 
 We recommend using https://jsbin.com.
 
-Consider using the non-minified version for this demo to create better error messages. 
+Consider using the non-minified version for this demo to create better error messages.
 E.g. `<script src='https://unpkg.com/maplibre-gl@1.15.2/dist/maplibre-gl-dev.js'></script><link href='https://unpkg.com/maplibre-gl@1.15.2/dist/maplibre-gl.css' rel='stylesheet' />`
 
 See https://stackoverflow.com/help/mcve for guidelines on creating an effective example.

--- a/.github/ISSUE_TEMPLATE/Feature_request.md
+++ b/.github/ISSUE_TEMPLATE/Feature_request.md
@@ -27,3 +27,10 @@ See also: https://en.wikipedia.org/wiki/User_story#Common_templates
 <!--
  - What if we do nothing? What is the impact to end-users if we don't implement this feature?
 -->
+
+## AI Assistance
+
+<!--
+If an AI tool helped you draft this request, note it briefly. This helps maintainers understand which parts to probe further and ask better follow-up questions.
+-->
+```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,15 @@ Some best practices for PRs for bugfixes are as follows:
 
 This is not intended to be a strict process but rather a guideline that will build confidence that your PR is addressing the problem.
 
+## AI-Assisted Contributions
+
+MapLibre welcomes contributors who use AI coding tools, but we must be vigilant to not incorporate copyrighted materials. You are responsible for everything you submit. Maintainers will not merge code that the author cannot explain or defend in review, regardless of how it was produced, and will need to close your PR or issue if you are not able to meet this bar.
+
+The full policy is at
+[maplibre/maplibre/AI_POLICY.md](https://github.com/maplibre/maplibre/blob/main/AI_POLICY.md). Please review this policy before submitting a PR or bug report.
+
+**Disclosure:** Disclose significant AI assistance in your PR (the PR template has a checkbox).
+
 ## Preparing your Development Environment
 
 ### CodeSpaces


### PR DESCRIPTION
Adding a few additional references and links to give contributors a heads-up about the revised [AI Policy (https://github.com/maplibre/maplibre/blob/main/AI_POLICY.md).

- Summary and link to the full policy in CONTRIBUTING.md
- Request disclosure in bug reporting template
- Request disclosure in feature request template

Feedback welcome.