### PR TITLE
fix: use role=img for non-interactive default markers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,114 @@
 ## main
 ### ✨ Features and improvements
+- Improve terrain render-to-texture preparation performance by skipping sources that are not rendered to terrain textures ([#7863](https://github.com/maplibre/maplibre-gl-js/pull/7863)) (by [@DoFabien](https://github.com/DoFabien))
+- Add `Map.setMissingStyleImageResolver` for resolving missing style images with sync or async callbacks ([#7850](https://github.com/maplibre/maplibre-gl-js/pull/7850)) (by [@birkskyum](https://github.com/birkskyum))
+- ⚠️ Stop allowing `styleimagemissing` listeners to resolve the current image request; use `Map.setMissingStyleImageResolver` instead ([#7892](https://github.com/maplibre/maplibre-gl-js/issues/7892)) (by [@birkskyum](https://github.com/birkskyum))
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes
+- Use `role=img` for non-interactive default markers and `role=button` when they become interactive ([#7790](https://github.com/maplibre/maplibre-gl-js/issues/7790))
 - _...Add new stuff here..._
+- Add `RasterTileSource#setPremultiplyAlpha(false)` to preserve raw RGBA tile values when alpha is used for data instead of opacity ([#7235](https://github.com/maplibre/maplibre-gl-js/pull/7235)) (by [@plantain](https://github.com/plantain)).
+
+## 6.0.0-20
+
+### ✨ Features and improvements
+
+- ⚠️ `Map` now composes a `Camera` instead of extending it (`Map` extends `Evented` directly and forwards the camera API). The internal `map.transform` was removed — use map's public API instead or open a PR if you need something that's not exposed. Removed the internal `transform.getMatrixForModel` helper ([#7800](https://github.com/maplibre/maplibre-gl-js/pull/7800)) (by [@HarelM](https://github.com/HarelM))
+
+### 🐞 Bug fixes
+
+- Fix `line-layer-opacity`/`fill-layer-opacity` clipping away a subsequent layer that shares the same source ([#7867](https://github.com/maplibre/maplibre-gl-js/pull/7867)) (by [@CommanderStorm](https://github.com/CommanderStorm))
+- Fix camera jump in flyTo when minZoom is set ([#7743](https://github.com/maplibre/maplibre-gl-js/pull/7743)) (by [@YuChunTsao](https://github.com/YuChunTsao))
+
+## 6.0.0-19
+
+### ✨ Features and improvements
+
+- Drop the archived `@mapbox/whoots-js` dependency by inlining its single `getTileBBox` helper ([#7838](https://github.com/maplibre/maplibre-gl-js/pull/7838)) (by [@qorexdevs](https://github.com/qorexdevs))
+- Debounce `setImages` broadcast to once per animation frame, fixing O(n²) serialization overhead when adding many images ([#7614](https://github.com/maplibre/maplibre-gl-js/pull/7614)) (by [@bradymadden97](https://github.com/bradymadden97))
+
+### 🐞 Bug fixes
+
+- Fix stale terrain depth and coordinate framebuffers when terrain tiles change without camera movement ([#7812](https://github.com/maplibre/maplibre-gl-js/pull/7812)) (by [@DoFabien](https://github.com/DoFabien))
+
+## 6.0.0-18
+
+### ✨ Features and improvements
+
+- Improve terrain rendering performance by avoiding unnecessary terrain data lookups during Mercator render-to-texture passes ([#7833](https://github.com/maplibre/maplibre-gl-js/pull/7833)) (by [@DoFabien](https://github.com/DoFabien))
+- Reduce allocation pressure while constructing DEM data and sampling terrain elevations ([#7814](https://github.com/maplibre/maplibre-gl-js/pull/7814)) (by [@DoFabien](https://github.com/DoFabien))
+- Reuse terrain DEM texture when preparing terrain ([#7813](https://github.com/maplibre/maplibre-gl-js/pull/7813)) (by [@DoFabien](https://github.com/DoFabien))
+
+### 🐞 Bug fixes
+
+- Fix a memory leak where aborting a worker request (e.g. a GeoJSON tile load cancelled while panning) left its promise pending forever, so the awaiting async frame and everything it captured was never released; `Actor.sendAsync` now rejects with an `AbortError` on abort ([#7826](https://github.com/maplibre/maplibre-gl-js/pull/7826)) (by [@kamil-sienkiewicz-asi](https://github.com/kamil-sienkiewicz-asi))
+
+## 6.0.0-17
+
+### ✨ Features and improvements
+
+- ⚠️ All map events are now real classes that are instantiated when they are fired. Renamed `MapLibreZoomEvent` to `MapBoxZoomEvent`, added the `rollstart`/`roll`/`rollend` and `style.load` (as `MapStyleLoadEvent`) events to `MapEventType`, and added event classes and type-map for `Marker`, `Popup`, `GeolocateControl` and `FullscreenControl`. Removed `MapDataEvent`: the `data`/`dataloading`/`dataabort` events are now `MapSourceDataEvent | MapStyleDataEvent`, so source data events carry the full source info (`sourceId`, `tile`, `sourceDataType`, …). Added `MapMovementEvent` as the type for all camera-transition events (`move`/`zoom`/`rotate`/`pitch`/`roll`/`drag` and their `start`/`end` variants). `Evented` is now generic over an event-type map (`Evented<EventType>`) and is `abstract`, so subclasses get strongly-typed `on`/`once`/`off` automatically without re-declaring overloads — this also types the events on `Camera`/`Style` (via `MapEventType`) and on the sources (via the new `SourceEventType`) ([#7789](https://github.com/maplibre/maplibre-gl-js/pull/7789)) (by [@HarelM](https://github.com/HarelM))
+
+### 🐞 Bug fixes
+
+- Skip `undefined` properties during worker serialization ([#7801](https://github.com/maplibre/maplibre-gl-js/pull/7801)) (by [@xavierjs](https://github.com/xavierjs))
+
+## 6.0.0-16
+
+### ✨ Features and improvements
+
+- ⚠️ Update maplibre-gl-style-spec to version 25, which has a breaking change in legacy expression validation ([#7792](https://github.com/maplibre/maplibre-gl-js/issues/7792)) (by [@HarelM](https://github.com/HarelM))
+
+### 🐞 Bug fixes
+
+- Fix cross-origin module worker loading to preserve ESM semantics ([#7796](https://github.com/maplibre/maplibre-gl-js/pull/7796)) (by [@dangkyokhoang](https://github.com/dangkyokhoang))
+
+## 6.0.0-15
+
+### ✨ Features and improvements
+
+- Add `fill-layer-opacity` and `line-layer-opacity` paint properties, which apply opacity to the entire layer output uniformly ([#7570](https://github.com/maplibre/maplibre-gl-js/pull/7570)) (by [@CommanderStorm](https://github.com/CommanderStorm))
+- Build main and worker in same build context to extract shared chunk ([#7745](https://github.com/maplibre/maplibre-gl-js/pull/7745)) (by [@dangkyokhoang](https://github.com/dangkyokhoang))
+
+### 🐞 Bug fixes
+
+- Fix conflicting reloads of tiles causing an error in `queryRenderedFeatures` ([#7765](https://github.com/maplibre/maplibre-gl-js/pull/7765)) (by [@ckolin](https://github.com/ckolin))
+
+## 6.0.0-14
+
+### ✨ Features and improvements
+
+- Revert the `line-opacity`-driven offscreen rendering introduced in [#7490](https://github.com/maplibre/maplibre-gl-js/pull/7490) ([#7764](https://github.com/maplibre/maplibre-gl-js/pull/7764)) (by [@CommanderStorm](https://github.com/CommanderStorm)). The overlap-artefact fix is now driven by `line-layer-opacity` instead.
+- ⚠️ Removed the remaining mapbox references in the code and in the tests. This changes the `#pragma mapbox` to `#pragma maplibre` in case you have shader code that relied on it. ([#7761](https://github.com/maplibre/maplibre-gl-js/issues/7761)) (by [@HarelM](https://github.com/HarelM))
+
+### 🐞 Bug fixes
+
+- Fix a race condition in geojson source after init and fast update data ([#7734](https://github.com/maplibre/maplibre-gl-js/issues/7734)) (by [@HarelM](https://github.com/HarelM))
+
+## 6.0.0-13
+
+### ✨ Features and improvements
+
+- Improve `ProjectionData` matrix backing types for renderer and custom layer projection matrices ([#6316](https://github.com/maplibre/maplibre-gl-js/issues/6316)) (by [@cat0825](https://github.com/cat0825))
+
+### 🐞 Bug fixes
+
+- Fix camera jump on dragend with globe + terrain at low pitch ([#7736](https://github.com/maplibre/maplibre-gl-js/pull/7736)) (by @kodeezabdullah)
+- Fix web font rendering by awaiting document.fonts.load() before TinySDF instantiation ([#7735](https://github.com/maplibre/maplibre-gl-js/pull/7735)) (by [@kodeezabdullah](https://github.com/kodeezabdullah))
+- Remove the framebuffer completeness check that threw an unhandled `Framebuffer is not complete` error on transient GPU resource loss (e.g. when a tab wakes from sleep); incomplete framebuffers now self-heal on the next frame instead ([#7303](https://github.com/maplibre/maplibre-gl-js/pull/7303)) (by [@johanrd](https://github.com/johanrd))
+- ⚠️ Disable icon scaling with offset, this is a render breaking change which we have decided to incorporate in both maplibre-gl-js and maplibre-native ([#7742](https://github.com/maplibre/maplibre-gl-js/issues/7742)) (by [@springmeyer](https://github.com/springmeyer) and [@HarelM](https://github.com/HarelM))
+
+## 6.0.0-12
+
+### ✨ Features and improvements
+
+- Optimization: vertex shader opacity culling for lines and fills [#7711](https://github.com/maplibre/maplibre-gl-js/pull/7711) (by [@xavierjs](https://github.com/xavierjs))
+
+### 🐞 Bug fixes
+
+- Fix handling cross-origin blob URL in Ajax utils ([#7675](https://github.com/maplibre/maplibre-gl-js/pull/7675)) (by [@katemihalikova](https://github.com/katemihalikova))
+- Avoid TypeErrors from style methods while the WebGL context is lost ([#7710](https://github.com/maplibre/maplibre-gl-js/issues/7710)) (by [@cyphercodes](https://github.com/cyphercodes))
 - querySourceFeatures() throws 'Block overruns tile' on overzoomed MLT tiles because the reported encoding doesn't match the re-encoded MVT data ([#7707](https://github.com/maplibre/maplibre-gl-js/pull/7707)) (by [@ted-piotrowski](https://github.com/ted-piotrowski))
 - Fix geometry length check for polygons and lines in LineBucket after duplicate vertex trimming([#7638](https://github.com/maplibre/maplibre-gl-js/pull/7638)) (by [@widefire](https://github.com/widefire))
 - `line-dasharray` step transition lags one zoom level when the step's branches are data-driven ([#7705](https://github.com/maplibre/maplibre-gl-js/pull/7705)) (by [@lucaswoj](https://github.com/lucaswoj))

--- a/src/ui/marker.test.ts
+++ b/src/ui/marker.test.ts
@@ -290,11 +290,80 @@ describe('marker', () => {
         expect(markerWithHtmlElement.getElement().getAttribute('aria-label')).toBe('custom aria label');
     });
 
-    test('Marker should have a role attribute to satisfy accessibility requirements for the aria-label', () => {
+    test('default non-interactive Marker uses role=img for the aria-label', () => {
         const map = createMap({locale: {'Marker.Title': 'alt title'}});
         const marker = new Marker().setLngLat([0, 0]).addTo(map);
 
+        expect(marker.getElement().getAttribute('role')).toBe('img');
+        map.remove();
+    });
+
+    test('default Marker uses role=button when interactive via popup', () => {
+        const map = createMap();
+        const marker = new Marker()
+            .setLngLat([0, 0])
+            .setPopup(new Popup().setText('popup'))
+            .addTo(map);
+
         expect(marker.getElement().getAttribute('role')).toBe('button');
+
+        marker.setPopup();
+        expect(marker.getElement().getAttribute('role')).toBe('img');
+        map.remove();
+    });
+
+    test('default Marker uses role=button when draggable', () => {
+        const map = createMap();
+        const marker = new Marker({draggable: true}).setLngLat([0, 0]).addTo(map);
+
+        expect(marker.getElement().getAttribute('role')).toBe('button');
+
+        marker.setDraggable(false);
+        expect(marker.getElement().getAttribute('role')).toBe('img');
+        map.remove();
+    });
+
+    test('default Marker uses role=button when a click listener is registered', () => {
+        const map = createMap();
+        const marker = new Marker().setLngLat([0, 0]).addTo(map);
+        const onClick = () => {};
+
+        expect(marker.getElement().getAttribute('role')).toBe('img');
+
+        marker.on('click', onClick);
+        expect(marker.getElement().getAttribute('role')).toBe('button');
+
+        marker.off('click', onClick);
+        expect(marker.getElement().getAttribute('role')).toBe('img');
+        map.remove();
+    });
+
+    test('default Marker uses role=button when a one-time click listener is registered', () => {
+        const map = createMap();
+        const marker = new Marker().setLngLat([0, 0]).addTo(map);
+
+        marker.once('click', () => {});
+        expect(marker.getElement().getAttribute('role')).toBe('button');
+        map.remove();
+    });
+
+    test('custom Marker element does not get an automatic role', () => {
+        const map = createMap();
+        const element = document.createElement('div');
+        const marker = new Marker({element}).setLngLat([0, 0]).addTo(map);
+
+        expect(marker.getElement().hasAttribute('role')).toBe(false);
+        map.remove();
+    });
+
+    test('explicit role on the default Marker element is preserved', () => {
+        const map = createMap();
+        const marker = new Marker().setLngLat([0, 0]);
+        marker.getElement().setAttribute('role', 'presentation');
+        marker.addTo(map);
+
+        expect(marker.getElement().getAttribute('role')).toBe('presentation');
+        map.remove();
     });
 
     test('Marker anchor defaults to center', () => {
@@ -939,7 +1008,7 @@ describe('marker', () => {
             .setLngLat([0, 0])
             .addTo(map);
         map.terrain = createTerrain();
-        map.transform.lngLatToCameraDepth = () => .95;
+        map._camera.transform.lngLatToCameraDepth = () => .95;
 
         marker.setOffset([10, 10]);
         await sleep(100);
@@ -1083,7 +1152,7 @@ describe('marker', () => {
 
     test('Applies options.opacityWhenCovered when marker is hidden by 3d terrain', async () => {
         const map = createMap();
-        map.transform.lngLatToCameraDepth = () => .95; // Mocking distance to marker
+        map._camera.transform.lngLatToCameraDepth = () => .95; // Mocking distance to marker
         const marker = new Marker({opacity: '0.7', opacityWhenCovered: '0.3'})
             .setLngLat([0, 0])
             .addTo(map);
@@ -1098,7 +1167,7 @@ describe('marker', () => {
 
     test('Applies new "opacityWhenCovered" provided by setOpacity when marker is hidden by 3d terrain', () => {
         const map = createMap();
-        map.transform.lngLatToCameraDepth = () => .95; // Mocking distance to marker
+        map._camera.transform.lngLatToCameraDepth = () => .95; // Mocking distance to marker
         const marker = new Marker({opacityWhenCovered: '0.15'})
             .setLngLat([0, 0])
             .addTo(map);
@@ -1152,7 +1221,7 @@ describe('marker', () => {
 
         expect(marker._popup.isOpen()).toBeTruthy();
 
-        map.transform.lngLatToCameraDepth = () => .95; // Mocking distance to marker
+        map._camera.transform.lngLatToCameraDepth = () => .95; // Mocking distance to marker
 
         map.terrain = createTerrain();
         map.fire('terrain');
@@ -1170,7 +1239,7 @@ describe('marker', () => {
             .addTo(map)
             .setPopup(new Popup());
 
-        map.transform.lngLatToCameraDepth = () => .95;
+        map._camera.transform.lngLatToCameraDepth = () => .95;
 
         map.terrain = createTerrain();
         map.fire('terrain');
@@ -1269,7 +1338,7 @@ describe('marker', () => {
 
     test('Applies new "opacityWhenCovered" provided by setOpacity when provided a number', () => {
         const map = createMap();
-        map.transform.lngLatToCameraDepth = () => .95; // Mocking distance to marker
+        map._camera.transform.lngLatToCameraDepth = () => .95; // Mocking distance to marker
         const marker = new Marker({opacityWhenCovered: 0.15})
             .setLngLat([0, 0])
             .addTo(map);

--- a/src/ui/marker.ts
+++ b/src/ui/marker.ts
@@ -1,13 +1,15 @@
 import {DOM} from '../util/dom.ts';
 import {browser} from '../util/browser.ts';
 import {LngLat} from '../geo/lng_lat.ts';
-import Point from '@mapbox/point-geometry';
 import {smartWrap} from '../util/smart_wrap.ts';
 import {anchorTranslate, applyAnchorClass} from './anchor.ts';
-import type {PositionAnchor} from './anchor.ts';
 import {Event, Evented} from '../util/evented.ts';
+import type {Subscription} from '../util/util.ts';
+import Point from '@mapbox/point-geometry';
+
+import type {PositionAnchor} from './anchor.ts';
 import type {Map} from './map.ts';
-import {type Popup, type Offset} from './popup.ts';
+import type {Popup, Offset} from './popup.ts';
 import type {LngLatLike} from '../geo/lng_lat.ts';
 import type {MapMouseEvent, MapTouchEvent} from './events.ts';
 import type {PointLike} from './camera.ts';
@@ -95,6 +97,61 @@ export type MarkerOptions = {
 };
 
 /**
+ * The event class for marker drag events (`dragstart`, `drag` and `dragend`).
+ *
+ * @group Event Related
+ */
+export class MarkerDragEvent extends Event {
+    type: 'dragstart' | 'drag' | 'dragend';
+    /**
+     * The `Marker` object that fired the event.
+     */
+    target: Marker;
+}
+
+/**
+ * The event class for the marker `click` event.
+ *
+ * @group Event Related
+ */
+export class MarkerClickEvent extends Event {
+    type: 'click';
+    /**
+     * The `Marker` object that fired the event.
+     */
+    target: Marker;
+    /**
+     * The DOM event which caused the marker click event.
+     */
+    originalEvent: MouseEvent;
+}
+
+/**
+ * `MarkerEventType` - a mapping between the marker event name and the event value.
+ * These events are used with the {@link Marker.on} method.
+ *
+ * @group Event Related
+ */
+export type MarkerEventType = {
+    /**
+     * Fired when dragging starts.
+     */
+    dragstart: MarkerDragEvent;
+    /**
+     * Fired while dragging.
+     */
+    drag: MarkerDragEvent;
+    /**
+     * Fired when the marker is finished being dragged.
+     */
+    dragend: MarkerDragEvent;
+    /**
+     * Fired when the marker is clicked.
+     */
+    click: MarkerClickEvent;
+};
+
+/**
  * Creates a marker component
  *
  * @group Markers and Controls
@@ -123,13 +180,13 @@ export type MarkerOptions = {
  *
  * ## Events
  *
- * **Event** `dragstart` of type {@link Event} will be fired when dragging starts.
+ * **Event** `dragstart` of type {@link MarkerDragEvent} will be fired when dragging starts.
  *
- * **Event** `drag` of type {@link Event} will be fired while dragging.
+ * **Event** `drag` of type {@link MarkerDragEvent} will be fired while dragging.
  *
- * **Event** `dragend` of type {@link Event} will be fired when the marker is finished being dragged.
+ * **Event** `dragend` of type {@link MarkerDragEvent} will be fired when the marker is finished being dragged.
  *
- * **Event** `click` of type {@link Event} will be fired when the marker is clicked.
+ * **Event** `click` of type {@link MarkerClickEvent} will be fired when the marker is clicked.
  *
  * ## CSS Classes
  *
@@ -145,7 +202,7 @@ export type MarkerOptions = {
  * }
  * ```
  */
-export class Marker extends Evented {
+export class Marker extends Evented<MarkerEventType> {
     _map: Map;
     _anchor: PositionAnchor;
     _offset: Point;
@@ -171,6 +228,7 @@ export class Marker extends Evented {
     _opacityWhenCovered: string;
     _opacityTimeout: ReturnType<typeof setTimeout>;
     _subpixelPositioning: boolean;
+    _roleManaged: boolean;
 
     /**
      * @param options - the options
@@ -185,6 +243,7 @@ export class Marker extends Evented {
         this._clickTolerance = options?.clickTolerance || 0;
         this._subpixelPositioning = options?.subpixelPositioning || false;
         this._isDragging = false;
+        this._roleManaged = false;
         this._state = 'inactive';
         this._rotation = options?.rotation || 0;
         this._rotationAlignment = options?.rotationAlignment || 'auto';
@@ -341,11 +400,10 @@ export class Marker extends Evented {
             this._element.setAttribute('aria-label', map._getUIString('Marker.Title'));
         }
 
-        // aria-label is set either by user or above default, so set role
-        // since div is interactive and cannot have aria-label without a role
-        if (!this._element.hasAttribute('role')) {
-            this._element.setAttribute('role', 'button');
-        }
+        // Default markers need a role because aria-label is set above.
+        // Non-interactive markers use role=img; interactive ones use role=button.
+        // Custom elements manage their own accessibility attributes.
+        this._updateAccessibilityRole();
 
         map.getCanvasContainer().appendChild(this._element);
         map.on('move', this._update);
@@ -497,6 +555,7 @@ export class Marker extends Evented {
             this._element.addEventListener('keypress', this._onKeyPress);
         }
 
+        this._updateAccessibilityRole();
         return this;
     }
 
@@ -517,7 +576,7 @@ export class Marker extends Evented {
     }
 
     _onClick = (e: MouseEvent): void => {
-        this.fire(new Event('click', {originalEvent: e}));
+        this.fire(new MarkerClickEvent('click', {originalEvent: e}));
     };
 
     _onKeyPress = (e: KeyboardEvent): void => {
@@ -580,7 +639,7 @@ export class Marker extends Evented {
 
     _updateOpacity(force: boolean = false): void {
         const terrain = this._map?.terrain;
-        const occluded = this._map.transform.isLocationOccluded(this._lngLat);
+        const occluded = this._map._camera.transform.isLocationOccluded(this._lngLat);
         if (!terrain || occluded) {
             const targetOpacity = occluded ? this._opacityWhenCovered : this._opacity;
             if (this._element.style.opacity !== targetOpacity) {
@@ -603,8 +662,8 @@ export class Marker extends Evented {
         // Read depth framebuffer, getting position of terrain in line of sight to marker
         const terrainDistance = map.terrain.depthAtPoint(this._pos);
         // Transform marker position to clip space
-        const elevation = map.terrain.getElevationForLngLat(this._lngLat, map.transform);
-        const markerDistance = map.transform.lngLatToCameraDepth(this._lngLat, elevation);
+        const elevation = map.terrain.getElevationForLngLat(this._lngLat, map._camera.transform);
+        const markerDistance = map._camera.transform.lngLatToCameraDepth(this._lngLat, elevation);
         const forgiveness = .006;
         if (markerDistance - terrainDistance < forgiveness) {
             this._element.style.opacity = this._opacity;
@@ -612,10 +671,10 @@ export class Marker extends Evented {
             return;
         }
         // If the base is obscured, use the offset to check if the marker's center is obscured.
-        const metersToCenter = -this._offset.y / map.transform.pixelsPerMeter;
+        const metersToCenter = -this._offset.y / map._camera.transform.pixelsPerMeter;
         const elevationToCenter = Math.sin(map.getPitch() * Math.PI / 180) * metersToCenter;
         const terrainDistanceCenter = map.terrain.depthAtPoint(new Point(this._pos.x, this._pos.y - this._offset.y));
-        const markerDistanceCenter = map.transform.lngLatToCameraDepth(this._lngLat, elevation + elevationToCenter);
+        const markerDistanceCenter = map._camera.transform.lngLatToCameraDepth(this._lngLat, elevation + elevationToCenter);
         // Display at full opacity if center is visible.
         const centerIsInvisible = markerDistanceCenter - terrainDistanceCenter > forgiveness;
 
@@ -632,12 +691,12 @@ export class Marker extends Evented {
             this._map.once('render', this._update);
         }
 
-        this._lngLat = smartWrap(this._lngLat, this._flatPos, this._map.transform);
+        this._lngLat = smartWrap(this._lngLat, this._flatPos, this._map._camera.transform);
 
         this._flatPos = this._pos = this._map.project(this._lngLat)._add(this._offset);
         if (this._map.terrain) {
             // flat position is saved because smartWrap needs non-elevated points
-            this._flatPos = this._map.transform.locationToScreenPoint(this._lngLat)._add(this._offset);
+            this._flatPos = this._map._camera.transform.locationToScreenPoint(this._lngLat)._add(this._offset);
         }
 
         let rotation = '';
@@ -751,9 +810,9 @@ export class Marker extends Evented {
         // imply that a drag is about to happen.
         if (this._state === 'pending') {
             this._state = 'active';
-            this.fire(new Event('dragstart'));
+            this.fire(new MarkerDragEvent('dragstart'));
         }
-        this.fire(new Event('drag'));
+        this.fire(new MarkerDragEvent('drag'));
     };
 
     _onUp = (): void => {
@@ -767,7 +826,7 @@ export class Marker extends Evented {
 
         // only fire dragend if it was preceded by at least one drag event
         if (this._state === 'active') {
-            this.fire(new Event('dragend'));
+            this.fire(new MarkerDragEvent('dragend'));
         }
 
         this._state = 'inactive';
@@ -814,6 +873,7 @@ export class Marker extends Evented {
             }
         }
 
+        this._updateAccessibilityRole();
         return this;
     }
 
@@ -823,6 +883,65 @@ export class Marker extends Evented {
      */
     isDraggable(): boolean {
         return this._draggable;
+    }
+
+    /**
+     * Default markers are interactive when they can be dragged, open a popup, or have a click listener.
+     */
+    _isInteractive(): boolean {
+        return this._draggable || !!this._popup || this.listens('click');
+    }
+
+    /**
+     * Keep the default marker role aligned with interactivity.
+     * Custom marker elements are left alone so applications own their a11y tree.
+     */
+    _updateAccessibilityRole(): void {
+        if (!this._defaultMarker) {
+            return;
+        }
+
+        // Preserve an explicit role chosen by the user unless we previously managed it.
+        if (this._element.hasAttribute('role') && !this._roleManaged) {
+            return;
+        }
+
+        const role = this._isInteractive() ? 'button' : 'img';
+        this._element.setAttribute('role', role);
+        this._roleManaged = true;
+    }
+
+    on<T extends keyof MarkerEventType>(type: T, listener: (event: MarkerEventType[T]) => void): Subscription {
+        const subscription = super.on(type, listener);
+        if (type === 'click') {
+            this._updateAccessibilityRole();
+        }
+        return subscription;
+    }
+
+    off<T extends keyof MarkerEventType>(type: T, listener: (event: MarkerEventType[T]) => void): this {
+        super.off(type, listener);
+        if (type === 'click') {
+            this._updateAccessibilityRole();
+        }
+        return this;
+    }
+
+    once<T extends keyof MarkerEventType>(type: T): Promise<MarkerEventType[T]>;
+    once<T extends keyof MarkerEventType>(type: T, listener: (event: MarkerEventType[T]) => void): this;
+    once<T extends keyof MarkerEventType>(type: T, listener?: (event: MarkerEventType[T]) => void): this | Promise<MarkerEventType[T]> {
+        if (!listener) {
+            const promise = super.once(type) as Promise<MarkerEventType[T]>;
+            if (type === 'click') {
+                this._updateAccessibilityRole();
+            }
+            return promise;
+        }
+        super.once(type, listener);
+        if (type === 'click') {
+            this._updateAccessibilityRole();
+        }
+        return this;
     }
 
     /**


### PR DESCRIPTION
## Launch Checklist

- [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
- [x] Briefly describe the changes in this PR.
- [x] Link to related issues.
- [ ] Include before/after visuals or gifs if this PR includes visual changes.
- [x] Write tests for all new functionality.
- [ ] Document any changes to public APIs.
- [ ] Post benchmark scores.
- [x] Add an entry to `CHANGELOG.md` under the `## main` section.
- [x] Confirm you have read our AI policy [here](https://github.com/maplibre/maplibre/blob/main/AI_POLICY.md).

### Description

Default markers were always assigned `role=button` even when non-interactive (no popup, not draggable, no click listener). That conflicts with the ARIA button role definition.

This PR:

- Uses `role=img` for non-interactive default markers (with the existing `aria-label`)
- Uses `role=button` when the marker becomes interactive via popup, drag, or a registered `click` listener (`on` / `once` / `off` keep the role in sync)
- Leaves custom `element` markers alone (applications own their a11y tree), matching maintainer guidance on #7790
- Preserves an explicit role set by the user on the default marker element

Fixes #7790

### Testing

- `npx vitest run --config vitest.config.unit.ts src/ui/marker.test.ts` (79 passed)

Assisted-By: GPT-5.4