### PR TITLE
add Styl to spellcheck dictionary

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -264,6 +264,11 @@
     "**/*.html",
     "**/*.md"
   ],
+  "ignorePaths": [
+    "site/**",
+    "coverage/**",
+    "test/integration/render/results.html"
+  ],
   "ignoreRegExpList": [
     "@\\w+",
     "\\[\\w+",

--- a/.cspell.json
+++ b/.cspell.json
@@ -186,6 +186,7 @@
     "SRPS",
     "stringifiable",
     "Struct",
+    "Styl",
     "tada",
     "Tatra",
     "tcpopup",
@@ -263,11 +264,6 @@
   "files": [
     "**/*.html",
     "**/*.md"
-  ],
-  "ignorePaths": [
-    "site/**",
-    "coverage/**",
-    "test/integration/render/results.html"
   ],
   "ignoreRegExpList": [
     "@\\w+",


### PR DESCRIPTION
i see code hygiene (spellcheck) trip over the word Styl, e.g. in the run below, and it's blocking PRs from completing ci checks:

- https://github.com/maplibre/maplibre-gl-js/actions/runs/25916986346/job/76175962831?pr=7641

It looks like a typo but Styl is the name of this plugin (style linter):

https://github.com/navidnabavi/styl

Add Styl to allowed words


## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items that are not relevant. -->


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [ ] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [ ] Add an entry to `CHANGELOG.md` under the `## main` section.
 - [ ] Confirm you have read our AI policy [here](https://github.com/maplibre/maplibre/blob/main/AI_POLICY.md).
<!--
  Add one of:    Assisted-By: | Generated-By:     and the model/version
-->
