### PR TITLE
docs: Vite worker snippet needs `?worker&url`, not `?url`

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -82,19 +82,24 @@ Pick your setup:
 
 === "Vite"
 
-    Use Vite's `?url` query to get the worker file's bundled URL:
+    Use Vite's `?worker&url` query to get a bundled, self-contained worker URL:
 
     ```ts
     import {Map, setWorkerUrl} from 'maplibre-gl';
     import 'maplibre-gl/dist/maplibre-gl.css';
-    import workerUrl from 'maplibre-gl/dist/maplibre-gl-worker.mjs?url';
+    import workerUrl from 'maplibre-gl/dist/maplibre-gl-worker.mjs?worker&url';
 
     setWorkerUrl(workerUrl);
 
     const map = new Map({/* … */});
     ```
 
-    Works in modern Vite, dev and production.
+    Use `?worker&url` rather than plain `?url`: the dist worker imports its
+    sibling `maplibre-gl-shared.mjs`, and `?url` emits the worker file verbatim
+    in production builds without that sibling — the worker then fails on its
+    first import and no vector tiles load. `?worker&url` routes the file
+    through Vite's worker pipeline, emitting a self-contained chunk. Dev mode
+    works with either.
 
     If your build uses SSR (TanStack Start, Astro, etc.) and Vite resolves the CommonJS entry on the server, also add:
 


### PR DESCRIPTION
The Vite tab in the installation docs recommends `?url` for the worker import and says it works in dev and production. Production is broken with plain `?url` on stock Vite: the dist worker is emitted verbatim as an asset, but its sibling import (`./maplibre-gl-shared.mjs`) is not emitted alongside it, so the worker throws on its first import and no vector tiles ever parse.

Verified against 6.0.0-22 with stock Vite 7 in a real app (the marine chartplotter from [this field report](https://github.com/maplibre/maplibre-gl-js/discussions/7980)):

| worker import | dev | production |
|---|---|---|
| `?url` (current docs) | ✅ | ❌ worker fails on `maplibre-gl-shared.mjs` import |
| `?worker&url` | ✅ | ✅ self-contained worker chunk emitted |

`test/integration/bundler/vite-rolldown` already uses `?worker&url` — the docs snippet had just drifted from the example. This PR aligns the snippet and adds one sentence explaining why the distinction matters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)