### PR TITLE
fix: guard style methods after WebGL context loss

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### 🐞 Bug fixes
 - _...Add new stuff here..._
+- Avoid TypeErrors from style methods while the WebGL context is lost ([#7710](https://github.com/maplibre/maplibre-gl-js/issues/7710)) (by [@cyphercodes](https://github.com/cyphercodes))
 - querySourceFeatures() throws 'Block overruns tile' on overzoomed MLT tiles because the reported encoding doesn't match the re-encoded MVT data ([#7707](https://github.com/maplibre/maplibre-gl-js/pull/7707)) (by [@ted-piotrowski](https://github.com/ted-piotrowski))
 - Fix geometry length check for polygons and lines in LineBucket after duplicate vertex trimming([#7638](https://github.com/maplibre/maplibre-gl-js/pull/7638)) (by [@widefire](https://github.com/widefire))
 - `line-dasharray` step transition lags one zoom level when the step's branches are data-driven ([#7705](https://github.com/maplibre/maplibre-gl-js/pull/7705)) (by [@lucaswoj](https://github.com/lucaswoj))

--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -2477,7 +2477,7 @@ export class Map extends Camera {
      * @see [Add live realtime data](https://maplibre.org/maplibre-gl-js/docs/examples/add-live-realtime-data/)
      */
     getSource<TSource extends Source>(id: string): TSource | undefined {
-        return this.style.getSource(id) as TSource;
+        return this.style?.getSource(id) as TSource | undefined;
     }
 
     /**
@@ -2770,7 +2770,7 @@ export class Map extends Camera {
      * ```
      */
     listImages(): string[] {
-        return this.style.listImages();
+        return this.style?.listImages() ?? [];
     }
 
     /**
@@ -2908,7 +2908,7 @@ export class Map extends Camera {
      * @see [Filter symbols by text input](https://maplibre.org/maplibre-gl-js/docs/examples/filter-symbols-by-text-input/)
      */
     getLayer(id: string): StyleLayer | undefined {
-        return this.style.getLayer(id);
+        return this.style?.getLayer(id);
     }
 
     /**
@@ -2922,7 +2922,7 @@ export class Map extends Camera {
      * ```
      */
     getLayersOrder(): string[] {
-        return this.style.getLayersOrder();
+        return this.style?.getLayersOrder() ?? [];
     }
 
     /**
@@ -2985,7 +2985,7 @@ export class Map extends Camera {
      * @see [Create a timeline animation](https://maplibre.org/maplibre-gl-js/docs/examples/create-a-time-slider/)
      */
     setFilter(layerId: string, filter?: FilterSpecification | null, options: StyleSetterOptions = {}): this {
-        this.style.setFilter(layerId, filter, options);
+        this.style?.setFilter(layerId, filter, options);
         return this._update(true);
     }
 
@@ -3016,7 +3016,7 @@ export class Map extends Camera {
      * @see [Create a draggable point](https://maplibre.org/maplibre-gl-js/docs/examples/create-a-draggable-point/)
      */
     setPaintProperty<K extends keyof AllPaintProperties>(layerId: string, name: K, value: AllPaintProperties[K], options: StyleSetterOptions = {}): this {
-        this.style.setPaintProperty(layerId, name, value, options);
+        this.style?.setPaintProperty(layerId, name, value, options);
         return this._update(true);
     }
 

--- a/src/ui/map_tests/map_webgl.test.ts
+++ b/src/ui/map_tests/map_webgl.test.ts
@@ -55,6 +55,26 @@ test('handles "webglcontextrestored" when map is created without style', async (
     map.remove();
 });
 
+test('style methods do not throw after WebGL context loss', async () => {
+    const map = createMap();
+    const canvas = map.getCanvas();
+
+    const contextLostPromise = map.once('webglcontextlost');
+    canvas.dispatchEvent(new window.Event('webglcontextlost'));
+    await contextLostPromise;
+
+    expect(() => {
+        map.getLayer('missing-layer');
+        map.getSource('missing-source');
+        map.getLayersOrder();
+        map.listImages();
+        map.setFilter('missing-layer', null);
+        map.setPaintProperty('missing-layer', 'background-color', '#000000');
+    }).not.toThrow();
+
+    map.remove();
+});
+
 test('does not fire "webglcontextrestored" after remove has been called', async () => {
     const map = createMap();
     const canvas = map.getCanvas();


### PR DESCRIPTION
## Description

Fixes #7710.

Guards the style-backed map methods reported in the issue so calling them while the WebGL context is lost does not throw while `this.style` is temporarily cleared.

## Testing

- `npm run test-unit -- src/ui/map_tests/map_webgl.test.ts`
- `npm run typecheck`
- `git diff --check -- CHANGELOG.md src/ui/map.ts src/ui/map_tests/map_webgl.test.ts`
