### PR TITLE
ci: serialize benchmark uploads to avoid gh-pages push races

### DIFF
--- a/.github/workflows/upload-benchmarks.yml
+++ b/.github/workflows/upload-benchmarks.yml
@@ -17,6 +17,10 @@ on:
         required: false
         type: string
 
+concurrency:
+  group: upload-benchmarks-gh-pages
+  cancel-in-progress: false
+
 jobs:
   upload_benchmarks:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Fixes [run 30169803184](https://github.com/maplibre/maplibre-gl-js/actions/runs/30169803184/job/89708922156).