### PR TITLE
Update readme with render tests' vitest changes

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -22,7 +22,7 @@ To run specific tests:
  - Unit test by file name : `npm run test-unit -- draw_symbol.test.ts`
  - Integration test by file name : `npm run test-integration -- browser`
  want to change the headless mode in the test file to be `false` to see what's happening in the browser.
- - Render tests that matches a folder or file names: `npm run test-render -- render-test-name` (e.g. `npm run test-render -- text-rotation-alignment`)
+ - Render tests that matches a folder or file names: `npm run test-render -- -t "render-test-name"` (e.g. `npm run test-render -- -t "slant"`)
 
 To run folders in watch mode, meaning they will run continuously as you make changes to relevant code, (i.e. for test driven development): use `npm run test-watch-roots *folder1* [*folder2*...]` (e.g. `npm run test-watch-roots ./src/ui/control`)
 

--- a/test/integration/README.md
+++ b/test/integration/README.md
@@ -151,10 +151,10 @@ To add a new render test:
 
 3. Generate an `expected.png` image from the given style by running the new test with the `UPDATE` flag enabled:
    ```
-   UPDATE=1 npm run test-render -- <property-name>/<new-test-name>
+   UPDATE=1 npm run test-render -- -t "<property-name>/<new-test-name>"
    ```
 
-4. Manually inspect `expected.png` to verify it looks as expected, and optionally run the test again without the update flag (`npm run test-render <property-name>/<new-test-name>`) to watch it pass (enjoy that dopamine kick!)
+4. Manually inspect `expected.png` to verify it looks as expected, and optionally run the test again without the update flag (`npm run test-render -t "<property-name>/<new-test-name>"`) to watch it pass (enjoy that dopamine kick!)
 
 5. Commit the new `style.json` and `expected.png` :rocket:
 


### PR DESCRIPTION
## Launch Checklist

- Resolves #7571
- Related to the changes made here: #7545

Changes the readme to match recent changes of render tests to use vitest.

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
