### PR TITLE
Improve projection data matrix types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## main
 ### ✨ Features and improvements
 - _...Add new stuff here..._
+- Improve `ProjectionData` matrix backing types for renderer and custom layer projection matrices ([#6316](https://github.com/maplibre/maplibre-gl-js/issues/6316)) (by [@cat0825](https://github.com/cat0825))
 
 ### 🐞 Bug fixes
 - _...Add new stuff here..._

--- a/src/geo/projection/globe_transform.ts
+++ b/src/geo/projection/globe_transform.ts
@@ -15,7 +15,7 @@ import type {PointProjection} from '../../symbol/projection.ts';
 import type {IReadonlyTransform, ITransform, TransformConstrainFunction} from '../transform_interface.ts';
 import type {TransformOptions} from '../transform_helper.ts';
 import type {PaddingOptions} from '../edge_insets.ts';
-import type {ProjectionData, ProjectionDataParams} from './projection_data.ts';
+import type {CustomLayerProjectionData, ProjectionDataParams, RendererProjectionData} from './projection_data.ts';
 import type {CoveringTilesDetailsProvider} from './covering_tiles_details_provider.ts';
 
 /**
@@ -285,7 +285,7 @@ export class GlobeTransform implements ITransform {
 
     public get cameraPosition(): vec3 { return this.currentTransform.cameraPosition; }
 
-    getProjectionData(params: ProjectionDataParams): ProjectionData {
+    getProjectionData(params: ProjectionDataParams): RendererProjectionData {
         const mercatorProjectionData = this._mercatorTransform.getProjectionData(params);
         const verticalPerspectiveProjectionData = this._verticalPerspectiveTransform.getProjectionData(params);
 
@@ -453,7 +453,7 @@ export class GlobeTransform implements ITransform {
         return this.currentTransform.getMatrixForModel(location, altitude);
     }
 
-    getProjectionDataForCustomLayer(applyGlobeMatrix: boolean = true): ProjectionData {
+    getProjectionDataForCustomLayer(applyGlobeMatrix: boolean = true): CustomLayerProjectionData {
         const mercatorData = this._mercatorTransform.getProjectionDataForCustomLayer(applyGlobeMatrix);
 
         if (!this.isGlobeRendering) {

--- a/src/geo/projection/mercator_transform.ts
+++ b/src/geo/projection/mercator_transform.ts
@@ -819,11 +819,10 @@ export class MercatorTransform implements ITransform {
     getProjectionDataForCustomLayer(applyGlobeMatrix: boolean = true): CustomLayerProjectionData {
         const tileID = new OverscaledTileID(0, 0, 0, 0, 0);
         const projectionData: CustomLayerProjectionData = this.getProjectionData({overscaledTileID: tileID, applyGlobeMatrix});
-
-        projectionData.tileMercatorCoords = [0, 0, 1, 1];
-
         const tileMatrix = calculateTileMatrix(tileID, this.worldSize);
         mat4.multiply(tileMatrix, this._viewProjMatrix, tileMatrix);
+
+        projectionData.tileMercatorCoords = [0, 0, 1, 1];
 
         // Even though we requested projection data for the mercator base tile which covers the entire mercator range,
         // the shader projection machinery still expects inputs to be in tile units range [0..EXTENT].

--- a/src/geo/projection/mercator_transform.ts
+++ b/src/geo/projection/mercator_transform.ts
@@ -816,8 +816,12 @@ export class MercatorTransform implements ITransform {
         return m;
     }
 
-    getProjectionDataForCustomLayer(_applyGlobeMatrix: boolean = true): CustomLayerProjectionData {
+    getProjectionDataForCustomLayer(applyGlobeMatrix: boolean = true): CustomLayerProjectionData {
         const tileID = new OverscaledTileID(0, 0, 0, 0, 0);
+        const projectionData: CustomLayerProjectionData = this.getProjectionData({overscaledTileID: tileID, applyGlobeMatrix});
+
+        projectionData.tileMercatorCoords = [0, 0, 1, 1];
+
         const tileMatrix = calculateTileMatrix(tileID, this.worldSize);
         mat4.multiply(tileMatrix, this._viewProjMatrix, tileMatrix);
 
@@ -833,13 +837,9 @@ export class MercatorTransform implements ITransform {
         const projectionMatrixScaled = createMat4f64();
         mat4.scale(projectionMatrixScaled, tileMatrix, scale);
 
-        return {
-            mainMatrix: projectionMatrixScaled,
-            tileMercatorCoords: [0, 0, 1, 1],
-            clippingPlane: [0, 0, 0, 0],
-            projectionTransition: 0.0,
-            fallbackMatrix: projectionMatrixScaled,
-        };
+        projectionData.fallbackMatrix = projectionMatrixScaled;
+        projectionData.mainMatrix = projectionMatrixScaled;
+        return projectionData;
     }
 
     getFastPathSimpleProjectionMatrix(tileID: OverscaledTileID): mat4 {

--- a/src/geo/projection/mercator_transform.ts
+++ b/src/geo/projection/mercator_transform.ts
@@ -818,11 +818,9 @@ export class MercatorTransform implements ITransform {
 
     getProjectionDataForCustomLayer(applyGlobeMatrix: boolean = true): CustomLayerProjectionData {
         const tileID = new OverscaledTileID(0, 0, 0, 0, 0);
-        const projectionData: CustomLayerProjectionData = this.getProjectionData({overscaledTileID: tileID, applyGlobeMatrix});
+        const rendererProjectionData = this.getProjectionData({overscaledTileID: tileID, applyGlobeMatrix});
         const tileMatrix = calculateTileMatrix(tileID, this.worldSize);
         mat4.multiply(tileMatrix, this._viewProjMatrix, tileMatrix);
-
-        projectionData.tileMercatorCoords = [0, 0, 1, 1];
 
         // Even though we requested projection data for the mercator base tile which covers the entire mercator range,
         // the shader projection machinery still expects inputs to be in tile units range [0..EXTENT].
@@ -836,9 +834,12 @@ export class MercatorTransform implements ITransform {
         const projectionMatrixScaled = createMat4f64();
         mat4.scale(projectionMatrixScaled, tileMatrix, scale);
 
-        projectionData.fallbackMatrix = projectionMatrixScaled;
-        projectionData.mainMatrix = projectionMatrixScaled;
-        return projectionData;
+        return {
+            ...rendererProjectionData,
+            tileMercatorCoords: [0, 0, 1, 1],
+            fallbackMatrix: projectionMatrixScaled,
+            mainMatrix: projectionMatrixScaled,
+        };
     }
 
     getFastPathSimpleProjectionMatrix(tileID: OverscaledTileID): mat4 {

--- a/src/geo/projection/mercator_transform.ts
+++ b/src/geo/projection/mercator_transform.ts
@@ -1,7 +1,7 @@
 import {LngLat, type LngLatLike} from '../lng_lat.ts';
 import {MercatorCoordinate, mercatorXfromLng, mercatorYfromLat, mercatorZfromAltitude} from '../mercator_coordinate.ts';
 import Point from '@mapbox/point-geometry';
-import {wrap, clamp, createIdentityMat4f64, createMat4f64, degreesToRadians, createIdentityMat4f32, zoomScale, scaleZoom} from '../../util/util.ts';
+import {wrap, clamp, createIdentityMat4f64, createMat4f64, degreesToRadians, createIdentityMat4f32, zoomScale, scaleZoom, type Mat4f32, type Mat4f64} from '../../util/util.ts';
 import {type mat2, mat4, vec3, vec4} from 'gl-matrix';
 import {UnwrappedTileID, OverscaledTileID, type CanonicalTileID, calculateTileKey} from '../../tile/tile_id.ts';
 import {interpolates} from '@maplibre/maplibre-gl-style-spec';
@@ -18,7 +18,7 @@ import type {Terrain} from '../../render/terrain.ts';
 import type {IReadonlyTransform, ITransform, TransformConstrainFunction} from '../transform_interface.ts';
 import type {TransformOptions} from '../transform_helper.ts';
 import type {PaddingOptions} from '../edge_insets.ts';
-import type {ProjectionData, ProjectionDataParams} from './projection_data.ts';
+import type {CustomLayerProjectionData, ProjectionDataParams, RendererProjectionData} from './projection_data.ts';
 import type {CoveringTilesDetailsProvider} from './covering_tiles_details_provider.ts';
 
 export class MercatorTransform implements ITransform {
@@ -238,8 +238,8 @@ export class MercatorTransform implements ITransform {
     private _pixelMatrixInverse: mat4;
     private _fogMatrix: mat4;
 
-    private _posMatrixCache: Map<string, {f64: mat4; f32: mat4}> = new Map();
-    private _alignedPosMatrixCache: Map<string, {f64: mat4; f32: mat4}> = new Map();
+    private _posMatrixCache: Map<string, {f64: Mat4f64; f32: Mat4f32}> = new Map();
+    private _alignedPosMatrixCache: Map<string, {f64: Mat4f64; f32: Mat4f32}> = new Map();
     private _fogMatrixCacheF32: Map<string, mat4> = new Map();
 
     private _coveringTilesDetailsProvider;
@@ -411,7 +411,9 @@ export class MercatorTransform implements ITransform {
      * @param aligned - whether to use a pixel-aligned matrix variant, intended for rendering raster tiles
      * @param useFloat32 - when true, returns a float32 matrix instead of float64. Use float32 for matrices that are passed to shaders, use float64 for everything else.
      */
-    calculatePosMatrix(tileID: UnwrappedTileID | OverscaledTileID, aligned: boolean = false, useFloat32?: boolean): mat4 {
+    calculatePosMatrix(tileID: UnwrappedTileID | OverscaledTileID, aligned: boolean | undefined, useFloat32: true): Mat4f32;
+    calculatePosMatrix(tileID: UnwrappedTileID | OverscaledTileID, aligned?: boolean, useFloat32?: false): Mat4f64;
+    calculatePosMatrix(tileID: UnwrappedTileID | OverscaledTileID, aligned: boolean = false, useFloat32: boolean = false): Mat4f32 | Mat4f64 {
         const posMatrixKey = tileID.key ?? calculateTileKey(tileID.wrap, tileID.canonical.z, tileID.canonical.z, tileID.canonical.x, tileID.canonical.y);
         const cache = aligned ? this._alignedPosMatrixCache : this._posMatrixCache;
         if (cache.has(posMatrixKey)) {
@@ -421,7 +423,7 @@ export class MercatorTransform implements ITransform {
 
         const tileMatrix = calculateTileMatrix(tileID, this.worldSize);
         mat4.multiply(tileMatrix, aligned ? this._alignedProjMatrix : this._viewProjMatrix, tileMatrix);
-        const matrices = {
+        const matrices: {f64: Mat4f64; f32: Mat4f32} = {
             f64: tileMatrix,
             f32: new Float32Array(tileMatrix), // Must have a 32 bit float version for WebGL, otherwise WebGL calls in Chrome get very slow.
         };
@@ -727,12 +729,12 @@ export class MercatorTransform implements ITransform {
         return (p[2] / p[3]);
     }
 
-    getProjectionData(params: ProjectionDataParams): ProjectionData {
+    getProjectionData(params: ProjectionDataParams): RendererProjectionData {
         const {overscaledTileID, aligned, applyTerrainMatrix} = params;
         const mercatorTileCoordinates = this._helper.getMercatorTileCoordinates(overscaledTileID);
         const tilePosMatrix = overscaledTileID ? this.calculatePosMatrix(overscaledTileID, aligned, true) : null;
 
-        let mainMatrix: mat4;
+        let mainMatrix: Mat4f32;
         if (overscaledTileID?.terrainRttPosMatrix32f && applyTerrainMatrix) {
             mainMatrix = overscaledTileID.terrainRttPosMatrix32f;
         } else if (tilePosMatrix) {
@@ -814,14 +816,10 @@ export class MercatorTransform implements ITransform {
         return m;
     }
 
-    getProjectionDataForCustomLayer(applyGlobeMatrix: boolean = true): ProjectionData {
+    getProjectionDataForCustomLayer(_applyGlobeMatrix: boolean = true): CustomLayerProjectionData {
         const tileID = new OverscaledTileID(0, 0, 0, 0, 0);
-        const projectionData = this.getProjectionData({overscaledTileID: tileID, applyGlobeMatrix});
-
         const tileMatrix = calculateTileMatrix(tileID, this.worldSize);
         mat4.multiply(tileMatrix, this._viewProjMatrix, tileMatrix);
-
-        projectionData.tileMercatorCoords = [0, 0, 1, 1];
 
         // Even though we requested projection data for the mercator base tile which covers the entire mercator range,
         // the shader projection machinery still expects inputs to be in tile units range [0..EXTENT].
@@ -835,9 +833,13 @@ export class MercatorTransform implements ITransform {
         const projectionMatrixScaled = createMat4f64();
         mat4.scale(projectionMatrixScaled, tileMatrix, scale);
 
-        projectionData.fallbackMatrix = projectionMatrixScaled;
-        projectionData.mainMatrix = projectionMatrixScaled;
-        return projectionData;
+        return {
+            mainMatrix: projectionMatrixScaled,
+            tileMercatorCoords: [0, 0, 1, 1],
+            clippingPlane: [0, 0, 0, 0],
+            projectionTransition: 0.0,
+            fallbackMatrix: projectionMatrixScaled,
+        };
     }
 
     getFastPathSimpleProjectionMatrix(tileID: OverscaledTileID): mat4 {

--- a/src/geo/projection/mercator_utils.ts
+++ b/src/geo/projection/mercator_utils.ts
@@ -1,6 +1,6 @@
 import {mat4} from 'gl-matrix';
 import {EXTENT} from '../../data/extent.ts';
-import {clamp, degreesToRadians, MAX_VALID_LATITUDE, zoomScale} from '../../util/util.ts';
+import {clamp, degreesToRadians, MAX_VALID_LATITUDE, zoomScale, type Mat4f64} from '../../util/util.ts';
 import {MercatorCoordinate, mercatorXfromLng, mercatorYfromLat, mercatorZfromAltitude} from '../mercator_coordinate.ts';
 import Point from '@mapbox/point-geometry';
 import type {UnwrappedTileIDType} from '../transform_helper.ts';
@@ -73,12 +73,13 @@ export function getMercatorHorizon(transform: {pitch: number; cameraToCenterDist
         Math.tan(degreesToRadians(maxMercatorHorizonAngle - transform.pitch)));
 }
 
-export function calculateTileMatrix(unwrappedTileID: UnwrappedTileIDType, worldSize: number): mat4 {
+export function calculateTileMatrix(unwrappedTileID: UnwrappedTileIDType, worldSize: number): Mat4f64 {
     const canonical = unwrappedTileID.canonical;
     const scale = worldSize / zoomScale(canonical.z);
     const unwrappedX = canonical.x + Math.pow(2, canonical.z) * unwrappedTileID.wrap;
 
-    const worldMatrix = mat4.identity(new Float64Array(16));
+    const worldMatrix: Mat4f64 = new Float64Array(16);
+    mat4.identity(worldMatrix);
     mat4.translate(worldMatrix, worldMatrix, [unwrappedX * scale, canonical.y * scale, 0]);
     mat4.scale(worldMatrix, worldMatrix, [scale / EXTENT, scale / EXTENT, 1]);
     return worldMatrix;

--- a/src/geo/projection/projection_data.ts
+++ b/src/geo/projection/projection_data.ts
@@ -1,17 +1,33 @@
 import type {mat4} from 'gl-matrix';
 import type {OverscaledTileID} from '../../tile/tile_id.ts';
+import type {Mat4f32, Mat4f64} from '../../util/util.ts';
+
+export type ProjectionMatrix = Mat4f32 | Mat4f64;
+
+/**
+ * Projection data used by renderer shader uniforms. Renderer matrices are stored
+ * as 32-bit floats so WebGL can consume them directly without per-upload copies.
+ */
+export type RendererProjectionData = ProjectionData<Mat4f32>;
+
+/**
+ * Projection data exposed to custom layers. Some matrices are stored as 64-bit
+ * floats so custom layer code can apply additional CPU-side transforms before
+ * converting to 32-bit floats for WebGL upload when necessary.
+ */
+export type CustomLayerProjectionData = ProjectionData<ProjectionMatrix, ProjectionMatrix>;
 
 /**
  * This type contains all data necessary to project a tile to screen in MapLibre's shader system.
  * Contains data used for both mercator and globe projection.
  */
-export type ProjectionData = {
+export type ProjectionData<MainMatrix extends mat4 = mat4, FallbackMatrix extends mat4 = MainMatrix> = {
     /**
      * The main projection matrix. For mercator projection, it usually projects in-tile coordinates 0..EXTENT to screen,
      * for globe projection, it projects a unit sphere planet to screen.
      * Uniform name: `u_projection_matrix`.
      */
-    mainMatrix: mat4;
+    mainMatrix: MainMatrix;
     /**
      * The extent of current tile in the mercator square.
      * Used by globe projection.
@@ -43,7 +59,7 @@ export type ProjectionData = {
      * Used by globe projection to fall back to mercator projection in an animated way.
      * Uniform name: `u_projection_fallback_matrix`.
      */
-    fallbackMatrix: mat4;
+    fallbackMatrix: FallbackMatrix;
 };
 
 /**

--- a/src/geo/projection/vertical_perspective_transform.ts
+++ b/src/geo/projection/vertical_perspective_transform.ts
@@ -1,7 +1,7 @@
 import {type mat2, mat4, vec3, vec4} from 'gl-matrix';
 import {TransformHelper} from '../transform_helper.ts';
 import {LngLat, type LngLatLike, earthRadius} from '../lng_lat.ts';
-import {angleToRotateBetweenVectors2D, clamp, createIdentityMat4f32, createIdentityMat4f64, createMat4f64, createVec3f64, createVec4f64, differenceOfAnglesDegrees, distanceOfAnglesRadians, MAX_VALID_LATITUDE, pointPlaneSignedDistance, warnOnce} from '../../util/util.ts';
+import {angleToRotateBetweenVectors2D, clamp, createIdentityMat4f32, createIdentityMat4f64, createMat4f64, createVec3f64, createVec4f64, differenceOfAnglesDegrees, distanceOfAnglesRadians, MAX_VALID_LATITUDE, pointPlaneSignedDistance, warnOnce, type Mat4f32} from '../../util/util.ts';
 import {OverscaledTileID, UnwrappedTileID, type CanonicalTileID} from '../../tile/tile_id.ts';
 import Point from '@mapbox/point-geometry';
 import {MercatorCoordinate} from '../mercator_coordinate.ts';
@@ -16,7 +16,7 @@ import type {PointProjection} from '../../symbol/projection.ts';
 import type {IReadonlyTransform, ITransform, TransformConstrainFunction} from '../transform_interface.ts';
 import type {TransformOptions} from '../transform_helper.ts';
 import type {PaddingOptions} from '../edge_insets.ts';
-import type {ProjectionData, ProjectionDataParams} from './projection_data.ts';
+import type {CustomLayerProjectionData, ProjectionDataParams, RendererProjectionData} from './projection_data.ts';
 import type {CoveringTilesDetailsProvider} from './covering_tiles_details_provider.ts';
 
 /**
@@ -244,7 +244,7 @@ export class VerticalPerspectiveTransform implements ITransform {
     private _cachedClippingPlane: vec4 = createVec4f64();
     private _cachedFrustum: Frustum;
     private _projectionMatrix: mat4 = createIdentityMat4f64();
-    private _globeViewProjMatrix32f: mat4 = createIdentityMat4f32(); // Must be 32 bit floats, otherwise WebGL calls in Chrome get very slow.
+    private _globeViewProjMatrix32f: Mat4f32 = createIdentityMat4f32(); // Must be 32 bit floats, otherwise WebGL calls in Chrome get very slow.
     private _globeViewProjMatrixNoCorrection: mat4 = createIdentityMat4f64();
     private _globeViewProjMatrixNoCorrectionInverted: mat4 = createIdentityMat4f64();
     private _globeProjMatrixInverted: mat4 = createIdentityMat4f64();
@@ -297,7 +297,7 @@ export class VerticalPerspectiveTransform implements ITransform {
         return this._helper.cameraToCenterDistance;
     }
 
-    getProjectionData(params: ProjectionDataParams): ProjectionData {
+    getProjectionData(params: ProjectionDataParams): RendererProjectionData {
         const {overscaledTileID, applyGlobeMatrix} = params;
         const mercatorTileCoordinates = this._helper.getMercatorTileCoordinates(overscaledTileID);
         return {
@@ -990,7 +990,7 @@ export class VerticalPerspectiveTransform implements ITransform {
         return m;
     }
 
-    getProjectionDataForCustomLayer(applyGlobeMatrix: boolean = true): ProjectionData {
+    getProjectionDataForCustomLayer(applyGlobeMatrix: boolean = true): CustomLayerProjectionData {
         const globeData = this.getProjectionData({overscaledTileID: new OverscaledTileID(0, 0, 0, 0, 0), applyGlobeMatrix});
         globeData.tileMercatorCoords = [0, 0, 1, 1];
         return globeData;

--- a/src/geo/transform_interface.ts
+++ b/src/geo/transform_interface.ts
@@ -7,7 +7,7 @@ import type {UnwrappedTileID, OverscaledTileID, CanonicalTileID} from '../tile/t
 import type {PaddingOptions} from './edge_insets.ts';
 import type {Terrain} from '../render/terrain.ts';
 import type {PointProjection} from '../symbol/projection.ts';
-import type {ProjectionData, ProjectionDataParams} from './projection/projection_data.ts';
+import type {CustomLayerProjectionData, ProjectionDataParams, RendererProjectionData} from './projection/projection_data.ts';
 import type {CoveringTilesDetailsProvider} from './projection/covering_tiles_details_provider.ts';
 import type {Frustum} from '../util/primitives/frustum.ts';
 
@@ -446,7 +446,7 @@ export interface IReadonlyTransform extends ITransformGetters {
      * Generates a `ProjectionData` instance to be used while rendering the supplied tile.
      * @param params - Parameters for the projection data generation.
      */
-    getProjectionData(params: ProjectionDataParams): ProjectionData;
+    getProjectionData(params: ProjectionDataParams): RendererProjectionData;
 
     /**
      * @internal
@@ -505,7 +505,7 @@ export interface IReadonlyTransform extends ITransformGetters {
     /**
      * Return projection data such that coordinates in mercator projection in range 0..1 will get projected to the map correctly.
      */
-    getProjectionDataForCustomLayer(applyGlobeMatrix: boolean): ProjectionData;
+    getProjectionDataForCustomLayer(applyGlobeMatrix: boolean): CustomLayerProjectionData;
 
     /**
      * Returns a tile-specific projection matrix. Used for symbol placement fast-path for mercator transform.

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,7 +54,7 @@ import type {CustomRenderMethod, CustomLayerInterface, CustomRenderMethodInput, 
 import type {AnimationOptions, CameraForBoundsOptions, CameraOptions, CameraUpdateTransformFunction, CenterZoomBearing, EaseToOptions, FitBoundsOptions, FlyToOptions, JumpToOptions, PointLike} from './ui/camera.ts';
 import type {DistributiveKeys, DistributiveOmit, GeoJSONFeature, MapGeoJSONFeature} from './util/vectortile_to_geojson.ts';
 import type {Handler, HandlerResult} from './ui/handler_manager.ts';
-import type {Complete, RequireAtLeastOne, Subscription} from './util/util.ts';
+import type {Complete, Mat4f32, Mat4f64, RequireAtLeastOne, Subscription} from './util/util.ts';
 import type {CalculateTileZoomFunction, CoveringTilesOptions} from './geo/projection/covering_tiles.ts';
 import type {TransformConstrainFunction} from './geo/transform_interface.ts';
 import type {StyleImage, StyleImageData, StyleImageInterface, StyleImageMetadata, TextFit} from './style/style_image.ts';
@@ -65,7 +65,7 @@ import type {QueryRenderedFeaturesOptions, QuerySourceFeatureOptions} from './so
 import type {RequestTransformFunction, ResourceType} from './util/request_manager.ts';
 import type {OverscaledTileID} from './tile/tile_id.ts';
 import type {PositionAnchor} from './ui/anchor.ts';
-import type {ProjectionData, ProjectionDataParams} from './geo/projection/projection_data.ts';
+import type {CustomLayerProjectionData, ProjectionData, ProjectionDataParams, ProjectionMatrix, RendererProjectionData} from './geo/projection/projection_data.ts';
 import type {WorkerTileResult} from './source/worker_source.ts';
 import type {Actor, IActor} from './util/actor.ts';
 import type {Bucket} from './data/bucket.ts';
@@ -318,6 +318,11 @@ export {
     type PositionAnchor,
     type ProjectionData,
     type ProjectionDataParams,
+    type CustomLayerProjectionData,
+    type Mat4f32,
+    type Mat4f64,
+    type ProjectionMatrix,
+    type RendererProjectionData,
     type GeoJSONFeatureId,
     type GeoJSONFeatureDiff,
     type TextFit,

--- a/src/style/style_layer/custom_style_layer.ts
+++ b/src/style/style_layer/custom_style_layer.ts
@@ -2,7 +2,7 @@ import {StyleLayer} from '../style_layer.ts';
 import type {Map} from '../../ui/map.ts';
 import {type mat4} from 'gl-matrix';
 import {type LayerSpecification} from '@maplibre/maplibre-gl-style-spec';
-import type {ProjectionData} from '../../geo/projection/projection_data.ts';
+import type {CustomLayerProjectionData, RendererProjectionData} from '../../geo/projection/projection_data.ts';
 
 /**
  * Type for an object literal that specifies a map tile.
@@ -134,8 +134,8 @@ export type CustomRenderMethodInput = {
      *
      * For projection 3D features, use `projectTileFor3D` in the shader.
      *
-     * If you just need a projection matrix, use `defaultProjectionData.projectionMatrix`.
-     * A projection matrix is sufficient for simple custom layers that also only support mercator projection.
+     * If you just need a projection matrix, use `defaultProjectionData.mainMatrix`.
+     * A projection matrix is sufficient for simple custom layers that only support mercator projection.
      *
      * Under mercator projection, when these uniforms are used, the shader's `projectTile` function projects spherical mercator
      * coordinates to gl clip space coordinates. The spherical mercator coordinate `[0, 0]` represents the
@@ -148,7 +148,7 @@ export type CustomRenderMethodInput = {
      * passed to `projectTileFor3D` in the shader is elevation in meters above "sea level",
      * or more accurately for globe, elevation above the surface of the perfect sphere used to render the planet.
      */
-    defaultProjectionData: ProjectionData;
+    defaultProjectionData: CustomLayerProjectionData;
 
     /**
      * Generates a {@link ProjectionData} instance to be used while rendering a given tile.
@@ -157,7 +157,7 @@ export type CustomRenderMethodInput = {
      * @see [Add a custom layer with tiles to a globe](https://maplibre.org/maplibre-gl-js/docs/examples/add-a-custom-layer-with-tiles-to-a-globe)
      * @param params - Parameters for the projection data generation.
      */
-    getProjectionData: (params: CustomLayerProjectionDataParams) => ProjectionData;
+    getProjectionData: (params: CustomLayerProjectionDataParams) => RendererProjectionData;
 };
 
 /**

--- a/src/symbol/collision_index.test.ts
+++ b/src/symbol/collision_index.test.ts
@@ -2,7 +2,7 @@ import {vi, describe, test, expect} from 'vitest';
 import {CollisionIndex} from './collision_index.ts';
 import {MercatorTransform} from '../geo/projection/mercator_transform.ts';
 import {CanonicalTileID, UnwrappedTileID} from '../tile/tile_id.ts';
-import {mat4} from 'gl-matrix';
+import {createIdentityMat4f64} from '../util/util.ts';
 
 describe('CollisionIndex', () => {
     test('floating point precision', () => {
@@ -10,7 +10,7 @@ describe('CollisionIndex', () => {
         const transform = new MercatorTransform({minZoom: 0, maxZoom: 22, minPitch: 0, maxPitch: 60, renderWorldCopies: true});
         transform.resize(200, 200);
         const tile = new UnwrappedTileID(0, new CanonicalTileID(0, 0, 0));
-        vi.spyOn(transform, 'calculatePosMatrix').mockImplementation(() => mat4.create());
+        vi.spyOn(transform, 'calculatePosMatrix').mockImplementation(() => createIdentityMat4f64());
 
         const ci = new CollisionIndex(transform);
         expect(ci.projectAndGetPerspectiveRatio(x, y, tile, null).x).toBeCloseTo(10000212.3456, 10);

--- a/src/tile/terrain_tile_manager.ts
+++ b/src/tile/terrain_tile_manager.ts
@@ -106,7 +106,7 @@ export class TerrainTileManager extends Evented {
             keys[tileID.key] = true;
             this._renderableTilesKeys.push(tileID.key);
             if (!this._tiles[tileID.key]) {
-                tileID.terrainRttPosMatrix32f = new Float64Array(16);
+                tileID.terrainRttPosMatrix32f = new Float32Array(16);
                 mat4.ortho(tileID.terrainRttPosMatrix32f, 0, EXTENT, EXTENT, 0, 0, 1);
                 this._tiles[tileID.key] = new Tile(tileID, this.tileSize);
                 this._lastTilesetChange = now();

--- a/src/tile/tile_id.ts
+++ b/src/tile/tile_id.ts
@@ -3,9 +3,8 @@ import {EXTENT} from '../data/extent.ts';
 import Point from '@mapbox/point-geometry';
 import {MercatorCoordinate} from '../geo/mercator_coordinate.ts';
 import {register} from '../util/web_worker_transfer.ts';
-import {type mat4} from 'gl-matrix';
+import {type Mat4f32, MAX_TILE_ZOOM, MIN_TILE_ZOOM} from '../util/util.ts';
 import {type ICanonicalTileID, type IMercatorCoordinate} from '@maplibre/maplibre-gl-style-spec';
-import {MAX_TILE_ZOOM, MIN_TILE_ZOOM} from '../util/util.ts';
 import {isInBoundsForTileZoomXY} from '../util/world_bounds.ts';
 
 /**
@@ -97,7 +96,7 @@ export class OverscaledTileID {
      * and should be used, otherwise this matrix will be null.
      * The matrix should be float32 in order to avoid slow WebGL calls in Chrome.
      */
-    terrainRttPosMatrix32f: mat4 | null = null;
+    terrainRttPosMatrix32f: Mat4f32 | null = null;
 
     constructor(overscaledZ: number, wrap: number, z: number, x: number, y: number) {
         if (overscaledZ < z) throw new Error(`overscaledZ should be >= z; overscaledZ = ${overscaledZ}; z = ${z}`);

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -8,6 +8,15 @@ import {pixelsToTileUnits} from '../source/pixels_to_tile_units.ts';
 import {type OverscaledTileID} from '../tile/tile_id.ts';
 import type {Event} from './evented.ts';
 
+/**
+ * A 4x4 gl-matrix matrix backed by 32-bit floats.
+ */
+export type Mat4f32 = mat4 & Float32Array;
+/**
+ * A 4x4 gl-matrix matrix backed by 64-bit floats.
+ */
+export type Mat4f64 = mat4 & Float64Array;
+
 export const JSON_PREFIX = '__$json__:';
 
 /**
@@ -31,24 +40,24 @@ export function createVec3f64(): vec3 { return new Float64Array(3); }
 /**
  * Returns a new 64 bit float mat4 of zeroes.
  */
-export function createMat4f64(): mat4 { return new Float64Array(16); }
+export function createMat4f64(): Mat4f64 { return new Float64Array(16); }
 /**
  * Returns a new 32 bit float mat4 of zeroes.
  */
-export function createMat4f32(): mat4 { return new Float32Array(16); }
+export function createMat4f32(): Mat4f32 { return new Float32Array(16); }
 /**
  * Returns a new 64 bit float mat4 set to identity.
  */
-export function createIdentityMat4f64(): mat4 {
-    const m = new Float64Array(16) as any;
+export function createIdentityMat4f64(): Mat4f64 {
+    const m: Mat4f64 = new Float64Array(16);
     mat4.identity(m);
     return m;
 }
 /**
  * Returns a new 32 bit float mat4 set to identity.
  */
-export function createIdentityMat4f32(): mat4 {
-    const m = new Float32Array(16) as any;
+export function createIdentityMat4f32(): Mat4f32 {
+    const m: Mat4f32 = new Float32Array(16);
     mat4.identity(m);
     return m;
 }

--- a/src/webgl/draw/draw_custom.test.ts
+++ b/src/webgl/draw/draw_custom.test.ts
@@ -80,6 +80,8 @@ describe('drawCustom', () => {
         expect(result.args.modelViewProjectionMatrix).toEqual(mockPainter.transform.modelViewProjectionMatrix);
         expect(result.args.projectionMatrix).toEqual(mockPainter.transform.projectionMatrix);
         expectToBeCloseToArray(result.args.defaultProjectionData.tileMercatorCoords, [0, 0, 1, 1]);
+        expect(result.args.defaultProjectionData.mainMatrix).toBeInstanceOf(Float64Array);
+        expect(result.args.defaultProjectionData.fallbackMatrix).toBeInstanceOf(Float64Array);
         expect(result.args.defaultProjectionData.mainMatrix[0]).toEqual(1536);
         expect(result.args.defaultProjectionData.mainMatrix[5]).toEqual(-1512.6647086267515);
         expect(result.args.defaultProjectionData.mainMatrix[15]).toEqual(794.4539334827342);
@@ -96,6 +98,8 @@ describe('drawCustom', () => {
             }
         });
         expectToBeCloseToArray(tileProjectionData.tileMercatorCoords, [0.5, 0, 0.00006103515625, 0.00006103515625]);
+        expect(tileProjectionData.mainMatrix).toBeInstanceOf(Float32Array);
+        expect(tileProjectionData.fallbackMatrix).toBeInstanceOf(Float32Array);
         expect(tileProjectionData.mainMatrix[0]).toBeCloseTo(0.09375, 6);
         expect(tileProjectionData.mainMatrix[5]).toBeCloseTo(-0.09232572466135025, 6);
         expect(tileProjectionData.mainMatrix[15]).toBeCloseTo(794.4539184570312, 6);

--- a/src/webgl/draw/draw_fill.test.ts
+++ b/src/webgl/draw/draw_fill.test.ts
@@ -16,6 +16,7 @@ import {drawFill} from './draw_fill.ts';
 import {FillBucket} from '../../data/bucket/fill_bucket.ts';
 import {type ProgramConfiguration, type ProgramConfigurationSet} from '../../data/program_configuration.ts';
 import type {ProjectionData} from '../../geo/projection/projection_data.ts';
+import {createIdentityMat4f32} from '../../util/util.ts';
 
 vi.mock('../../render/painter');
 vi.mock('../program');
@@ -118,7 +119,7 @@ describe('drawFill', () => {
 
     function constructMockTile(layer: FillStyleLayer): Tile {
         const tileId = new OverscaledTileID(1, 0, 1, 0, 0);
-        tileId.terrainRttPosMatrix32f = mat4.create();
+        tileId.terrainRttPosMatrix32f = createIdentityMat4f32();
 
         const tile = new Tile(tileId, 256);
         tile.tileID = tileId;

--- a/src/webgl/draw/draw_symbol.test.ts
+++ b/src/webgl/draw/draw_symbol.test.ts
@@ -17,6 +17,7 @@ import type {SymbolLayerSpecification} from '@maplibre/maplibre-gl-style-spec';
 import {type Style} from '../../style/style.ts';
 import {MercatorProjection} from '../../geo/projection/mercator_projection.ts';
 import type {ProjectionData} from '../../geo/projection/projection_data.ts';
+import {createIdentityMat4f32} from '../../util/util.ts';
 
 vi.mock('../../render/painter');
 vi.mock('../program');
@@ -90,7 +91,7 @@ describe('drawSymbol', () => {
         layer.recalculate({zoom: 0, zoomHistory: {} as ZoomHistory} as EvaluationParameters, []);
 
         const tileId = new OverscaledTileID(1, 0, 1, 0, 0);
-        tileId.terrainRttPosMatrix32f = mat4.create();
+        tileId.terrainRttPosMatrix32f = createIdentityMat4f32();
         const programMock = new Program(null, null, null, null, null, null, null, null);
         (painterMock.useProgram as Mock).mockReturnValue(programMock);
         const bucketMock = new SymbolBucket(null);
@@ -153,7 +154,7 @@ describe('drawSymbol', () => {
         layer.recalculate({zoom: 0, zoomHistory: {} as ZoomHistory} as EvaluationParameters, []);
 
         const tileId = new OverscaledTileID(1, 0, 1, 0, 0);
-        tileId.terrainRttPosMatrix32f = mat4.create();
+        tileId.terrainRttPosMatrix32f = createIdentityMat4f32();
         const programMock = new Program(null, null, null, null, null, null, null, null);
         (painterMock.useProgram as Mock).mockReturnValue(programMock);
         const bucketMock = new SymbolBucket(null);
@@ -220,7 +221,7 @@ describe('drawSymbol', () => {
         layer.recalculate({zoom: 0, zoomHistory: {} as ZoomHistory} as EvaluationParameters, []);
 
         const tileId = new OverscaledTileID(1, 0, 1, 0, 0);
-        tileId.terrainRttPosMatrix32f = mat4.create();
+        tileId.terrainRttPosMatrix32f = createIdentityMat4f32();
         const programMock = new Program(null, null, null, null, null, null, null, null);
         (painterMock.useProgram as Mock).mockReturnValue(programMock);
         const bucketMock = new SymbolBucket(null);


### PR DESCRIPTION
## Summary

- Add explicit `Mat4f32` / `Mat4f64` aliases and make `ProjectionData` generic over its matrix backing arrays.
- Split projection data typing between renderer shader uniforms (`RendererProjectionData`, 32-bit matrices) and custom layer inputs (`CustomLayerProjectionData`, 32-bit or 64-bit matrices).
- Type terrain RTT projection matrices as `Mat4f32` and initialize the render-to-texture tile matrix as `Float32Array` to match the field contract.
- Fix the custom layer docs reference from the non-existent `defaultProjectionData.projectionMatrix` to `defaultProjectionData.mainMatrix`.

Fixes #6316
Replaces #7712

## Verification

- `npm run typecheck`
- `npx eslint src/geo/projection/globe_transform.ts src/geo/projection/mercator_transform.ts src/geo/projection/mercator_utils.ts src/geo/projection/projection_data.ts src/geo/projection/vertical_perspective_transform.ts src/geo/transform_interface.ts src/index.ts src/style/style_layer/custom_style_layer.ts src/symbol/collision_index.test.ts src/tile/terrain_tile_manager.ts src/tile/tile_id.ts src/util/util.ts src/webgl/draw/draw_custom.test.ts src/webgl/draw/draw_fill.test.ts src/webgl/draw/draw_symbol.test.ts`
- `git diff --check`
- `npx vitest run --config vitest.config.unit.ts src/geo/projection/mercator_transform.test.ts src/geo/projection/mercator_utils.test.ts src/geo/projection/globe_transform.test.ts src/webgl/draw/draw_custom.test.ts src/webgl/draw/draw_fill.test.ts src/webgl/draw/draw_symbol.test.ts src/symbol/collision_index.test.ts src/tile/terrain_tile_manager.test.ts`

Local note: generated code artifacts were created before verification with `npx tsx build/generate-unicode-data.ts`, `npx tsx build/generate-style-code.ts`, `npx tsx build/generate-struct-arrays.ts`, `npx tsx build/generate-shaders.ts`, and `npm run generate-typings`; no generated artifacts are included in this PR.

## Launch Checklist

- [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - no Mapbox backports are included.
- [x] Briefly describe the changes in this PR.
- [x] Link to related issues.
- [x] Include before/after visuals or gifs if this PR includes visual changes. Not applicable; this is a TypeScript API/runtime matrix backing fix.
- [x] Write tests for all new functionality.
- [x] Document any changes to public APIs.
- [x] Post benchmark scores. Not applicable; this is not a performance PR.
- [x] Add an entry to `CHANGELOG.md` under the `## main` section.
- [x] Confirm you have read our AI policy [here](https://github.com/maplibre/maplibre/blob/main/AI_POLICY.md).

Assisted-By: OpenAI ChatGPT coding agent via Oh My Pi harness
