### PR TITLE
querySourceFeatures() throws 'Block overruns tile' on overzoomed MLT …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### 🐞 Bug fixes
 - _...Add new stuff here..._
+- querySourceFeatures() throws 'Block overruns tile' on overzoomed MLT tiles because the reported encoding doesn't match the re-encoded MVT data ([#7707](https://github.com/maplibre/maplibre-gl-js/pull/7707)) (by [@ted-piotrowski](https://github.com/ted-piotrowski))
 - Fix geometry length check for polygons and lines in LineBucket after duplicate vertex trimming([#7638](https://github.com/maplibre/maplibre-gl-js/pull/7638)) (by [@widefire](https://github.com/widefire))
 - `line-dasharray` step transition lags one zoom level when the step's branches are data-driven ([#7705](https://github.com/maplibre/maplibre-gl-js/pull/7705)) (by [@lucaswoj](https://github.com/lucaswoj))
 

--- a/src/source/vector_tile_worker_source.test.ts
+++ b/src/source/vector_tile_worker_source.test.ts
@@ -258,6 +258,42 @@ describe('vector tile worker source', () => {
         expect(getOverzoomTileSpy).toHaveBeenCalledWith(params, mockVectorTile);
     });
 
+    test('VectorTileWorkerSource uses mvt encoding for overzoomed mlt tiles', async () => {
+        const source = new VectorTileWorkerSource(actor, new StyleLayerIndex(), []);
+        const mockVectorTile = {layers: {}} as any;
+
+        source.loadVectorTile = vi.fn().mockReturnValue({
+            vectorTile: mockVectorTile,
+            rawData: new ArrayBuffer(0)
+        });
+
+        vi.spyOn(source as any, '_getOverzoomTile').mockReturnValue({
+            vectorTile: mockVectorTile,
+            rawData: new ArrayBuffer(0)
+        });
+
+        server.respondWith(request => {
+            request.respond(200, {'Content-Type': 'application/pbf'}, new ArrayBuffer(0) as any);
+        });
+
+        const params = {
+            uid: '1',
+            tileID: new OverscaledTileID(16, 0, 16, 100, 100),
+            source: 'test',
+            encoding: 'mlt',
+            overzoomParameters: {
+                maxZoomTileID: new CanonicalTileID(14, 25, 25),
+                overzoomRequest: {url: ''}
+            }
+        } as WorkerTileParameters;
+
+        const promise = source.loadTile(params);
+        server.respond();
+        const res = await promise as WorkerTileWithData;
+
+        expect(res.encoding).toBe('mvt');
+    });
+
     test('VectorTileWorkerSource.reloadTile does not reparse tiles with no vectorTile data but does call callback', async () => {
         const source = new VectorTileWorkerSource(actor, new StyleLayerIndex(), []);
         const parse = vi.fn();

--- a/src/source/vector_tile_worker_source.ts
+++ b/src/source/vector_tile_worker_source.ts
@@ -133,8 +133,10 @@ export class VectorTileWorkerSource implements WorkerSource {
 
         if (parseState) {
             const {rawData, cacheControl, resourceTiming} = parseState;
+            // Overzoomed tiles are always re-encoded to MVT protobuf by _getOverzoomTile
+            const encoding = params.overzoomParameters ? 'mvt' : params.encoding;
             // Transferring a copy of rawTileData because the worker needs to retain its copy.
-            result = extend({rawTileData: rawData.slice(0), encoding: params.encoding}, result, cacheControl, resourceTiming);
+            result = extend({rawTileData: rawData.slice(0), encoding}, result, cacheControl, resourceTiming);
         }
 
         return result;


### PR DESCRIPTION
…tiles because overzoomed tiles are re-encoded in MVT format

With the addition of `zoomLevelsToOverscale: 4`, Maplibre now overzooms tiles by default. This revealed a bug with MLT tiles that are overzoomed because the overzoomed data is re-encoded in MVT format. The tile encoding for these overzoomed tiles was incorrectly stored in the feature index as MLT. This caused a decoding error on subsequent attempts to decode the data during querySourceFeatures() calls

- Fixes https://github.com/maplibre/maplibre-gl-js/issues/7701

Root cause and fix was investigated and validated by @ted-piotrowski

Fix and test was Generated-By: Claude 5.8
