### PR TITLE
fix: add CanvasSourceSpecification to SourceSpecification union

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -81,6 +81,8 @@ import type {WorkerGlobalScopeInterface} from './util/web_worker.ts';
 const version = packageJSON.version;
 
 export type * from '@maplibre/maplibre-gl-style-spec';
+import type {SourceSpecification as StyleSpecSourceSpecification} from '@maplibre/maplibre-gl-style-spec';
+type SourceSpecification = StyleSpecSourceSpecification | CanvasSourceSpecification;
 
 /**
  * Sets the map's [RTL text plugin](https://www.mapbox.com/mapbox-gl-js/plugins/#mapbox-gl-rtl-text).
@@ -372,6 +374,7 @@ export {
     type CustomLayerProjectionDataParams,
     type UnwrappedTileIDLiteral,
     type CanvasSourceSpecification,
+    type SourceSpecification,
     type PaddingOptions,
     type LngLatLike,
     type PointLike,

--- a/src/style/style.ts
+++ b/src/style/style.ts
@@ -204,7 +204,7 @@ export type StyleSwapOptions = {
  * Specifies a layer to be added to a {@link Style}. In addition to a standard {@link LayerSpecification}
  * or a {@link CustomLayerInterface}, a {@link LayerSpecification} with an embedded {@link SourceSpecification} can also be provided.
  */
-export type AddLayerObject = LayerSpecification | (Omit<LayerSpecification, 'source'> & {source: SourceSpecification}) | CustomLayerInterface;
+export type AddLayerObject = LayerSpecification | (Omit<LayerSpecification, 'source'> & {source: SourceSpecification | CanvasSourceSpecification}) | CustomLayerInterface;
 
 /**
  * The Style base class


### PR DESCRIPTION
Fixes #2242

### Description
`CanvasSourceSpecification` was successfully imported into `src/index.ts` but was never added to the master `SourceSpecification` union, causing strict TypeScript errors when developers tried to use a canvas source. 

This PR explicitly merges it into the `SourceSpecification` union exported to the public API.

## Launch Checklist

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes. *(N/A - purely a TypeScript type definition fix)*
 - [ ] Write tests for all new functionality. *(N/A - covered by standard TS compilation)*
 - [x] Document any changes to public APIs.
 - [ ] Post benchmark scores. *(N/A)*
 - [ ] Add an entry to `CHANGELOG.md` under the `## main` section. *(Happy to add this if reviewers require it for a type fix!)*
 - [x] Confirm you have read our AI policy [here](https://github.com/maplibre/maplibre/blob/main/AI_POLICY.md).

Assisted-By: Gemini
