### PR TITLE
Fix cross-origin module worker loading to preserve ESM semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### 🐞 Bug fixes
 - _...Add new stuff here..._
+- Fix cross-origin module worker loading to preserve ESM semantics ([#7796](https://github.com/maplibre/maplibre-gl-js/pull/7796)) (by [@dangkyokhoang](https://github.com/dangkyokhoang))
 
 ## 6.0.0-15
 

--- a/src/util/web_worker.test.ts
+++ b/src/util/web_worker.test.ts
@@ -67,7 +67,33 @@ describe('workerFactory', () => {
         );
     });
 
-    test('cross-origin URL is fetched and the worker is constructed from a Blob URL', async () => {
+    test('cross-origin module worker URL is converted to an import script and the worker is constructed from a Blob URL', async () => {
+        const WorkerSpy = vi.fn(function() {
+            return {postMessage: vi.fn(), addEventListener: vi.fn(), removeEventListener: vi.fn(), terminate: vi.fn()};
+        });
+        (globalThis as any).Worker = WorkerSpy;
+
+        const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+            ok: true,
+            text: () => Promise.resolve('// worker code'),
+        } as any);
+        const BlobSpy = vi.spyOn(globalThis, 'Blob');
+        const createObjectURLSpy = vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:http://localhost/abc');
+        const revokeObjectURLSpy = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {});
+
+        config.WORKER_URL = 'https://unpkg.com/maplibre-gl/dist/maplibre-gl-worker.mjs';
+
+        await workerFactory();
+
+        expect(fetchSpy).toHaveBeenCalledTimes(0);
+        expect(BlobSpy).toHaveBeenCalledWith(['import "https://unpkg.com/maplibre-gl/dist/maplibre-gl-worker.mjs"'], {type: 'text/javascript'});
+        expect(createObjectURLSpy).toHaveBeenCalled();
+        expect(WorkerSpy).toHaveBeenCalledTimes(1);
+        expect(WorkerSpy.mock.calls[0]).toEqual(['blob:http://localhost/abc', {type: 'module'}]);
+        expect(revokeObjectURLSpy).toHaveBeenCalledWith('blob:http://localhost/abc');
+    });
+
+    test('cross-origin classic worker URL is fetched and the worker is constructed from a Blob URL', async () => {
         const WorkerSpy = vi.fn(function() {
             return {postMessage: vi.fn(), addEventListener: vi.fn(), removeEventListener: vi.fn(), terminate: vi.fn()};
         });
@@ -80,20 +106,20 @@ describe('workerFactory', () => {
         const createObjectURLSpy = vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:http://localhost/abc');
         const revokeObjectURLSpy = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {});
 
-        config.WORKER_URL = 'https://unpkg.com/maplibre-gl/dist/maplibre-gl-worker.mjs';
+        config.WORKER_URL = 'https://unpkg.com/maplibre-gl/dist/maplibre-gl-worker.cjs';
 
         await workerFactory();
 
-        expect(fetchSpy).toHaveBeenCalledWith('https://unpkg.com/maplibre-gl/dist/maplibre-gl-worker.mjs');
+        expect(fetchSpy).toHaveBeenCalledWith('https://unpkg.com/maplibre-gl/dist/maplibre-gl-worker.cjs');
         expect(createObjectURLSpy).toHaveBeenCalled();
         expect(WorkerSpy).toHaveBeenCalledTimes(1);
-        expect(WorkerSpy.mock.calls[0]).toEqual(['blob:http://localhost/abc', {type: 'module'}]);
+        expect(WorkerSpy.mock.calls[0]).toEqual(['blob:http://localhost/abc']);
         expect(revokeObjectURLSpy).toHaveBeenCalledWith('blob:http://localhost/abc');
     });
 
     test('cross-origin fetch failure rejects the promise', async () => {
         vi.spyOn(globalThis, 'fetch').mockResolvedValue({ok: false, status: 404} as any);
-        config.WORKER_URL = 'https://unpkg.com/maplibre-gl/dist/maplibre-gl-worker.mjs';
+        config.WORKER_URL = 'https://unpkg.com/maplibre-gl/dist/maplibre-gl-worker.cjs';
 
         await expect(workerFactory()).rejects.toThrow('Failed to fetch worker script (404)');
     });

--- a/src/util/web_worker.ts
+++ b/src/util/web_worker.ts
@@ -53,12 +53,26 @@ async function fetchAsBlobUrl(url: string): Promise<string> {
     return URL.createObjectURL(blob);
 }
 
+function importAsBlobUrl(url: string): string {
+    const blob = new Blob([`import ${JSON.stringify(new URL(url, import.meta.url).href)}`], {type: 'text/javascript'});
+    return URL.createObjectURL(blob);
+}
+
 export async function workerFactory(): Promise<Worker> {
     const url = config.WORKER_URL || defaultWorkerUrl();
     const asModule = url?.endsWith('.cjs') ? false : true;
 
     if (!isCrossOrigin(url)) {
         return createWorker(url, asModule);
+    }
+
+    if (asModule) {
+        const blobUrl = importAsBlobUrl(url);
+        try {
+            return createWorker(blobUrl, asModule);
+        } finally {
+            URL.revokeObjectURL(blobUrl);
+        }
     }
 
     const blobUrl = await fetchAsBlobUrl(url);


### PR DESCRIPTION
Problem: Cross-origin module workers were loaded by fetching the script via fetch() and creating an inline blob. This changed the worker module URL, breaking `import.meta.url` resolution.

Solution: For cross-origin module workers, create a blob containing `import "resolved-url"` so the browser's native module loader handles the actual loading, `import.meta.url` is preserved.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items that are not relevant. -->


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [ ] Add an entry to `CHANGELOG.md` under the `## main` section.
 - [x] Confirm you have read our AI policy [here](https://github.com/maplibre/maplibre/blob/main/AI_POLICY.md).
<!--
  Add one of:    Assisted-By: | Generated-By:     and the model/version
-->
