### PR TITLE
Fix: reuse terrain DEM texture when preparing terrain

### DIFF
--- a/src/render/terrain.test.ts
+++ b/src/render/terrain.test.ts
@@ -217,64 +217,6 @@ describe('Terrain', () => {
         expect(minMaxNoDEM.maxElevation).toBeNull();
     });
 
-    test('getTerrainData reuses DEM texture across repeated terrain prepares', () => {
-        const tileID = new OverscaledTileID(5, 0, 5, 17, 11);
-        const tile = new Tile(tileID, 256);
-        const pixels = new RGBAImage({width: 4, height: 4}, new Uint8Array(4 * 4 * 4));
-        tile.dem = {
-            stride: 4,
-            dim: 2,
-            getPixels: vi.fn(() => pixels),
-            getUnpackVector: () => [6553.6, 25.6, 0.1, 10000.0],
-        } as any as DEMData;
-        tile.needsTerrainPrepare = true;
-
-        const firstTexture = {
-            texture: {},
-            update: vi.fn(),
-            bind: vi.fn(),
-        };
-        const leakedTexture = {
-            texture: {},
-            update: vi.fn(),
-            bind: vi.fn(),
-        };
-        const painter = {
-            context: new Context(gl),
-            width: 1,
-            height: 1,
-            getTileTexture: vi.fn()
-                .mockReturnValueOnce(firstTexture)
-                .mockReturnValueOnce(leakedTexture),
-            saveTileTexture: vi.fn(),
-        } as any as Painter;
-        const tileManager = {
-            _source: {minzoom: 0, maxzoom: 22, tileSize: 512},
-            _cache: {max: 10},
-        } as any as TileManager;
-        const terrain = new Terrain(
-            painter,
-            tileManager,
-            {exaggeration: 2} as any as TerrainSpecification,
-        );
-        terrain.tileManager.getSourceTile = vi.fn(() => tile);
-
-        terrain.getTerrainData(tileID);
-        const demTexture = tile.demTexture;
-        tile.needsTerrainPrepare = true;
-        terrain.getTerrainData(tileID);
-
-        expect(tile.demTexture).toBe(demTexture);
-        expect(painter.getTileTexture).toHaveBeenCalledOnce();
-        expect(firstTexture.update).toHaveBeenCalledTimes(2);
-
-        tile.clearTextures(painter);
-
-        expect(painter.saveTileTexture).toHaveBeenCalledOnce();
-        expect(painter.saveTileTexture).toHaveBeenCalledWith(demTexture);
-        expect(tile.demTexture).toBeNull();
-    });
-
     test('create mesh with border', () => {
         let actualIndexArray;
         let actualVertexArray;

--- a/src/render/terrain.test.ts
+++ b/src/render/terrain.test.ts
@@ -217,6 +217,64 @@ describe('Terrain', () => {
         expect(minMaxNoDEM.maxElevation).toBeNull();
     });
 
+    test('getTerrainData reuses DEM texture across repeated terrain prepares', () => {
+        const tileID = new OverscaledTileID(5, 0, 5, 17, 11);
+        const tile = new Tile(tileID, 256);
+        const pixels = new RGBAImage({width: 4, height: 4}, new Uint8Array(4 * 4 * 4));
+        tile.dem = {
+            stride: 4,
+            dim: 2,
+            getPixels: vi.fn(() => pixels),
+            getUnpackVector: () => [6553.6, 25.6, 0.1, 10000.0],
+        } as any as DEMData;
+        tile.needsTerrainPrepare = true;
+
+        const firstTexture = {
+            texture: {},
+            update: vi.fn(),
+            bind: vi.fn(),
+        };
+        const leakedTexture = {
+            texture: {},
+            update: vi.fn(),
+            bind: vi.fn(),
+        };
+        const painter = {
+            context: new Context(gl),
+            width: 1,
+            height: 1,
+            getTileTexture: vi.fn()
+                .mockReturnValueOnce(firstTexture)
+                .mockReturnValueOnce(leakedTexture),
+            saveTileTexture: vi.fn(),
+        } as any as Painter;
+        const tileManager = {
+            _source: {minzoom: 0, maxzoom: 22, tileSize: 512},
+            _cache: {max: 10},
+        } as any as TileManager;
+        const terrain = new Terrain(
+            painter,
+            tileManager,
+            {exaggeration: 2} as any as TerrainSpecification,
+        );
+        terrain.tileManager.getSourceTile = vi.fn(() => tile);
+
+        terrain.getTerrainData(tileID);
+        const demTexture = tile.demTexture;
+        tile.needsTerrainPrepare = true;
+        terrain.getTerrainData(tileID);
+
+        expect(tile.demTexture).toBe(demTexture);
+        expect(painter.getTileTexture).toHaveBeenCalledOnce();
+        expect(firstTexture.update).toHaveBeenCalledTimes(2);
+
+        tile.clearTextures(painter);
+
+        expect(painter.saveTileTexture).toHaveBeenCalledOnce();
+        expect(painter.saveTileTexture).toHaveBeenCalledWith(demTexture);
+        expect(tile.demTexture).toBeNull();
+    });
+
     test('create mesh with border', () => {
         let actualIndexArray;
         let actualVertexArray;

--- a/src/render/terrain.ts
+++ b/src/render/terrain.ts
@@ -282,7 +282,7 @@ export class Terrain {
         const sourceTile = this.tileManager.getSourceTile(tileID, true);
         if (sourceTile?.dem && (!sourceTile.demTexture || sourceTile.needsTerrainPrepare)) {
             const context = this.painter.context;
-            sourceTile.demTexture = this.painter.getTileTexture(sourceTile.dem.stride);
+            sourceTile.demTexture ||= this.painter.getTileTexture(sourceTile.dem.stride);
             if (sourceTile.demTexture) sourceTile.demTexture.update(sourceTile.dem.getPixels(), {premultiply: false});
             else sourceTile.demTexture = new Texture(context, sourceTile.dem.getPixels(), context.gl.RGBA, {premultiply: false});
             sourceTile.demTexture.bind(context.gl.NEAREST, context.gl.CLAMP_TO_EDGE);


### PR DESCRIPTION
## Summary

This PR fixes a small GPU resource leak in the terrain DEM texture path.

When a raster-dem tile needed terrain preparation again, for example after DEM border backfilling, `getTerrainData()` always requested a new pooled texture and assigned it to `sourceTile.demTexture`.

If the tile already had a DEM texture, that old texture was overwritten without being returned to the texture pool or destroyed.

## Changes

- Reuse the existing `sourceTile.demTexture` when terrain preparation runs again.
- Keep updating the texture contents when DEM pixels change.
- Add a regression test that simulates repeated terrain preparation on the same tile.

The code change is intentionally small:

```ts
sourceTile.demTexture = this.painter.getTileTexture(sourceTile.dem.stride);
```
becomes:
```ts
sourceTile.demTexture ||= this.painter.getTileTexture(sourceTile.dem.stride);
```

So we only request a pooled texture when the tile does not already have one.

The test checks that:

- the DEM texture object stays the same;
- `getTileTexture()` is only called once;
- the same texture is returned to the painter when tile textures are cleared.

I also verified the first commit fails before the fix, then passes after the texture reuse change.
