### PR TITLE
Add types to getLineWidth

### DIFF
--- a/src/style/style_layer/line_style_layer.ts
+++ b/src/style/style_layer/line_style_layer.ts
@@ -119,7 +119,7 @@ export class LineStyleLayer extends StyleLayer {
     }
 }
 
-function getLineWidth(lineWidth, lineGapWidth) {
+function getLineWidth(lineWidth: number, lineGapWidth: number): number {
     if (lineGapWidth > 0) {
         return lineGapWidth + 2 * lineWidth;
     } else {


### PR DESCRIPTION
## Summary

Add explicit parameter and return types to the internal getLineWidth helper.


## Launch Checklist
 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Confirm you have read our AI policy [here](https://github.com/maplibre/maplibre/blob/main/AI_POLICY.md).
