### PR TITLE
Fix benchmark display names when compare refs share a commit

### DIFF
--- a/test/bench/versions/index.html
+++ b/test/bench/versions/index.html
@@ -41,20 +41,28 @@
         async function runComparison() {
             try {
                 const params = new URL(location).searchParams;
-                window.versionsDisplayName = params.getAll('compare').filter(Boolean);
+                const requestedVersionsDisplayName = params.getAll('compare').filter(Boolean);
                 if (!params.has('compare')) {
-                    const response = await fetch('https://registry.npmjs.org/maplibre-gl/latest', {});
+                    const response = await fetch('https://api.github.com/repos/maplibre/maplibre-gl-js/releases/latest');
                     const responseJson = await response.json();
-                    window.versionsDisplayName = [`v${responseJson['version']}`, 'main'];
+                    requestedVersionsDisplayName.push(responseJson['tag_name'], 'main');
                 }
-                console.log(`Comparing versions: ${window.versionsDisplayName}`);
+                console.log(`Comparing versions: ${requestedVersionsDisplayName}`);
 
-                for (const v of window.versionsDisplayName) {
+                const versionDisplayNameByVersion = {};
+                for (const v of requestedVersionsDisplayName) {
+                    const beforeVersions = getBenchmarkVersions();
                     await loadVersion(v);
+                    const afterVersions = getBenchmarkVersions();
+                    const newVersions = afterVersions.filter(version => !beforeVersions.includes(version));
+                    for (const version of newVersions) {
+                        versionDisplayNameByVersion[version] = v;
+                    }
                 }
                 await import('/test/bench/versions/benchmarks_generated.mjs');
 
                 const benchmarks = [];
+                window.versionsDisplayName = [];
                 const benchmarkNameList = Object.keys(window.maplibreglBenchmarks).sort();
                 for (const benchmarkName of benchmarkNameList) {
                     const versions = [];
@@ -66,11 +74,10 @@
 
                     let index = 0;
                     for (const version in window.maplibreglBenchmarks[benchmarkName]) {
-                        if (!window.versionsDisplayName[index]) {
-                            window.versionsDisplayName[index] = version;
-                        }
+                        const displayName = versionDisplayNameByVersion[version] || version;
+                        window.versionsDisplayName[index] = displayName;
                         versions.push({
-                            displayName: window.versionsDisplayName[index],
+                            displayName,
                             name: version,
                             bench: window.maplibreglBenchmarks[benchmarkName][version]
                         });
@@ -92,6 +99,26 @@
                 window.maplibreglBenchmarkFinished = true;
             } catch (ex) {
                 console.error(ex);
+            }
+        }
+
+        function getBenchmarkVersions() {
+            const versions = new Set();
+            addBenchmarkVersions(window.maplibreglBenchmarks, versions);
+            addBenchmarkVersions(window.mapboxglBenchmarks, versions);
+            return Array.from(versions);
+        }
+
+        function addBenchmarkVersions(benchmarks, versions) {
+            if (!benchmarks) {
+                return;
+            }
+            const benchmarkName = Object.keys(benchmarks)[0];
+            if (!benchmarkName) {
+                return;
+            }
+            for (const version of Object.keys(benchmarks[benchmarkName])) {
+                versions.add(version);
             }
         }
 

--- a/test/bench/versions/index.html
+++ b/test/bench/versions/index.html
@@ -43,9 +43,9 @@
                 const params = new URL(location).searchParams;
                 const requestedVersionsDisplayName = params.getAll('compare').filter(Boolean);
                 if (!params.has('compare')) {
-                    const response = await fetch('https://api.github.com/repos/maplibre/maplibre-gl-js/releases/latest');
+                    const response = await fetch('https://registry.npmjs.org/maplibre-gl/latest');
                     const responseJson = await response.json();
-                    requestedVersionsDisplayName.push(responseJson['tag_name'], 'main');
+                    requestedVersionsDisplayName.push(responseJson['version'], 'main');
                 }
                 console.log(`Comparing versions: ${requestedVersionsDisplayName}`);
 


### PR DESCRIPTION
## Description

This fixes an issue where the benchmark page can show incorrect labels when two compare refs resolve to the same generated benchmark version key.

Previously, the page stored requested labels in `window.versionsDisplayName` and later matched them to loaded benchmark versions by array position. If two refs, for example `v4.7.1` and `main`, point to the same generated benchmark key, loading the second script does not add a new benchmark version. However, its label still remains in the display-name array, causing later labels to shift. As a result, the local branch can be displayed with the wrong label.

To fix this, the benchmark loader now checks which benchmark version keys exist before and after each compare script is loaded. It only maps a requested display label to version keys that were newly added by that script. If no display label is mapped, it falls back to the actual benchmark version key.

## Screenshot

Before, duplicate refs could shift labels and show the local branch as `main`.

After this change, labels stay aligned with the loaded benchmark versions:

<img width="1349" height="835" alt="image" src="https://github.com/user-attachments/assets/110763c6-3007-4962-96c3-185595d49757" />


This keeps labels aligned with the benchmark data that was actually loaded, including cases where multiple refs point to the same commit.

Fixes #4762