### PR TITLE
Show grab cursor for draggable markers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Add `GeoJSONSource.getClusterOptions` to get a source's current cluster options (`cluster`, `clusterMaxZoom`, `clusterRadius`) ([#7948](https://github.com/maplibre/maplibre-gl-js/pull/7948)) (by [@lazerg](https://github.com/lazerg))
 - Support `global-state` expressions in `sky.*`, `light.*` and `projection.type` properties ([#7966](https://github.com/maplibre/maplibre-gl-js/pull/7966), [#7967](https://github.com/maplibre/maplibre-gl-js/pull/7967), [#7968](https://github.com/maplibre/maplibre-gl-js/pull/7968)) (by [@CommanderStorm](https://github.com/CommanderStorm))
 - Add `MapOptions.rotateSpeed` and `MapOptions.pitchSpeed`, the degrees the bearing/pitch change per pixel dragged ([#7949](https://github.com/maplibre/maplibre-gl-js/pull/7949)) (by [@clement-igonet](https://github.com/clement-igonet))
+- Show a grab cursor over draggable markers, including on non-interactive maps ([#8019](https://github.com/maplibre/maplibre-gl-js/issues/8019)) (by [@hugosmoreira](https://github.com/hugosmoreira))
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes

--- a/src/css/maplibre-gl.css
+++ b/src/css/maplibre-gl.css
@@ -788,6 +788,10 @@ a.maplibregl-ctrl-logo.maplibregl-compact {
     transition: opacity 0.2s;
 }
 
+.maplibregl-marker-draggable {
+    cursor: grab;
+}
+
 .maplibregl-user-location-dot {
     background-color: #1da1f2;
     width: 15px;

--- a/src/ui/marker.test.ts
+++ b/src/ui/marker.test.ts
@@ -543,13 +543,13 @@ describe('marker', () => {
             .setLngLat([0, 0])
             .addTo(map);
 
-        expect(marker.getElement().classList.contains('maplibregl-marker-draggable')).toBe(true);
+        expect(marker.getElement().classList).toContain('maplibregl-marker-draggable');
 
         marker.setDraggable(false);
-        expect(marker.getElement().classList.contains('maplibregl-marker-draggable')).toBe(false);
+        expect(marker.getElement().classList).not.toContain('maplibregl-marker-draggable');
 
         marker.setDraggable(true);
-        expect(marker.getElement().classList.contains('maplibregl-marker-draggable')).toBe(true);
+        expect(marker.getElement().classList).toContain('maplibregl-marker-draggable');
 
         map.remove();
     });

--- a/src/ui/marker.test.ts
+++ b/src/ui/marker.test.ts
@@ -537,6 +537,23 @@ describe('marker', () => {
         map.remove();
     });
 
+    test('Marker.setDraggable toggles the draggable cursor class', () => {
+        const map = createMap();
+        const marker = new Marker({draggable: true})
+            .setLngLat([0, 0])
+            .addTo(map);
+
+        expect(marker.getElement().classList.contains('maplibregl-marker-draggable')).toBe(true);
+
+        marker.setDraggable(false);
+        expect(marker.getElement().classList.contains('maplibregl-marker-draggable')).toBe(false);
+
+        marker.setDraggable(true);
+        expect(marker.getElement().classList.contains('maplibregl-marker-draggable')).toBe(true);
+
+        map.remove();
+    });
+
     test('Marker with draggable:true fires dragstart, drag, and dragend events at appropriate times in response to mouse-triggered drag with map-inherited clickTolerance', () => {
         const map = createMap();
         const marker = new Marker({draggable: true})

--- a/src/ui/marker.ts
+++ b/src/ui/marker.ts
@@ -856,6 +856,7 @@ export class Marker extends Evented<MarkerEventType> {
      */
     setDraggable(shouldBeDraggable?: boolean): this {
         this._draggable = !!shouldBeDraggable; // convert possible undefined value to false
+        this._element.classList.toggle('maplibregl-marker-draggable', this._draggable);
 
         // handle case where map may not exist yet
         // e.g. when setDraggable is called before addTo


### PR DESCRIPTION
## Launch Checklist

- [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license).
- [x] Briefly describe the changes in this PR.
- [x] Link to related issues.
- [ ] Include before/after visuals or gifs if this PR includes visual changes. (A cursor shape is not visible in a static screenshot; the state and CSS rule are covered by tests and lint.)
- [x] Write tests for all new functionality.
- [x] Document any changes to public APIs. (No public API signatures changed.)
- [x] Post benchmark scores. (Not applicable: this is not a performance-sensitive change.)
- [x] Add an entry to `CHANGELOG.md` under the `## main` section.
- [x] Confirm you have read the MapLibre AI policy.

## Description

Draggable markers currently inherit the map container's grab cursor. This works for interactive maps, but a map created with `interactive: false` does not provide that cursor hint.

This PR:

- toggles a `maplibregl-marker-draggable` class from `Marker.setDraggable()`;
- applies `cursor: grab` to that state class; and
- tests the initial `draggable` option plus runtime disabling and re-enabling.

This keeps the cursor state aligned with the existing draggable behavior without changing the public API.

Closes #8019

## Testing

- `npx vitest run --config vitest.config.unit.ts src/ui/marker.test.ts` — 78 tests passed
- `npx eslint src/ui/marker.ts src/ui/marker.test.ts`
- `npx stylelint src/css/maplibre-gl.css verbose`
- `npm run typecheck`
- `npm run build-css`

## AI assistance

Generated-By: OpenAI Codex (GPT-5)

Codex was used to analyze the issue and repository, implement the change, write the regression test, run validation, and draft this description. The PR is intentionally left in draft until the contributor completes the human review required by MapLibre's AI policy.
