### PR TITLE
Fix/tile manager used undefined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### 🐞 Bug fixes
 - Fix Benchmarks remote compare issue ([#7607](https://github.com/maplibre/maplibre-gl-js/pull/7607)) (by [@xavierjs](https://github.com/xavierjs))
+- Fix `TileManager` calling `update()` in `_dataHandler` when `used` is `undefined`, causing tile eviction and empty `querySourceFeatures()` results when `setData()` is called before the first render frame ([#7636](https://github.com/maplibre/maplibre-gl-js/pull/7636)) (by [@dojchek-sg](https://github.com/dojchek-sg))
 - _...Add new stuff here..._
 
 ## 6.0.0-9

--- a/src/tile/tile_manager.test.ts
+++ b/src/tile/tile_manager.test.ts
@@ -588,6 +588,35 @@ describe('TileManager / Source lifecycle', () => {
 
     });
 
+    test('does not call update in _dataHandler when used is undefined', () => {
+        const transform = new MercatorTransform();
+        transform.resize(511, 511);
+        transform.setZoom(0);
+
+        const tileManager = createTileManager();
+        // Simulate the race: content event fires before style.recalculate() sets used=true
+        (tileManager as any).used = undefined;
+
+        const updateSpy = vi.spyOn(tileManager, 'update');
+
+        tileManager.on('data', (e) => {
+            if (e.dataType === 'source' && e.sourceDataType === 'metadata') {
+                // Set transform directly so _dataHandler's `if (this.transform)` check passes,
+                // without going through update() which would change used
+                (tileManager as any).transform = transform;
+                // Fire content event while used is still undefined (microtask race scenario)
+                tileManager.getSource().fire(new Event('data', {
+                    dataType: 'source',
+                    sourceDataType: 'content',
+                    sourceDataChanged: true,
+                }));
+            }
+        });
+
+        tileManager.onAdd(undefined);
+        expect(updateSpy).not.toHaveBeenCalled();
+    });
+
 });
 
 describe('TileManager.update', () => {

--- a/src/tile/tile_manager.ts
+++ b/src/tile/tile_manager.ts
@@ -813,7 +813,7 @@ export class TileManager extends Evented {
         }
 
         this.reload(e.sourceDataChanged, e.shouldReloadTileOptions);
-        if (this.transform) {
+        if (this.transform && this.used) {
             this.update(this.transform, this.terrain);
         }
         this._didEmitContent = true;


### PR DESCRIPTION
 ---
  Launch Checklist
  
  - Confirm your changes do not include backports from Mapbox projects (unless with compliant license)
  - Briefly describe the changes in this PR.
  - Link to related issues.
  - ~~Include before/after visuals or gifs if this PR includes visual changes.~~ (no visual changes)
  - Write tests for all new functionality.
  - ~~Document any changes to public APIs.~~ (no public API changes)
  - ~~Post benchmark scores.~~ (no performance-sensitive changes)
  - Add an entry to CHANGELOG.md under the ## main section.
  - Confirm you have read our AI policy (https://github.com/maplibre/maplibre/blob/main/AI_POLICY.md).

  Assisted-By: Claude Sonnet 4.6

  ---
  Description
  
  Fixes #7634.

  TileManager.used is declared as used: boolean but never initialized, so it starts as undefined. In _dataHandler, when a source content event fires (e.g. from setData()), the method calls this.update() whenever
  this.transform is set — without checking this.used.

  Inside update(), the guard if (!this.used && !this.usedForTerrain) evaluates to true when used is undefined, which resets idealTileIDs to [] and evicts all tiles from InViewTiles. As a result,
  querySourceFeatures() returns [] and isSourceLoaded() returns true vacuously — the source appears loaded but data is inaccessible.

  The race condition is triggered when setData() is called before the first requestAnimationFrame fires (before style.recalculate() sets used = true). This happens for example when setData() is called from a
  microtask (Promise.resolve().then(...)).

  Fix: add && this.used to the condition in _dataHandler. When used is not yet true, the render loop's _updateSources() will call update() in the next frame after style.recalculate() runs — deferring tile loading
  by at most ~16 ms but preventing the destructive eviction.

  This is a regression introduced in the SourceCache → TileManager refactor in 5.20.0. SourceCache did not have this issue because querySourceFeatures read from a flat data cache independent of the used gate.

