### PR TITLE
Fix handling cross-origin blob URL in Ajax utils

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes
+- Fix handling cross-origin blob URL in Ajax utils ([#7675](https://github.com/maplibre/maplibre-gl-js/pull/7675)) (by [@katemihalikova](https://github.com/katemihalikova))
 - _...Add new stuff here..._
 - querySourceFeatures() throws 'Block overruns tile' on overzoomed MLT tiles because the reported encoding doesn't match the re-encoded MVT data ([#7707](https://github.com/maplibre/maplibre-gl-js/pull/7707)) (by [@ted-piotrowski](https://github.com/ted-piotrowski))
 - Fix geometry length check for polygons and lines in LineBucket after duplicate vertex trimming([#7638](https://github.com/maplibre/maplibre-gl-js/pull/7638)) (by [@widefire](https://github.com/widefire))

--- a/src/util/ajax.test.ts
+++ b/src/util/ajax.test.ts
@@ -3,6 +3,7 @@ import {
     getArrayBuffer,
     getJSON,
     type AJAXError,
+    getReferrer,
     sameOrigin
 } from './ajax.ts';
 import {isAbortError} from './abort_error.ts';
@@ -133,6 +134,46 @@ describe('ajax', () => {
         }
     });
 
+    test('getReferrer method (outside Worker)', () => {
+        vi.spyOn(window, 'location', 'get').mockReturnValue({
+            href: 'https://somewhere.com',
+            protocol: 'https:'
+        } as any);
+
+        expect(getReferrer()).toBe('https://somewhere.com');
+
+        vi.spyOn(window, 'parent', 'get').mockReturnValue({
+            location: {
+                href: 'https://somewhere.com',
+                protocol: 'https:',
+                host: 'elsewhere.com'
+            }
+        } as any);
+        vi.spyOn(window, 'location', 'get').mockReturnValue({
+            href: 'blob:https://somewhere.com/123e4567-e89b-12d3-a456-426614174000',
+            protocol: 'blob:',
+            host: ''
+        } as any);
+
+        expect(getReferrer()).toBe('https://somewhere.com');
+
+        vi.spyOn(window, 'parent', 'get').mockReturnValue({
+            location: {
+                get href() {
+                    throw new DOMException();
+                },
+                get protocol() {
+                    throw new DOMException();
+                },
+                get host() {
+                    throw new DOMException();
+                }
+            }
+        } as any);
+
+        expect(getReferrer()).toBe('blob:https://somewhere.com/123e4567-e89b-12d3-a456-426614174000');
+    });
+
     test('sameOrigin method', () => {
         vi.spyOn(window, 'location', 'get').mockReturnValue({
             protocol: 'https:',
@@ -146,7 +187,10 @@ describe('ajax', () => {
         expect(sameOrigin('https://somewhere.com:443/path')).toBe(true);
 
         expect(sameOrigin('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVQYV2NgAAIAAAUAAarVyFEAAAAASUVORK5CYII=')).toBe(true);
-        expect(sameOrigin('blob:https://www.bing.com/09f36686-e57a-420f-9004-918548219b75')).toBe(true);
+        expect(sameOrigin('blob:https://www.bing.com/09f36686-e57a-420f-9004-918548219b75')).toBe(false);
+        expect(sameOrigin('blob:https://somewhere.com/123e4567-e89b-12d3-a456-426614174000')).toBe(true);
+        expect(sameOrigin('blob:http://somewhere.com/123e4567-e89b-12d3-a456-426614174000')).toBe(false);
+        expect(sameOrigin('blob:null/123e4567-e89b-12d3-a456-426614174000')).toBe(false);
 
         // relative URL is same origin for sure
         expect(sameOrigin('/foo')).toBe(true);

--- a/src/util/ajax.test.ts
+++ b/src/util/ajax.test.ts
@@ -134,19 +134,21 @@ describe('ajax', () => {
         }
     });
 
-    test('getReferrer method (outside Worker)', () => {
+    test('getReferrer method (outside Worker), same origin https URL', () => {
         vi.spyOn(window, 'location', 'get').mockReturnValue({
             href: 'https://somewhere.com',
             protocol: 'https:'
         } as any);
 
         expect(getReferrer()).toBe('https://somewhere.com');
+    });
 
+    test('getReferrer method (outside Worker), same origin blob URL', () => {
         vi.spyOn(window, 'parent', 'get').mockReturnValue({
             location: {
                 href: 'https://somewhere.com',
                 protocol: 'https:',
-                host: 'elsewhere.com'
+                host: 'somewhere.com'
             }
         } as any);
         vi.spyOn(window, 'location', 'get').mockReturnValue({
@@ -156,7 +158,9 @@ describe('ajax', () => {
         } as any);
 
         expect(getReferrer()).toBe('https://somewhere.com');
+    });
 
+    test('getReferrer method (outside Worker), different origin https URL', () => {
         vi.spyOn(window, 'parent', 'get').mockReturnValue({
             location: {
                 get href() {
@@ -169,6 +173,34 @@ describe('ajax', () => {
                     throw new DOMException();
                 }
             }
+        } as any);
+        vi.spyOn(window, 'location', 'get').mockReturnValue({
+            href: 'https://somewhere.com',
+            protocol: 'https:',
+            host: 'somewhere.com'
+        } as any);
+
+        expect(getReferrer()).toBe('https://somewhere.com');
+    });
+
+    test('getReferrer method (outside Worker), different origin blob URL', () => {
+        vi.spyOn(window, 'parent', 'get').mockReturnValue({
+            location: {
+                get href() {
+                    throw new DOMException();
+                },
+                get protocol() {
+                    throw new DOMException();
+                },
+                get host() {
+                    throw new DOMException();
+                }
+            }
+        } as any);
+        vi.spyOn(window, 'location', 'get').mockReturnValue({
+            href: 'blob:https://somewhere.com/123e4567-e89b-12d3-a456-426614174000',
+            protocol: 'blob:',
+            host: ''
         } as any);
 
         expect(getReferrer()).toBe('blob:https://somewhere.com/123e4567-e89b-12d3-a456-426614174000');

--- a/src/util/ajax.ts
+++ b/src/util/ajax.ts
@@ -129,10 +129,18 @@ export class AJAXError extends Error {
  * For files loaded from the local file system, `location.origin` will be set
  * to the string(!) "null" (Firefox), or "file://" (Chrome, Safari, Edge),
  * and we will set an empty referrer. Otherwise, we're using the document's URL.
+ * If we're on a blob URL and parent window is cross-origin, parent.location throws
+ * SecurityError DOMException, this means we are probably not in blob URL worker bundle.
  */
-export const getReferrer = (): string => isWorker(self) ?
-    self.worker?.referrer :
-    (window.location.protocol === 'blob:' ? window.parent : window).location.href;
+export function getReferrer(): string {
+    if (isWorker(self)) return self.worker?.referrer;
+    if (window.location.protocol === 'blob:') {
+        try {
+            return window.parent.location.href;
+        } catch {}
+    }
+    return window.location.href;
+}
 
 /**
  * Determines whether a URL is a file:// URL. This is obviously the case if it begins
@@ -285,16 +293,30 @@ export const getArrayBuffer = (requestParameters: RequestParameters, abortContro
     return makeRequest(extend(requestParameters, {type: 'arrayBuffer'}), abortController);
 };
 
+/** 
+ * Determines whether a URL is same origin as the current location. Supports relative URLs too.
+ * 
+ * A relative URL "/foo" or "./foo" will throw exception in URL's ctor,
+ * try-catch is expansive so just use a heuristic check to avoid it
+ * 
+ * - Relative URL and empty URL are always same origin.
+ * - data URL containing an image is always same origin.
+ * - blob URL is checked using `URL` constructor by its parent URL; opaque blob URL is never same origin.
+ * - Absolute URL is checked using `URL` constructor.
+ * 
+ * Checks blob URL before relative URL because opaque blob URL does not contain `://` too.
+ * 
+ * @param inComingUrl - The URL to check
+ * @returns `true` if the URL is same origin as current location, `false` otherwise
+ */
 export function sameOrigin(inComingUrl: string): boolean {
-    // A relative URL "/foo" or "./foo" will throw exception in URL's ctor,
-    // try-catch is expansive so just use a heuristic check to avoid it
-    // also check data URL
-    if (!inComingUrl ||
-        inComingUrl.indexOf('://') <= 0 || // relative URL
-        inComingUrl.startsWith('data:image/') || // data image URL
-        inComingUrl.startsWith('blob:')) { // blob
-        return true;
+    if (!inComingUrl) return true; // empty URL
+    if (inComingUrl.startsWith('data:image/')) return true; // data image URL
+    if (inComingUrl.startsWith('blob:')) { // blob URL
+        inComingUrl = inComingUrl.slice(5);
+        if (inComingUrl.startsWith('null')) return false; // opaque blob URL
     }
+    if (inComingUrl.indexOf('://') <= 0) return true; // relative URL
     const urlObj = new URL(inComingUrl);
     const locationObj = window.location;
     return urlObj.protocol === locationObj.protocol && urlObj.host === locationObj.host;

--- a/test/build/bundle_size.json
+++ b/test/build/bundle_size.json
@@ -1,10 +1,10 @@
 {
     "dist/maplibre-gl.mjs": {
-        "raw": 964777,
-        "gzip": 247855
+        "raw": 964627,
+        "gzip": 247948
     },
     "dist/maplibre-gl-worker.mjs": {
-        "raw": 455712,
-        "gzip": 125587
+        "raw": 455623,
+        "gzip": 125558
     }
 }


### PR DESCRIPTION
When map runs inside a `blob:` URL that is of different origin than parent, `getReferrer` (from Ajax utils) thinks it's in blob URL worker bundle and tries to access `window.parent.location.href`, which fails with `DOMException` `SecurityError`, preventing the map from loading. This can happen, for example, in some development environments, e.g. in Google Gemini Canvas environment (not to be confused with HTML Canvas) which compiles its AI-generated page into a cross-origin blob for user preview. Example here: https://gemini.google.com/share/1bba61e0f224.

I fixed the `getReferrer` function by adding try-catch block around the parent access to catch the `DOMException`. Alternative would be to use `window.location.origin === window.location.ancestorOrigins[0]` to check that parent is same-origin, however `location.ancestorOrigins` has been added to Firefox only earlier this year so it's still pretty new feature.

I also fixed the other place where `blob:` URLs are handled - `sameOrigin` (also from Ajax utils). This one uses heuristic to determine whether a URL is same-origin. Before, it considered any `blob:` URL to be same-origin, I fixed it to actually check the origin too, also added a check for opaque `blob:` URL.

## Launch Checklist

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Write tests for all new functionality.
 - [x] Add an entry to `CHANGELOG.md` under the `## main` section.
 - [x] Confirm you have read our AI policy [here](https://github.com/maplibre/maplibre/blob/main/AI_POLICY.md).