### PR TITLE
Change package ecosystem from 'docker' to 'docker-compose'

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,7 +32,7 @@ updates:
       # => no specific configuration for this
       include:
         - "*"
-  - package-ecosystem: "docker"
+  - package-ecosystem: "docker-compose"
     directory: "/"
     schedule:
       interval: "daily"


### PR DESCRIPTION
## Launch Checklist

- Related to #7628

This updates dependabot for docker compose instead of docker, which is the correct way apparently for docker compose files (zensical mainly).


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.