### PR TITLE
More instructive docs for the terrainSkirtLength MapOption

### DIFF
--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -397,12 +397,14 @@ export type MapOptions = {
     centerClampedToGround?: boolean;
     /**
      * Controls the length of the vertical extensions which are added to the edges of terrain tiles.
-     * It is recommended to set this to "none" only when using a transparent background along with an elevation terrain.
      *
-     * - `"none"` disables skirts entirely, eliminating vertical artifacts that occur on tile boundaries when a transparent background is used along with a terrain, but might introduce some horizontal hairline gaps (stitches).
-     * - `"auto"` renders skirts to eliminate horizontal hairline gaps (stitches) that might occur on tile boundaries with different zoomlevels for some terrain datasets, but introduces vertical artifacts if using a transparent background along with a terrain.
+     * If the skirts are introducing visually unappealing vertical artifacts, consider avoiding transparent or semi-transparent backgrounds,
+     * for example, by having the first layer be a background layer with a [`background-color`](https://maplibre.org/maplibre-style-spec/layers/#background-color).
+     * If that is impossible or insufficient, you can entirely disable skirts,
+     * at the cost of potentially introducing some horizontal hairline gaps (stitches) on tile boundaries with different zoomlevels for some terrain datasets.
      *
-     * Currently, this parameter is a tradeoff. Future rendering techniques may eliminate the need for it.
+     * - `"none"` disables skirts entirely.
+     * - `"auto"` renders skirts with an automatically chosen length.
      * @defaultValue "auto"
      */
     terrainSkirtLength?: 'none' | 'auto';


### PR DESCRIPTION
Current instructions can confuse the user regarding the best course of action. This clarifies things by being more instructive regarding skirt usage.

- Inspired by the discussion at #6920
- Followup for PR #7523
- Also relevant: #1602 #2967 #4991 

## Launch Checklist

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Confirm you have read our AI policy [here](https://github.com/maplibre/maplibre/blob/main/AI_POLICY.md).
