### PR TITLE
fix: give globe projection error measurement per-readback PBO ownership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes
+- Fix a Chromium performance warning caused by the globe projection error measurement reusing a single fenced `STREAM_READ` pixel-pack buffer for every asynchronous readback; each measurement now owns a fresh PBO that is deleted after readback ([#7872](https://github.com/maplibre/maplibre-gl-js/issues/7872)) (by [@mondsichtung](https://github.com/mondsichtung))
 - _...Add new stuff here..._
 
 ## 6.0.0-21

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes
-- Fix a Chromium performance warning caused by the globe projection error measurement reusing a single fenced `STREAM_READ` pixel-pack buffer for every asynchronous readback; each measurement now owns a fresh PBO that is deleted after readback ([#7872](https://github.com/maplibre/maplibre-gl-js/issues/7872)) (by [@mondsichtung](https://github.com/mondsichtung))
+- Fix a Chromium performance warning caused by the globe projection error measurement reusing a single fenced `STREAM_READ` pixel-pack buffer for every asynchronous readback; each measurement now owns a fresh PBO that is deleted after readback ([#7943](https://github.com/maplibre/maplibre-gl-js/pull/7943)) (by [@mondsichtung](https://github.com/mondsichtung))
 - _...Add new stuff here..._
 
 ## 6.0.0-21

--- a/src/geo/projection/globe_projection_error_measurement.ts
+++ b/src/geo/projection/globe_projection_error_measurement.ts
@@ -55,7 +55,6 @@ export class ProjectionErrorMeasurement {
     private _fullscreenTriangle: Mesh;
     private _fbo: Framebuffer;
     private _resultBuffer: Uint8Array;
-    private _pbo: WebGLBuffer;
     private _cachedRenderContext: ProjectionGPUContext;
 
     private _measuredError: number = 0; // Result of last measurement
@@ -70,6 +69,7 @@ export class ProjectionErrorMeasurement {
     private _readbackQueue: {
         frameNumberIssued: number; // Frame number when the data was first computed
         sync: WebGLSync;
+        pbo: WebGLBuffer;
     } = null;
 
     public constructor(renderContext: ProjectionGPUContext) {
@@ -108,21 +108,14 @@ export class ProjectionErrorMeasurement {
 
         this._fbo = context.createFramebuffer(this._texWidth, this._texHeight, false, false);
         this._fbo.colorAttachment.set(texture);
-
-        this._pbo = gl.createBuffer();
-        gl.bindBuffer(gl.PIXEL_PACK_BUFFER, this._pbo);
-        gl.bufferData(gl.PIXEL_PACK_BUFFER, 4, gl.STREAM_READ);
-        gl.bindBuffer(gl.PIXEL_PACK_BUFFER, null);
     }
 
     public destroy(): void {
-        const gl = this._cachedRenderContext.context.gl;
+        this._releaseReadback();
         this._fullscreenTriangle.destroy();
         this._fbo.destroy();
-        gl.deleteBuffer(this._pbo);
         this._fullscreenTriangle = null;
         this._fbo = null;
-        this._pbo = null;
         this._resultBuffer = null;
     }
 
@@ -172,8 +165,10 @@ export class ProjectionErrorMeasurement {
             '$clipping', this._fullscreenTriangle.vertexBuffer, this._fullscreenTriangle.indexBuffer,
             this._fullscreenTriangle.segments);
 
-        // Read back into PBO
-        gl.bindBuffer(gl.PIXEL_PACK_BUFFER, this._pbo);
+        // Read back into a PBO owned exclusively by this measurement
+        const pbo = gl.createBuffer();
+        gl.bindBuffer(gl.PIXEL_PACK_BUFFER, pbo);
+        gl.bufferData(gl.PIXEL_PACK_BUFFER, 4, gl.STREAM_READ);
         gl.readBuffer(gl.COLOR_ATTACHMENT0);
         gl.readPixels(0, 0, this._texWidth, this._texHeight, this._texFormat, this._texType, 0);
         gl.bindBuffer(gl.PIXEL_PACK_BUFFER, null);
@@ -183,6 +178,7 @@ export class ProjectionErrorMeasurement {
         this._readbackQueue = {
             frameNumberIssued: this._updateCount,
             sync,
+            pbo,
         };
     }
 
@@ -197,7 +193,7 @@ export class ProjectionErrorMeasurement {
 
         if (waitResult === gl.WAIT_FAILED) {
             warnOnce('WebGL2 clientWaitSync failed.');
-            this._readbackQueue = null;
+            this._releaseReadback();
             this._lastReadbackFrame = this._updateCount;
             return;
         }
@@ -206,14 +202,24 @@ export class ProjectionErrorMeasurement {
             return; // Wait one more frame
         }
 
-        gl.bindBuffer(gl.PIXEL_PACK_BUFFER, this._pbo);
+        gl.bindBuffer(gl.PIXEL_PACK_BUFFER, this._readbackQueue.pbo);
         gl.getBufferSubData(gl.PIXEL_PACK_BUFFER, 0, this._resultBuffer, 0, 4);
         gl.bindBuffer(gl.PIXEL_PACK_BUFFER, null);
 
         // If we made it here, _resultBuffer contains the new measurement
-        this._readbackQueue = null;
+        this._releaseReadback();
         this._measuredError = ProjectionErrorMeasurement._parseRGBA8float(this._resultBuffer);
         this._lastReadbackFrame = this._updateCount;
+    }
+
+    private _releaseReadback(): void {
+        if (!this._readbackQueue) {
+            return;
+        }
+        const gl = this._cachedRenderContext.context.gl;
+        gl.deleteBuffer(this._readbackQueue.pbo);
+        gl.deleteSync(this._readbackQueue.sync);
+        this._readbackQueue = null;
     }
 
     private static _parseRGBA8float(buffer: Uint8Array): number {


### PR DESCRIPTION
The globe projection error measurement reused a single STREAM_READ pixel-pack buffer for every asynchronous readback. On affected Chromium builds the fenced buffer is written again before its shadow copy is read back, which discards the accelerated readback copy and emits a performance warning.

Give each in-flight measurement its own four-byte PBO stored alongside its fence in _readbackQueue, and delete both the PBO and the WebGLSync after successful readback, on WAIT_FAILED, and on destruction.

Fixes https://github.com/maplibre/maplibre-gl-js/issues/7872

Minimal reproduction: https://output.jsbin.com/solabez


## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items that are not relevant. -->


 - [X] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [X] Briefly describe the changes in this PR.
 - [X] Link to related issues.
 - [X] Include before/after visuals or gifs if this PR includes visual changes.
 - [X] Write tests for all new functionality.
 - [X] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [X] Add an entry to `CHANGELOG.md` under the `## main` section.
 - [X] Confirm you have read our AI policy [here](https://github.com/maplibre/maplibre/blob/main/AI_POLICY.md).
<!--
  Add one of:    Assisted-By: | 
-->

Generated-By: GPT 5.6 Sol (High) & Review by: Claude Opus 4.8 (xhigh)