### PR TITLE
feat: async stylemissingimage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## main
 ### ✨ Features and improvements
 - Reduce allocation pressure while constructing DEM data and sampling terrain elevations ([#7814](https://github.com/maplibre/maplibre-gl-js/pull/7814)) (by [@DoFabien](https://github.com/DoFabien))
+- Support async `styleimagemissing` handlers for missing image loading ([#7839](https://github.com/maplibre/maplibre-gl-js/pull/7839)) (by [@birkskyum](https://github.com/birkskyum))
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes

--- a/src/render/image_manager.ts
+++ b/src/render/image_manager.ts
@@ -259,7 +259,7 @@ export class ImageManager extends Evented {
 
         let request = this.missingImageRequests.get(id);
         if (!request) {
-            request = this.fireAsync(new MapStyleImageMissingEvent({id}))
+            request = this.fireAndWaitForListeners(new MapStyleImageMissingEvent({id}))
                 .then(() => {})
                 .finally(() => {
                     this.missingImageRequests.delete(id);

--- a/src/render/image_manager.ts
+++ b/src/render/image_manager.ts
@@ -49,8 +49,9 @@ export class ImageManager extends Evented {
      */
     requestors: Array<{
         ids: string[];
-        promiseResolve: (value: GetImagesResponse) => void;
+        promiseResolve: (value: GetImagesResponse | PromiseLike<GetImagesResponse>) => void;
     }>;
+    missingImageRequests: Map<string, Promise<void>>;
 
     patterns: {[_: string]: Pattern};
     atlasImage: RGBAImage;
@@ -64,6 +65,7 @@ export class ImageManager extends Evented {
         this.callbackDispatchedThisFrame = {};
         this.loaded = false;
         this.requestors = [];
+        this.missingImageRequests = new Map();
 
         this.patterns = {};
         this.atlasImage = new RGBAImage({width: 1, height: 1});
@@ -82,6 +84,7 @@ export class ImageManager extends Evented {
         }
 
         this.patterns = {};
+        this.missingImageRequests.clear();
         this.atlasImage = new RGBAImage({width: 1, height: 1});
         this.dirty = true;
     }
@@ -218,17 +221,15 @@ export class ImageManager extends Evented {
         });
     }
 
-    _getImagesForIds(ids: string[]): GetImagesResponse {
+    async _getImagesForIds(ids: string[]): Promise<GetImagesResponse> {
+        const missingIds = Array.from(new Set(ids.filter((id) => !this.getImage(id))));
+
+        await Promise.all(missingIds.map((id) => this._notifyMissingImage(id)));
+
         const response: GetImagesResponse = {};
 
         for (const id of ids) {
-            let image = this.getImage(id);
-
-            if (!image) {
-                this.fire(new MapStyleImageMissingEvent({id}));
-                //Try to acquire image again in case styleimagemissing has populated it
-                image = this.getImage(id);
-            }
+            const image = this.getImage(id);
 
             if (image) {
                 // Clone the image so that our own copy of its ArrayBuffer doesn't get transferred.
@@ -249,6 +250,24 @@ export class ImageManager extends Evented {
             }
         }
         return response;
+    }
+
+    async _notifyMissingImage(id: string): Promise<void> {
+        if (this.getImage(id)) {
+            return;
+        }
+
+        let request = this.missingImageRequests.get(id);
+        if (!request) {
+            request = this.fireAsync(new MapStyleImageMissingEvent({id}))
+                .then(() => {})
+                .finally(() => {
+                    this.missingImageRequests.delete(id);
+                });
+            this.missingImageRequests.set(id, request);
+        }
+
+        await request;
     }
 
     // Pattern stuff

--- a/src/ui/events.ts
+++ b/src/ui/events.ts
@@ -240,7 +240,9 @@ export type MapEventType = {
     /**
      * Fired when an icon or pattern needed by the style is missing. The missing image can
      * be added with {@link Map.addImage} within this event listener callback to prevent the image from
-     * being skipped. This event can be used to dynamically generate icons and patterns.
+     * being skipped. If the listener returns a promise, the image request waits for the promise to
+     * resolve before checking whether the image has been added. If the promise rejects, the image
+     * request rejects. This event can be used to dynamically generate icons and patterns.
      * @see [Generate and add a missing icon to the map](https://maplibre.org/maplibre-gl-js/docs/examples/generate-and-add-a-missing-icon-to-the-map/)
      */
     styleimagemissing: MapStyleImageMissingEvent;
@@ -860,7 +862,9 @@ export class MapContextEvent extends MapLibreEvent<WebGLContextEvent> {
 };
 
 /**
- * The style image missing event
+ * The style image missing event. If a listener returns a promise, the image request waits for
+ * the promise to resolve before checking whether the image has been added. If the promise rejects,
+ * the image request rejects.
  *
  * @group Event Related
  *

--- a/src/ui/events.ts
+++ b/src/ui/events.ts
@@ -240,9 +240,9 @@ export type MapEventType = {
     /**
      * Fired when an icon or pattern needed by the style is missing. The missing image can
      * be added with {@link Map.addImage} within this event listener callback to prevent the image from
-     * being skipped. If the listener returns a promise, the image request waits for the promise to
-     * resolve before checking whether the image has been added. If the promise rejects, the image
-     * request rejects. This event can be used to dynamically generate icons and patterns.
+     * being skipped. If one or more listeners return promises, the image request waits for those
+     * promises to resolve before checking whether the image has been added. If a promise rejects,
+     * the image request rejects. This event can be used to dynamically generate icons and patterns.
      * @see [Generate and add a missing icon to the map](https://maplibre.org/maplibre-gl-js/docs/examples/generate-and-add-a-missing-icon-to-the-map/)
      */
     styleimagemissing: MapStyleImageMissingEvent;
@@ -862,9 +862,9 @@ export class MapContextEvent extends MapLibreEvent<WebGLContextEvent> {
 };
 
 /**
- * The style image missing event. If a listener returns a promise, the image request waits for
- * the promise to resolve before checking whether the image has been added. If the promise rejects,
- * the image request rejects.
+ * The style image missing event. If one or more listeners return promises, the image request waits
+ * for those promises to resolve before checking whether the image has been added. If a promise
+ * rejects, the image request rejects.
  *
  * @group Event Related
  *

--- a/src/ui/map_tests/map_images.test.ts
+++ b/src/ui/map_tests/map_images.test.ts
@@ -30,6 +30,8 @@ test('listImages throws an error if called before "load"', () => {
 test('map fires `styleimagemissing` for missing icons', async () => {
     const map = createMap();
 
+    await map.once('load');
+
     const id = 'missing-image';
 
     const sampleImage = {width: 2, height: 1, data: new Uint8Array(8)};
@@ -42,12 +44,104 @@ test('map fires `styleimagemissing` for missing icons', async () => {
 
     expect(map.hasImage(id)).toBeFalsy();
 
+    const generatedImagePromise = map.style.imageManager.getImages([id]);
+    expect(called).toBe(id);
+
+    const generatedImage = await generatedImagePromise;
+    expect(generatedImage[id].data.width).toEqual(sampleImage.width);
+    expect(generatedImage[id].data.height).toEqual(sampleImage.height);
+    expect(generatedImage[id].data.data).toEqual(sampleImage.data);
+    expect(called).toBe(id);
+    expect(map.hasImage(id)).toBeTruthy();
+});
+
+test('map waits for async `styleimagemissing` listeners', async () => {
+    const map = createMap();
+
+    const id = 'missing-image-async';
+    const sampleImage = {width: 2, height: 1, data: new Uint8Array(8)};
+
+    let called: string;
+    map.on('styleimagemissing', async e => {
+        await Promise.resolve();
+        map.addImage(e.id, sampleImage);
+        called = e.id;
+    });
+
+    expect(map.hasImage(id)).toBeFalsy();
+
     const generatedImage = await map.style.imageManager.getImages([id]);
     expect(generatedImage[id].data.width).toEqual(sampleImage.width);
     expect(generatedImage[id].data.height).toEqual(sampleImage.height);
     expect(generatedImage[id].data.data).toEqual(sampleImage.data);
     expect(called).toBe(id);
     expect(map.hasImage(id)).toBeTruthy();
+});
+
+test('map shares in-flight async `styleimagemissing` listeners for the same missing icon', async () => {
+    const map = createMap();
+
+    await map.once('load');
+
+    const id = 'missing-image-async-shared';
+    const sampleImage = {width: 2, height: 1, data: new Uint8Array(8)};
+    const requested = [];
+    let resolveMissingImage: () => void;
+
+    map.on('styleimagemissing', async e => {
+        requested.push(e.id);
+        await new Promise<void>((resolve) => {
+            resolveMissingImage = resolve;
+        });
+        map.addImage(e.id, sampleImage);
+    });
+
+    const firstGeneratedImagesPromise = map.style.imageManager.getImages([id]);
+    const secondGeneratedImagesPromise = map.style.imageManager.getImages([id]);
+
+    expect(requested).toEqual([id]);
+
+    resolveMissingImage();
+
+    const [firstGeneratedImages, secondGeneratedImages] = await Promise.all([
+        firstGeneratedImagesPromise,
+        secondGeneratedImagesPromise
+    ]);
+    expect(firstGeneratedImages[id].data.width).toEqual(sampleImage.width);
+    expect(secondGeneratedImages[id].data.width).toEqual(sampleImage.width);
+    expect(map.hasImage(id)).toBeTruthy();
+});
+
+test('map clears failed async `styleimagemissing` listeners from in-flight requests', async () => {
+    const map = createMap();
+
+    const id = 'missing-image-async-failed';
+    const error = new Error('missing image load failed');
+    const sampleImage = {width: 2, height: 1, data: new Uint8Array(8)};
+    let shouldFail = true;
+
+    map.on('styleimagemissing', async e => {
+        if (shouldFail) {
+            throw error;
+        }
+        map.addImage(e.id, sampleImage);
+    });
+
+    await expect(map.style.imageManager.getImages([id])).rejects.toBe(error);
+
+    shouldFail = false;
+    const generatedImages = await map.style.imageManager.getImages([id]);
+    expect(generatedImages[id].data.width).toEqual(sampleImage.width);
+    expect(map.hasImage(id)).toBeTruthy();
+});
+
+test('image manager clears in-flight missing image requests on destroy', () => {
+    const map = createMap();
+
+    map.style.imageManager.missingImageRequests.set('missing-image', Promise.resolve());
+    map.style.imageManager.destroy();
+
+    expect(map.style.imageManager.missingImageRequests.size).toBe(0);
 });
 
 test('map getImage matches addImage, uintArray', () => {

--- a/src/ui/map_tests/map_images.test.ts
+++ b/src/ui/map_tests/map_images.test.ts
@@ -78,6 +78,37 @@ test('map waits for async `styleimagemissing` listeners', async () => {
     expect(map.hasImage(id)).toBeTruthy();
 });
 
+test('map does not refire `styleimagemissing` for images added by another missing-image listener', async () => {
+    const map = createMap();
+
+    await map.once('load');
+
+    const firstId = 'missing-image-first';
+    const secondId = 'missing-image-second';
+    const firstImage = {width: 2, height: 1, data: new Uint8Array(8)};
+    const secondImage = {width: 1, height: 2, data: new Uint8Array(8)};
+    const requested = [];
+
+    map.on('styleimagemissing', e => {
+        requested.push(e.id);
+
+        if (!map.hasImage(firstId)) {
+            map.addImage(firstId, firstImage);
+        }
+        if (!map.hasImage(secondId)) {
+            map.addImage(secondId, secondImage);
+        }
+    });
+
+    const generatedImages = await map.style.imageManager.getImages([firstId, secondId]);
+
+    expect(requested).toEqual([firstId]);
+    expect(generatedImages[firstId].data.width).toEqual(firstImage.width);
+    expect(generatedImages[secondId].data.width).toEqual(secondImage.width);
+    expect(map.hasImage(firstId)).toBeTruthy();
+    expect(map.hasImage(secondId)).toBeTruthy();
+});
+
 test('map shares in-flight async `styleimagemissing` listeners for the same missing icon', async () => {
     const map = createMap();
 

--- a/src/util/evented.ts
+++ b/src/util/evented.ts
@@ -184,7 +184,7 @@ export abstract class Evented<EventType extends Record<string, any> = Record<str
         return this;
     }
 
-    protected async fireAsync(event: Event): Promise<this> {
+    protected async fireAndWaitForListeners(event: Event): Promise<this> {
         const promises: Array<PromiseLike<unknown>> = [];
         const asyncEvent = event as AsyncEvent;
         // Store the collector on the event so parent listeners are included as the event bubbles.

--- a/src/util/evented.ts
+++ b/src/util/evented.ts
@@ -184,14 +184,9 @@ export abstract class Evented<EventType extends Record<string, any> = Record<str
         return this;
     }
 
-    protected async fireAsync(event: Event | string, properties?: any): Promise<this> {
-        if (typeof event === 'string') {
-            event = new Event(event, properties || {});
-        }
-
+    protected async fireAsync(event: Event): Promise<this> {
         const promises: Array<PromiseLike<unknown>> = [];
         const asyncEvent = event as AsyncEvent;
-        const previousPromises = asyncEvent[asyncListenerPromises];
         // Store the collector on the event so parent listeners are included as the event bubbles.
         asyncEvent[asyncListenerPromises] = promises;
 
@@ -199,11 +194,7 @@ export abstract class Evented<EventType extends Record<string, any> = Record<str
             this.fire(event);
             await Promise.all(promises);
         } finally {
-            if (previousPromises) {
-                asyncEvent[asyncListenerPromises] = previousPromises;
-            } else {
-                delete asyncEvent[asyncListenerPromises];
-            }
+            delete asyncEvent[asyncListenerPromises];
         }
 
         return this;

--- a/src/util/evented.ts
+++ b/src/util/evented.ts
@@ -6,6 +6,8 @@ import {extend, type Subscription} from './util.ts';
 export type Listener = (a: any) => any;
 
 type Listeners<EventType extends Record<string, any>> = {[_ in keyof EventType]?: Listener[]};
+const asyncListenerPromises = Symbol('asyncListenerPromises');
+type AsyncEvent = Event & {[asyncListenerPromises]?: Array<PromiseLike<unknown>>};
 
 function _addEventListener<T extends Record<string, any>>(type: keyof T, listener: Listener, listenerList: Listeners<T>) {
     const listenerExists = listenerList[type]?.includes(listener);
@@ -21,6 +23,17 @@ function _removeEventListener<T extends Record<string, any>>(type: keyof T, list
         if (index !== -1) {
             listenerList[type].splice(index, 1);
         }
+    }
+}
+
+function _isPromiseLike(value: unknown): value is PromiseLike<unknown> {
+    return Boolean(value) && typeof (value as PromiseLike<unknown>).then === 'function';
+}
+
+function _trackAsyncListener(event: Event, result: unknown): void {
+    const promises = (event as AsyncEvent)[asyncListenerPromises];
+    if (promises && _isPromiseLike(result)) {
+        promises.push(result);
     }
 }
 
@@ -144,13 +157,13 @@ export abstract class Evented<EventType extends Record<string, any> = Record<str
             // make sure adding or removing listeners inside other listeners won't cause an infinite loop
             const listeners = this._listeners?.[type] ? this._listeners[type].slice() : [];
             for (const listener of listeners) {
-                listener.call(this, event);
+                _trackAsyncListener(event, listener.call(this, event));
             }
 
             const oneTimeListeners = this._oneTimeListeners?.[type] ? this._oneTimeListeners[type].slice() : [];
             for (const listener of oneTimeListeners) {
                 _removeEventListener(type, listener, this._oneTimeListeners);
-                listener.call(this, event);
+                _trackAsyncListener(event, listener.call(this, event));
             }
 
             const parent = this._eventedParent;
@@ -166,6 +179,31 @@ export abstract class Evented<EventType extends Record<string, any> = Record<str
         // console if they have no listeners.
         } else if (event instanceof ErrorEvent) {
             console.error(event.error);
+        }
+
+        return this;
+    }
+
+    protected async fireAsync(event: Event | string, properties?: any): Promise<this> {
+        if (typeof event === 'string') {
+            event = new Event(event, properties || {});
+        }
+
+        const promises: Array<PromiseLike<unknown>> = [];
+        const asyncEvent = event as AsyncEvent;
+        const previousPromises = asyncEvent[asyncListenerPromises];
+        // Store the collector on the event so parent listeners are included as the event bubbles.
+        asyncEvent[asyncListenerPromises] = promises;
+
+        try {
+            this.fire(event);
+            await Promise.all(promises);
+        } finally {
+            if (previousPromises) {
+                asyncEvent[asyncListenerPromises] = previousPromises;
+            } else {
+                delete asyncEvent[asyncListenerPromises];
+            }
         }
 
         return this;


### PR DESCRIPTION
Currently, a user can listen for `styleimagemissing` and call `map.addImage()` from that handler (as in our docs example [here](https://maplibre.org/maplibre-gl-js/docs/examples/generate-and-add-a-missing-icon-to-the-map/)). Here the user can provide the image synchronously, and all is good. Unfortunately, it's very often the case that a missing image has to be fetched from somewhere in an async manner, and in that case this setup breaks down: MapLibre checks for if the image exists, before that async work finishes and treats it as still missing.

Because of this lack of async-support, users who rely on async resources have to identify this limitation and setup one of these undocumented workarounds:
- Preloading of icon assets before the styleimagemissing event fire
- Adding a placeholder synchronously and updating it later
- Arranging another refresh after the async load registers the image

With this PR, the handler attached to `styleimagemissing` can optionally be async and return a promise. MapLibre waits for that promise before checking whether the image was added, so async icon loading works naturally:

```ts
map.on('styleimagemissing', async (e) => {
    const image = await loadIcon(e.id);
    map.addImage(e.id, image);
});
```

It's implemented as an backwards-compatible alternative approach. The code checks if the function is PromiseLike (if it returns something with a `.then` function on it), so that existing users with a sync function are unaffected by it.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items that are not relevant. -->


 - [X] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [ ] Link to related issues.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality.
 - [x] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [x] Add an entry to `CHANGELOG.md` under the `## main` section.
 - [x] Confirm you have read our AI policy [here](https://github.com/maplibre/maplibre/blob/main/AI_POLICY.md).
<!--
  Add one of:    Assisted-By: | Generated-By:     and the model/version
-->
Assisted-By: GPT 5.5