### PR TITLE
fix: reject sendAsync promise on abort to stop leaking suspended frames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes
+- Fix a memory leak where aborting a worker request (e.g. a GeoJSON tile load cancelled while panning) left its promise pending forever, so the awaiting async frame and everything it captured was never released; `Actor.sendAsync` now rejects with an `AbortError` on abort ([#XXXX](https://github.com/maplibre/maplibre-gl-js/pull/XXXX)) (by [@kamil-sienkiewicz-asi](https://github.com/kamil-sienkiewicz-asi))
 - _...Add new stuff here..._
 
 ## 6.0.0-16

--- a/src/source/geojson_source.test.ts
+++ b/src/source/geojson_source.test.ts
@@ -8,6 +8,7 @@ import {extend} from '../util/util.ts';
 import {SubdivisionGranularitySetting} from '../render/subdivision_granularity_settings.ts';
 import {MercatorTransform} from '../geo/projection/mercator_transform.ts';
 import {getWrapDispatcher, sleep, waitForEvent} from '../util/test/util.ts';
+import {AbortError} from '../util/abort_error.ts';
 import {type ActorMessage, type ClusterIDAndSource, type GeoJSONWorkerSourceLoadDataResult, MessageType} from '../util/actor_messages.ts';
 import type {IReadonlyTransform} from '../geo/transform_interface.ts';
 import type {RequestManager} from '../util/request_manager.ts';
@@ -233,6 +234,69 @@ describe('GeoJSONSource.setData', () => {
         source.setData({} as GeoJSON.GeoJSON);
         await promise;
         expect(source.loaded()).toBeTruthy();
+    });
+});
+
+describe('GeoJSONSource.loadTile', () => {
+    const mapStub = {
+        getPixelRatio() { return 1; },
+        showCollisionBoxes: false,
+        style: {
+            projection: {
+                get subdivisionGranularity() {
+                    return SubdivisionGranularitySetting.noSubdivision;
+                }
+            }
+        }
+    } as any;
+
+    test('swallows an AbortError from the worker request', async () => {
+        const source = new GeoJSONSource('id', {data: {}} as GeoJSONSourceOptions, wrapDispatcher({
+            sendAsync() {
+                return Promise.reject(new AbortError());
+            }
+        }), undefined);
+        source.map = mapStub;
+
+        const tile = new Tile(new OverscaledTileID(0, 0, 0, 0, 0), source.tileSize);
+        const loadVectorDataSpy = vi.spyOn(tile, 'loadVectorData');
+
+        await expect(source.loadTile(tile)).resolves.toBeUndefined();
+        expect(loadVectorDataSpy).not.toHaveBeenCalled();
+        expect(tile.abortController).toBeUndefined();
+    });
+
+    test('swallows a worker error when the tile was aborted', async () => {
+        const tile = new Tile(new OverscaledTileID(0, 0, 0, 0, 0), 512);
+        const source = new GeoJSONSource('id', {data: {}} as GeoJSONSourceOptions, wrapDispatcher({
+            sendAsync() {
+                tile.aborted = true;
+                return Promise.reject(new Error('worker error'));
+            }
+        }), undefined);
+        source.map = mapStub;
+
+        const loadVectorDataSpy = vi.spyOn(tile, 'loadVectorData');
+
+        await expect(source.loadTile(tile)).resolves.toBeUndefined();
+        expect(loadVectorDataSpy).not.toHaveBeenCalled();
+        expect(tile.abortController).toBeUndefined();
+    });
+
+    test('rethrows a non-abort error from the worker request', async () => {
+        const source = new GeoJSONSource('id', {data: {}} as GeoJSONSourceOptions, wrapDispatcher({
+            sendAsync() {
+                return Promise.reject(new Error('worker error'));
+            }
+        }), undefined);
+        source.map = mapStub;
+
+        const tile = new Tile(new OverscaledTileID(0, 0, 0, 0, 0), source.tileSize);
+        const loadVectorDataSpy = vi.spyOn(tile, 'loadVectorData');
+
+        await expect(source.loadTile(tile)).rejects.toThrow('worker error');
+        expect(loadVectorDataSpy).not.toHaveBeenCalled();
+        expect(tile.abortController).toBeUndefined();
     });
 });
 

--- a/src/source/geojson_source.ts
+++ b/src/source/geojson_source.ts
@@ -6,6 +6,7 @@ import {ResourceType} from '../util/request_manager.ts';
 import {browser} from '../util/browser.ts';
 import {applySourceDiff, mergeSourceDiffs, toUpdateable} from './geojson_source_diff.ts';
 import {getGeoJSONBounds} from '../util/geojson_bounds.ts';
+import {isAbortError} from '../util/abort_error.ts';
 import {MessageType} from '../util/actor_messages.ts';
 import {tileIdToLngLatBounds} from '../tile/tile_id_to_lng_lat_bounds.ts';
 
