### PR TITLE
Remove some code from render tests

### DIFF
--- a/test/integration/assets/test-page.html
+++ b/test/integration/assets/test-page.html
@@ -4,6 +4,14 @@
     <title>MapLibre integration test page</title>
     <meta charset='utf-8'>
     <link rel='stylesheet' href='/dist/maplibre-gl.css' />
+    <style>
+        body { margin: 0; padding: 0; }
+        #map { 
+            box-sizing:content-box;
+            width:100vw;
+            height:100vh; 
+        }
+    </style>
 </head>
 <body>
 <div id="map"></div>

--- a/test/integration/browser/browser.test.ts
+++ b/test/integration/browser/browser.test.ts
@@ -57,9 +57,7 @@ describe('Browser tests', () => {
 
     afterAll(async () => {
         await browser.close();
-        if (server) {
-            server.close();
-        }
+        server?.close();
     }, 40000);
 
     test('Contextmenu event triggered during scrollzoom', {retry: 3, timeout: 20000}, async () => {

--- a/test/integration/render/run_render_tests.ts
+++ b/test/integration/render/run_render_tests.ts
@@ -257,24 +257,6 @@ async function getImageFromStyle(styleForTest: StyleWithTestData, page: Page): P
 
     await page.setViewport({width, height, deviceScaleFactor: 2});
 
-    await page.setContent(`
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <title>Query Test Page</title>
-    <meta charset='utf-8'>
-    <link rel="icon" href="about:blank">
-    <style>#map {
-        box-sizing:content-box;
-        width:${width}px;
-        height:${height}px;
-    }</style>
-</head>
-<body>
-    <div id='map'></div>
-</body>
-</html>`);
-
     const evaluatedArray = await page.evaluate(async (style: StyleWithTestData) => {
 
         const options = style.metadata.test;


### PR DESCRIPTION
## Launch Checklist

Small refactoring to remove a `setContent` from render test and an "if" from browser tests.
This is also to compare how much time it take without vitest.

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are 
 

