### PR TITLE
CONTRIBUTING.md: Fix links to README-docs.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -140,7 +140,7 @@ cd maplibre-gl-js &&
 npm install
 ```
 
-Before you can [run the docs](./docs/README.md), you need to ensure Docker is installed and you have permission to run `docker` commands without `sudo`, as explained [here in the Docker docs](https://docs.docker.com/engine/install/linux-postinstall/).
+Before you can [run the docs](./developer-guides/README-docs.md), you need to ensure Docker is installed and you have permission to run `docker` commands without `sudo`, as explained [here in the Docker docs](https://docs.docker.com/engine/install/linux-postinstall/).
 
 
 ### Windows
@@ -184,7 +184,7 @@ npm run bundle-stats
 
 ## Testing changes and Writing Documentation
 
-See [`docs/README.md`](./docs/README.md)
+See [`developer-guides/README-docs.md`](./developer-guides/README-docs.md)
 
 ## Writing & Running Tests
 


### PR DESCRIPTION
docs/README.md was moved in https://github.com/maplibre/maplibre-gl-js/pull/7628, but the links in CONTRIBUTING.md were not updated.