### PR TITLE
Remove error on unregistered actor message type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes
+- Remove error when actor doesn't have a registered message type for better usability of custom messages in workers ([#7589](https://github.com/maplibre/maplibre-gl-js/issues/7589)) (by [@HarelM](https://github.com/HarelM))
 - _...Add new stuff here..._
 
 ## 6.0.0-8

--- a/src/index.ts
+++ b/src/index.ts
@@ -77,6 +77,7 @@ import type {StyleGlyph} from './style/style_glyph.ts';
 import type {FeatureIndex} from './data/feature_index.ts';
 import type {DashEntry} from './render/line_atlas.ts';
 import type {Painter} from './render/painter.ts';
+import type {WorkerGlobalScopeInterface} from './util/web_worker.ts';
 const version = packageJSON.version;
 
 export type * from '@maplibre/maplibre-gl-style-spec';
@@ -371,6 +372,7 @@ export {
     type CoveringTilesOptions,
     type DashEntry,
     type Painter,
+    type WorkerGlobalScopeInterface,
     setRTLTextPlugin,
     getRTLTextPluginStatus,
     prewarm,

--- a/src/util/actor.test.ts
+++ b/src/util/actor.test.ts
@@ -215,7 +215,7 @@ describe('Actor', () => {
         const worker = workerFactory() as any as WorkerGlobalScopeInterface & ActorTarget;
         const actor = new Actor(worker, '1');
 
-        await expect(actor.sendAsync({type: "custom" as any, data: {type: 'geojson'} as any})).resolves.toBeNull();
+        await expect(actor.sendAsync({type: 'custom' as any, data: {type: 'geojson'} as any})).resolves.toBeNull();
     });
 
     test('should not process a message with the wrong map id', async () => {

--- a/src/util/actor.test.ts
+++ b/src/util/actor.test.ts
@@ -211,13 +211,11 @@ describe('Actor', () => {
         expect(response).toBe(42);
     });
 
-    test('send a message is not registered should throw', async () => {
+    test('send a message is not registered should return null', async () => {
         const worker = workerFactory() as any as WorkerGlobalScopeInterface & ActorTarget;
         const actor = new Actor(worker, '1');
 
-        delete worker.worker.actor.messageHandlers[MessageType.abortTile];
-
-        await expect(async () => actor.sendAsync({type: MessageType.abortTile, data: {type: 'geojson'} as any})).rejects.toThrow(/Could not find a registered handler for.*/);
+        await expect(actor.sendAsync({type: "custom" as any, data: {type: 'geojson'} as any})).resolves.toBeNull();
     });
 
     test('should not process a message with the wrong map id', async () => {

--- a/src/util/actor.ts
+++ b/src/util/actor.ts
@@ -229,7 +229,10 @@ export class Actor implements IActor {
             return;
         }
         if (!this.messageHandlers[task.type]) {
-            this.completeTask(id, new Error(`Could not find a registered handler for ${task.type}, map ID: ${this.mapId}, available handlers: ${Object.keys(this.messageHandlers).join(', ')}`));
+            // This might be the case of a custom worker code sending messages to the main thread. 
+            // No need to do anything.
+            // This can be changed for debug in case there's a need to make sure all messages are being handled.
+            this.completeTask(id, null, null);
             return;
         }
         const params = deserialize(task.data) as RequestResponseMessageMap[MessageType][0];

--- a/src/util/web_worker_transfer.test.ts
+++ b/src/util/web_worker_transfer.test.ts
@@ -62,6 +62,10 @@ describe('web worker transfer', () => {
         expect(deserialized instanceof Klass).toBeTruthy();
     });
 
+    test('null', () => {
+        expect(() => serialize(null)).not.toThrow();
+    });
+
     test('custom serialization', () => {
         class CustomSerialization {
             id;


### PR DESCRIPTION
## Launch Checklist

This is in continue to the following PR:
 - #7451

This removes the error for unregistered message types.
This allows someone that uses import scripts to create a custom message type and not get console or map errors when sending a message from the worker.

Exported the type of `WorkerGlobalScopeInterface` to allow using it in worker related code.

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [x] Write tests for all new functionality.
 - [x] Document any changes to public APIs.
 - [x] Add an entry to `CHANGELOG.md` under the `## main` section.
 - [x] Confirm you have read our AI policy [here](https://github.com/maplibre/maplibre/blob/main/AI_POLICY.md).
