### PR TITLE
Skip terrain data for Mercator RTT draws

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## main
 ### ✨ Features and improvements
+- Improve terrain rendering performance by avoiding unnecessary terrain data lookups during Mercator render-to-texture passes ([#7833](https://github.com/maplibre/maplibre-gl-js/pull/7833)) (by [@DoFabien](https://github.com/DoFabien))
 - Reduce allocation pressure while constructing DEM data and sampling terrain elevations ([#7814](https://github.com/maplibre/maplibre-gl-js/pull/7814)) (by [@DoFabien](https://github.com/DoFabien))
 - _...Add new stuff here..._
 

--- a/src/render/painter.test.ts
+++ b/src/render/painter.test.ts
@@ -5,6 +5,7 @@ import {Style} from '../style/style.ts';
 import {StubMap} from '../util/test/util.ts';
 import {Texture} from '../webgl/texture.ts';
 import {createNullGL} from '../util/test/null_gl.ts';
+import {OverscaledTileID} from '../tile/tile_id.ts';
 
 describe('render', () => {
     let painter: Painter;
@@ -32,6 +33,16 @@ describe('render', () => {
         style._updatePlacement(transform, false, 0, false);
     });
 
+    function mockTerrainData() {
+        const tileID = new OverscaledTileID(0, 0, 0, 0, 0);
+        const terrainData = {tile: null};
+        const getTerrainData = vi.fn(() => terrainData);
+        map.terrain = {getTerrainData};
+        painter.style = style;
+
+        return {tileID, terrainData, getTerrainData};
+    }
+
     test('must not fail with incompletely loaded style', () => {
         painter.render(style, renderOptions);
     });
@@ -45,6 +56,28 @@ describe('render', () => {
 
         expect(terrainDepth).toHaveBeenCalled();
         expect(terrainCoords).not.toHaveBeenCalled();
+    });
+
+    test('uses terrain data for regular Mercator draws', () => {
+        const {tileID, terrainData, getTerrainData} = mockTerrainData();
+
+        expect(painter.getTerrainDataForTile(tileID, false)).toBe(terrainData);
+        expect(getTerrainData).toHaveBeenCalledWith(tileID);
+    });
+
+    test('skips terrain data for Mercator render-to-texture draws', () => {
+        const {tileID, getTerrainData} = mockTerrainData();
+
+        expect(painter.getTerrainDataForTile(tileID, true)).toBeNull();
+        expect(getTerrainData).not.toHaveBeenCalled();
+    });
+
+    test('keeps terrain data for non-Mercator render-to-texture draws', () => {
+        const {tileID, terrainData, getTerrainData} = mockTerrainData();
+        style._setProjectionInternal('globe');
+
+        expect(painter.getTerrainDataForTile(tileID, true)).toBe(terrainData);
+        expect(getTerrainData).toHaveBeenCalledWith(tileID);
     });
 });
 

--- a/src/render/painter.ts
+++ b/src/render/painter.ts
@@ -35,6 +35,7 @@ import type {IndexBuffer} from '../webgl/index_buffer.ts';
 import type {DepthRangeType, DepthMaskType, DepthFuncType} from '../webgl/types.ts';
 import type {ResolvedImage} from '@maplibre/maplibre-gl-style-spec';
 import type {IRenderToTexture} from './render_to_texture_interface.ts';
+import type {TerrainData} from './terrain.ts';
 import type {ProjectionData} from '../geo/projection/projection_data.ts';
 import type {Framebuffer} from '../webgl/framebuffer.ts';
 import {coveringTiles} from '../geo/projection/covering_tiles.ts';
@@ -338,7 +339,7 @@ export class Painter {
         // tiles are usually supplied in ascending order of z, then y, then x
         for (const tileID of tileIDs) {
             const stencilRef = tileStencilRefs[tileID.key];
-            const terrainData = this.style.map.terrain?.getTerrainData(tileID);
+            const terrainData = this.getTerrainDataForTile(tileID, renderToTexture);
 
             const mesh = projection.getMeshFromTileID(this.context, tileID.canonical, useBorders, true, 'stencil');
 
@@ -351,6 +352,11 @@ export class Painter {
                 terrainData, projectionData, '$clipping', mesh.vertexBuffer,
                 mesh.indexBuffer, mesh.segments);
         }
+    }
+
+    getTerrainDataForTile(tileID: OverscaledTileID, isRenderingToTexture: boolean): TerrainData | null {
+        if (isRenderingToTexture && this.style.projection?.name === 'mercator') return null;
+        return this.style.map.terrain?.getTerrainData(tileID) || null;
     }
 
     /**

--- a/src/webgl/draw/draw_background.ts
+++ b/src/webgl/draw/draw_background.ts
@@ -54,7 +54,7 @@ export function drawBackground(painter: Painter, tileManager: TileManager, layer
         const uniformValues = image ?
             backgroundPatternUniformValues(opacity, painter, image, {tileID, tileSize}, crossfade) :
             backgroundUniformValues(opacity, color);
-        const terrainData = painter.style.map.terrain?.getTerrainData(tileID);
+        const terrainData = painter.getTerrainDataForTile(tileID, isRenderingToTexture);
 
         // For globe rendering, background uses tile meshes *without* borders and no stencil clipping.
         // This works assuming the tileIDs list contains only tiles of the same zoom level.

--- a/src/webgl/draw/draw_color_relief.ts
+++ b/src/webgl/draw/draw_color_relief.ts
@@ -99,7 +99,7 @@ function renderColorRelief(
 
         const mesh = projection.getMeshFromTileID(context, coord.canonical, useBorder, true, 'raster');
 
-        const terrainData = painter.style.map.terrain?.getTerrainData(coord);
+        const terrainData = painter.getTerrainDataForTile(coord, isRenderingToTexture);
 
         const projectionData = transform.getProjectionData({
             overscaledTileID: coord,

--- a/src/webgl/draw/draw_fill.ts
+++ b/src/webgl/draw/draw_fill.ts
@@ -144,7 +144,7 @@ function drawFillTiles(
 
         const programConfiguration = bucket.programConfigurations.get(layer.id);
         const program = painter.useProgram(programName, programConfiguration);
-        const terrainData = painter.style.map.terrain?.getTerrainData(coord);
+        const terrainData = painter.getTerrainDataForTile(coord, isRenderingToTexture);
 
         if (image) {
             painter.context.activeTexture.set(gl.TEXTURE0);

--- a/src/webgl/draw/draw_hillshade.ts
+++ b/src/webgl/draw/draw_hillshade.ts
@@ -72,7 +72,7 @@ function renderHillshade(
         }
         const mesh = projection.getMeshFromTileID(context, coord.canonical, useBorder, true, 'raster');
 
-        const terrainData = painter.style.map.terrain?.getTerrainData(coord);
+        const terrainData = painter.getTerrainDataForTile(coord, isRenderingToTexture);
 
         context.activeTexture.set(gl.TEXTURE0);
         gl.bindTexture(gl.TEXTURE_2D, fbo.colorAttachment.get());

--- a/src/webgl/draw/draw_line.ts
+++ b/src/webgl/draw/draw_line.ts
@@ -205,7 +205,7 @@ function drawLineTiles(
         const prevProgram = painter.context.program.get();
         const program = painter.useProgram(programId, programConfiguration);
         const programChanged = firstTile || program.program !== prevProgram;
-        const terrainData = useTerrain ? painter.style.map.terrain?.getTerrainData(coord) : null;
+        const terrainData = useTerrain ? painter.getTerrainDataForTile(coord, isRenderingToTexture) : null;
 
         const constantPattern = patternProperty.constantOr(null);
         const constantDasharray = dasharrayProperty?.constantOr(null);
@@ -258,4 +258,3 @@ function drawLineTiles(
         // once refactored so that bound texture state is managed, we'll also be able to remove this firstTile/programChanged logic
     }
 }
-

--- a/src/webgl/draw/draw_raster.ts
+++ b/src/webgl/draw/draw_raster.ts
@@ -131,7 +131,7 @@ function drawTiles(
                 context.extTextureFilterAnisotropicMax);
         }
 
-        const terrainData = painter.style.map.terrain?.getTerrainData(coord);
+        const terrainData = painter.getTerrainDataForTile(coord, isRenderingToTexture);
         const projectionData = transform.getProjectionData({overscaledTileID: coord, aligned: align, applyGlobeMatrix: !isRenderingToTexture, applyTerrainMatrix: true});
         const uniformValues = rasterUniformValues(parentTopLeft, parentScaleBy, fadeValues.fadeMix, layer, corners);
 


### PR DESCRIPTION
## Launch Checklist
I am working on optimizing terrain rendering, and this PR looks like a low-risk change to me: it avoids unnecessary work in a specific rendering path without changing what gets drawn.

This PR avoids passing terrain DEM/depth data to render-to-texture draws in Mercator projection.

These RTT passes first render layers into a flat texture. That texture is then draped over terrain later during the terrain rendering pass. Passing terrain data during the Mercator RTT pass does not change the final result, but it adds repeated terrain lookups, texture bindings, and uniform uploads.

The change keeps the terrain matrix path intact and only skips the `terrainData` object for Mercator RTT. Normal terrain rendering still uses terrain data, and Globe RTT keeps the previous behavior.

In the dedicated RTT replay benchmark, in the scenario that forces 100 cold RTT rebuilds, the paired median time improves by about 5.9%. The most important signal is the reduction in work submitted to WebGL: `terrain.getTerrainData()` goes from 27 300 to 15 900 calls, `gl.bindTexture()` from 27 000 to 4 200, and `gl.activeTexture()` from 27 100 to 2 200. The number of draw calls stays the same, so this mainly removes unnecessary CPU/driver work around rendering, without changing what is drawn. In the RTT hot-cache control, the counters touched by this PR stay identical, which indicates that the change does not add work when RTT textures are already reused.


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Write tests for all new functionality.
 - [x] Post benchmark scores.
 - [x] Add an entry to `CHANGELOG.md` under the `## main` section.
 - [x] Confirm you have read our AI policy [here](https://github.com/maplibre/maplibre/blob/main/AI_POLICY.md).

Assisted-By: GPT 5.5
