### PR TITLE
perf: move some feature-independent work outside of the feature-eval-loop

### DIFF
--- a/src/data/bucket/circle_bucket.ts
+++ b/src/data/bucket/circle_bucket.ts
@@ -102,11 +102,12 @@ export class CircleBucket<Layer extends CircleStyleLayer | HeatmapStyleLayer> im
 
         const granularity = subdivide ? options.subdivisionGranularity.circle : 1;
 
+        const globalProperties = new EvaluationParameters(this.zoom);
+        const needGeometry = this.layers[0]._featureFilter.needGeometry;
         for (const {feature, id, index, sourceLayerIndex} of features) {
-            const needGeometry = this.layers[0]._featureFilter.needGeometry;
             const evaluationFeature = toEvaluationFeature(feature, needGeometry);
 
-            if (!this.layers[0]._featureFilter.filter(new EvaluationParameters(this.zoom), evaluationFeature, canonical)) continue;
+            if (!this.layers[0]._featureFilter.filter(globalProperties, evaluationFeature, canonical)) continue;
 
             const sortKey = sortFeaturesByKey ?
                 circleSortKey.evaluate(evaluationFeature, {}, canonical) :

--- a/src/data/bucket/fill_bucket.ts
+++ b/src/data/bucket/fill_bucket.ts
@@ -81,11 +81,12 @@ export class FillBucket implements Bucket {
         const sortFeaturesByKey = !fillSortKey.isConstant();
         const bucketFeatures: BucketFeature[] = [];
 
+        const globalProperties = new EvaluationParameters(this.zoom);
+        const needGeometry = this.layers[0]._featureFilter.needGeometry;
         for (const {feature, id, index, sourceLayerIndex} of features) {
-            const needGeometry = this.layers[0]._featureFilter.needGeometry;
             const evaluationFeature = toEvaluationFeature(feature, needGeometry);
 
-            if (!this.layers[0]._featureFilter.filter(new EvaluationParameters(this.zoom), evaluationFeature, canonical)) continue;
+            if (!this.layers[0]._featureFilter.filter(globalProperties, evaluationFeature, canonical)) continue;
 
             const sortKey = sortFeaturesByKey ?
                 fillSortKey.evaluate(evaluationFeature, {}, canonical, options.availableImages) :

--- a/src/data/bucket/fill_extrusion_bucket.ts
+++ b/src/data/bucket/fill_extrusion_bucket.ts
@@ -101,11 +101,12 @@ export class FillExtrusionBucket implements Bucket {
         this.features = [];
         this.hasDependencies = hasPattern('fill-extrusion', this.layers, options);
 
+        const globalProperties = new EvaluationParameters(this.zoom);
+        const needGeometry = this.layers[0]._featureFilter.needGeometry;
         for (const {feature, id, index, sourceLayerIndex} of features) {
-            const needGeometry = this.layers[0]._featureFilter.needGeometry;
             const evaluationFeature = toEvaluationFeature(feature, needGeometry);
 
-            if (!this.layers[0]._featureFilter.filter(new EvaluationParameters(this.zoom), evaluationFeature, canonical)) continue;
+            if (!this.layers[0]._featureFilter.filter(globalProperties, evaluationFeature, canonical)) continue;
 
             const bucketFeature: BucketFeature = {
                 id,

--- a/src/data/bucket/line_bucket.ts
+++ b/src/data/bucket/line_bucket.ts
@@ -151,11 +151,12 @@ export class LineBucket implements Bucket {
         const sortFeaturesByKey = !lineSortKey.isConstant();
         const bucketFeatures: BucketFeature[] = [];
 
+        const globalProperties = new EvaluationParameters(this.zoom);
+        const needGeometry = this.layers[0]._featureFilter.needGeometry;
         for (const {feature, id, index, sourceLayerIndex} of features) {
-            const needGeometry = this.layers[0]._featureFilter.needGeometry;
             const evaluationFeature = toEvaluationFeature(feature, needGeometry);
 
-            if (!this.layers[0]._featureFilter.filter(new EvaluationParameters(this.zoom), evaluationFeature, canonical)) continue;
+            if (!this.layers[0]._featureFilter.filter(globalProperties, evaluationFeature, canonical)) continue;
 
             const sortKey = sortFeaturesByKey ?
                 lineSortKey.evaluate(evaluationFeature, {}, canonical) :


### PR DESCRIPTION
During my thesis, I noticed that there is a bigger performance difference for some expression rewrites.
This PR optimises the non-const feature-eval case.

It is a minor ~2% (variance is a bit high, some benchmarks hit more than this, but 2% seems to be the floor for the ones that show a diff) performance boost by moving some feature-constant work outside of the per-feature loop.
I think this is effective because the JIIT can only over longer runs detect this as extractable. For some reason this is not quite happening sometimes. So weird.
Maybe it is also the alloc that cannot be extracted or something stupid like that.

No changelog entry because it is not a large perf diff.