### PR TITLE
Fix symbol occlusion below opaque draped rasters (#7828)

### DIFF
--- a/src/webgl/render_to_texture.test.ts
+++ b/src/webgl/render_to_texture.test.ts
@@ -37,6 +37,9 @@ describe('render to texture', () => {
         id: 'maine-raster',
         type: 'raster',
         source: 'maine',
+        paint: {
+            get: (property: string) => property === 'raster-opacity' ? 1 : undefined
+        },
         isHidden: () => false
     } as any as RasterStyleLayer;
     const hillshadeLayer = {
@@ -214,6 +217,28 @@ describe('render to texture', () => {
         expect(rtt.renderLayer(lineLayer, renderOptions)).toBeTruthy();
         expect(rtt.renderLayer(symbolLayer, renderOptions)).toBeFalsy();
         expect(layersDrawn).toBe(3);
+    });
+
+    test('skips symbols below a later opaque draped raster', () => {
+        const symbolLayerAboveRaster = {
+            ...symbolLayer,
+            id: 'maine-symbol-above-raster',
+        } as SymbolStyleLayer;
+        const fillExtrusionLayer = {
+            id: 'maine-building',
+            type: 'fill-extrusion',
+            source: 'maine',
+            isHidden: () => false
+        } as any;
+        style._layers['maine-symbol-above-raster'] = symbolLayerAboveRaster;
+        style._layers['maine-building'] = fillExtrusionLayer;
+        style._order = ['maine-background', 'maine-symbol', 'maine-building', 'maine-raster', 'maine-symbol-above-raster'];
+        rtt.prepareForRender(style, 0);
+
+        const renderOptions = {isRenderingToTexture: false, isRenderingGlobe: false};
+        expect(rtt.renderLayer(symbolLayer, renderOptions)).toBeTruthy();
+        expect(rtt.renderLayer(symbolLayerAboveRaster, renderOptions)).toBeFalsy();
+        expect(rtt.renderLayer(fillExtrusionLayer, renderOptions)).toBeFalsy();
     });
 
     test('should clear tile cache on source state update', () => {

--- a/src/webgl/render_to_texture.ts
+++ b/src/webgl/render_to_texture.ts
@@ -8,6 +8,7 @@ import {type Terrain} from '../render/terrain.ts';
 import {type Texture} from './texture.ts';
 import type {StyleLayer} from '../style/style_layer.ts';
 import {ImageSource} from '../source/image_source.ts';
+import {isRasterStyleLayer} from '../style/style_layer/raster_style_layer.ts';
 
 /**
  * lookup table which layers should rendered to texture
@@ -87,7 +88,7 @@ export class RenderToTexture {
         this._topOpaqueDrapedRasterIndex = -1;
         for (let i = 0; i < this._renderableLayerIds.length; i++) {
             const layer = style._layers[this._renderableLayerIds[i]];
-            if (layer.type === 'raster' && layer.paint.get('raster-opacity') === 1) this._topOpaqueDrapedRasterIndex = i;
+            if (isRasterStyleLayer(layer) && layer.paint.get('raster-opacity') === 1) this._topOpaqueDrapedRasterIndex = i;
         }
 
         this._coordsAscending = {};

--- a/src/webgl/render_to_texture.ts
+++ b/src/webgl/render_to_texture.ts
@@ -67,6 +67,7 @@ export class RenderToTexture {
      * a list of all layer-ids which should be rendered
      */
     _renderableLayerIds: string[];
+    _topOpaqueDrapedRasterIndex: number;
     constructor(painter: Painter, terrain: Terrain) {
         this.painter = painter;
         this.terrain = terrain;
@@ -83,6 +84,11 @@ export class RenderToTexture {
         this._rttTiles = [];
         this._renderableTiles = this.terrain.tileManager.getRenderableTiles();
         this._renderableLayerIds = style._order.filter(id => !style._layers[id].isHidden(zoom));
+        this._topOpaqueDrapedRasterIndex = -1;
+        for (let i = 0; i < this._renderableLayerIds.length; i++) {
+            const layer = style._layers[this._renderableLayerIds[i]];
+            if (layer.type === 'raster' && layer.paint.get('raster-opacity') === 1) this._topOpaqueDrapedRasterIndex = i;
+        }
 
         this._coordsAscending = {};
         for (const id in style.tileManagers) {
@@ -138,6 +144,7 @@ export class RenderToTexture {
      */
     renderLayer(layer: StyleLayer, renderOptions: RenderOptions): boolean {
         if (layer.isHidden(this.painter.transform.zoom)) return false;
+        if (this._isSymbolBelowOpaqueDrapedRaster(layer)) return true;
 
         const options: RenderOptions = {...renderOptions, isRenderingToTexture: true};
         const type = layer.type;
@@ -185,4 +192,9 @@ export class RenderToTexture {
         return false;
     }
 
+    _isSymbolBelowOpaqueDrapedRaster(layer: StyleLayer): boolean {
+        if (layer.type !== 'symbol' || this._topOpaqueDrapedRasterIndex < 0) return false;
+        const layerIndex = this._renderableLayerIds.indexOf(layer.id);
+        return layerIndex >= 0 && layerIndex < this._topOpaqueDrapedRasterIndex;
+    }
 }


### PR DESCRIPTION
This PR fixes a concrete terrain rendering ordering bug from #7828.

With terrain enabled, draped layers such as raster/fill/line are rendered to terrain textures, while symbol layers are rendered live. Because of that, labels from a basemap could still appear above an opaque raster layer that was placed later in the style. In 2D, the raster correctly covers those labels.

This patch keeps the fix narrow. `RenderToTexture` tracks the top opaque draped raster layer, and `Painter` skips live symbol rendering only for symbol layers below that raster. Symbols above the raster are still rendered, and `fill-extrusion` rendering is left unchanged so 3D buildings can still appear above the raster.

The fix is scoped to opaque raster overlays and the symbol layers that should be hidden by style order.


before: 
<img width="910" height="554" alt="image" src="https://github.com/user-attachments/assets/e389a839-f69f-4c2e-9280-4496e7b84ed4" />

after: 
<img width="910" height="554" alt="image" src="https://github.com/user-attachments/assets/c4c0c984-e92a-46fc-bdd1-1b8cfd200f78" />



## Launch Checklist

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues. #7828
 - [x] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [ ] Add an entry to `CHANGELOG.md` under the `## main` section.
 - [x] Confirm you have read our AI policy [here](https://github.com/maplibre/maplibre/blob/main/AI_POLICY.md).

 Assisted-By:  GPT 5.5