@@ -594,12 +595,20 @@ export class GeoJSONSource extends Evented<SourceEventType> implements Source {
         };
 
         tile.abortController = new AbortController();
-        const data = await (await this.actorPromise).sendAsync({type: message, data: params}, tile.abortController);
-        delete tile.abortController;
-        tile.unloadVectorData();
+        try {
+            const data = await (await this.actorPromise).sendAsync({type: message, data: params}, tile.abortController);
+            delete tile.abortController;
+            tile.unloadVectorData();
 
-        if (!tile.aborted) {
-            tile.loadVectorData(data, this.map.painter, message ===  MessageType.reloadTile);
+            if (!tile.aborted) {
+                tile.loadVectorData(data, this.map.painter, message ===  MessageType.reloadTile);
+            }
+        } catch (err) {
+            delete tile.abortController;
+            if (tile.aborted || isAbortError(err)) {
+                return;
+            }
+            throw err;
         }
     }
 

--- a/src/source/vector_tile_source.test.ts
+++ b/src/source/vector_tile_source.test.ts
@@ -4,6 +4,7 @@ import {type Source} from './source.ts';
 import {VectorTileSource} from './vector_tile_source.ts';
 import {type Tile} from '../tile/tile.ts';
 import {AJAXError} from '../util/ajax.ts';
+import {AbortError} from '../util/abort_error.ts';
 import {OverscaledTileID} from '../tile/tile_id.ts';
 import {Evented} from '../util/evented.ts';
 import {RequestManager} from '../util/request_manager.ts';
