### PR TITLE
Release geolocation camera lock on zoom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ### ✨ Features and improvements
 - Improve terrain render-to-texture preparation performance by skipping sources that are not rendered to terrain textures ([#7863](https://github.com/maplibre/maplibre-gl-js/pull/7863)) (by [@DoFabien](https://github.com/DoFabien))
 - Add `Map.setMissingStyleImageResolver` for resolving missing style images with sync or async callbacks ([#7850](https://github.com/maplibre/maplibre-gl-js/pull/7850)) (by [@birkskyum](https://github.com/birkskyum))
+- Release the active `GeolocateControl` camera lock when the user zooms the map (by [@timsluis](https://github.com/timsluis))
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes

--- a/src/ui/control/geolocate_control.test.ts
+++ b/src/ui/control/geolocate_control.test.ts
@@ -730,7 +730,7 @@ describe('GeolocateControl with no options', () => {
         expect(geolocate._watchState).toBe('ACTIVE_LOCK');
     });
 
-    test('does not switch to BACKGROUND and stays in ACTIVE_LOCK state on zoom', async () => {
+    test('switches to BACKGROUND state on zoom', async () => {
         const geolocate = new GeolocateControl({
             trackUserLocation: true,
         });
@@ -748,7 +748,7 @@ describe('GeolocateControl with no options', () => {
         map.zoomTo(10, {duration: 0});
         await zoomendPromise;
 
-        expect(geolocate._watchState).toBe('ACTIVE_LOCK');
+        expect(geolocate._watchState).toBe('BACKGROUND');
     });
 
     test('switches to BACKGROUND state on map manipulation', async () => {

--- a/src/ui/control/geolocate_control.ts
+++ b/src/ui/control/geolocate_control.ts
@@ -630,7 +630,7 @@ export class GeolocateControl extends Evented<GeolocateControlEventType> impleme
     _onMoveStart = (event: any): void => {
         if (!this._map) return;
         const fromResize = event?.[0] instanceof ResizeObserverEntry;
-        if (!event.geolocateSource && this._watchState === 'ACTIVE_LOCK' && !fromResize && !this._map.isZooming()) {
+        if (!event.geolocateSource && this._watchState === 'ACTIVE_LOCK' && !fromResize) {
             this._watchState = 'BACKGROUND';
             this._geolocateButton.classList.add('maplibregl-ctrl-geolocate-background');
             this._geolocateButton.classList.remove('maplibregl-ctrl-geolocate-active');


### PR DESCRIPTION
Fixes #7908.

When `GeolocateControl` was configured with `trackUserLocation: true`, manually panning the map released the active camera lock, while manually zooming did not.

The PR ensures that zooming releases the active camera lock, just like panning, by transitioning the control from `ACTIVE_LOCK` to `BACKGROUND`.

## Launch Checklist

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [x] Add an entry to `CHANGELOG.md` under the `## main` section.
 - [x] Confirm you have read our AI policy [here](https://github.com/maplibre/maplibre/blob/main/AI_POLICY.md).

Assisted-By: Codex (GPT-5)
