### PR TITLE
perf: cache terrain sampling context for symbols

### DIFF
--- a/src/render/painter.test.ts
+++ b/src/render/painter.test.ts
@@ -2,7 +2,7 @@ import {describe, beforeEach, test, expect, vi, afterEach} from 'vitest';
 import {Painter} from './painter.ts';
 import {MercatorTransform} from '../geo/projection/mercator_transform.ts';
 import {Style} from '../style/style.ts';
-import {StubMap} from '../util/test/util.ts';
+import {createTerrain, StubMap} from '../util/test/util.ts';
 import {Texture} from '../webgl/texture.ts';
 import {createNullGL} from '../util/test/null_gl.ts';
 import {restoreNow, setNow} from '../util/time_control.ts';
@@ -38,7 +38,7 @@ describe('render', () => {
         const tileID = new OverscaledTileID(0, 0, 0, 0, 0);
         const terrainData = {tile: null};
         const getTerrainData = vi.fn(() => terrainData);
-        map.terrain = {getTerrainData};
+        map.terrain = {...createTerrain(), getTerrainData};
         painter.style = style;
 
         return {tileID, terrainData, getTerrainData};
@@ -51,7 +51,7 @@ describe('render', () => {
     test('calls terrainDepth but not terrainCoords', () => {
         const terrainDepth = vi.spyOn(painter.drawFunctions, 'terrainDepth').mockImplementation(() => {});
         const terrainCoords = vi.spyOn(painter.drawFunctions, 'terrainCoords').mockImplementation(() => {});
-        map.terrain = {tileManager: {anyTilesAfterTime: () => false}};
+        map.terrain = createTerrain();
 
         painter.render(style, renderOptions);
 
@@ -83,7 +83,7 @@ describe('render', () => {
     describe('terrain render time', () => {
         beforeEach(() => {
             vi.spyOn(painter.drawFunctions, 'terrainDepth').mockImplementation(() => {});
-            map.terrain = {tileManager: {anyTilesAfterTime: () => false}};
+            map.terrain = createTerrain();
         });
 
         afterEach(() => {

--- a/src/render/painter.ts
+++ b/src/render/painter.ts
@@ -512,6 +512,7 @@ export class Painter {
     render(style: Style, options: PainterOptions): void {
         this.style = style;
         this.options = options;
+        style.map.terrain?.resetElevationCache();
 
         this.lineAtlas = style.lineAtlas;
         this.imageManager = style.imageManager;

--- a/src/render/terrain.test.ts
+++ b/src/render/terrain.test.ts
@@ -321,6 +321,63 @@ describe('Terrain', () => {
         expect(terrain.tileManager.getSourceTile).toHaveBeenCalledTimes(2);
     });
 
+    test('getElevationLookup retries sampling setup when DEM data becomes available', () => {
+        const terrain = new Terrain(null, {_source: {tileSize: 512}} as any, {exaggeration: 1} as any);
+        const tileID = new OverscaledTileID(1, 0, 1, 0, 0);
+        let tileHasDem = false;
+
+        terrain.tileManager.getSourceTile = vi.fn(() => ({
+            tileID,
+            dem: tileHasDem ? {
+                dim: 1,
+                sampleBilinear: (x: number, y: number) => 100 * x + 10 * y
+            } : undefined,
+            toString: () => 'source-tile'
+        }) as any as Tile);
+        terrain.tileManager.getSource = vi.fn(() => ({minzoom: 0, maxzoom: 22}) as any);
+
+        expect(terrain.getElevationLookup(tileID)).toBeNull();
+
+        tileHasDem = true;
+        const lookup = terrain.getElevationLookup(tileID);
+        if (!lookup) throw new Error('Expected elevation lookup to be available');
+        expect(lookup(EXTENT / 2, EXTENT / 2)).toBeCloseTo(55);
+        expect(terrain.tileManager.getSourceTile).toHaveBeenCalledTimes(2);
+    });
+
+    test('getElevationLookup normalizes coordinates that cross tile boundaries', () => {
+        const terrain = new Terrain(null, {_source: {tileSize: 512}} as any, {exaggeration: 1} as any);
+        const tileID = new OverscaledTileID(1, 0, 1, 0, 0);
+        const neighborID = new OverscaledTileID(1, 0, 1, 1, 0);
+        const sourceTiles = new Map([
+            [tileID.key, {
+                tileID,
+                dem: {
+                    dim: 1,
+                    sampleBilinear: (x: number, y: number) => 100 * x + 10 * y
+                },
+                toString: () => 'source-tile-0'
+            } as any as Tile],
+            [neighborID.key, {
+                tileID: neighborID,
+                dem: {
+                    dim: 1,
+                    sampleBilinear: (x: number, y: number) => 1000 + 100 * x + 10 * y
+                },
+                toString: () => 'source-tile-1'
+            } as any as Tile]
+        ]);
+        terrain.tileManager.getSourceTile = vi.fn((id: OverscaledTileID) => sourceTiles.get(id.key));
+        terrain.tileManager.getSource = vi.fn(() => ({minzoom: 0, maxzoom: 22}) as any);
+
+        const lookup = terrain.getElevationLookup(tileID);
+        if (!lookup) throw new Error('Expected elevation lookup to be available');
+
+        expect(lookup(EXTENT + EXTENT / 2, EXTENT / 2)).toBeCloseTo(1055);
+        expect(terrain.tileManager.getSourceTile).toHaveBeenCalledTimes(2);
+        expect((terrain.tileManager.getSourceTile as any).mock.calls.map(([id]) => id.key)).toEqual([tileID.key, neighborID.key]);
+    });
+
     test('getElevationForLngLat uses covering tiles to get the right zoom', () => {
         const zoom = 10;
         const painter = {

--- a/src/render/terrain.test.ts
+++ b/src/render/terrain.test.ts
@@ -275,6 +275,30 @@ describe('Terrain', () => {
         expect(mockTerrain.getDEMElevation(tileID, 0.4, 0.2)).toBeCloseTo(42);
     });
 
+    test('getElevation reuses DEM sampling setup until reset', () => {
+        const terrain = new Terrain(null, {_source: {tileSize: 512}} as any, {exaggeration: 2} as any);
+        const tileID = new OverscaledTileID(1, 0, 1, 0, 0);
+        const sourceTile = {
+            tileID,
+            dem: {
+                dim: 1,
+                sampleBilinear: (x: number, y: number) => 100 * x + 10 * y
+            },
+            toString: () => 'source-tile'
+        } as any as Tile;
+        terrain.tileManager.getSourceTile = vi.fn(() => sourceTile);
+        terrain.tileManager.getSource = vi.fn(() => ({minzoom: 0, maxzoom: 22}) as any);
+
+        expect(terrain.getElevation(tileID, EXTENT / 2, EXTENT / 2)).toBeCloseTo(110);
+        expect(terrain.getElevation(tileID, EXTENT / 2, EXTENT / 2)).toBeCloseTo(110);
+        expect(terrain.tileManager.getSourceTile).toHaveBeenCalledTimes(1);
+
+        terrain.resetElevationCache();
+        expect(terrain.getElevation(tileID, EXTENT / 2, EXTENT / 2)).toBeCloseTo(110);
+
+        expect(terrain.tileManager.getSourceTile).toHaveBeenCalledTimes(2);
+    });
+
     test('getElevationForLngLat uses covering tiles to get the right zoom', () => {
         const zoom = 10;
         const painter = {

--- a/src/render/terrain.test.ts
+++ b/src/render/terrain.test.ts
@@ -299,6 +299,28 @@ describe('Terrain', () => {
         expect(terrain.tileManager.getSourceTile).toHaveBeenCalledTimes(2);
     });
 
+    test('getElevation retries sampling setup when DEM data becomes available', () => {
+        const terrain = new Terrain(null, {_source: {tileSize: 512}} as any, {exaggeration: 1} as any);
+        const tileID = new OverscaledTileID(1, 0, 1, 0, 0);
+        let tileHasDem = false;
+
+        terrain.tileManager.getSourceTile = vi.fn(() => ({
+            tileID,
+            dem: tileHasDem ? {
+                dim: 1,
+                sampleBilinear: (x: number, y: number) => 100 * x + 10 * y
+            } : undefined,
+            toString: () => 'source-tile'
+        }) as any as Tile);
+        terrain.tileManager.getSource = vi.fn(() => ({minzoom: 0, maxzoom: 22}) as any);
+
+        expect(terrain.getElevation(tileID, EXTENT / 2, EXTENT / 2)).toBe(0);
+
+        tileHasDem = true;
+        expect(terrain.getElevation(tileID, EXTENT / 2, EXTENT / 2)).toBeCloseTo(55);
+        expect(terrain.tileManager.getSourceTile).toHaveBeenCalledTimes(2);
+    });
+
     test('getElevationForLngLat uses covering tiles to get the right zoom', () => {
         const zoom = 10;
         const painter = {

--- a/src/render/terrain.ts
+++ b/src/render/terrain.ts
@@ -45,6 +45,14 @@ type TerrainElevationLookup = (x: number, y: number, extent?: number) => number;
 
 /**
  * @internal
+ */
+type PreparedTerrainElevationLookup = {
+    lookup: TerrainElevationLookup;
+    sampleInTile: (x: number, y: number, extent: number) => number;
+};
+
+/**
+ * @internal
  * This is the main class which handles most of the 3D Terrain logic. It has the following topics:
  *
  * 1. loads raster-dem tiles via the internal tileManager this.tileManager
@@ -141,7 +149,7 @@ export class Terrain {
      * matrices to transform from vector-tile coords to raster-dem-tile coords.
      */
     _demMatrixCache: {[_: string]: {matrix: mat4}};
-    _elevationLookupCache: Map<string, TerrainElevationLookup>;
+    _preparedElevationLookupCache: Map<string, PreparedTerrainElevationLookup>;
     /**
      * Controls how terrain skirt length is calculated.
      * @see {@link MapOptions.terrainSkirtLength}
@@ -156,7 +164,7 @@ export class Terrain {
         this.qualityFactor = 2;
         this.meshSize = 128;
         this._demMatrixCache = {};
-        this._elevationLookupCache = new Map();
+        this._preparedElevationLookupCache = new Map();
         this.coordsIndex = [];
         this._coordsTextureSize = 1024;
     }
@@ -267,32 +275,32 @@ export class Terrain {
      * @returns a prepared elevation lookup for this tile, or null while DEM data is unavailable
      */
     getElevationLookup(tileID: OverscaledTileID): TerrainElevationLookup | null {
-        return this._getElevationLookup(tileID);
+        return this._getPreparedElevationLookup(tileID)?.lookup ?? null;
     }
 
     resetElevationCache(): void {
-        this._elevationLookupCache.clear();
+        this._preparedElevationLookupCache.clear();
     }
 
     _getElevationByNormalizingCoordinates(tileID: OverscaledTileID, x: number, y: number, extent: number): number {
         const normalized = tileID.normalizeCoordinates(x, y, extent);
         if (!normalized) return 0;
 
-        const normalizedTileLookup = this._getElevationLookup(normalized.tileID);
-        return normalizedTileLookup ? normalizedTileLookup(normalized.x, normalized.y, extent) : 0;
+        const normalizedEntry = this._getPreparedElevationLookup(normalized.tileID);
+        return normalizedEntry ? normalizedEntry.sampleInTile(normalized.x, normalized.y, extent) : 0;
     }
 
-    _getElevationLookup(tileID: OverscaledTileID): TerrainElevationLookup | null {
+    _getPreparedElevationLookup(tileID: OverscaledTileID): PreparedTerrainElevationLookup | null {
         const key = tileID.key;
-        const cachedLookup = this._elevationLookupCache.get(key);
-        if (cachedLookup) return cachedLookup;
+        const cachedEntry = this._preparedElevationLookupCache.get(key);
+        if (cachedEntry) return cachedEntry;
 
-        const createdLookup = this._createElevationLookup(tileID, this.exaggeration);
-        if (createdLookup) this._elevationLookupCache.set(key, createdLookup);
-        return createdLookup;
+        const createdEntry = this._createPreparedElevationLookup(tileID, this.exaggeration);
+        if (createdEntry) this._preparedElevationLookupCache.set(key, createdEntry);
+        return createdEntry;
     }
 
-    _createElevationLookup(tileID: OverscaledTileID, exaggeration: number): TerrainElevationLookup | null {
+    _createPreparedElevationLookup(tileID: OverscaledTileID, exaggeration: number): PreparedTerrainElevationLookup | null {
         if (tileID.overscaledZ - this.tileManager.deltaZoom < this.tileManager.minzoom) return null;
 
         const sourceTile = this.tileManager.getSourceTile(tileID, true);
@@ -305,18 +313,21 @@ export class Terrain {
         const demPixelScaleY = matrix[5] * dem.dim;
         const demPixelOffsetX = matrix[12] * dem.dim;
         const demPixelOffsetY = matrix[13] * dem.dim;
-        return (x: number, y: number, extent: number = EXTENT): number => {
-            if (x < 0 || x >= extent || y < 0 || y >= extent) {
-                // Boundary fallback: normalize to the neighboring tile and use that tile's cached lookup.
-                return this._getElevationByNormalizingCoordinates(tileID, x, y, extent);
-            }
-
+        const sampleInTile = (x: number, y: number, extent: number): number => {
             const extentScale = extent === EXTENT ? 1 : EXTENT / extent;
             return dem.sampleBilinear(
                 x * extentScale * demPixelScaleX + demPixelOffsetX,
                 y * extentScale * demPixelScaleY + demPixelOffsetY
             ) * exaggeration;
         };
+        const lookup: TerrainElevationLookup = (x: number, y: number, extent: number = EXTENT): number => {
+            if (x < 0 || x >= extent || y < 0 || y >= extent) {
+                return this._getElevationByNormalizingCoordinates(tileID, x, y, extent);
+            }
+
+            return sampleInTile(x, y, extent);
+        };
+        return {lookup, sampleInTile};
     }
 
     _getDEMTileMatrix(tileID: OverscaledTileID, sourceTile: Tile): mat4 {

--- a/src/render/terrain.ts
+++ b/src/render/terrain.ts
@@ -46,7 +46,7 @@ type TerrainElevationLookup = (x: number, y: number, extent?: number) => number;
 /**
  * @internal
  */
-type PreparedTerrainElevationLookup = (x: number, y: number, extent: number) => number;
+type InTileTerrainElevationLookup = (x: number, y: number, extent: number) => number;
 
 /**
  * @internal
@@ -146,7 +146,7 @@ export class Terrain {
      * matrices to transform from vector-tile coords to raster-dem-tile coords.
      */
     _demMatrixCache: {[_: string]: {matrix: mat4}};
-    _elevationLookupCache: Map<string, PreparedTerrainElevationLookup>;
+    _inTileElevationLookupCache: Map<string, InTileTerrainElevationLookup>;
     /**
      * Controls how terrain skirt length is calculated.
      * @see {@link MapOptions.terrainSkirtLength}
@@ -161,7 +161,7 @@ export class Terrain {
         this.qualityFactor = 2;
         this.meshSize = 128;
         this._demMatrixCache = {};
-        this._elevationLookupCache = new Map();
+        this._inTileElevationLookupCache = new Map();
         this.coordsIndex = [];
         this._coordsTextureSize = 1024;
     }
@@ -259,50 +259,52 @@ export class Terrain {
      * @returns the elevation
      */
     getElevation(tileID: OverscaledTileID, x: number, y: number, extent: number = EXTENT): number {
-        const normalized = tileID.normalizeCoordinates(x, y, extent);
-        if (!normalized) return 0;
-
-        const lookup = this._getElevationLookup(normalized.tileID);
-        return lookup ? lookup(normalized.x, normalized.y, extent) : 0;
+        return this._getElevationByNormalizingCoordinates(tileID, x, y, extent);
     }
 
     /**
      * @internal
      * Resolve DEM tile/matrix once for hot loops that sample many points from the same tile.
+     * In-tile samples stay on the prepared fast path; samples that cross a tile boundary are
+     * normalized to the neighboring tile only when needed.
      * Use {@link Terrain.getElevation} for one-off lookups and general coordinate normalization.
      * @param tileID - the tile id
      * @returns a prepared elevation lookup for this tile, or null while DEM data is unavailable
      */
     getElevationLookup(tileID: OverscaledTileID): TerrainElevationLookup | null {
-        const lookup = this._getElevationLookup(tileID);
-        if (!lookup) return null;
+        const inTileLookup = this._getInTileElevationLookup(tileID);
+        if (!inTileLookup) return null;
 
         return (x: number, y: number, extent: number = EXTENT): number => {
-            if (x >= 0 && x < extent && y >= 0 && y < extent) return lookup(x, y, extent);
+            if (x >= 0 && x < extent && y >= 0 && y < extent) return inTileLookup(x, y, extent);
 
-            const normalized = tileID.normalizeCoordinates(x, y, extent);
-            if (!normalized) return 0;
-
-            const normalizedLookup = this._getElevationLookup(normalized.tileID);
-            return normalizedLookup ? normalizedLookup(normalized.x, normalized.y, extent) : 0;
+            return this._getElevationByNormalizingCoordinates(tileID, x, y, extent);
         };
     }
 
     resetElevationCache(): void {
-        this._elevationLookupCache.clear();
+        this._inTileElevationLookupCache.clear();
     }
 
-    _getElevationLookup(tileID: OverscaledTileID): PreparedTerrainElevationLookup | null {
-        const key = tileID.key;
-        const lookup = this._elevationLookupCache.get(key);
-        if (lookup) return lookup;
+    _getElevationByNormalizingCoordinates(tileID: OverscaledTileID, x: number, y: number, extent: number): number {
+        const normalized = tileID.normalizeCoordinates(x, y, extent);
+        if (!normalized) return 0;
 
-        const createdLookup = this._createElevationLookup(tileID, this.exaggeration);
-        if (createdLookup) this._elevationLookupCache.set(key, createdLookup);
+        const inTileLookup = this._getInTileElevationLookup(normalized.tileID);
+        return inTileLookup ? inTileLookup(normalized.x, normalized.y, extent) : 0;
+    }
+
+    _getInTileElevationLookup(tileID: OverscaledTileID): InTileTerrainElevationLookup | null {
+        const key = tileID.key;
+        const cachedLookup = this._inTileElevationLookupCache.get(key);
+        if (cachedLookup) return cachedLookup;
+
+        const createdLookup = this._createInTileElevationLookup(tileID, this.exaggeration);
+        if (createdLookup) this._inTileElevationLookupCache.set(key, createdLookup);
         return createdLookup;
     }
 
-    _createElevationLookup(tileID: OverscaledTileID, exaggeration: number): PreparedTerrainElevationLookup | null {
+    _createInTileElevationLookup(tileID: OverscaledTileID, exaggeration: number): InTileTerrainElevationLookup | null {
         if (tileID.overscaledZ - this.tileManager.deltaZoom < this.tileManager.minzoom) return null;
 
         const sourceTile = this.tileManager.getSourceTile(tileID, true);

--- a/src/render/terrain.ts
+++ b/src/render/terrain.ts
@@ -46,10 +46,7 @@ type TerrainElevationLookup = (x: number, y: number, extent?: number) => number;
 /**
  * @internal
  */
-type _PreparedTerrainElevationLookup = {
-    getElevation: TerrainElevationLookup;
-    sample: (x: number, y: number, extent: number) => number;
-};
+type PreparedTerrainElevationLookup = (x: number, y: number, extent: number) => number;
 
 /**
  * @internal
@@ -149,7 +146,7 @@ export class Terrain {
      * matrices to transform from vector-tile coords to raster-dem-tile coords.
      */
     _demMatrixCache: {[_: string]: { matrix: mat4; coord: OverscaledTileID }};
-    _elevationLookupCache: Map<string, _PreparedTerrainElevationLookup>;
+    _elevationLookupCache: Map<string, PreparedTerrainElevationLookup>;
     /**
      * Controls how terrain skirt length is calculated.
      * @see {@link MapOptions.terrainSkirtLength}
@@ -266,7 +263,7 @@ export class Terrain {
         if (!normalized) return 0;
 
         const lookup = this._getElevationLookup(normalized.tileID);
-        return lookup ? lookup.sample(normalized.x, normalized.y, extent) : 0;
+        return lookup ? lookup(normalized.x, normalized.y, extent) : 0;
     }
 
     /**
@@ -278,14 +275,24 @@ export class Terrain {
      */
     getElevationLookup(tileID: OverscaledTileID): TerrainElevationLookup | null {
         const lookup = this._getElevationLookup(tileID);
-        return lookup ? lookup.getElevation : null;
+        if (!lookup) return null;
+
+        return (x: number, y: number, extent: number = EXTENT): number => {
+            if (x >= 0 && x < extent && y >= 0 && y < extent) return lookup(x, y, extent);
+
+            const normalized = tileID.normalizeCoordinates(x, y, extent);
+            if (!normalized) return 0;
+
+            const normalizedLookup = this._getElevationLookup(normalized.tileID);
+            return normalizedLookup ? normalizedLookup(normalized.x, normalized.y, extent) : 0;
+        };
     }
 
     resetElevationCache(): void {
         this._elevationLookupCache.clear();
     }
 
-    _getElevationLookup(tileID: OverscaledTileID): _PreparedTerrainElevationLookup | null {
+    _getElevationLookup(tileID: OverscaledTileID): PreparedTerrainElevationLookup | null {
         const key = tileID.key;
         const lookup = this._elevationLookupCache.get(key);
         if (lookup) return lookup;
@@ -295,7 +302,7 @@ export class Terrain {
         return createdLookup;
     }
 
-    _createElevationLookup(tileID: OverscaledTileID, exaggeration: number): _PreparedTerrainElevationLookup | null {
+    _createElevationLookup(tileID: OverscaledTileID, exaggeration: number): PreparedTerrainElevationLookup | null {
         if (tileID.overscaledZ - this.tileManager.deltaZoom < this.tileManager.minzoom) return null;
 
         const sourceTile = this.tileManager.getSourceTile(tileID, true);
@@ -308,25 +315,12 @@ export class Terrain {
         const demPixelScaleY = matrix[5] * dem.dim;
         const demPixelOffsetX = matrix[12] * dem.dim;
         const demPixelOffsetY = matrix[13] * dem.dim;
-        const sample = (x: number, y: number, extent: number): number => {
+        return (x: number, y: number, extent: number): number => {
             const extentScale = extent === EXTENT ? 1 : EXTENT / extent;
             return dem.sampleBilinear(
                 x * extentScale * demPixelScaleX + demPixelOffsetX,
                 y * extentScale * demPixelScaleY + demPixelOffsetY
             ) * exaggeration;
-        };
-
-        return {
-            sample,
-            getElevation: (x: number, y: number, extent: number = EXTENT): number => {
-                if (x >= 0 && x < extent && y >= 0 && y < extent) return sample(x, y, extent);
-
-                const normalized = tileID.normalizeCoordinates(x, y, extent);
-                if (!normalized) return 0;
-
-                const lookup = this._getElevationLookup(normalized.tileID);
-                return lookup ? lookup.sample(normalized.x, normalized.y, extent) : 0;
-            }
         };
     }
 

--- a/src/render/terrain.ts
+++ b/src/render/terrain.ts
@@ -21,6 +21,7 @@ import type {TileManager} from '../tile/tile_manager.ts';
 import type {TerrainSpecification} from '@maplibre/maplibre-gl-style-spec';
 import type {Painter} from './painter.ts';
 import type {IReadonlyTransform} from '../geo/transform_interface.ts';
+import type {DEMData} from '../data/dem_data.ts';
 
 /**
  * @internal
@@ -253,16 +254,11 @@ export class Terrain {
      * @returns the elevation
      */
     getElevation(tileID: OverscaledTileID, x: number, y: number, extent: number = EXTENT): number {
-        if (x >= 0 && x < extent && y >= 0 && y < extent) {
-            const sampler = this._getElevationSampler(tileID);
-            return sampler ? sampler.getElevation(x, y, extent) : 0;
-        }
-
         const normalized = tileID.normalizeCoordinates(x, y, extent);
         if (!normalized) return 0;
 
-        const normalizedSampler = this._getElevationSampler(normalized.tileID);
-        return normalizedSampler ? normalizedSampler.getElevation(normalized.x, normalized.y, extent) : 0;
+        const sampler = this._getElevationSampler(normalized.tileID);
+        return sampler ? sampler.getElevation(normalized.x, normalized.y, extent) : 0;
     }
 
     resetElevationCache(): void {
@@ -287,31 +283,18 @@ export class Terrain {
         if (!sourceTile || !dem) return null;
 
         const matrix = this._getDEMTileMatrix(tileID, sourceTile);
-        const scaleX = matrix[0];
-        const scaleY = matrix[5];
-        const offsetX = matrix[12];
-        const offsetY = matrix[13];
-        const sample = (x: number, y: number, extent: number): number => {
-            const extentScale = extent === EXTENT ? 1 : EXTENT / extent;
-            return dem.sampleBilinear(
-                (x * extentScale * scaleX + offsetX) * dem.dim,
-                (y * extentScale * scaleY + offsetY) * dem.dim
-            ) * exaggeration;
-        };
 
         return {
-            getElevation: (x: number, y: number, extent: number = EXTENT): number => {
-                if (x >= 0 && x < extent && y >= 0 && y < extent) {
-                    return sample(x, y, extent);
-                }
-
-                const normalized = tileID.normalizeCoordinates(x, y, extent);
-                if (!normalized) return 0;
-
-                const sampler = this._getElevationSampler(normalized.tileID);
-                return sampler ? sampler.getElevation(normalized.x, normalized.y, extent) : 0;
-            }
+            getElevation: (x: number, y: number, extent: number = EXTENT): number => this._sampleElevation(dem, matrix, exaggeration, x, y, extent)
         };
+    }
+
+    _sampleElevation(dem: DEMData, matrix: mat4, exaggeration: number, x: number, y: number, extent: number): number {
+        const extentScale = extent === EXTENT ? 1 : EXTENT / extent;
+        return dem.sampleBilinear(
+            (x * extentScale * matrix[0] + matrix[12]) * dem.dim,
+            (y * extentScale * matrix[5] + matrix[13]) * dem.dim
+        ) * exaggeration;
     }
 
     _getDEMTileMatrix(tileID: OverscaledTileID, sourceTile: Tile): mat4 {

--- a/src/render/terrain.ts
+++ b/src/render/terrain.ts
@@ -21,7 +21,6 @@ import type {TileManager} from '../tile/tile_manager.ts';
 import type {TerrainSpecification} from '@maplibre/maplibre-gl-style-spec';
 import type {Painter} from './painter.ts';
 import type {IReadonlyTransform} from '../geo/transform_interface.ts';
-import type {DEMData} from '../data/dem_data.ts';
 
 /**
  * @internal
@@ -39,8 +38,17 @@ export type TerrainData = {
     tile: Tile;
 };
 
-type TerrainElevationSampler = {
-    getElevation: (x: number, y: number, extent?: number) => number;
+/**
+ * @internal
+ */
+type TerrainElevationLookup = (x: number, y: number, extent?: number) => number;
+
+/**
+ * @internal
+ */
+type _PreparedTerrainElevationLookup = {
+    getElevation: TerrainElevationLookup;
+    sample: (x: number, y: number, extent: number) => number;
 };
 
 /**
@@ -141,7 +149,7 @@ export class Terrain {
      * matrices to transform from vector-tile coords to raster-dem-tile coords.
      */
     _demMatrixCache: {[_: string]: { matrix: mat4; coord: OverscaledTileID }};
-    _elevationSamplerCache: Map<string, TerrainElevationSampler>;
+    _elevationLookupCache: Map<string, _PreparedTerrainElevationLookup>;
     /**
      * Controls how terrain skirt length is calculated.
      * @see {@link MapOptions.terrainSkirtLength}
@@ -156,7 +164,7 @@ export class Terrain {
         this.qualityFactor = 2;
         this.meshSize = 128;
         this._demMatrixCache = {};
-        this._elevationSamplerCache = new Map();
+        this._elevationLookupCache = new Map();
         this.coordsIndex = [];
         this._coordsTextureSize = 1024;
     }
@@ -257,25 +265,37 @@ export class Terrain {
         const normalized = tileID.normalizeCoordinates(x, y, extent);
         if (!normalized) return 0;
 
-        const sampler = this._getElevationSampler(normalized.tileID);
-        return sampler ? sampler.getElevation(normalized.x, normalized.y, extent) : 0;
+        const lookup = this._getElevationLookup(normalized.tileID);
+        return lookup ? lookup.sample(normalized.x, normalized.y, extent) : 0;
+    }
+
+    /**
+     * @internal
+     * Resolve DEM tile/matrix once for hot loops that sample many points from the same tile.
+     * Use {@link Terrain.getElevation} for one-off lookups and general coordinate normalization.
+     * @param tileID - the tile id
+     * @returns a prepared elevation lookup for this tile, or null while DEM data is unavailable
+     */
+    getElevationLookup(tileID: OverscaledTileID): TerrainElevationLookup | null {
+        const lookup = this._getElevationLookup(tileID);
+        return lookup ? lookup.getElevation : null;
     }
 
     resetElevationCache(): void {
-        this._elevationSamplerCache.clear();
+        this._elevationLookupCache.clear();
     }
 
-    _getElevationSampler(tileID: OverscaledTileID): TerrainElevationSampler | null {
+    _getElevationLookup(tileID: OverscaledTileID): _PreparedTerrainElevationLookup | null {
         const key = tileID.key;
-        const sampler = this._elevationSamplerCache.get(key);
-        if (sampler) return sampler;
+        const lookup = this._elevationLookupCache.get(key);
+        if (lookup) return lookup;
 
-        const createdSampler = this._createElevationSampler(tileID, this.exaggeration);
-        if (createdSampler) this._elevationSamplerCache.set(key, createdSampler);
-        return createdSampler;
+        const createdLookup = this._createElevationLookup(tileID, this.exaggeration);
+        if (createdLookup) this._elevationLookupCache.set(key, createdLookup);
+        return createdLookup;
     }
 
-    _createElevationSampler(tileID: OverscaledTileID, exaggeration: number): TerrainElevationSampler | null {
+    _createElevationLookup(tileID: OverscaledTileID, exaggeration: number): _PreparedTerrainElevationLookup | null {
         if (tileID.overscaledZ - this.tileManager.deltaZoom < this.tileManager.minzoom) return null;
 
         const sourceTile = this.tileManager.getSourceTile(tileID, true);
@@ -283,18 +303,31 @@ export class Terrain {
         if (!sourceTile || !dem) return null;
 
         const matrix = this._getDEMTileMatrix(tileID, sourceTile);
+        // Store the vector-tile to DEM-pixel transform once for the hot sampling loop.
+        const demPixelScaleX = matrix[0] * dem.dim;
+        const demPixelScaleY = matrix[5] * dem.dim;
+        const demPixelOffsetX = matrix[12] * dem.dim;
+        const demPixelOffsetY = matrix[13] * dem.dim;
+        const sample = (x: number, y: number, extent: number): number => {
+            const extentScale = extent === EXTENT ? 1 : EXTENT / extent;
+            return dem.sampleBilinear(
+                x * extentScale * demPixelScaleX + demPixelOffsetX,
+                y * extentScale * demPixelScaleY + demPixelOffsetY
+            ) * exaggeration;
+        };
 
         return {
-            getElevation: (x: number, y: number, extent: number = EXTENT): number => this._sampleElevation(dem, matrix, exaggeration, x, y, extent)
-        };
-    }
+            sample,
+            getElevation: (x: number, y: number, extent: number = EXTENT): number => {
+                if (x >= 0 && x < extent && y >= 0 && y < extent) return sample(x, y, extent);
 
-    _sampleElevation(dem: DEMData, matrix: mat4, exaggeration: number, x: number, y: number, extent: number): number {
-        const extentScale = extent === EXTENT ? 1 : EXTENT / extent;
-        return dem.sampleBilinear(
-            (x * extentScale * matrix[0] + matrix[12]) * dem.dim,
-            (y * extentScale * matrix[5] + matrix[13]) * dem.dim
-        ) * exaggeration;
+                const normalized = tileID.normalizeCoordinates(x, y, extent);
+                if (!normalized) return 0;
+
+                const lookup = this._getElevationLookup(normalized.tileID);
+                return lookup ? lookup.sample(normalized.x, normalized.y, extent) : 0;
+            }
+        };
     }
 
     _getDEMTileMatrix(tileID: OverscaledTileID, sourceTile: Tile): mat4 {

--- a/src/render/terrain.ts
+++ b/src/render/terrain.ts
@@ -145,7 +145,7 @@ export class Terrain {
      * as of overzooming of raster-dem tiles in high zoomlevels, this cache contains
      * matrices to transform from vector-tile coords to raster-dem-tile coords.
      */
-    _demMatrixCache: {[_: string]: { matrix: mat4; coord: OverscaledTileID }};
+    _demMatrixCache: {[_: string]: {matrix: mat4}};
     _elevationLookupCache: Map<string, PreparedTerrainElevationLookup>;
     /**
      * Controls how terrain skirt length is calculated.
@@ -326,20 +326,21 @@ export class Terrain {
 
     _getDEMTileMatrix(tileID: OverscaledTileID, sourceTile: Tile): mat4 {
         const matrixKey = sourceTile.toString() + sourceTile.tileID.key + tileID.key;
-        if (!this._demMatrixCache[matrixKey]) {
-            const maxzoom = this.tileManager.getSource().maxzoom;
-            let dz = tileID.canonical.z - sourceTile.tileID.canonical.z;
-            if (tileID.overscaledZ > tileID.canonical.z) {
-                if (tileID.canonical.z >= maxzoom) dz =  tileID.canonical.z - maxzoom;
-                else warnOnce('cannot calculate elevation if elevation maxzoom > source.maxzoom');
-            }
-            const dx = tileID.canonical.x - (tileID.canonical.x >> dz << dz);
-            const dy = tileID.canonical.y - (tileID.canonical.y >> dz << dz);
-            const demMatrix = mat4.fromScaling(new Float64Array(16), [1 / (EXTENT << dz), 1 / (EXTENT << dz), 0]);
-            mat4.translate(demMatrix, demMatrix, [dx * EXTENT, dy * EXTENT, 0]);
-            this._demMatrixCache[matrixKey] = {matrix: demMatrix, coord: tileID};
+        const cachedMatrix = this._demMatrixCache[matrixKey];
+        if (cachedMatrix) return cachedMatrix.matrix;
+
+        const maxzoom = this.tileManager.getSource().maxzoom;
+        let dz = tileID.canonical.z - sourceTile.tileID.canonical.z;
+        if (tileID.overscaledZ > tileID.canonical.z) {
+            if (tileID.canonical.z >= maxzoom) dz =  tileID.canonical.z - maxzoom;
+            else warnOnce('cannot calculate elevation if elevation maxzoom > source.maxzoom');
         }
-        return this._demMatrixCache[matrixKey].matrix;
+        const dx = tileID.canonical.x - (tileID.canonical.x >> dz << dz);
+        const dy = tileID.canonical.y - (tileID.canonical.y >> dz << dz);
+        const demMatrix = mat4.fromScaling(new Float64Array(16), [1 / (EXTENT << dz), 1 / (EXTENT << dz), 0]);
+        mat4.translate(demMatrix, demMatrix, [dx * EXTENT, dy * EXTENT, 0]);
+        this._demMatrixCache[matrixKey] = {matrix: demMatrix};
+        return demMatrix;
     }
 
     /**

--- a/src/render/terrain.ts
+++ b/src/render/terrain.ts
@@ -45,11 +45,6 @@ type TerrainElevationLookup = (x: number, y: number, extent?: number) => number;
 
 /**
  * @internal
- */
-type InTileTerrainElevationLookup = (x: number, y: number, extent: number) => number;
-
-/**
- * @internal
  * This is the main class which handles most of the 3D Terrain logic. It has the following topics:
  *
  * 1. loads raster-dem tiles via the internal tileManager this.tileManager
@@ -146,7 +141,7 @@ export class Terrain {
      * matrices to transform from vector-tile coords to raster-dem-tile coords.
      */
     _demMatrixCache: {[_: string]: {matrix: mat4}};
-    _inTileElevationLookupCache: Map<string, InTileTerrainElevationLookup>;
+    _elevationLookupCache: Map<string, TerrainElevationLookup>;
     /**
      * Controls how terrain skirt length is calculated.
      * @see {@link MapOptions.terrainSkirtLength}
@@ -161,7 +156,7 @@ export class Terrain {
         this.qualityFactor = 2;
         this.meshSize = 128;
         this._demMatrixCache = {};
-        this._inTileElevationLookupCache = new Map();
+        this._elevationLookupCache = new Map();
         this.coordsIndex = [];
         this._coordsTextureSize = 1024;
     }
@@ -265,46 +260,39 @@ export class Terrain {
     /**
      * @internal
      * Resolve DEM tile/matrix once for hot loops that sample many points from the same tile.
-     * In-tile samples stay on the prepared fast path; samples that cross a tile boundary are
-     * normalized to the neighboring tile only when needed.
-     * Use {@link Terrain.getElevation} for one-off lookups and general coordinate normalization.
+     * The returned lookup samples directly while coordinates stay inside this tile, and
+     * normalizes only the samples that cross a tile boundary.
+     * Use {@link Terrain.getElevation} for one-off lookups.
      * @param tileID - the tile id
      * @returns a prepared elevation lookup for this tile, or null while DEM data is unavailable
      */
     getElevationLookup(tileID: OverscaledTileID): TerrainElevationLookup | null {
-        const inTileLookup = this._getInTileElevationLookup(tileID);
-        if (!inTileLookup) return null;
-
-        return (x: number, y: number, extent: number = EXTENT): number => {
-            if (x >= 0 && x < extent && y >= 0 && y < extent) return inTileLookup(x, y, extent);
-
-            return this._getElevationByNormalizingCoordinates(tileID, x, y, extent);
-        };
+        return this._getElevationLookup(tileID);
     }
 
     resetElevationCache(): void {
-        this._inTileElevationLookupCache.clear();
+        this._elevationLookupCache.clear();
     }
 
     _getElevationByNormalizingCoordinates(tileID: OverscaledTileID, x: number, y: number, extent: number): number {
         const normalized = tileID.normalizeCoordinates(x, y, extent);
         if (!normalized) return 0;
 
-        const inTileLookup = this._getInTileElevationLookup(normalized.tileID);
-        return inTileLookup ? inTileLookup(normalized.x, normalized.y, extent) : 0;
+        const normalizedTileLookup = this._getElevationLookup(normalized.tileID);
+        return normalizedTileLookup ? normalizedTileLookup(normalized.x, normalized.y, extent) : 0;
     }
 
-    _getInTileElevationLookup(tileID: OverscaledTileID): InTileTerrainElevationLookup | null {
+    _getElevationLookup(tileID: OverscaledTileID): TerrainElevationLookup | null {
         const key = tileID.key;
-        const cachedLookup = this._inTileElevationLookupCache.get(key);
+        const cachedLookup = this._elevationLookupCache.get(key);
         if (cachedLookup) return cachedLookup;
 
-        const createdLookup = this._createInTileElevationLookup(tileID, this.exaggeration);
-        if (createdLookup) this._inTileElevationLookupCache.set(key, createdLookup);
+        const createdLookup = this._createElevationLookup(tileID, this.exaggeration);
+        if (createdLookup) this._elevationLookupCache.set(key, createdLookup);
         return createdLookup;
     }
 
-    _createInTileElevationLookup(tileID: OverscaledTileID, exaggeration: number): InTileTerrainElevationLookup | null {
+    _createElevationLookup(tileID: OverscaledTileID, exaggeration: number): TerrainElevationLookup | null {
         if (tileID.overscaledZ - this.tileManager.deltaZoom < this.tileManager.minzoom) return null;
 
         const sourceTile = this.tileManager.getSourceTile(tileID, true);
@@ -317,7 +305,12 @@ export class Terrain {
         const demPixelScaleY = matrix[5] * dem.dim;
         const demPixelOffsetX = matrix[12] * dem.dim;
         const demPixelOffsetY = matrix[13] * dem.dim;
-        return (x: number, y: number, extent: number): number => {
+        return (x: number, y: number, extent: number = EXTENT): number => {
+            if (x < 0 || x >= extent || y < 0 || y >= extent) {
+                // Boundary fallback: normalize to the neighboring tile and use that tile's cached lookup.
+                return this._getElevationByNormalizingCoordinates(tileID, x, y, extent);
+            }
+
             const extentScale = extent === EXTENT ? 1 : EXTENT / extent;
             return dem.sampleBilinear(
                 x * extentScale * demPixelScaleX + demPixelOffsetX,

--- a/src/render/terrain.ts
+++ b/src/render/terrain.ts
@@ -38,6 +38,10 @@ export type TerrainData = {
     tile: Tile;
 };
 
+type TerrainElevationSampler = {
+    getElevation: (x: number, y: number, extent?: number) => number;
+};
+
 /**
  * @internal
  * This is the main class which handles most of the 3D Terrain logic. It has the following topics:
@@ -136,6 +140,7 @@ export class Terrain {
      * matrices to transform from vector-tile coords to raster-dem-tile coords.
      */
     _demMatrixCache: {[_: string]: { matrix: mat4; coord: OverscaledTileID }};
+    _elevationSamplerCache: Map<string, TerrainElevationSampler | null>;
     /**
      * Controls how terrain skirt length is calculated.
      * @see {@link MapOptions.terrainSkirtLength}
@@ -150,6 +155,7 @@ export class Terrain {
         this.qualityFactor = 2;
         this.meshSize = 128;
         this._demMatrixCache = {};
+        this._elevationSamplerCache = new Map();
         this.coordsIndex = [];
         this._coordsTextureSize = 1024;
     }
@@ -247,7 +253,81 @@ export class Terrain {
      * @returns the elevation
      */
     getElevation(tileID: OverscaledTileID, x: number, y: number, extent: number = EXTENT): number {
-        return this.getDEMElevation(tileID, x, y, extent) * this.exaggeration;
+        const sampler = this._getElevationSampler(tileID);
+        if (sampler) return sampler.getElevation(x, y, extent);
+
+        if (x >= 0 && x < extent && y >= 0 && y < extent) return 0;
+
+        const normalized = tileID.normalizeCoordinates(x, y, extent);
+        if (!normalized) return 0;
+
+        const normalizedSampler = this._getElevationSampler(normalized.tileID);
+        return normalizedSampler ? normalizedSampler.getElevation(normalized.x, normalized.y, extent) : 0;
+    }
+
+    resetElevationCache(): void {
+        this._elevationSamplerCache.clear();
+    }
+
+    _getElevationSampler(tileID: OverscaledTileID): TerrainElevationSampler | null {
+        const key = tileID.key;
+        if (!this._elevationSamplerCache.has(key)) {
+            this._elevationSamplerCache.set(key, this._createElevationSampler(tileID, this.exaggeration));
+        }
+        return this._elevationSamplerCache.get(key);
+    }
+
+    _createElevationSampler(tileID: OverscaledTileID, exaggeration: number): TerrainElevationSampler | null {
+        if (tileID.overscaledZ - this.tileManager.deltaZoom < this.tileManager.minzoom) return null;
+
+        const sourceTile = this.tileManager.getSourceTile(tileID, true);
+        const dem = sourceTile?.dem;
+        if (!sourceTile || !dem) return null;
+
+        const matrix = this._getDEMTileMatrix(tileID, sourceTile);
+        const scaleX = matrix[0];
+        const scaleY = matrix[5];
+        const offsetX = matrix[12];
+        const offsetY = matrix[13];
+        const sample = (x: number, y: number, extent: number): number => {
+            const extentScale = extent === EXTENT ? 1 : EXTENT / extent;
+            return dem.sampleBilinear(
+                (x * extentScale * scaleX + offsetX) * dem.dim,
+                (y * extentScale * scaleY + offsetY) * dem.dim
+            ) * exaggeration;
+        };
+
+        return {
+            getElevation: (x: number, y: number, extent: number = EXTENT): number => {
+                if (x >= 0 && x < extent && y >= 0 && y < extent) {
+                    return sample(x, y, extent);
+                }
+
+                const normalized = tileID.normalizeCoordinates(x, y, extent);
+                if (!normalized) return 0;
+
+                const sampler = this._getElevationSampler(normalized.tileID);
+                return sampler ? sampler.getElevation(normalized.x, normalized.y, extent) : 0;
+            }
+        };
+    }
+
+    _getDEMTileMatrix(tileID: OverscaledTileID, sourceTile: Tile): mat4 {
+        const matrixKey = sourceTile.toString() + sourceTile.tileID.key + tileID.key;
+        if (!this._demMatrixCache[matrixKey]) {
+            const maxzoom = this.tileManager.getSource().maxzoom;
+            let dz = tileID.canonical.z - sourceTile.tileID.canonical.z;
+            if (tileID.overscaledZ > tileID.canonical.z) {
+                if (tileID.canonical.z >= maxzoom) dz =  tileID.canonical.z - maxzoom;
+                else warnOnce('cannot calculate elevation if elevation maxzoom > source.maxzoom');
+            }
+            const dx = tileID.canonical.x - (tileID.canonical.x >> dz << dz);
+            const dy = tileID.canonical.y - (tileID.canonical.y >> dz << dz);
+            const demMatrix = mat4.fromScaling(new Float64Array(16), [1 / (EXTENT << dz), 1 / (EXTENT << dz), 0]);
+            mat4.translate(demMatrix, demMatrix, [dx * EXTENT, dy * EXTENT, 0]);
+            this._demMatrixCache[matrixKey] = {matrix: demMatrix, coord: tileID};
+        }
+        return this._demMatrixCache[matrixKey].matrix;
     }
 
     /**
@@ -277,27 +357,13 @@ export class Terrain {
             sourceTile.demTexture.bind(context.gl.NEAREST, context.gl.CLAMP_TO_EDGE);
             sourceTile.needsTerrainPrepare = false;
         }
-        // create matrix for lookup in dem data
-        const matrixKey = sourceTile && sourceTile.toString() + sourceTile.tileID.key + tileID.key;
-        if (matrixKey && !this._demMatrixCache[matrixKey]) {
-            const maxzoom = this.tileManager.getSource().maxzoom;
-            let dz = tileID.canonical.z - sourceTile.tileID.canonical.z;
-            if (tileID.overscaledZ > tileID.canonical.z) {
-                if (tileID.canonical.z >= maxzoom) dz =  tileID.canonical.z - maxzoom;
-                else warnOnce('cannot calculate elevation if elevation maxzoom > source.maxzoom');
-            }
-            const dx = tileID.canonical.x - (tileID.canonical.x >> dz << dz);
-            const dy = tileID.canonical.y - (tileID.canonical.y >> dz << dz);
-            const demMatrix = mat4.fromScaling(new Float64Array(16), [1 / (EXTENT << dz), 1 / (EXTENT << dz), 0]);
-            mat4.translate(demMatrix, demMatrix, [dx * EXTENT, dy * EXTENT, 0]);
-            this._demMatrixCache[matrixKey] = {matrix: demMatrix, coord: tileID};
-        }
+        const terrainMatrix = sourceTile ? this._getDEMTileMatrix(tileID, sourceTile) : this._emptyDemMatrix;
         // return uniform values & textures
         return {
             'u_depth': 2,
             'u_terrain': 3,
             'u_terrain_dim': sourceTile?.dem?.dim || 1,
-            'u_terrain_matrix': matrixKey ? this._demMatrixCache[matrixKey].matrix : this._emptyDemMatrix,
+            'u_terrain_matrix': terrainMatrix,
             'u_terrain_unpack': sourceTile?.dem?.getUnpackVector() || this._emptyDemUnpack,
             'u_terrain_exaggeration': this.exaggeration,
             texture: (sourceTile?.demTexture || this._emptyDemTexture).texture,

--- a/src/render/terrain.ts
+++ b/src/render/terrain.ts
@@ -140,7 +140,7 @@ export class Terrain {
      * matrices to transform from vector-tile coords to raster-dem-tile coords.
      */
     _demMatrixCache: {[_: string]: { matrix: mat4; coord: OverscaledTileID }};
-    _elevationSamplerCache: Map<string, TerrainElevationSampler | null>;
+    _elevationSamplerCache: Map<string, TerrainElevationSampler>;
     /**
      * Controls how terrain skirt length is calculated.
      * @see {@link MapOptions.terrainSkirtLength}
@@ -253,10 +253,10 @@ export class Terrain {
      * @returns the elevation
      */
     getElevation(tileID: OverscaledTileID, x: number, y: number, extent: number = EXTENT): number {
-        const sampler = this._getElevationSampler(tileID);
-        if (sampler) return sampler.getElevation(x, y, extent);
-
-        if (x >= 0 && x < extent && y >= 0 && y < extent) return 0;
+        if (x >= 0 && x < extent && y >= 0 && y < extent) {
+            const sampler = this._getElevationSampler(tileID);
+            return sampler ? sampler.getElevation(x, y, extent) : 0;
+        }
 
         const normalized = tileID.normalizeCoordinates(x, y, extent);
         if (!normalized) return 0;
@@ -271,10 +271,12 @@ export class Terrain {
 
     _getElevationSampler(tileID: OverscaledTileID): TerrainElevationSampler | null {
         const key = tileID.key;
-        if (!this._elevationSamplerCache.has(key)) {
-            this._elevationSamplerCache.set(key, this._createElevationSampler(tileID, this.exaggeration));
-        }
-        return this._elevationSamplerCache.get(key);
+        const sampler = this._elevationSamplerCache.get(key);
+        if (sampler) return sampler;
+
+        const createdSampler = this._createElevationSampler(tileID, this.exaggeration);
+        if (createdSampler) this._elevationSamplerCache.set(key, createdSampler);
+        return createdSampler;
     }
 
     _createElevationSampler(tileID: OverscaledTileID, exaggeration: number): TerrainElevationSampler | null {

--- a/src/style/style.ts
+++ b/src/style/style.ts
@@ -1880,6 +1880,7 @@ export class Style extends Evented<MapEventType> {
             // render frame
             this.placement.setStale();
         } else {
+            this.map.terrain?.resetElevationCache();
             this.pauseablePlacement.continuePlacement(this._order, this._layers, layerTiles);
 
             if (this.pauseablePlacement.isDone()) {

--- a/src/symbol/placement.ts
+++ b/src/symbol/placement.ts
@@ -239,7 +239,7 @@ export class Placement {
     private _getTerrainElevationFunc(tileID: OverscaledTileID) {
         const terrain = this.terrain;
         if (!terrain) return null;
-        return (x: number, y: number) => terrain.getElevation(tileID, x, y);
+        return terrain.getElevationLookup(tileID);
     }
 
     getBucketParts(results: BucketPart[], styleLayer: StyleLayer, tile: Tile, sortAcrossTiles: boolean): void {

--- a/src/util/test/util.ts
+++ b/src/util/test/util.ts
@@ -239,6 +239,8 @@ export function expectToBeCloseToArray(actual: number[], expected: number[], pre
 export function createTerrain(): Terrain {
     return {
         pointCoordinate: () => null,
+        getElevation: () => 1000,
+        getElevationLookup: () => () => 1000,
         getElevationForLngLatZoom: () => 1000,
         getElevationForLngLat: () => 1000,
         getMinTileElevationForLngLatZoom: () => 0,

--- a/src/util/test/util.ts
+++ b/src/util/test/util.ts
@@ -242,6 +242,7 @@ export function createTerrain(): Terrain {
         getElevationForLngLatZoom: () => 1000,
         getElevationForLngLat: () => 1000,
         getMinTileElevationForLngLatZoom: () => 0,
+        resetElevationCache: () => {},
         getFramebuffer: () => ({}),
         getCoordsTexture: () => ({}),
         depthAtPoint: () => .9,

--- a/src/webgl/draw/draw_symbol.ts
+++ b/src/webgl/draw/draw_symbol.ts
@@ -154,7 +154,7 @@ function updateVariableAnchors(coords: OverscaledTileID[],
 
         if (size) {
             const tileScale = Math.pow(2, transform.zoom - tile.tileID.overscaledZ);
-            const getElevation = terrain ? (x: number, y: number) => terrain.getElevation(coord, x, y) : null;
+            const getElevation = terrain?.getElevationLookup(coord) ?? null;
             const translation = translatePosition(transform, tile, translate, translateAnchor);
             updateVariableAnchorsForBucket(bucket, rotateWithMap, pitchWithMap, variableOffsets,
                 transform, pitchedLabelPlaneMatrix, tileScale, size, updateTextFitIcon, translation, coord.toUnwrapped(), getElevation);
@@ -391,7 +391,7 @@ function drawLayerSymbols(
             const pitchedLabelPlaneMatrixInverse = mat4.create();
             fastInvertTransformMat4(pitchedLabelPlaneMatrixInverse, pitchedLabelPlaneMatrix);
 
-            const getElevation = painter.style.map.terrain ? (x: number, y: number) => painter.style.map.terrain.getElevation(coord, x, y) : null;
+            const getElevation = painter.style.map.terrain?.getElevationLookup(coord) ?? null;
             const rotateToLine = layer.layout.get('text-rotation-alignment') === 'map';
             updateLineLabels(bucket, painter, isText, pitchedLabelPlaneMatrix, pitchedLabelPlaneMatrixInverse, pitchWithMap, keepUpright, rotateToLine, coord.toUnwrapped(), transform.width, transform.height, translation, getElevation);
         }


### PR DESCRIPTION
This PR reduces CPU work when symbol placement samples terrain elevation many times for the same tile.

Before this change, the symbol terrain path repeatedly resolved the covering DEM tile and DEM matrix before doing the DEM sample. Dense symbol styles can hit that path hundreds of thousands or millions of times while the map is moving.

This change adds a small per-tile `TerrainSamplingContext` for the current render/placement pass. The cache is reset during render/placement, so it is only reused within the current frame's render/placement work. Symbol placement and symbol drawing resolve the sampler once for a tile, then reuse it inside the hot loops.

The terrain result is unchanged, this only allows to avoid repeating setup work inside the symbol hot paths.


## Benchmarks

Local deterministic moving replay, 480 measured frames, terrain + hillshade enabled, Linux `perf` counters enabled.

### Demotiles with grid of 160 symbols

Controlled test using the demotiles terrain in Austria, with an added grid of 160 symbols.

| Metric | main avg | candidate avg | delta |
|---|---:|---:|---:|
| frame median | 9.55 ms | 9.00 ms | -5.8% |
| frame mean | 10.15 ms | 9.43 ms | -7.2% |
| frame p95 | 16.00 ms | 13.95 ms | -12.8% |
| `Style._updatePlacement` | 1806.6 ms | 1380.1 ms | -23.6% |
| `perf` task-clock | 8151.0 ms | 7810.9 ms | -4.2% |
| `perf` cycles | 23372.8 M | 20860.3 M | -10.8% |
| `perf` instructions | 29004.1 M | 26002.7 M | -10.4% |
| `Terrain.getTerrainData` calls | 490671 | 272630 | -44.4% |

### Real dense symbol style

Real dense [Mapeak](https://github.com/IsraelHikingMap/VectorMap/blob/master/Styles/mapeak-hike.json) hiking style, with many symbol layers and buckets visible in the tested viewport.

| Metric | main avg | candidate avg | delta |
|---|---:|---:|---:|
| frame median | 54.75 ms | 33.50 ms | -38.8% |
| frame mean | 56.81 ms | 34.47 ms | -39.3% |
| frame p95 | 80.60 ms | 48.80 ms | -39.5% |
| `Style._updatePlacement` | 18545.4 ms | 9355.9 ms | -49.6% |
| `Draw.symbol` | 5105.4 ms | 3606.2 ms | -29.4% |
| `perf` task-clock | 36926.3 ms | 25016.1 ms | -32.3% |
| `perf` cycles | 88934.8 M | 58835.5 M | -33.8% |
| `perf` instructions | 140149.9 M | 94096.7 M | -32.9% |
| `Terrain.getTerrainData` calls | 4334699 | 361345 | -91.7% |


## Launch Checklist

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [ ] Link to related issues.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [x] Post benchmark scores.
 - [ ] Add an entry to `CHANGELOG.md` under the `## main` section.
 - [x] Confirm you have read our AI policy [here](https://github.com/maplibre/maplibre/blob/main/AI_POLICY.md).

Assisted-By: GPT 5.5