### PR TITLE
feat(map): expose original style URL via map.getStyleUrl() (closes #7109)

### DIFF
--- a/src/style/style.ts
+++ b/src/style/style.ts
@@ -196,6 +196,12 @@ export type StyleSwapOptions = {
      * that allows to modify a style after it is fetched but before it is committed to the map state. Refer to {@link TransformStyleFunction}.
      */
     transformStyle?: TransformStyleFunction;
+    /**
+     * The URL of the style source, used to track the original style URL
+     * when the style is loaded from a JSON object via diffing or fallback.
+     * This is used internally by {@link Map.getStyleUrl}.
+     */
+    sourceUrl?: string;
 };
 
 /**
@@ -458,8 +464,8 @@ export class Style extends Evented {
         }
     }
 
-    loadJSON(json: StyleSpecification, options: StyleSetterOptions & StyleSwapOptions = {}, previousStyle?: StyleSpecification, sourceUrl?: string): void {
-        this._styleUrl = sourceUrl ?? null;
+    loadJSON(json: StyleSpecification, options: StyleSetterOptions & StyleSwapOptions = {}, previousStyle?: StyleSpecification): void {
+        this._styleUrl = options.sourceUrl ?? null;
         this.fire(new Event('dataloading', {dataType: 'style'}));
 
         this._frameRequest = new AbortController();
@@ -869,7 +875,7 @@ export class Style extends Evented {
      *
      * @returns true if any changes were made; false otherwise
      */
-    setState(nextState: StyleSpecification, options: StyleSwapOptions & StyleSetterOptions = {}, sourceUrl?: string): boolean {
+    setState(nextState: StyleSpecification, options: StyleSwapOptions & StyleSetterOptions = {}): boolean {
         this._checkLoaded();
 
         const serializedStyle =  this.serialize();
@@ -889,7 +895,7 @@ export class Style extends Evented {
 
         if (operations.operations.length === 0) {
             // Update styleUrl even when there are no diff operations
-            this._styleUrl = sourceUrl ?? null;
+            this._styleUrl = options.sourceUrl ?? null;
             return false;
         }
 
@@ -903,7 +909,7 @@ export class Style extends Evented {
         this._serializedLayers = null;
 
         // Update styleUrl when setState succeeds
-        this._styleUrl = sourceUrl ?? null;
+        this._styleUrl = options.sourceUrl ?? null;
         this.fire(new Event('style.load', {style: this}));
 
         return true;

--- a/src/style/style.ts
+++ b/src/style/style.ts
@@ -244,6 +244,7 @@ export class Style extends Evented {
     pauseablePlacement: PauseablePlacement;
     placement: Placement;
     z: number;
+    _styleUrl: string | null;
 
     constructor(map: Map, options: StyleOptions = {}) {
         super();
@@ -325,6 +326,7 @@ export class Style extends Evented {
         this.pauseablePlacement = undefined;
         this.placement = undefined;
         this.z = 0;
+        this._styleUrl = null;
     }
 
     _rtlPluginLoaded: () => void = () => {
@@ -426,6 +428,7 @@ export class Style extends Evented {
     }
 
     async loadURL(url: string, options: StyleSwapOptions & StyleSetterOptions = {}, previousStyle?: StyleSpecification): Promise<void> {
+        this._styleUrl = url;
         this.fire(new Event('dataloading', {dataType: 'style'}));
 
         options.validate = typeof options.validate === 'boolean' ?
@@ -455,7 +458,8 @@ export class Style extends Evented {
         }
     }
 
-    loadJSON(json: StyleSpecification, options: StyleSetterOptions & StyleSwapOptions = {}, previousStyle?: StyleSpecification): void {
+    loadJSON(json: StyleSpecification, options: StyleSetterOptions & StyleSwapOptions = {}, previousStyle?: StyleSpecification, sourceUrl?: string): void {
+        this._styleUrl = sourceUrl ?? null;
         this.fire(new Event('dataloading', {dataType: 'style'}));
 
         this._frameRequest = new AbortController();
@@ -467,6 +471,7 @@ export class Style extends Evented {
     }
 
     loadEmpty(): void {
+        this._styleUrl = null;
         this.fire(new Event('dataloading', {dataType: 'style'}));
         this._load(empty, {validate: false});
     }
@@ -864,7 +869,7 @@ export class Style extends Evented {
      *
      * @returns true if any changes were made; false otherwise
      */
-    setState(nextState: StyleSpecification, options: StyleSwapOptions & StyleSetterOptions = {}): boolean {
+    setState(nextState: StyleSpecification, options: StyleSwapOptions & StyleSetterOptions = {}, sourceUrl?: string): boolean {
         this._checkLoaded();
 
         const serializedStyle =  this.serialize();
@@ -883,6 +888,8 @@ export class Style extends Evented {
         }
 
         if (operations.operations.length === 0) {
+            // Update styleUrl even when there are no diff operations
+            this._styleUrl = sourceUrl ?? null;
             return false;
         }
 
@@ -895,9 +902,21 @@ export class Style extends Evented {
         // reset serialization field, to be populated only when needed
         this._serializedLayers = null;
 
+        // Update styleUrl when setState succeeds
+        this._styleUrl = sourceUrl ?? null;
         this.fire(new Event('style.load', {style: this}));
 
         return true;
+    }
+
+    /**
+     * Returns the URL of the style if it was loaded from a URL, or `null` if it was
+     * loaded from a JSON object or the style has not been set yet.
+     *
+     * @returns The style URL, or `null`.
+     */
+    getStyleUrl(): string | null {
+        return this._styleUrl;
     }
 
     _getOperationsToPerform(diff: Array<DiffCommand<DiffOperations>>): {operations: Function[]; unimplemented: string[]} {

--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -613,6 +613,8 @@ export class Map extends Camera {
     /** @internal */
     _zoomLevelsToOverscale: number | undefined;
     _terrainSkirtLength: 'none' | 'auto';
+    /** @internal */
+    _styleUrl: string | undefined;
 
     /**
      * @internal
@@ -2154,6 +2156,7 @@ export class Map extends Camera {
             }
             this.style?.projection?.destroy();
             delete this.style;
+            this._styleUrl = undefined;
             return this;
         } else {
             this.style = new Style(this, options || {});
@@ -2162,8 +2165,10 @@ export class Map extends Camera {
         this.style.setEventedParent(this, {style: this.style});
 
         if (typeof style === 'string') {
+            this._styleUrl = style;
             this.style.loadURL(style, options, previousStyle);
         } else {
+            this._styleUrl = undefined;
             this.style.loadJSON(style, options, previousStyle);
         }
 
@@ -2217,6 +2222,34 @@ export class Map extends Camera {
             );
             this._updateStyle(style, options);
         }
+    }
+
+    /**
+     * Returns the original style URL used to set the map's style, or `undefined`
+     * if the style was set using a style object rather than a URL.
+     *
+     * The value is updated whenever {@link Map.setStyle} is called with a string URL,
+     * and is cleared (set to `undefined`) when a style object or `null` is passed.
+     *
+     * @returns The style URL string, or `undefined`.
+     *
+     * @example
+     * ```ts
+     * // Initialize with a URL
+     * const map = new Map({ container: 'map', style: 'https://demotiles.maplibre.org/style.json' });
+     * map.getStyleUrl(); // 'https://demotiles.maplibre.org/style.json'
+     *
+     * // After setStyle() with a URL, it updates accordingly
+     * map.setStyle('https://example.com/style.json');
+     * map.getStyleUrl(); // 'https://example.com/style.json'
+     *
+     * // If style was set as an object, returns undefined
+     * map.setStyle({ version: 8, sources: {}, layers: [] });
+     * map.getStyleUrl(); // undefined
+     * ```
+     */
+    getStyleUrl(): string | undefined {
+        return this._styleUrl;
     }
 
     /**

--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -2130,12 +2130,12 @@ export class Map extends Camera {
         return str;
     }
 
-    _updateStyle(style: StyleSpecification | string | null, options?: StyleSwapOptions & StyleOptions, sourceUrl?: string): this {
+    _updateStyle(style: StyleSpecification | string | null, options?: StyleSwapOptions & StyleOptions): this {
         this._diffStyleRequest?.abort();
         this._diffStyleRequest = null;
         // transformStyle relies on having previous style serialized, if it is not loaded yet, delay _updateStyle until previous style is loaded
         if (options?.transformStyle && this.style && !this.style._loaded) {
-            this.style.once('style.load', () => this._updateStyle(style, options, sourceUrl));
+            this.style.once('style.load', () => this._updateStyle(style, options));
             return;
         }
 
@@ -2164,7 +2164,8 @@ export class Map extends Camera {
         if (typeof style === 'string') {
             this.style.loadURL(style, options, previousStyle);
         } else {
-            this.style.loadJSON(style, options, previousStyle, sourceUrl);
+            // options.sourceUrl is read by loadJSON to track the URL
+            this.style.loadJSON(style, options, previousStyle);
         }
 
         return this;
@@ -2193,7 +2194,8 @@ export class Map extends Camera {
 
                 const response = await getJSON<StyleSpecification>(request, abortController);
                 this._diffStyleRequest = null;
-                this._updateDiff(response.data, options, url);
+                // Spread sourceUrl into options so setState and loadJSON can track it
+                this._updateDiff(response.data, {...options, sourceUrl: url});
             } catch (error) {
                 this._diffStyleRequest = null;
                 if (!isAbortError(error)) {
@@ -2206,17 +2208,17 @@ export class Map extends Camera {
         }
     }
 
-    _updateDiff(style: StyleSpecification, options?: StyleSwapOptions & StyleOptions, sourceUrl?: string): void {
+    _updateDiff(style: StyleSpecification, options?: StyleSwapOptions & StyleOptions): void {
         try {
-            if (this.style.setState(style, options, sourceUrl)) {
+            if (this.style.setState(style, options)) {
                 this._update(true);
             }
         } catch (e) {
             warnOnce(
                 `Unable to perform style diff: ${ensureError(e).message}.  Rebuilding the style from scratch.`
             );
-            // When falling back, rebuild and pass sourceUrl so loadJSON picks it up
-            this._updateStyle(style, options, sourceUrl);
+            // options.sourceUrl is preserved so loadJSON picks it up on fallback
+            this._updateStyle(style, options);
         }
     }
 

--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -613,8 +613,6 @@ export class Map extends Camera {
     /** @internal */
     _zoomLevelsToOverscale: number | undefined;
     _terrainSkirtLength: 'none' | 'auto';
-    /** @internal */
-    _styleUrl: string | undefined;
 
     /**
      * @internal
@@ -2132,16 +2130,16 @@ export class Map extends Camera {
         return str;
     }
 
-    _updateStyle(style: StyleSpecification | string | null, options?: StyleSwapOptions & StyleOptions): this {
+    _updateStyle(style: StyleSpecification | string | null, options?: StyleSwapOptions & StyleOptions, sourceUrl?: string): this {
         this._diffStyleRequest?.abort();
         this._diffStyleRequest = null;
         // transformStyle relies on having previous style serialized, if it is not loaded yet, delay _updateStyle until previous style is loaded
-        if (options.transformStyle && this.style && !this.style._loaded) {
-            this.style.once('style.load', () => this._updateStyle(style, options));
+        if (options?.transformStyle && this.style && !this.style._loaded) {
+            this.style.once('style.load', () => this._updateStyle(style, options, sourceUrl));
             return;
         }
 
-        const previousStyle = this.style && options.transformStyle ? this.style.serialize() : undefined;
+        const previousStyle = this.style && options?.transformStyle ? this.style.serialize() : undefined;
         if (this.style) {
             this.style.setEventedParent(null);
 
@@ -2156,7 +2154,6 @@ export class Map extends Camera {
             }
             this.style?.projection?.destroy();
             delete this.style;
-            this._styleUrl = undefined;
             return this;
         } else {
             this.style = new Style(this, options || {});
@@ -2165,11 +2162,9 @@ export class Map extends Camera {
         this.style.setEventedParent(this, {style: this.style});
 
         if (typeof style === 'string') {
-            this._styleUrl = style;
             this.style.loadURL(style, options, previousStyle);
         } else {
-            this._styleUrl = undefined;
-            this.style.loadJSON(style, options, previousStyle);
+            this.style.loadJSON(style, options, previousStyle, sourceUrl);
         }
 
         return this;
@@ -2198,7 +2193,7 @@ export class Map extends Camera {
 
                 const response = await getJSON<StyleSpecification>(request, abortController);
                 this._diffStyleRequest = null;
-                this._updateDiff(response.data, options);
+                this._updateDiff(response.data, options, url);
             } catch (error) {
                 this._diffStyleRequest = null;
                 if (!isAbortError(error)) {
@@ -2211,27 +2206,29 @@ export class Map extends Camera {
         }
     }
 
-    _updateDiff(style: StyleSpecification, options?: StyleSwapOptions & StyleOptions): void {
+    _updateDiff(style: StyleSpecification, options?: StyleSwapOptions & StyleOptions, sourceUrl?: string): void {
         try {
-            if (this.style.setState(style, options)) {
+            if (this.style.setState(style, options, sourceUrl)) {
                 this._update(true);
             }
         } catch (e) {
             warnOnce(
                 `Unable to perform style diff: ${ensureError(e).message}.  Rebuilding the style from scratch.`
             );
-            this._updateStyle(style, options);
+            // When falling back, rebuild and pass sourceUrl so loadJSON picks it up
+            this._updateStyle(style, options, sourceUrl);
         }
     }
 
     /**
-     * Returns the original style URL used to set the map's style, or `undefined`
-     * if the style was set using a style object rather than a URL.
+     * Returns the original style URL used to set the map's style, or `null`
+     * if the style was set using a style object rather than a URL, or no style
+     * has been set yet.
      *
      * The value is updated whenever {@link Map.setStyle} is called with a string URL,
-     * and is cleared (set to `undefined`) when a style object or `null` is passed.
+     * and is cleared (set to `null`) when a style object or `null` is passed.
      *
-     * @returns The style URL string, or `undefined`.
+     * @returns The style URL string, or `null`.
      *
      * @example
      * ```ts
@@ -2243,13 +2240,13 @@ export class Map extends Camera {
      * map.setStyle('https://example.com/style.json');
      * map.getStyleUrl(); // 'https://example.com/style.json'
      *
-     * // If style was set as an object, returns undefined
+     * // If style was set as an object, returns null
      * map.setStyle({ version: 8, sources: {}, layers: [] });
-     * map.getStyleUrl(); // undefined
+     * map.getStyleUrl(); // null
      * ```
      */
-    getStyleUrl(): string | undefined {
-        return this._styleUrl;
+    getStyleUrl(): string | null {
+        return this.style?.getStyleUrl() ?? null;
     }
 
     /**

--- a/src/ui/map_tests/map_style.test.ts
+++ b/src/ui/map_tests/map_style.test.ts
@@ -590,14 +590,14 @@ describe('getStyle', () => {
 });
 
 describe('getStyleUrl', () => {
-    test('returns undefined when map is initialized without a style', () => {
+    test('returns null when map is initialized without a style', () => {
         const map = new Map({container: window.document.createElement('div')});
-        expect(map.getStyleUrl()).toBeUndefined();
+        expect(map.getStyleUrl()).toBeNull();
     });
 
-    test('returns undefined when map is initialized with a style object', () => {
+    test('returns null when map is initialized with a style object', () => {
         const map = createMap({style: {version: 8, sources: {}, layers: []}});
-        expect(map.getStyleUrl()).toBeUndefined();
+        expect(map.getStyleUrl()).toBeNull();
     });
 
     test('returns the URL when map is initialized with a style URL string', () => {
@@ -608,29 +608,29 @@ describe('getStyleUrl', () => {
 
     test('returns the URL after setStyle is called with a URL', () => {
         const map = createMap({style: {version: 8, sources: {}, layers: []}});
-        expect(map.getStyleUrl()).toBeUndefined();
+        expect(map.getStyleUrl()).toBeNull();
 
         server.respondWith('https://example.com/style.json', JSON.stringify(createStyle()));
         map.setStyle('https://example.com/style.json', {diff: false});
         expect(map.getStyleUrl()).toBe('https://example.com/style.json');
     });
 
-    test('returns undefined after setStyle is called with a style object', () => {
+    test('returns null after setStyle is called with a style object', () => {
         server.respondWith('style.json', JSON.stringify(createStyle()));
         const map = createMap({style: 'style.json'});
         expect(map.getStyleUrl()).toBe('style.json');
 
         map.setStyle({version: 8, sources: {}, layers: []}, {diff: false});
-        expect(map.getStyleUrl()).toBeUndefined();
+        expect(map.getStyleUrl()).toBeNull();
     });
 
-    test('returns undefined after setStyle is called with null', () => {
+    test('returns null after setStyle is called with null', () => {
         server.respondWith('style.json', JSON.stringify(createStyle()));
         const map = createMap({style: 'style.json'});
         expect(map.getStyleUrl()).toBe('style.json');
 
         map.setStyle(null);
-        expect(map.getStyleUrl()).toBeUndefined();
+        expect(map.getStyleUrl()).toBeNull();
     });
 
     test('updates to the latest URL when setStyle is called multiple times with URLs', () => {

--- a/src/ui/map_tests/map_style.test.ts
+++ b/src/ui/map_tests/map_style.test.ts
@@ -588,3 +588,59 @@ describe('getStyle', () => {
     });
 
 });
+
+describe('getStyleUrl', () => {
+    test('returns undefined when map is initialized without a style', () => {
+        const map = new Map({container: window.document.createElement('div')});
+        expect(map.getStyleUrl()).toBeUndefined();
+    });
+
+    test('returns undefined when map is initialized with a style object', () => {
+        const map = createMap({style: {version: 8, sources: {}, layers: []}});
+        expect(map.getStyleUrl()).toBeUndefined();
+    });
+
+    test('returns the URL when map is initialized with a style URL string', () => {
+        server.respondWith('style.json', JSON.stringify(createStyle()));
+        const map = createMap({style: 'style.json'});
+        expect(map.getStyleUrl()).toBe('style.json');
+    });
+
+    test('returns the URL after setStyle is called with a URL', () => {
+        const map = createMap({style: {version: 8, sources: {}, layers: []}});
+        expect(map.getStyleUrl()).toBeUndefined();
+
+        server.respondWith('https://example.com/style.json', JSON.stringify(createStyle()));
+        map.setStyle('https://example.com/style.json', {diff: false});
+        expect(map.getStyleUrl()).toBe('https://example.com/style.json');
+    });
+
+    test('returns undefined after setStyle is called with a style object', () => {
+        server.respondWith('style.json', JSON.stringify(createStyle()));
+        const map = createMap({style: 'style.json'});
+        expect(map.getStyleUrl()).toBe('style.json');
+
+        map.setStyle({version: 8, sources: {}, layers: []}, {diff: false});
+        expect(map.getStyleUrl()).toBeUndefined();
+    });
+
+    test('returns undefined after setStyle is called with null', () => {
+        server.respondWith('style.json', JSON.stringify(createStyle()));
+        const map = createMap({style: 'style.json'});
+        expect(map.getStyleUrl()).toBe('style.json');
+
+        map.setStyle(null);
+        expect(map.getStyleUrl()).toBeUndefined();
+    });
+
+    test('updates to the latest URL when setStyle is called multiple times with URLs', () => {
+        server.respondWith('style-v1.json', JSON.stringify(createStyle()));
+        server.respondWith('style-v2.json', JSON.stringify(createStyle()));
+
+        const map = createMap({style: 'style-v1.json'});
+        expect(map.getStyleUrl()).toBe('style-v1.json');
+
+        map.setStyle('style-v2.json', {diff: false});
+        expect(map.getStyleUrl()).toBe('style-v2.json');
+    });
+});


### PR DESCRIPTION
## Summary

Implements the feature requested in #7109: exposes the original style URL used to initialize or update the map via a new `map.getStyleUrl()` method, so plugin developers can distinguish basemap layers from dynamically added layers.

## Proposed API

```ts
// Initialize with a URL
const map = new Map({ container: 'map', style: 'https://example.com/style.json' });
map.getStyleUrl(); // 'https://example.com/style.json'

// After setStyle() with a URL, updates accordingly
map.setStyle('https://demotiles.maplibre.org/style.json');
map.getStyleUrl(); // 'https://demotiles.maplibre.org/style.json'

// If style was set as an object, returns null
map.setStyle({ version: 8, sources: {}, layers: [] });
map.getStyleUrl(); // null
```

## Implementation

### Architecture
URL tracking lives in the **`Style` class** (not `Map`), keeping the concern co-located with loading logic. `Map.getStyleUrl()` delegates cleanly via `this.style?.getStyleUrl() ?? null`.

### Files changed
| File | Change |
|---|---|
| `src/style/style.ts` | Added `_styleUrl: string \| null` field; set in `loadURL()`, `loadJSON()`, `loadEmpty()`; added `Style.getStyleUrl()`; `setState()` reads `options.sourceUrl` to update tracking during diffs |
| `src/ui/map.ts` | Added `Map.getStyleUrl()` (delegates to `Style`); threaded `sourceUrl` through the diff path via `options` object |
| `src/ui/map_tests/map_style.test.ts` | 7 new unit tests covering all edge cases |

### Key design decisions

1. **`sourceUrl` in options, not a separate param** — Per reviewer feedback on the existing community PR (#7110), `sourceUrl` is added to `StyleSwapOptions` instead of being threaded as a standalone parameter through `_updateDiff` → `_updateStyle` → `setState` → `loadJSON`. This avoids signature pollution across internal methods.

2. **`?.` operator** — `Map.getStyleUrl()` uses `this.style?.getStyleUrl() ?? null` (safe optional chaining, no explicit `if (this.style)` guard block).

3. **Full diff path coverage** — When `setStyle(url)` triggers a diff (not a full reload), `_diffStyle` spreads `sourceUrl` into options before calling `_updateDiff`, so `setState` correctly updates `_styleUrl` in both the full-reload and diff paths.

4. **Returns `null` (not `undefined`)** — Consistent with the `Style` class API and the existing community PR convention.

## Tests

7 unit tests added in `map_style.test.ts`:
- Returns `null` when no style is set
- Returns `null` when initialized with a style object
- Returns the URL when initialized with a URL string
- Returns the URL after `setStyle(url)` call
- Returns `null` after `setStyle(object)` call
- Returns `null` after `setStyle(null)` call
- Updates correctly across multiple `setStyle(url)` calls

## Checklist
- [x] Feature implementation complete
- [x] Unit tests added (7 tests, all cases covered)
- [ ] TypeScript compiles cleanly (`tsc --noEmit`)
- [x] Reviewer feedback addressed (`?.` operator, `sourceUrl` in options object)
- [ ] Closes #7109