### PR TITLE
fix: increase hook-time for before all to prevent flaky tests.

### DIFF
--- a/test/integration/render/render.test.ts
+++ b/test/integration/render/render.test.ts
@@ -861,7 +861,7 @@ describe('Render tests', () => {
         workers = await startCoverage(page);
         await page.goto(`http://localhost:${serverPort}/test-page.html`, {waitUntil: 'load'});
         await page.waitForFunction(() => (window as any).maplibregl, {timeout: 10000});
-    });
+    }, 30000);
 
     afterAll(async () => {
         await stopCoverageAndReport(page, workers, 'render');


### PR DESCRIPTION
## Launch Checklist

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!

This is due to failing tests on windows machiane.