### PR TITLE
Explore opt-in flattening of terrain RTT stacks

### DIFF
--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -407,6 +407,14 @@ export type MapOptions = {
      */
     terrainSkirtLength?: 'none' | 'auto';
     /**
+     * If `true`, terrain rendering may reorder symbol layers between draped layers to reduce render-to-texture passes.
+     *
+     * Enable this only for styles where rendering those symbols after the combined terrain pass is acceptable.
+     *
+     * @defaultValue false
+     */
+    allowTerrainDrapedLayerReordering?: boolean;
+    /**
      * Defines the number of zoom level that will overscale instead of split tiles below (inclusive) a map's `maxZoom`.
      * When `undefined`, all zoom levels after source's max zoom will be overscaled.
      *
@@ -522,6 +530,7 @@ const defaultOptions: Readonly<Partial<MapOptions>> = {
     cancelPendingTileRequestsWhileZooming: true,
     centerClampedToGround: true,
     terrainSkirtLength: 'auto',
+    allowTerrainDrapedLayerReordering: false,
     zoomLevelsToOverscale: 4,
     anisotropicFilterPitch: defaultAnisotropicFilterPitch,
 };
@@ -612,6 +621,7 @@ export class Map extends Camera {
     /** @internal */
     _zoomLevelsToOverscale: number | undefined;
     _terrainSkirtLength: 'none' | 'auto';
+    _allowTerrainDrapedLayerReordering: boolean;
 
     /**
      * @internal
@@ -766,6 +776,7 @@ export class Map extends Camera {
         this._zoomSnap = resolvedOptions.zoomSnap;
         this._centerClampedToGround = resolvedOptions.centerClampedToGround;
         this._terrainSkirtLength = resolvedOptions.terrainSkirtLength;
+        this._allowTerrainDrapedLayerReordering = resolvedOptions.allowTerrainDrapedLayerReordering === true;
         this._refreshExpiredTiles = resolvedOptions.refreshExpiredTiles === true;
         this._fadeDuration = resolvedOptions.fadeDuration;
         this._crossSourceCollisions = resolvedOptions.crossSourceCollisions === true;

--- a/src/webgl/render_to_texture.test.ts
+++ b/src/webgl/render_to_texture.test.ts
@@ -126,6 +126,8 @@ describe('render to texture', () => {
     beforeEach(() => {
         tile.rttObjects.length = 0;
         tile.rttFingerprint = {};
+        map._allowTerrainDrapedLayerReordering = false;
+        style._order = ['maine-fill', 'maine-symbol'];
     });
 
     test('should call painter with overlay tiles for terrain tile', () => {
@@ -214,6 +216,30 @@ describe('render to texture', () => {
         expect(rtt.renderLayer(lineLayer, renderOptions)).toBeTruthy();
         expect(rtt.renderLayer(symbolLayer, renderOptions)).toBeFalsy();
         expect(layersDrawn).toBe(3);
+    });
+
+    test('should allow symbols to be rendered after flattened draped layers when enabled', () => {
+        map._allowTerrainDrapedLayerReordering = true;
+        style._order = ['maine-background', 'maine-symbol', 'maine-hillshade', 'maine-line'];
+
+        rtt.prepareForRender(style, 0);
+        layersDrawn = 0;
+        (painter.renderLayer as Mock).mockClear();
+        const renderOptions = {isRenderingToTexture: false, isRenderingGlobe: false};
+
+        rtt.renderLayer(backgroundLayer, renderOptions);
+        expect(rtt.renderLayer(symbolLayer, renderOptions)).toBeTruthy();
+        rtt.renderLayer(hillshadeLayer, renderOptions);
+        rtt.renderLayer(lineLayer, renderOptions);
+
+        expect(rtt._stacks).toEqual([['maine-background', 'maine-hillshade', 'maine-line']]);
+        expect(layersDrawn).toBe(1);
+        expect((painter.renderLayer as Mock).mock.calls.map(call => [call[2].id, call[4].isRenderingToTexture])).toEqual([
+            ['maine-background', true],
+            ['maine-hillshade', true],
+            ['maine-line', true],
+            ['maine-symbol', false]
+        ]);
     });
 
     test('should clear tile cache on source state update', () => {

--- a/src/webgl/render_to_texture.ts
+++ b/src/webgl/render_to_texture.ts
@@ -67,6 +67,7 @@ export class RenderToTexture {
      * a list of all layer-ids which should be rendered
      */
     _renderableLayerIds: string[];
+    _deferredLayerIds: string[];
     constructor(painter: Painter, terrain: Terrain) {
         this.painter = painter;
         this.terrain = terrain;
@@ -81,6 +82,7 @@ export class RenderToTexture {
         this._stacks = [];
         this._prevType = null;
         this._rttTiles = [];
+        this._deferredLayerIds = [];
         this._renderableTiles = this.terrain.tileManager.getRenderableTiles();
         this._renderableLayerIds = style._order.filter(id => !style._layers[id].isHidden(zoom));
 
@@ -143,6 +145,12 @@ export class RenderToTexture {
         const type = layer.type;
         const painter = this.painter;
         const isLastLayer = this._renderableLayerIds[this._renderableLayerIds.length - 1] === layer.id;
+        const shouldDeferLayer = painter.style.map._allowTerrainDrapedLayerReordering && type === 'symbol' && LAYERS_TO_TEXTURES[this._prevType];
+
+        if (shouldDeferLayer && !isLastLayer) {
+            this._deferredLayerIds.push(layer.id);
+            return true;
+        }
 
         // remember background, fill, line & raster layer to render into a stack
         if (LAYERS_TO_TEXTURES[type]) {
@@ -178,6 +186,15 @@ export class RenderToTexture {
             }
             drawTerrain(this.painter, this.terrain, this._rttTiles, options);
             this._rttTiles = [];
+
+            for (const layerId of this._deferredLayerIds) {
+                const layer = painter.style._layers[layerId];
+                const tileManager = painter.style.tileManagers[layer.source];
+                const coords = tileManager.getVisibleCoordinates(true).reverse();
+                painter.renderTileClippingMasks(layer, tileManager.getVisibleCoordinates(), true);
+                painter.renderLayer(painter, tileManager, layer, coords, renderOptions);
+            }
+            this._deferredLayerIds = [];
 
             return LAYERS_TO_TEXTURES[type];
         }


### PR DESCRIPTION
## Context

While profiling terrain rendering with the OpenMapTiles Positron style, I noticed that a symbol layer between draped layers splits the render-to-texture work into multiple stacks.

In this particular style, terrain rendering uses 3 RTT stacks in both Mercator and Globe. I wanted to test whether combining these stacks could be worthwhile when an application is willing to accept a different ordering for the affected symbol layers.

I am keeping this PR as a draft because I would like feedback on the API and the rendering tradeoff before taking it further.

## Approach

This adds an opt-in `MapOptions` flag:

```js
allowTerrainDrapedLayerReordering: true
```

The default is `false`, so existing rendering is unchanged.

When enabled, symbol layers found between terrain-draped layers are deferred until after the combined terrain pass. This allows the draped layers to remain in one RTT stack instead of starting a new stack after each symbol layer.

The tradeoff is visual ordering: deferred symbols are rendered after the combined terrain pass instead of between the original draped layer groups. This is why I do not think the behavior should be enabled by default.

## Benchmark

I tested this with the OpenMapTiles Positron style, which has 51 style layers in this setup.

Each result measures the wall time for 125 synchronous rendered frames after warmup, with 20 samples per option. The same local bundle was used, changing only the option value.

| Projection | Option | RTT stacks | Median | Change |
| --- | --- | ---: | ---: | ---: |
| Mercator | `false` | 3 | 2466.9 ms | baseline |
| Mercator | `true` | 1 | 2075.6 ms | -15.9% |
| Globe | `false` | 3 | 2633.2 ms | baseline |
| Globe | `true` | 1 | 2243.8 ms | -14.8% |

These are end-to-end measurements for this scenario, not isolated GPU timings.

## Tests

I added a unit test that checks:

- the draped layers are collected into one stack when the option is enabled;
- the symbol layer is deferred;
- the symbol layer is rendered outside the terrain texture pass.

Before marking this ready, I still want to add a visual example showing the ordering difference.

## Feedback requested

I would especially appreciate feedback on:

- whether a public `MapOptions` flag is the right way to expose this;
- whether this ordering tradeoff is acceptable as an explicit opt-in;
- whether the option belongs somewhere else or should remain internal.

## Launch Checklist

- [x] Confirm my changes do not include backports from Mapbox projects.
- [x] Briefly describe the changes in this PR.
- [x] Link to related issues. N/A — this came from profiling the current terrain RTT path.
- [ ] Include before/after visuals or gifs. TODO before marking the PR ready.
- [x] Write tests for the new behavior.
- [x] Document the new public option.
- [x] Post benchmark results.
- [ ] Add an entry to `CHANGELOG.md`. TODO before marking the PR ready.
- [x] Confirm I have read the MapLibre AI policy.

Assisted-By: GPT-5.5