### PR TITLE
docs: add nested GeoJSON properties to v5-to-v6 migration guide

### DIFF
--- a/docs/guides/v5-to-v6-migration-guide.md
+++ b/docs/guides/v5-to-v6-migration-guide.md
@@ -63,6 +63,15 @@ We tested it, and it looks like it fixes a lot of issue in labeling etc.
 It does changes rendering and the results of queryRenderedFeatures.
 If you would like to revert to the previous behavior you can set `zoomLevelsToOverscale: undefined` when initializing the map.
 
+## Nested GeoJSON properties
+
+Nested objects and arrays in GeoJSON feature properties are now preserved: features returned from events and `queryRenderedFeatures` contain them as real objects instead of JSON strings. If you called `JSON.parse` on such properties, remove it — it now throws `SyntaxError: "[object Object]" is not valid JSON`.
+
+```diff
+-const info = JSON.parse(e.features[0].properties.info);
++const info = e.features[0].properties.info;
+```
+
 ## pragma mapbox
 
 In case you were using `#pragma mapbox` in your shared code please replace it with `#pragma maplibre`.


### PR DESCRIPTION
Adds a short migration-guide entry for the nested GeoJSON properties change (#6992): feature properties from events / `queryRenderedFeatures` are now real objects, so existing `JSON.parse` calls on them throw `SyntaxError: "[object Object]" is not valid JSON` and should be removed.

Docs-only change.