### PR TITLE
Add a Vitest bench lane for micro benchmarks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ coverage
 test/bench/**/benchmarks_worker.mjs
 test/bench/**/benchmarks_worker.mjs.map
 test/bench/data.json.gz
+bench-baseline.json
 test/integration/**/results*.html
 test/integration/**/actual.png
 test/integration/**/actual.json

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -194,6 +194,8 @@ See [`test/README.md`](./test/README.md).
 
 See [`test/bench/README.md`](./test/bench/README.md).
 
+Micro benchmarks live next to the code they measure (`src/**/*.bench.ts`) and run with `npm run bench`; the browser-based version-comparison harness lives in `test/bench/`. If your PR claims a performance effect, include a before/after table from `npm run bench -- --compare` in the description.
+
 ## Further guides
 
 See [`developer-guides`](./developer-guides) directory for guides on the release process and tile lifecycle.

--- a/package.json
+++ b/package.json
@@ -166,6 +166,7 @@
     "test-watch-roots": "vitest --config vitest.config.unit.ts --watch",
     "test-render": "vitest test/integration/render/render.test.ts",
     "codegen": "run-p --print-label generate-style-code generate-unicode-data generate-struct-arrays generate-shaders && npm run generate-typings",
+    "bench": "vitest bench --run --config vitest.config.bench.ts",
     "benchmark": "node test/bench/run-benchmarks.ts",
     "gl-stats": "node test/bench/gl-stats.ts",
     "prepare": "npm run codegen",

--- a/src/geo/projection/covering_tiles.bench.ts
+++ b/src/geo/projection/covering_tiles.bench.ts
@@ -1,0 +1,39 @@
+import {bench, describe} from 'vitest';
+import {LngLat} from '../lng_lat.ts';
+import {coveringTiles} from './covering_tiles.ts';
+import {MercatorTransform} from './mercator_transform.ts';
+import {GlobeTransform} from './globe_transform.ts';
+import type {ITransform} from '../transform_interface.ts';
+
+function coverWithPitch(transform: ITransform, pitch: number): void {
+    transform.setCenter(new LngLat(0, 0));
+    transform.setZoom(4);
+    transform.resize(4096, 4096, true);
+    transform.setMaxPitch(pitch);
+    transform.setPitch(pitch);
+
+    for (let i = 0; i < 40; i++) {
+        transform.setCenter(new LngLat(i * 0.2, 0));
+        coveringTiles(transform, {
+            tileSize: 256,
+        });
+    }
+}
+
+describe('coveringTiles', () => {
+    bench('mercator', () => {
+        coverWithPitch(new MercatorTransform(), 0);
+    });
+
+    bench('mercator pitched', () => {
+        coverWithPitch(new MercatorTransform(), 60);
+    });
+
+    bench('globe', () => {
+        coverWithPitch(new GlobeTransform(), 0);
+    });
+
+    bench('globe pitched', () => {
+        coverWithPitch(new GlobeTransform(), 60);
+    });
+});

--- a/src/render/subdivision.bench.ts
+++ b/src/render/subdivision.bench.ts
@@ -1,0 +1,39 @@
+import {bench} from 'vitest';
+import Point from '@mapbox/point-geometry';
+import {CanonicalTileID} from '../tile/tile_id.ts';
+import {EXTENT} from '../data/extent.ts';
+import {subdividePolygon} from './subdivision.ts';
+
+function generateRing(cx: number, cy: number, radius: number, vertexCount: number): Point[] {
+    const ring = [];
+
+    for (let i = 0; i < vertexCount; i++) {
+        const angle = i / vertexCount * 2.0 * Math.PI;
+        ring.push(new Point(
+            Math.round(cx + Math.cos(angle) * radius),
+            Math.round(cy + Math.sin(angle) * radius)
+        ));
+    }
+
+    return ring;
+}
+
+const vertexCountMultiplier = 11;
+const granularity = 64;
+const tileID = new CanonicalTileID(2, 1, 1);
+
+const polygon: Point[][] = [generateRing(EXTENT / 2, EXTENT / 2, EXTENT * 1.1 / 2, 81 * vertexCountMultiplier)];
+
+function generateHole(cx: number, cy: number, r: number, vertexCount: number) {
+    polygon.push(generateRing(cx * EXTENT, cy * EXTENT, r * EXTENT, vertexCount));
+}
+
+generateHole(0.25, 0.5, 0.15, 16 * vertexCountMultiplier);
+generateHole(0.75, 0.5, 0.15, 2 * vertexCountMultiplier);
+generateHole(0.5, 0.1, 0.05, 4 * vertexCountMultiplier);
+
+bench('subdividePolygon', () => {
+    for (let i = 0; i < 10; i++) {
+        subdividePolygon(polygon, tileID, granularity, true);
+    }
+});

