### PR TITLE
Fire contextmenu on long press for touch devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## main
 ### ✨ Features and improvements
+- Fire a `contextmenu` map event on long press for touch devices ([#373](https://github.com/maplibre/maplibre-gl-js/issues/373)) (by [@kirthi-b](https://github.com/kirthi-b))
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes

--- a/src/css/maplibre-gl.css
+++ b/src/css/maplibre-gl.css
@@ -3,6 +3,10 @@
     overflow: hidden;
     position: relative;
     -webkit-tap-highlight-color: rgb(0 0 0 / 0);
+    /* A long press is now a map gesture (contextmenu), so stop iOS Safari from
+       popping its own callout or selection on the map, its controls, or the
+       attribution while holding. */
+    -webkit-touch-callout: none;
 }
 
 .maplibregl-canvas {

--- a/src/css/maplibre-gl.css
+++ b/src/css/maplibre-gl.css
@@ -143,6 +143,12 @@
     cursor: pointer;
 }
 
+.maplibregl-ctrl button {
+    /* a long press on a control (for example the compact attribution button)
+       must not start iOS text selection of the button's glyph */
+    user-select: none;
+}
+
 .maplibregl-ctrl-group button + button {
     border-top: 1px solid #ddd;
 }

--- a/src/css/maplibre-gl.css
+++ b/src/css/maplibre-gl.css
@@ -3,6 +3,7 @@
     overflow: hidden;
     position: relative;
     -webkit-tap-highlight-color: rgb(0 0 0 / 0);
+
     /* A long press is now a map gesture (contextmenu), so stop iOS Safari from
        popping its own callout or selection on the map, its controls, or the
        attribution while holding. */

--- a/src/ui/handler/map_event.test.ts
+++ b/src/ui/handler/map_event.test.ts
@@ -157,42 +157,110 @@ describe('map events', () => {
         expect(contextmenu).toHaveBeenCalledTimes(0);
     });
 
-    test('MapEvent handler fires contextmenu on touch long press', () => {
+    test('MapEvent handler fires a contextmenu after a single finger is held in place (touch long press)', () => {
         const map = createMap();
-        const relatedTarget = map.getCanvas();
-        map.dragPan.enable();
-
         const contextmenu = vi.fn();
-
         map.on('contextmenu', contextmenu);
-
         const touches = [{target: map.getCanvas(), clientX: 10, clientY: 10}];
-        simulate.touchstart(map.getCanvas(), {touches, targetTouches: touches});
-        simulate.contextmenu(map.getCanvas(), {relatedTarget}); // browser fires contextmenu during the long press
-        expect(contextmenu).toHaveBeenCalledTimes(0);
-        simulate.touchend(map.getCanvas(), {touches: [], targetTouches: [], changedTouches: touches});
-        expect(contextmenu).toHaveBeenCalledTimes(1);
+        vi.useFakeTimers();
+        try {
+            simulate.touchstart(map.getCanvas(), {touches, targetTouches: touches});
+            expect(contextmenu).toHaveBeenCalledTimes(0); // still holding
+            vi.advanceTimersByTime(500);
+            expect(contextmenu).toHaveBeenCalledTimes(1); // long press elapsed
+            expect(contextmenu.mock.calls[0][0].point).toBeTruthy();
+        } finally {
+            vi.useRealTimers();
+        }
     });
 
-    test('MapEvent handler does not fire contextmenu on a cancelled touch long press, and does not leak to the next tap', () => {
+    test('MapEvent handler suppresses a native contextmenu during a touch so the long press does not double-fire', () => {
         const map = createMap();
         const relatedTarget = map.getCanvas();
-        map.dragPan.enable();
-
         const contextmenu = vi.fn();
         map.on('contextmenu', contextmenu);
-
         const touches = [{target: map.getCanvas(), clientX: 10, clientY: 10}];
-        // A long press the browser cancels (touchcancel) instead of ending normally.
-        simulate.touchstart(map.getCanvas(), {touches, targetTouches: touches});
-        simulate.contextmenu(map.getCanvas(), {relatedTarget}); // native contextmenu during the press
-        simulate.touchcancel(map.getCanvas(), {touches: [], targetTouches: [], changedTouches: touches});
-        expect(contextmenu).toHaveBeenCalledTimes(0); // cancelled press never fires
+        vi.useFakeTimers();
+        try {
+            simulate.touchstart(map.getCanvas(), {touches, targetTouches: touches});
+            // Android fires a native contextmenu mid-press; it must be suppressed so
+            // only the timer fires the map event.
+            simulate.contextmenu(map.getCanvas(), {relatedTarget});
+            vi.advanceTimersByTime(500);
+            simulate.touchend(map.getCanvas(), {touches: [], targetTouches: [], changedTouches: touches});
+            expect(contextmenu).toHaveBeenCalledTimes(1); // exactly once, from the timer
+        } finally {
+            vi.useRealTimers();
+        }
+    });
 
-        // A following tap must not fire a stale contextmenu from the cancelled press.
-        simulate.touchstart(map.getCanvas(), {touches, targetTouches: touches});
-        simulate.touchend(map.getCanvas(), {touches: [], targetTouches: [], changedTouches: touches});
-        expect(contextmenu).toHaveBeenCalledTimes(0);
+    test('MapEvent handler does not fire a contextmenu on a short tap', () => {
+        const map = createMap();
+        const contextmenu = vi.fn();
+        map.on('contextmenu', contextmenu);
+        const touches = [{target: map.getCanvas(), clientX: 10, clientY: 10}];
+        vi.useFakeTimers();
+        try {
+            simulate.touchstart(map.getCanvas(), {touches, targetTouches: touches});
+            simulate.touchend(map.getCanvas(), {touches: [], targetTouches: [], changedTouches: touches}); // lifts before the delay
+            vi.advanceTimersByTime(500);
+            expect(contextmenu).toHaveBeenCalledTimes(0);
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
+    test('MapEvent handler cancels the long press when the finger moves (a pan)', () => {
+        const map = createMap();
+        const contextmenu = vi.fn();
+        map.on('contextmenu', contextmenu);
+        const start = [{target: map.getCanvas(), clientX: 10, clientY: 10}];
+        const moved = [{target: map.getCanvas(), clientX: 40, clientY: 40}];
+        vi.useFakeTimers();
+        try {
+            simulate.touchstart(map.getCanvas(), {touches: start, targetTouches: start});
+            simulate.touchmove(map.getCanvas(), {touches: moved, targetTouches: moved});
+            vi.advanceTimersByTime(500);
+            expect(contextmenu).toHaveBeenCalledTimes(0);
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
+    test('MapEvent handler cancels the long press on touchcancel, and does not leak to the next tap', () => {
+        const map = createMap();
+        const contextmenu = vi.fn();
+        map.on('contextmenu', contextmenu);
+        const touches = [{target: map.getCanvas(), clientX: 10, clientY: 10}];
+        vi.useFakeTimers();
+        try {
+            simulate.touchstart(map.getCanvas(), {touches, targetTouches: touches});
+            simulate.touchcancel(map.getCanvas(), {touches: [], targetTouches: [], changedTouches: touches});
+            vi.advanceTimersByTime(500);
+            expect(contextmenu).toHaveBeenCalledTimes(0);
+            // a following quick tap must not fire anything either
+            simulate.touchstart(map.getCanvas(), {touches, targetTouches: touches});
+            simulate.touchend(map.getCanvas(), {touches: [], targetTouches: [], changedTouches: touches});
+            vi.advanceTimersByTime(500);
+            expect(contextmenu).toHaveBeenCalledTimes(0);
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
+    test('MapEvent handler does not start a long press for a two-finger touch (pinch)', () => {
+        const map = createMap();
+        const contextmenu = vi.fn();
+        map.on('contextmenu', contextmenu);
+        const two = [{target: map.getCanvas(), clientX: 10, clientY: 10}, {target: map.getCanvas(), clientX: 60, clientY: 60}];
+        vi.useFakeTimers();
+        try {
+            simulate.touchstart(map.getCanvas(), {touches: two, targetTouches: two});
+            vi.advanceTimersByTime(500);
+            expect(contextmenu).toHaveBeenCalledTimes(0);
+        } finally {
+            vi.useRealTimers();
+        }
     });
 
     test('MapMouseEvent constructor does not throw error with Event instance instead of MouseEvent as originalEvent param', () => {

--- a/src/ui/handler/map_event.test.ts
+++ b/src/ui/handler/map_event.test.ts
@@ -174,6 +174,27 @@ describe('map events', () => {
         expect(contextmenu).toHaveBeenCalledTimes(1);
     });
 
+    test('MapEvent handler does not fire contextmenu on a cancelled touch long press, and does not leak to the next tap', () => {
+        const map = createMap();
+        const relatedTarget = map.getCanvas();
+        map.dragPan.enable();
+
+        const contextmenu = vi.fn();
+        map.on('contextmenu', contextmenu);
+
+        const touches = [{target: map.getCanvas(), clientX: 10, clientY: 10}];
+        // A long press the browser cancels (touchcancel) instead of ending normally.
+        simulate.touchstart(map.getCanvas(), {touches, targetTouches: touches});
+        simulate.contextmenu(map.getCanvas(), {relatedTarget}); // native contextmenu during the press
+        simulate.touchcancel(map.getCanvas(), {touches: [], targetTouches: [], changedTouches: touches});
+        expect(contextmenu).toHaveBeenCalledTimes(0); // cancelled press never fires
+
+        // A following tap must not fire a stale contextmenu from the cancelled press.
+        simulate.touchstart(map.getCanvas(), {touches, targetTouches: touches});
+        simulate.touchend(map.getCanvas(), {touches: [], targetTouches: [], changedTouches: touches});
+        expect(contextmenu).toHaveBeenCalledTimes(0);
+    });
+
     test('MapMouseEvent constructor does not throw error with Event instance instead of MouseEvent as originalEvent param', () => {
         const map = createMap();
         const target = map.getCanvasContainer();

--- a/src/ui/handler/map_event.test.ts
+++ b/src/ui/handler/map_event.test.ts
@@ -1,4 +1,4 @@
-import {describe, beforeEach, test, expect, vi} from 'vitest';
+import {describe, beforeEach, afterEach, test, expect, vi} from 'vitest';
 import {Map} from '../map.ts';
 import {DOM} from '../../util/dom.ts';
 import simulate from '../../../test/unit/lib/simulate_interaction.ts';
@@ -157,31 +157,35 @@ describe('map events', () => {
         expect(contextmenu).toHaveBeenCalledTimes(0);
     });
 
-    test('MapEvent handler fires a contextmenu after a single finger is held in place (touch long press)', () => {
-        const map = createMap();
-        const contextmenu = vi.fn();
-        map.on('contextmenu', contextmenu);
-        const touches = [{target: map.getCanvas(), clientX: 10, clientY: 10}];
-        vi.useFakeTimers();
-        try {
+    describe('touch long press', () => {
+        beforeEach(() => {
+            vi.useFakeTimers();
+        });
+
+        afterEach(() => {
+            vi.useRealTimers();
+        });
+
+        test('MapEvent handler fires a contextmenu after a single finger is held in place', () => {
+            const map = createMap();
+            const contextmenu = vi.fn();
+            map.on('contextmenu', contextmenu);
+            const touches = [{target: map.getCanvas(), clientX: 10, clientY: 10}];
+
             simulate.touchstart(map.getCanvas(), {touches, targetTouches: touches});
             expect(contextmenu).toHaveBeenCalledTimes(0); // still holding
             vi.advanceTimersByTime(500);
             expect(contextmenu).toHaveBeenCalledTimes(1); // long press elapsed
             expect(contextmenu.mock.calls[0][0].point).toBeTruthy();
-        } finally {
-            vi.useRealTimers();
-        }
-    });
+        });
 
-    test('MapEvent handler suppresses a native contextmenu during a touch so the long press does not double-fire', () => {
-        const map = createMap();
-        const relatedTarget = map.getCanvas();
-        const contextmenu = vi.fn();
-        map.on('contextmenu', contextmenu);
-        const touches = [{target: map.getCanvas(), clientX: 10, clientY: 10}];
-        vi.useFakeTimers();
-        try {
+        test('MapEvent handler suppresses a native contextmenu during a touch so the long press does not double-fire', () => {
+            const map = createMap();
+            const relatedTarget = map.getCanvas();
+            const contextmenu = vi.fn();
+            map.on('contextmenu', contextmenu);
+            const touches = [{target: map.getCanvas(), clientX: 10, clientY: 10}];
+
             simulate.touchstart(map.getCanvas(), {touches, targetTouches: touches});
             // Android fires a native contextmenu mid-press; it must be suppressed so
             // only the timer fires the map event.
@@ -189,51 +193,69 @@ describe('map events', () => {
             vi.advanceTimersByTime(500);
             simulate.touchend(map.getCanvas(), {touches: [], targetTouches: [], changedTouches: touches});
             expect(contextmenu).toHaveBeenCalledTimes(1); // exactly once, from the timer
-        } finally {
-            vi.useRealTimers();
-        }
-    });
+        });
 
-    test('MapEvent handler does not fire a contextmenu on a short tap', () => {
-        const map = createMap();
-        const contextmenu = vi.fn();
-        map.on('contextmenu', contextmenu);
-        const touches = [{target: map.getCanvas(), clientX: 10, clientY: 10}];
-        vi.useFakeTimers();
-        try {
+        test('MapEvent handler does not fire a contextmenu on a short tap', () => {
+            const map = createMap();
+            const contextmenu = vi.fn();
+            map.on('contextmenu', contextmenu);
+            const touches = [{target: map.getCanvas(), clientX: 10, clientY: 10}];
+
             simulate.touchstart(map.getCanvas(), {touches, targetTouches: touches});
             simulate.touchend(map.getCanvas(), {touches: [], targetTouches: [], changedTouches: touches}); // lifts before the delay
             vi.advanceTimersByTime(500);
             expect(contextmenu).toHaveBeenCalledTimes(0);
-        } finally {
-            vi.useRealTimers();
-        }
-    });
+        });
 
-    test('MapEvent handler cancels the long press when the finger moves (a pan)', () => {
-        const map = createMap();
-        const contextmenu = vi.fn();
-        map.on('contextmenu', contextmenu);
-        const start = [{target: map.getCanvas(), clientX: 10, clientY: 10}];
-        const moved = [{target: map.getCanvas(), clientX: 40, clientY: 40}];
-        vi.useFakeTimers();
-        try {
+        test('MapEvent handler cancels the long press when the finger moves further than the click tolerance (a pan)', () => {
+            const map = createMap();
+            const contextmenu = vi.fn();
+            map.on('contextmenu', contextmenu);
+            const start = [{target: map.getCanvas(), clientX: 10, clientY: 10}];
+            const moved = [{target: map.getCanvas(), clientX: 40, clientY: 40}];
+
             simulate.touchstart(map.getCanvas(), {touches: start, targetTouches: start});
             simulate.touchmove(map.getCanvas(), {touches: moved, targetTouches: moved});
             vi.advanceTimersByTime(500);
             expect(contextmenu).toHaveBeenCalledTimes(0);
-        } finally {
-            vi.useRealTimers();
-        }
-    });
+        });
 
-    test('MapEvent handler cancels the long press on touchcancel, and does not leak to the next tap', () => {
-        const map = createMap();
-        const contextmenu = vi.fn();
-        map.on('contextmenu', contextmenu);
-        const touches = [{target: map.getCanvas(), clientX: 10, clientY: 10}];
-        vi.useFakeTimers();
-        try {
+        test('MapEvent handler keeps the long press alive when the finger drifts within the click tolerance', () => {
+            const map = createMap();
+            const contextmenu = vi.fn();
+            map.on('contextmenu', contextmenu);
+            const start = [{target: map.getCanvas(), clientX: 10, clientY: 10}];
+            const drifted = [{target: map.getCanvas(), clientX: 11, clientY: 11}]; // ~1.4px, under the default tolerance of 3
+
+            simulate.touchstart(map.getCanvas(), {touches: start, targetTouches: start});
+            simulate.touchmove(map.getCanvas(), {touches: drifted, targetTouches: drifted});
+            vi.advanceTimersByTime(500);
+            expect(contextmenu).toHaveBeenCalledTimes(1);
+        });
+
+        test('MapEvent handler fires the contextmenu once when the press is held past the delay and then dragged', () => {
+            const map = createMap();
+            const contextmenu = vi.fn();
+            map.on('contextmenu', contextmenu);
+            const start = [{target: map.getCanvas(), clientX: 10, clientY: 10}];
+            const moved = [{target: map.getCanvas(), clientX: 40, clientY: 40}];
+
+            simulate.touchstart(map.getCanvas(), {touches: start, targetTouches: start});
+            vi.advanceTimersByTime(500);
+            expect(contextmenu).toHaveBeenCalledTimes(1); // fired at the delay, before the drag
+            // the drag afterwards pans as usual and must not fire a second contextmenu
+            simulate.touchmove(map.getCanvas(), {touches: moved, targetTouches: moved});
+            simulate.touchend(map.getCanvas(), {touches: [], targetTouches: [], changedTouches: moved});
+            vi.advanceTimersByTime(500);
+            expect(contextmenu).toHaveBeenCalledTimes(1);
+        });
+
+        test('MapEvent handler cancels the long press on touchcancel, and does not leak to the next tap', () => {
+            const map = createMap();
+            const contextmenu = vi.fn();
+            map.on('contextmenu', contextmenu);
+            const touches = [{target: map.getCanvas(), clientX: 10, clientY: 10}];
+
             simulate.touchstart(map.getCanvas(), {touches, targetTouches: touches});
             simulate.touchcancel(map.getCanvas(), {touches: [], targetTouches: [], changedTouches: touches});
             vi.advanceTimersByTime(500);
@@ -243,24 +265,18 @@ describe('map events', () => {
             simulate.touchend(map.getCanvas(), {touches: [], targetTouches: [], changedTouches: touches});
             vi.advanceTimersByTime(500);
             expect(contextmenu).toHaveBeenCalledTimes(0);
-        } finally {
-            vi.useRealTimers();
-        }
-    });
+        });
 
-    test('MapEvent handler does not start a long press for a two-finger touch (pinch)', () => {
-        const map = createMap();
-        const contextmenu = vi.fn();
-        map.on('contextmenu', contextmenu);
-        const two = [{target: map.getCanvas(), clientX: 10, clientY: 10}, {target: map.getCanvas(), clientX: 60, clientY: 60}];
-        vi.useFakeTimers();
-        try {
+        test('MapEvent handler does not start a long press for a two-finger touch (pinch)', () => {
+            const map = createMap();
+            const contextmenu = vi.fn();
+            map.on('contextmenu', contextmenu);
+            const two = [{target: map.getCanvas(), clientX: 10, clientY: 10}, {target: map.getCanvas(), clientX: 60, clientY: 60}];
+
             simulate.touchstart(map.getCanvas(), {touches: two, targetTouches: two});
             vi.advanceTimersByTime(500);
             expect(contextmenu).toHaveBeenCalledTimes(0);
-        } finally {
-            vi.useRealTimers();
-        }
+        });
     });
 
     test('MapMouseEvent constructor does not throw error with Event instance instead of MouseEvent as originalEvent param', () => {

--- a/src/ui/handler/map_event.test.ts
+++ b/src/ui/handler/map_event.test.ts
@@ -157,6 +157,23 @@ describe('map events', () => {
         expect(contextmenu).toHaveBeenCalledTimes(0);
     });
 
+    test('MapEvent handler fires contextmenu on touch long press', () => {
+        const map = createMap();
+        const relatedTarget = map.getCanvas();
+        map.dragPan.enable();
+
+        const contextmenu = vi.fn();
+
+        map.on('contextmenu', contextmenu);
+
+        const touches = [{target: map.getCanvas(), clientX: 10, clientY: 10}];
+        simulate.touchstart(map.getCanvas(), {touches, targetTouches: touches});
+        simulate.contextmenu(map.getCanvas(), {relatedTarget}); // browser fires contextmenu during the long press
+        expect(contextmenu).toHaveBeenCalledTimes(0);
+        simulate.touchend(map.getCanvas(), {touches: [], targetTouches: [], changedTouches: touches});
+        expect(contextmenu).toHaveBeenCalledTimes(1);
+    });
+
     test('MapMouseEvent constructor does not throw error with Event instance instead of MouseEvent as originalEvent param', () => {
         const map = createMap();
         const target = map.getCanvasContainer();

--- a/src/ui/handler/map_event.ts
+++ b/src/ui/handler/map_event.ts
@@ -134,6 +134,18 @@ export class BlockableMapEventHandler {
             delete this._contextMenuEvent;
         }
     }
+
+    touchstart(): void {
+        // Touch devices have no right click, so a long press is used to open the
+        // context menu. Reuse the mouse flow: arm the delayed contextmenu here and
+        // fire it on touchend once the browser has emitted its native contextmenu.
+        this.mousedown();
+    }
+
+    touchend(): void {
+        this.mouseup();
+    }
+
     contextmenu(e: MouseEvent): void {
         if (this._delayContextMenu) {
             // Mac: contextmenu fired on mousedown; we save it until mouseup for consistency's sake

--- a/src/ui/handler/map_event.ts
+++ b/src/ui/handler/map_event.ts
@@ -101,13 +101,14 @@ export class MapEventHandler implements Handler {
     disable(): void {}
 }
 
-// A single finger held in place this long fires a long-press contextmenu.
+/**
+ * A single finger held in place this long fires a long-press contextmenu.
+ */
 const LONG_PRESS_DELAY = 500;
-// How far the finger may drift before it counts as a pan, not a long press.
-const LONG_PRESS_MOVE_TOLERANCE = 10;
 
 export class BlockableMapEventHandler {
     _map: Map;
+    _clickTolerance: number;
     _delayContextMenu: boolean;
     _ignoreContextMenu: boolean;
     _contextMenuEvent: MouseEvent;
@@ -115,8 +116,11 @@ export class BlockableMapEventHandler {
     _longPressTimer: ReturnType<typeof setTimeout>;
     _longPressStart: Point;
 
-    constructor(map: Map) {
+    constructor(map: Map, options: {
+        clickTolerance: number;
+    }) {
         this._map = map;
+        this._clickTolerance = options.clickTolerance || 1;
     }
 
     reset(): void {
@@ -145,11 +149,16 @@ export class BlockableMapEventHandler {
         }
     }
 
-    // Touch long press. Touch devices have no right click, so a long press opens
-    // the context menu. We detect it with a timer rather than relying on a native
-    // contextmenu event, because Android Chrome fires one on a long press but iOS
-    // Safari does not. A single finger held past the delay without moving fires a
-    // contextmenu at that point; a pan or a lift cancels it.
+    /**
+     * Starts the touch long press. Touch devices have no right click, so a long press opens
+     * the context menu. It is detected with a timer rather than by relying on a native
+     * contextmenu event, because Android Chrome fires one on a long press but iOS
+     * Safari does not. A single finger held past the delay without moving fires a
+     * contextmenu at that point; a pan or a lift cancels it.
+     * @param e - the touch event
+     * @param points - the touch points, in map coordinates
+     * @param mapTouches - the touches that are on the map
+     */
     touchstart(e: TouchEvent, points: Point[], mapTouches: Touch[]): void {
         this._clearLongPress();
         this._touchActive = mapTouches.length > 0;
@@ -163,9 +172,16 @@ export class BlockableMapEventHandler {
         }, LONG_PRESS_DELAY);
     }
 
+    /**
+     * Cancels a pending long press once the finger has moved further than the map's
+     * click tolerance, or once a second finger lands.
+     * @param e - the touch event
+     * @param points - the touch points, in map coordinates
+     * @param mapTouches - the touches that are on the map
+     */
     touchmove(e: TouchEvent, points: Point[], mapTouches: Touch[]): void {
         if (!this._longPressTimer) return;
-        if (mapTouches.length !== 1 || !this._longPressStart || points[0].dist(this._longPressStart) > LONG_PRESS_MOVE_TOLERANCE) {
+        if (mapTouches.length !== 1 || !this._longPressStart || points[0].dist(this._longPressStart) > this._clickTolerance) {
             this._clearLongPress();
         }
     }

--- a/src/ui/handler/map_event.ts
+++ b/src/ui/handler/map_event.ts
@@ -146,6 +146,14 @@ export class BlockableMapEventHandler {
         this.mouseup();
     }
 
+    touchcancel(): void {
+        // A cancelled touch (for example when the browser takes over a long
+        // press) must not fire a contextmenu, and must not leave the delayed
+        // event armed, or the next tap would fire a stale contextmenu.
+        this._delayContextMenu = false;
+        delete this._contextMenuEvent;
+    }
+
     contextmenu(e: MouseEvent): void {
         if (this._delayContextMenu) {
             // Mac: contextmenu fired on mousedown; we save it until mouseup for consistency's sake

--- a/src/ui/handler/map_event.ts
+++ b/src/ui/handler/map_event.ts
@@ -101,11 +101,19 @@ export class MapEventHandler implements Handler {
     disable(): void {}
 }
 
+// A single finger held in place this long fires a long-press contextmenu.
+const LONG_PRESS_DELAY = 500;
+// How far the finger may drift before it counts as a pan, not a long press.
+const LONG_PRESS_MOVE_TOLERANCE = 10;
+
 export class BlockableMapEventHandler {
     _map: Map;
     _delayContextMenu: boolean;
     _ignoreContextMenu: boolean;
     _contextMenuEvent: MouseEvent;
+    _touchActive: boolean;
+    _longPressTimer: ReturnType<typeof setTimeout>;
+    _longPressStart: Point;
 
     constructor(map: Map) {
         this._map = map;
@@ -115,6 +123,8 @@ export class BlockableMapEventHandler {
         this._delayContextMenu = false;
         this._ignoreContextMenu = true;
         delete this._contextMenuEvent;
+        this._clearLongPress();
+        this._touchActive = false;
     }
 
     mousemove(e: MouseEvent): void {
@@ -135,26 +145,57 @@ export class BlockableMapEventHandler {
         }
     }
 
-    touchstart(): void {
-        // Touch devices have no right click, so a long press is used to open the
-        // context menu. Reuse the mouse flow: arm the delayed contextmenu here and
-        // fire it on touchend once the browser has emitted its native contextmenu.
-        this.mousedown();
+    // Touch long press. Touch devices have no right click, so a long press opens
+    // the context menu. We detect it with a timer rather than relying on a native
+    // contextmenu event, because Android Chrome fires one on a long press but iOS
+    // Safari does not. A single finger held past the delay without moving fires a
+    // contextmenu at that point; a pan or a lift cancels it.
+    touchstart(e: TouchEvent, points: Point[], mapTouches: Touch[]): void {
+        this._clearLongPress();
+        this._touchActive = mapTouches.length > 0;
+        if (mapTouches.length !== 1) return; // single finger only, never during a pinch
+        this._longPressStart = points[0];
+        const touch = mapTouches[0];
+        this._longPressTimer = setTimeout(() => {
+            this._longPressTimer = undefined;
+            const originalEvent = new MouseEvent('contextmenu', {clientX: touch.clientX, clientY: touch.clientY, button: 2, bubbles: true, cancelable: true});
+            this._map.fire(new MapMouseEvent('contextmenu', this._map, originalEvent));
+        }, LONG_PRESS_DELAY);
+    }
+
+    touchmove(e: TouchEvent, points: Point[], mapTouches: Touch[]): void {
+        if (!this._longPressTimer) return;
+        if (mapTouches.length !== 1 || !this._longPressStart || points[0].dist(this._longPressStart) > LONG_PRESS_MOVE_TOLERANCE) {
+            this._clearLongPress();
+        }
     }
 
     touchend(): void {
-        this.mouseup();
+        this._touchActive = false;
+        this._clearLongPress();
     }
 
     touchcancel(): void {
-        // A cancelled touch (for example when the browser takes over a long
-        // press) must not fire a contextmenu, and must not leave the delayed
-        // event armed, or the next tap would fire a stale contextmenu.
-        this._delayContextMenu = false;
-        delete this._contextMenuEvent;
+        this._touchActive = false;
+        this._clearLongPress();
+    }
+
+    _clearLongPress(): void {
+        if (this._longPressTimer) {
+            clearTimeout(this._longPressTimer);
+            this._longPressTimer = undefined;
+        }
+        this._longPressStart = undefined;
     }
 
     contextmenu(e: MouseEvent): void {
+        if (this._touchActive) {
+            // A native contextmenu during a touch (Android's long press, or an iOS
+            // callout) is suppressed: the long-press timer owns touch, so letting
+            // this through would double-fire or pop the browser's own menu.
+            e.preventDefault();
+            return;
+        }
         if (this._delayContextMenu) {
             // Mac: contextmenu fired on mousedown; we save it until mouseup for consistency's sake
             this._contextMenuEvent = e;

--- a/src/ui/handler_manager.ts
+++ b/src/ui/handler_manager.ts
@@ -319,7 +319,9 @@ export class HandlerManager {
             map.touchZoomRotate.enable(options.touchZoomRotate);
         }
 
-        this._add('blockableMapEvent', new BlockableMapEventHandler(map));
+        // touchPan is allowed to stay active so that a long press which produces
+        // small finger movement still results in a contextmenu event on touch devices.
+        this._add('blockableMapEvent', new BlockableMapEventHandler(map), ['touchPan']);
 
         const scrollZoom = map.scrollZoom = new ScrollZoomHandler(map, () => this._triggerRenderFrame(), this._transformProvider);
         this._add('scrollZoom', scrollZoom, ['mousePan']);

--- a/src/ui/handler_manager.ts
+++ b/src/ui/handler_manager.ts
@@ -321,7 +321,7 @@ export class HandlerManager {
 
         // touchPan is allowed to stay active so that a long press which produces
         // small finger movement still results in a contextmenu event on touch devices.
-        this._add('blockableMapEvent', new BlockableMapEventHandler(map), ['touchPan']);
+        this._add('blockableMapEvent', new BlockableMapEventHandler(map, options), ['touchPan']);
 
         const scrollZoom = map.scrollZoom = new ScrollZoomHandler(map, () => this._triggerRenderFrame(), this._transformProvider);
         this._add('scrollZoom', scrollZoom, ['mousePan']);


### PR DESCRIPTION
Fixes #373. This implements the approach @HarelM scoped in the issue:

> Looking at the code related to this issue the following can be achieved relatively easily [...] in file handler_manager.ts: pass ['touchPan'] to the BlockableMapEventHandler, and in BlockableMapEventHandler in file map_event.ts add touchstart -> mousedown() and touchend -> mouseup().

On a mouse, the context menu opens on right click. Touch devices have no right click, so this wires a long press to the same event.

## Changes
- handler_manager.ts: allow touchPan to stay active for the blockableMapEvent handler (['touchPan']) so small finger movement during a long press does not reset the delayed contextmenu.
- map_event.ts: add touchstart and touchend to BlockableMapEventHandler, reusing the existing delayed-contextmenu flow (arm on touchstart, fire on touchend).
- Unit test asserting a touchstart, native contextmenu, then touchend fires a single contextmenu map event.

## Known limitation
As HarelM noted in the issue, the contextmenu still fires when the finger leaves the screen after a long press even if the map was moved afterward. Fully addressing that needs deeper changes to the block-by-active mechanism, so it is left out of this minimal change.

Fixes #373
