### PR TITLE
Enable camera-position-only tile level of detail (#8057)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Support `global-state` expressions in `sky.*`, `light.*` and `projection.type` properties ([#7966](https://github.com/maplibre/maplibre-gl-js/pull/7966), [#7967](https://github.com/maplibre/maplibre-gl-js/pull/7967), [#7968](https://github.com/maplibre/maplibre-gl-js/pull/7968)) (by [@CommanderStorm](https://github.com/CommanderStorm))
 - Add `MapOptions.rotateSpeed` and `MapOptions.pitchSpeed`, the degrees the bearing/pitch change per pixel dragged ([#7949](https://github.com/maplibre/maplibre-gl-js/pull/7949)) (by [@clement-igonet](https://github.com/clement-igonet))
 - Show a grab cursor over draggable markers, including on non-interactive maps ([#8019](https://github.com/maplibre/maplibre-gl-js/issues/8019)) (by [@hugosmoreira](https://github.com/hugosmoreira))
+- Pass the camera altitude to `calculateTileZoom` and add `Source.alwaysCalculateTileZoom` to run a custom function at any pitch, enabling camera-position-only tile level of detail for first-person views ([#8057](https://github.com/maplibre/maplibre-gl-js/issues/8057)) (by [@clement-igonet](https://github.com/clement-igonet))
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes

--- a/developer-guides/covering-tiles.md
+++ b/developer-guides/covering-tiles.md
@@ -103,3 +103,18 @@ The term $\int_{\theta_1}^{\theta2} \cos^{p}\theta d\theta$ appears twice in the
 $$\int_{\theta_1}^{\theta2} \cos^{p}\theta d\theta = - \frac{\sin\theta_2}{|\sin\theta_2|}\frac{\cos^{p+1}\theta_2}{p+1} {}_2F_1(\frac{1}{2}, \frac{p+1}{2},\frac{p+3}{2}, \cos^2\theta_2) + \frac{\sin\theta_1}{|\sin\theta_1|}\frac{\cos^{p+1}\theta_1}{p+1} {}_2F_1(\frac{1}{2}, \frac{p+1}{2},\frac{p+3}{2}, \cos^2\theta_1)$$
 
 where ${}_2F_1()$ is the hypergeometric function.
+## Camera-position-only level of detail
+
+The default per-tile zoom is relative to the camera-to-center distance, so it changes when the view direction changes. For first-person views where the camera stands still and looks around, a custom `calculateTileZoom` can instead derive the zoom from the camera-to-tile distance alone, using the `cameraAltitudeZ` argument as the orientation-invariant vertical reference:
+
+```js
+map.getSource('mySource').calculateTileZoom =
+    (requestedCenterZoom, distanceToTile2D, distanceToTileZ, distanceToCenter3D, fov, cameraAltitudeZ) => {
+        const distanceToTile3D = Math.hypot(distanceToTile2D, cameraAltitudeZ);
+        const grazing = Math.atan(distanceToTile2D / cameraAltitudeZ);
+        return C - Math.log2(distanceToTile3D) + K * Math.log2(Math.cos(grazing)) / 2;
+    };
+map.getSource('mySource').alwaysCalculateTileZoom = true;
+```
+
+With this, the tile organization depends only on the camera position: looking around never changes it, and the same position always reproduces the same tiles. `C` calibrates the zoom at the nadir (for the default field of view, `C = log2(1.5 * viewportHeightPx / 512)`), and `K` (around 1) recovers the default's coarsening of tiles seen at grazing angles, whose angle for ground tiles depends only on camera height and distance. `alwaysCalculateTileZoom` keeps the function in charge below the pitch threshold that normally disables variable zoom.

--- a/src/geo/projection/covering_tiles.test.ts
+++ b/src/geo/projection/covering_tiles.test.ts
@@ -831,3 +831,50 @@ describe('coveringZoomLevel', () => {
         expect(coveringZoomLevel(transform, options)).toBe(13);
     });
 });
+describe('position-only LOD inputs (#8057)', () => {
+    const makeTransform = (pitch: number, bearing = 0) => {
+        const transform = new MercatorTransform(0, 22, 0, 85, true);
+        transform.setMaxPitch(85);
+        transform.resize(800, 600);
+        transform.setCenter(new LngLat(11.39, 47.27));
+        transform.setZoom(15);
+        transform.setPitch(pitch);
+        transform.setBearing(bearing);
+        return transform;
+    };
+
+    test('calculateTileZoom receives the camera altitude, independent of bearing', () => {
+        const altitudes = new Set<number>();
+        const spy = (requestedCenterZoom: number, d2d: number, dz: number, dc3d: number, fov: number, cameraAltitudeZ?: number) => {
+            altitudes.add(cameraAltitudeZ);
+            return requestedCenterZoom;
+        };
+        for (const bearing of [0, 90, 210]) {
+            coveringTiles(makeTransform(70, bearing), {tileSize: 512, calculateTileZoom: spy});
+        }
+        expect(altitudes.size).toBe(1);
+        const altitude = altitudes.values().next().value;
+        expect(altitude).toBeGreaterThan(0);
+        expect(altitude).toBeLessThan(1);
+    });
+
+    test('custom calculateTileZoom is skipped at low pitch by default', () => {
+        let calls = 0;
+        const spy = (requestedCenterZoom: number) => { calls++; return requestedCenterZoom; };
+        coveringTiles(makeTransform(20), {tileSize: 512, calculateTileZoom: spy});
+        expect(calls).toBe(0);
+    });
+
+    test('alwaysCalculateTileZoom runs the custom function at any pitch', () => {
+        let calls = 0;
+        const spy = (requestedCenterZoom: number) => { calls++; return requestedCenterZoom; };
+        coveringTiles(makeTransform(20), {tileSize: 512, calculateTileZoom: spy, alwaysCalculateTileZoom: true});
+        expect(calls).toBeGreaterThan(0);
+    });
+
+    test('alwaysCalculateTileZoom without a custom function keeps the default gate', () => {
+        const withFlag = coveringTiles(makeTransform(20), {tileSize: 512, alwaysCalculateTileZoom: true});
+        const without = coveringTiles(makeTransform(20), {tileSize: 512});
+        expect(withFlag).toEqual(without);
+    });
+});

--- a/src/geo/projection/covering_tiles.ts
+++ b/src/geo/projection/covering_tiles.ts
@@ -58,6 +58,13 @@ export type CoveringTilesOptionsInternal = CoveringTilesOptions & {
      * Optional function to redefine how tiles are loaded at high pitch angles.
      */
     calculateTileZoom?: CalculateTileZoomFunction;
+    /**
+     * When true, `calculateTileZoom` runs for every view instead of only when
+     * variable zoom is active (terrain, or pitch above roughly 60 degrees).
+     * Lets a custom function own the level-of-detail decision at any pitch,
+     * for example a position-only LOD for first-person views (#8057).
+     */
+    alwaysCalculateTileZoom?: boolean;
 };
 
 /**
@@ -67,13 +74,17 @@ export type CoveringTilesOptionsInternal = CoveringTilesOptions & {
  * @param distanceToTileZ - vertical distance from the camera to the candidate tile, in mercator units.
  * @param distanceToCenter3D - distance from camera to center point, in mercator units
  * @param cameraVerticalFOV - camera vertical field of view, in degrees
+ * @param cameraAltitudeZ - vertical distance from the camera to the ground plane, in mercator
+ * units. Unlike `distanceToTileZ`, this does not depend on the view center, so it is the vertical
+ * reference for camera-position-only level of detail (#8057).
  * @return the desired zoom level for this tile. May not be an integer.
  */
 export type CalculateTileZoomFunction = (requestedCenterZoom: number,
     distanceToTile2D: number,
     distanceToTileZ: number,
     distanceToCenter3D: number,
-    cameraVerticalFOV: number) => number;
+    cameraVerticalFOV: number,
+    cameraAltitudeZ?: number) => number;
 
 /**
  * A simple/heuristic function that returns whether the tile is visible under the current transform.
@@ -222,7 +233,8 @@ export function coveringTiles(transform: IReadonlyTransform, options: CoveringTi
     cameraCoord.z = centerCoord.z + Math.cos(transform.pitchInRadians) * transform.cameraToCenterDistance / transform.worldSize;
     const elevationForTileCulling = getElevationForTileCulling(transform);
     const detailsProvider = transform.getCoveringTilesDetailsProvider();
-    const allowVariableZoom = detailsProvider.allowVariableZoom(transform, options);
+    const allowVariableZoom = detailsProvider.allowVariableZoom(transform, options) ||
+        (options.alwaysCalculateTileZoom === true && options.calculateTileZoom !== undefined);
     
     const desiredZ = coveringZoomLevel(transform, options);
     const minZoom = options.minzoom || 0;
@@ -287,7 +299,8 @@ export function coveringTiles(transform: IReadonlyTransform, options: CoveringTi
                 distToTile2d,
                 distanceZ,
                 distanceToCenter3d,
-                transform.fov);
+                transform.fov,
+                cameraCoord.z);
         }
         thisTileDesiredZ = (options.roundZoom ? Math.round : Math.floor)(thisTileDesiredZ);
         thisTileDesiredZ = Math.max(0, thisTileDesiredZ);

--- a/src/source/source.ts
+++ b/src/source/source.ts
@@ -123,6 +123,11 @@ export interface Source {
      */
     calculateTileZoom?: CalculateTileZoomFunction;
     /**
+     * When true, `calculateTileZoom` runs for every view instead of only when
+     * variable zoom is active (terrain, or pitch above roughly 60 degrees).
+     */
+    alwaysCalculateTileZoom?: boolean;
+    /**
      * Optional function to determine whether a tile should be reloaded, given a
      * set of options associated with a `MapSourceDataChangedEvent`.
      * @internal

--- a/src/tile/tile_manager.ts
+++ b/src/tile/tile_manager.ts
@@ -520,6 +520,7 @@ export class TileManager extends Evented {
                 reparseOverscaled: this._source.reparseOverscaled,
                 terrain,
                 calculateTileZoom: this._source.calculateTileZoom,
+                alwaysCalculateTileZoom: this._source.alwaysCalculateTileZoom,
             });
 
             if (this._source.hasTile) { // tile should be in bounds


### PR DESCRIPTION
Implements the two additions requested in #8057, both additive and default-off:

- `calculateTileZoom` receives the camera altitude as a new last argument, an orientation-invariant vertical reference (the existing `distanceToTileZ` is relative to the view center, which moves with the look direction).
- `Source.alwaysCalculateTileZoom` runs a custom `calculateTileZoom` at any pitch instead of only above the variable-zoom threshold.

Together they make a camera-position-only LOD implementable in userland: the tile organization stays fixed while a first-person camera looks around, and the same camera position always reproduces the same tiles. Live comparison (right side): https://maplibre.confinia.io/debug/position-only-lod-8057.html

A new section in `developer-guides/covering-tiles.md` documents the pattern.

## Launch Checklist

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues: #8057
 - [x] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality.
 - [x] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [x] Add an entry to `CHANGELOG.md` under the `## main` section.
 - [x] Confirm you have read our AI policy [here](https://github.com/maplibre/maplibre/blob/main/AI_POLICY.md).

Assisted-By: Claude (claude-fable-5)
