### PR TITLE
Fix unresolved link references in JSDoc comments

### DIFF
--- a/src/geo/lng_lat_bounds.ts
+++ b/src/geo/lng_lat_bounds.ts
@@ -3,8 +3,8 @@ import type {LngLatLike} from './lng_lat';
 import {wrap} from '../util/util';
 
 /**
- * A {@link LngLatBounds} object, an array of {@link LngLatLike} objects in [sw, ne] order,
- * or an array of numbers in [west, south, east, north] order.
+ * A {@link LngLatBounds} object, an array of {@link LngLatLike} objects in `[sw, ne]` order,
+ * or an array of numbers in `[west, south, east, north]` order.
  *
  * @group Geography and Geometry
  *
@@ -47,7 +47,7 @@ export class LngLatBounds {
     /**
      * @param sw - The southwest corner of the bounding box.
      * OR array of 4 numbers in the order of  west, south, east, north
-     * OR array of 2 LngLatLike: [sw,ne]
+     * OR array of 2 LngLatLike: `[sw, ne]`
      * @param ne - The northeast corner of the bounding box.
      * @example
      * ```ts

--- a/src/source/query_features.ts
+++ b/src/source/query_features.ts
@@ -33,7 +33,7 @@ export type QueryRenderedFeaturesOptions = {
      */
     availableImages?: string[];
     /**
-     * Whether to check if the [options.filter] conforms to the MapLibre Style Specification. Disabling validation is a performance optimization that should only be used if you have previously validated the values you will be passing to this function.
+     * Whether to check if the `options.filter` conforms to the MapLibre Style Specification. Disabling validation is a performance optimization that should only be used if you have previously validated the values you will be passing to this function.
      */
     validate?: boolean;
 };
@@ -61,7 +61,7 @@ export type QuerySourceFeatureOptions = {
      */
     filter?: FilterSpecification;
     /**
-     * Whether to check if the [parameters.filter] conforms to the MapLibre Style Specification. Disabling validation is a performance optimization that should only be used if you have previously validated the values you will be passing to this function.
+     * Whether to check if the `parameters.filter` conforms to the MapLibre Style Specification. Disabling validation is a performance optimization that should only be used if you have previously validated the values you will be passing to this function.
      * @defaultValue true
      */
     validate?: boolean;

--- a/src/ui/camera.ts
+++ b/src/ui/camera.ts
@@ -772,7 +772,7 @@ export abstract class Camera extends Evented {
      * @param bounds - Calculate the center for these bounds in the viewport and use
      * the highest zoom level up to and including {@link Map.getMaxZoom} that fits
      * in the viewport. LngLatBounds represent a box that is always axis-aligned with bearing 0.
-     * Bounds will be taken in [sw, ne] order. Southwest point will always be to the left of the northeast point.
+     * Bounds will be taken in `[sw, ne]` order. Southwest point will always be to the left of the northeast point.
      * @param options - Options object
      * @returns If map is able to fit to provided bounds, returns `center`, `zoom`, and `bearing`.
      * If map is unable to fit, method will warn and return undefined.
@@ -855,7 +855,7 @@ export abstract class Camera extends Evented {
      *
      * @param bounds - Center these bounds in the viewport and use the highest
      * zoom level up to and including {@link Map.getMaxZoom} that fits them in the viewport.
-     * Bounds will be taken in [sw, ne] order. Southwest point will always be to the left of the northeast point.
+     * Bounds will be taken in `[sw, ne]` order. Southwest point will always be to the left of the northeast point.
      * @param options - Options supports all properties from {@link AnimationOptions} and {@link CameraOptions} in addition to the fields below.
      * @param eventData - Additional properties to be added to event objects of events triggered by this method.
      * @example
@@ -1669,7 +1669,7 @@ export abstract class Camera extends Evented {
      * Returns null if terrain is not enabled.
      * If terrain is enabled with some exaggeration value, the value returned here will be reflective of (multiplied by) that exaggeration value.
      * This method should be used for proper positioning of custom 3d objects, as explained [here](https://maplibre.org/maplibre-gl-js/docs/examples/adding-3d-models-using-threejs-on-terrain/)
-     * @param lngLatLike - [x,y] or LngLat coordinates of the location
+     * @param lngLatLike - `[x, y]` or LngLat coordinates of the location
      * @returns elevation in meters
      */
     queryTerrainElevation(lngLatLike: LngLatLike): number | null {


### PR DESCRIPTION
The ["Code Hygiene" build started failing recently](https://github.com/maplibre/maplibre-gl-js/actions/runs/25186515179/job/73845123765?pr=7549) because [zensical's `:latest` Docker tag was updated to `v0.0.38` which finally supports the `--strict` flag](https://github.com/zensical/zensical/releases/tag/v0.0.38). The previous image version logged `Warning: Strict mode is currently unsupported.` and exited 0, which is why this never tripped CI before. Eight JSDoc strings use bracket notation like `[sw, ne]`, `[x, y]`, `[west, south, east, north]`, `[options.filter]`, and `[parameters.filter]` as prose. `typedoc-plugin-markdown` emits them verbatim into the generated `.md` files, where CommonMark parses them as unresolved link references.

The fix wraps each in backticks so they render as inline code and bypass link-reference parsing. Verified locally with `docker run --rm -v $PWD:/docs zensical/zensical build --strict` → `No issues found`.

`main` is currently green only because no CI run has happened since the zensical image refresh. The next push to `main` will fail with the same error.

We might consider pinning the zensical image tag in `package.json` to prevent silent toolchain drift like this.

## Launch Checklist

 - [x] Confirm **your changes do not include backports from Mapbox projects**
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [x] ~Include before/after visuals or gifs if this PR includes visual changes.~
 - [x] ~Write tests for all new functionality.~ (docstring-only change)
 - [x] ~Document any changes to public APIs.~ (no API change; the rendered docs are the change)
 - [x] ~Post benchmark scores.~
 - [x] ~Add an entry to `CHANGELOG.md` under the `## main` section.~
 - [x] Confirm you have read our AI policy.

Assisted-By: Claude Opus 4.7