--- a/test/README.md
+++ b/test/README.md
@@ -45,3 +45,7 @@ See [`test/integration/README.md`](./integration/README.md).
 In the tests you can leverage the Vitest functions for mocking, as described [in the manual of Vitest](https://vitest.dev/guide/mocking.html).
 
 The test framework is set up such that spies, stubs, and mocks on global objects are restored at the end of each test.
+
+## Benchmarks
+
+Micro benchmarks (`src/**/*.bench.ts`) run with `npm run bench`. See [`test/bench/README.md`](./bench/README.md) for both benchmark lanes and the before/after comparison workflow.

--- a/test/bench/README.md
+++ b/test/bench/README.md
@@ -2,6 +2,50 @@
 
 Benchmarks help us catch performance regressions and improve performance.
 
+There are two kinds of benchmarks in this repository, answering two different questions:
+
+* **Micro benchmarks** live next to the code they measure as `src/**/*.bench.ts` files and run under [Vitest bench mode](https://vitest.dev/guide/features.html#benchmarking). They answer "did my change make this code path faster on my machine, right now" while you work on it.
+* **The version-comparison harness** under `test/bench/` runs the full benchmark suite in a browser and compares the working copy against published builds of `main` and past releases. It answers "did the library get slower between versions" and is documented from [Running Benchmarks](#running-benchmarks) onward.
+
+## Micro benchmarks
+
+Run all micro benchmarks:
+
+```bash
+npm run bench
+```
+
+Run a single file, or only benchmarks matching a name:
+
+```bash
+npm run bench -- src/render/subdivision.bench.ts
+npm run bench -- -t mercator
+```
+
+To measure a change, record a baseline before it, then compare against that baseline after:
+
+```bash
+git checkout main && npm run bench -- --outputJson bench-baseline.json
+git checkout your-branch && npm run bench -- --compare bench-baseline.json
+```
+
+The compare run annotates every result with its ratio against the baseline. If your PR claims a performance effect, paste that table into the PR description so reviewers can reproduce it with the same two commands.
+
+Results are only comparable on the same machine in the same session: identical code routinely drifts a few percent between runs, so treat small deltas as noise. Vitest also runs the source through its own transform rather than the production build, which makes micro benchmark numbers useful for relative comparison but not as absolute production numbers.
+
+To write a micro benchmark, create a `*.bench.ts` file next to the code you are measuring:
+
+```ts
+import {bench} from 'vitest';
+import {subdividePolygon} from './subdivision.ts';
+
+bench('subdividePolygon', () => {
+    subdividePolygon(polygon, tileID, granularity, true);
+});
+```
+
+Keep setup work (building fixtures, parsing data) at module level so the measured call is the only thing inside `bench()`. See `src/geo/projection/covering_tiles.bench.ts` and `src/render/subdivision.bench.ts` for examples.
+
 ## Running Benchmarks
 
 Start the benchmark server with `npm run start-bench`.

--- a/test/build/sourcemaps.test.ts
+++ b/test/build/sourcemaps.test.ts
@@ -38,6 +38,7 @@ describe.each(distjs)('release file %s', (file) => {
         const j = await getSourceMapForFile(sourceFileURL);
         for (const f of j.sources) {
             expect(f).not.toMatch('[.]test[.]ts$');
+            expect(f).not.toMatch('[.]bench[.]ts$');
             expect(f).not.toMatch('^test');
         }
     });
@@ -63,7 +64,7 @@ describe('main sourcemap', () => {
         // *.mjs.map files should have these files
         const srcFiles = await glob('src/**/*.ts');
         const expectedEntriesInSourcemapJSON = srcFiles.filter(f => {
-            if (f.endsWith('.test.ts'))
+            if (f.endsWith('.test.ts') || f.endsWith('.bench.ts'))
                 return false;
             if (f.startsWith(path.join('src', 'style-spec')))
                 return false;

--- a/vitest.config.bench.ts
+++ b/vitest.config.bench.ts
@@ -1,0 +1,13 @@
+import {defineConfig, type ViteUserConfig} from 'vitest/config';
+
+const config: ViteUserConfig = defineConfig({
+    test: {
+        name: 'bench',
+        environment: 'node',
+        benchmark: {
+            include: ['src/**/*.bench.ts'],
+        },
+    }
+});
+
+export default config;


### PR DESCRIPTION
First PR from the #982 redesign, scoped to what came out of the discussion there: the micro benchmark lane and the documentation.

`npm run bench` runs `src/**/*.bench.ts` under Vitest bench mode in plain node. I ported the coveringTiles benchmarks (mercator and globe, level and pitched) and subdividePolygon as working examples; they sit next to the code they measure. The originals stay in test/bench; nothing is deleted in this PR.

Before/after comparison uses Vitest's own JSON workflow: record a baseline with `npm run bench -- --outputJson bench-baseline.json`, then diff a branch against it with `npm run bench -- --compare bench-baseline.json`. The compare run annotates each result with its ratio against the baseline. On my machine, identical code drifts a few percent between runs, so the README says to treat small deltas as noise; it also notes that Vitest measures transformed source rather than the production build, so these numbers are for relative comparison only.

Docs, per the thread: test/bench/README.md now opens with the two-lane split and documents the micro workflow end to end; CONTRIBUTING.md and test/README.md point at it.

Sample run:

```
 ✓ |bench| src/geo/projection/covering_tiles.bench.ts > coveringTiles
     name                   hz      min      max     mean      p75      rme  samples
   · mercator           141.23   6.7511   7.5840   7.0808   7.1836   ±0.71%       71
   · mercator pitched  81.0145  12.0173  12.8577  12.3435  12.4609   ±0.51%       41
   · globe             45.2266  20.8734  23.1852  22.1109  22.7311   ±1.32%       23
   · globe pitched     31.0235  31.4068  33.5770  32.2336  32.6065   ±0.97%       16

 ✓ |bench| src/render/subdivision.bench.ts
   · subdividePolygon  14.4470  67.6381  71.6772  69.2183  70.1525   ±1.33%       10
```

- [x] No backports from Mapbox projects
- [x] Related: #982
- [x] Benchmark scores: sample run above
- [x] No CHANGELOG entry, per the CONTRIBUTING rule that benchmark changes don't get one