@@ -514,6 +515,31 @@ describe('VectorTileSource', () => {
         expect(result).toBeUndefined();
         expect(tile.loadVectorData).toHaveBeenCalledTimes(0);
         expect(tile.etag).toBeUndefined();
+    });
+
+    test('swallows an AbortError from the worker request', async () => {
+        const source = createSource({
+            tiles: ['http://example.com/{z}/{x}/{y}.png']
+        });
+        await waitForMetadataEvent(source);
+
+        const tile = {
+            tileID: new OverscaledTileID(10, 0, 10, 5, 5),
+            state: 'loading',
+            aborted: false,
+            etag: undefined,
+            loadVectorData: vi.fn(),
+            setExpiryData() {}
+        } as any as Tile;
+
+        source.dispatcher = getWrapDispatcher()({
+            sendAsync() {
+                return Promise.reject(new AbortError());
+            }
+        });
+
+        await expect(source.loadTile(tile)).resolves.toBeUndefined();
+        expect(tile.loadVectorData).toHaveBeenCalledTimes(0);
     });
 
     test('stores worker etag on tile when present', async () => {

--- a/src/source/vector_tile_source.ts
+++ b/src/source/vector_tile_source.ts
@@ -247,7 +247,7 @@ export class VectorTileSource extends Evented<SourceEventType> implements Source
         } catch (err) {
             delete tile.abortController;
 
-            if (tile.aborted) {
+            if (tile.aborted || isAbortError(err)) {
                 return;
             }
             if (err && err.status !== 404) {

--- a/src/util/actor.test.ts
+++ b/src/util/actor.test.ts
@@ -47,7 +47,7 @@ describe('Actor', () => {
         actor.sendAsync({
             type: MessageType.getClusterExpansionZoom,
             data: {type: 'geojson', source: '', clusterId: 1729}
-        }, abortController);
+        }, abortController).catch(() => {});
 
         expect(addSpy).toHaveBeenCalledTimes(1);
 
@@ -98,7 +98,7 @@ describe('Actor', () => {
         await expect(p2).resolves.toBe(4104);
     });
 
-    test('cancel a request does not reject or resolve a promise', async () => {
+    test('aborting a request rejects its promise with an AbortError', async () => {
         const worker = await workerFactory() as any as WorkerGlobalScopeInterface & ActorTarget;
         worker.worker.actor.registerMessageHandler(MessageType.getClusterExpansionZoom, async (_mapId, params) => {
             await sleep(200);
@@ -107,21 +107,15 @@ describe('Actor', () => {
 
         const m1 = new Actor(worker, '1');
 
-        let received = false;
         const abortController = new AbortController();
-        const p1 = m1.sendAsync({type: MessageType.getClusterExpansionZoom, data: {type: 'geojson', source: '', clusterId: 1729}}, abortController)
-            .then(() => received = true)
-            .catch(() => received = true);
+        const p1 = m1.sendAsync({type: MessageType.getClusterExpansionZoom, data: {type: 'geojson', source: '', clusterId: 1729}}, abortController);
 
         abortController.abort();
 
-        const p2 = new Promise((resolve) => (setTimeout(resolve, 500)));
-
-        await Promise.any([p1, p2]);
-        expect(received).toBeFalsy();
+        await expect(p1).rejects.toMatchObject({name: ABORT_ERROR});
     });
 
-    test('aborting a request will successfully abort it', async () => {
+    test('aborting a request rejects the caller and aborts the worker handler', async () => {
         const worker = await workerFactory() as any as WorkerGlobalScopeInterface & ActorTarget;
         let gotAbortSignal = false;
         worker.worker.actor.registerMessageHandler(MessageType.getClusterExpansionZoom, (_mapId, _params, handlerAbortController) => {
@@ -136,17 +130,13 @@ describe('Actor', () => {
 
         const m1 = new Actor(worker, '1');
 
-        let received = false;
         const abortController = new AbortController();
-        m1.sendAsync({type: MessageType.getClusterExpansionZoom, data: {type: 'geojson', source: '', clusterId: 1729}}, abortController)
-            .then(() => received = true)
-            .catch(() => received = true);
+        const p1 = m1.sendAsync({type: MessageType.getClusterExpansionZoom, data: {type: 'geojson', source: '', clusterId: 1729}}, abortController);
 
         abortController.abort();
 
-        await sleep(500);
-
-        expect(received).toBeFalsy();
+        await expect(p1).rejects.toMatchObject({name: ABORT_ERROR});
+        await sleep(300);
         expect(gotAbortSignal).toBeTruthy();
     });
 
@@ -163,18 +153,13 @@ describe('Actor', () => {
             worker.worker.actor.process();
         };
 
-        let received = false;
         const abortController = new AbortController();
-        const p1 = actor.sendAsync({type: MessageType.getClusterExpansionZoom, data: {type: 'geojson', source: '', clusterId: 1729}, mustQueue: true}, abortController)
-            .then(() => received = true)
-            .catch(() => received = true);
+        const p1 = actor.sendAsync({type: MessageType.getClusterExpansionZoom, data: {type: 'geojson', source: '', clusterId: 1729}, mustQueue: true}, abortController);
 
         abortController.abort();
 
-        const p2 = sleep(500);
-
-        await Promise.any([p1, p2]);
-        expect(received).toBeFalsy();
+        await expect(p1).rejects.toMatchObject({name: ABORT_ERROR});
+        await sleep(500);
         expect(spy).not.toHaveBeenCalled();
     });
 

--- a/src/util/actor.ts
+++ b/src/util/actor.ts
@@ -1,4 +1,5 @@
 import {type Subscription, ensureError, isWorker, subscribe} from './util.ts';
+import {AbortError} from './abort_error.ts';
 import {serialize, deserialize, type Serialized} from './web_worker_transfer.ts';
 import {ThrottledInvoker} from './throttled_invoker.ts';
 
@@ -118,7 +119,9 @@ export class Actor implements IActor {
                     sourceMapId: this.mapId
                 };
                 this.target.postMessage(cancelMessage);
-                // In case of abort the current behavior is to keep the promise pending.
+                // Reject the promise so the awaiting caller unwinds; leaving it pending kept the
+                // suspended async frame (and everything it captured) alive forever.
+                reject(new AbortError(abortController.signal.reason));
             }, addEventDefaultOptions) : null;
 
             this.resolveRejects[id] = {


### PR DESCRIPTION
## Launch Checklist

- [x] Confirm **your changes do not include backports from Mapbox projects**
- [x] Briefly describe the changes in this PR.
- [ ] Link to related issues.
- [ ] Include before/after visuals or gifs if this PR includes visual changes.
- [x] Write tests for all new functionality.
- [ ] Document any changes to public APIs.
- [ ] Post benchmark scores.
- [x] Add an entry to `CHANGELOG.md` under the `## main` section.
- [x] Confirm you have read the AI policy.

### What

`Actor.sendAsync` left its returned promise pending forever when the request was aborted. Any caller that `await`ed it was therefore suspended permanently.

When a tile is aborted - which happens constantly as the viewport changes - that `await` never settles, so the `loadTile` async frame (and the `Tile` + worker data it captured) is never released. In a long-running session with frequent map movement / `setData`, these suspended frames accumulate without bound.

### Changes

- **`Actor.sendAsync`**: on abort, `reject(new AbortError(signal.reason))` instead of leaving the promise pending, so awaiters unwind and can be garbage-collected.
- **`GeoJSONSource.loadTile`**: wrap the `await` in try/catch and treat an aborted tile (`tile.aborted` / `isAbortError`) as a no-op `return` - matching the existing pattern in `VectorTileSource.loadTile`.

How leak was found:
- I'm working on automatic memory leak detection in our apps, while doing it I've noticed that my button (which is starting the animation loop of a lot of features on the map) is the starting point of reference holding which lead me to maplibre internals. After that, Opus 4.8 was helping me with investigation of maplibre code. I've created my own release of maplibre with this fix and run the test again, where thousands of promises were no longer visible in memory heap snapshots. 