### PR TITLE
chore: fix missing console logging of render test failures

### DIFF
--- a/test/integration/render/render.test.ts
+++ b/test/integration/render/render.test.ts
@@ -876,9 +876,7 @@ describe('Render tests', () => {
     });
 
     beforeEach((ctx) => {
-        const previousResult = ctx.task.result;
-        const wasFailedOrTimedOut = previousResult?.state === 'fail';
-        if (wasFailedOrTimedOut) {
+        if (ctx.task.result?.retryCount > 0) {
             console.log(`Retry ${ctx.task.name} with console logging enabled`);
             addConsoleLogging(page);
         }


### PR DESCRIPTION
## Launch Checklist

This adds back the missing logging when render test fails.
I needed that when debugging 
- #7570
This was supposed to be done here, but I think it didn't work well enough. 
- #7545

This is simply a fix for something that didn't work.


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [x] Confirm you have read our AI policy [here](https://github.com/maplibre/maplibre/blob/main/AI_POLICY.md).

No: AI.