### PR TITLE
chore: enable @vitest/eslint-plugin rules and fix what they found

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -137,6 +137,68 @@ export default [
         },
     },
     {
+        files: ['src/**/*.test.ts', 'test/**/*.test.{ts,js}'],
+        plugins: {
+            vitest
+        },
+        rules: {
+            ...vitest.configs.recommended.rules,
+
+            'vitest/expect-expect': ['error', {
+                assertFunctionNames: ['expect', 'expect.*', 'expect*', 'equalWithPrecision'],
+            }],
+            // unbound-method: tests stash method references to restore them afterwards
+            'vitest/unbound-method': 'off',
+            // prefer-spy-on: stubs are built as `{} as T`, and vi.spyOn needs an existing property
+            'vitest/prefer-spy-on': 'off',
+            // prefer-called-once is the exact inverse of prefer-called-times
+            'vitest/prefer-called-once': 'off',
+
+            // vitest supports expect(actual, message), unlike jest
+            'vitest/valid-expect': ['error', {maxArgs: 2}],
+            'vitest/valid-title': ['error', {allowArguments: true}],
+
+            'vitest/no-duplicate-hooks': 'error',
+            'vitest/no-test-return-statement': 'error',
+            'vitest/prefer-hooks-in-order': 'error',
+            'vitest/prefer-hooks-on-top': 'error',
+            'vitest/require-awaited-expect-poll': 'error',
+
+            'vitest/consistent-test-it': ['error', {fn: 'test', withinDescribe: 'test'}],
+            'vitest/consistent-vitest-vi': ['error', {fn: 'vi'}],
+            'vitest/prefer-importing-vitest-globals': 'error',
+            'vitest/no-alias-methods': 'error',
+            'vitest/no-test-prefixes': 'error',
+            'vitest/prefer-todo': 'error',
+
+            'vitest/prefer-to-be': 'error',
+            'vitest/prefer-to-be-object': 'error',
+            'vitest/prefer-to-contain': 'error',
+            'vitest/prefer-to-have-length': 'error',
+            'vitest/prefer-comparison-matcher': 'error',
+            'vitest/prefer-equality-matcher': 'error',
+            'vitest/prefer-expect-resolves': 'error',
+            'vitest/prefer-expect-type-of': 'error',
+
+            'vitest/prefer-called-times': 'error',
+            'vitest/prefer-to-have-been-called-times': 'error',
+            'vitest/prefer-mock-promise-shorthand': 'error',
+            'vitest/prefer-mock-return-shorthand': 'error',
+            'vitest/prefer-vi-mocked': 'error',
+            'vitest/prefer-import-in-mock': 'error',
+        },
+    },
+    {
+        // render and query tests derive their titles from the fixture files
+        files: ['test/integration/render/render.test.ts', 'test/integration/query/query.test.ts'],
+        plugins: {
+            vitest
+        },
+        rules: {
+            'vitest/valid-title': 'off'
+        },
+    },
+    {
         files: ['**/*.html'],
         plugins: {
             html

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -159,6 +159,7 @@ export default [
             'vitest/valid-title': ['error', {allowArguments: true}],
 
             'vitest/no-duplicate-hooks': 'error',
+            'vitest/require-to-throw-message': 'error',
             'vitest/no-test-return-statement': 'error',
             'vitest/prefer-hooks-in-order': 'error',
             'vitest/prefer-hooks-on-top': 'error',

--- a/src/data/dem_data.test.ts
+++ b/src/data/dem_data.test.ts
@@ -53,7 +53,7 @@ describe('DEMData', () => {
     });
 });
 
-function testDEMBorderRegion(dem: DEMData) {
+function expectDEMBorderRegion(dem: DEMData) {
     return () => {
         let nonempty = true;
         for (let x = -1; x < 5; x++) {
@@ -96,7 +96,7 @@ function testDEMBorderRegion(dem: DEMData) {
     };
 }
 
-function testDEMBackfill(dem0: DEMData, dem1: DEMData) {
+function expectDEMBackfill(dem0: DEMData, dem1: DEMData) {
     return  () => {
         dem0.backfillBorder(dem1, -1, 0);
         for (let y = 0; y < 4; y++) {
@@ -138,16 +138,16 @@ describe('DEMData.backfillBorder with encoding', () => {
         const dem0 = new DEMData('0', createMockImage(4, 4), 'mapbox');
         const dem1 = new DEMData('1', createMockImage(4, 4), 'mapbox');
 
-        test('border region is initially populated with neighboring data', testDEMBorderRegion(dem0));
-        test('backfillBorder correctly populates borders with neighboring data', testDEMBackfill(dem0, dem1));
+        test('border region is initially populated with neighboring data', expectDEMBorderRegion(dem0));
+        test('backfillBorder correctly populates borders with neighboring data', expectDEMBackfill(dem0, dem1));
     });
 
     describe('terrarium encoding', () => {
         const dem0 = new DEMData('0', createMockImage(4, 4), 'terrarium');
         const dem1 = new DEMData('1', createMockImage(4, 4), 'terrarium');
 
-        test('border region is initially populated with neighboring data', testDEMBorderRegion(dem0));
-        test('backfillBorder correctly populates borders with neighboring data', testDEMBackfill(dem0, dem1));
+        test('border region is initially populated with neighboring data', expectDEMBorderRegion(dem0));
+        test('backfillBorder correctly populates borders with neighboring data', expectDEMBackfill(dem0, dem1));
     });
 });
 
@@ -175,7 +175,7 @@ describe('DEMData.sampleBilinear', () => {
     });
 });
 
-function testSerialization(dem0: DEMData, redFactor: number, greenFactor: number, blueFactor: number, baseShift: number) {
+function expectSerialization(dem0: DEMData, redFactor: number, greenFactor: number, blueFactor: number, baseShift: number) {
     return () => {
         const serialized = serialize(dem0);
 
@@ -210,7 +210,7 @@ function testSerialization(dem0: DEMData, redFactor: number, greenFactor: number
     };
 }
 
-function testDeserialization(dem0: DEMData) {
+function expectDeserialization(dem0: DEMData) {
     return () => {
         const serialized = serialize(dem0);
 
@@ -223,13 +223,13 @@ describe('DEMData is correctly serialized and deserialized', () => {
     const mapboxDEM = new DEMData('0', createMockImage(4, 4), 'mapbox');
     const terrariumDEM = new DEMData('0', createMockImage(4, 4), 'terrarium');
     const customDEM = new DEMData('0', createMockImage(4, 4), 'custom', 1.0, 2.0, 3.0, 4.0);
-    test('serialized - mapbox', testSerialization(mapboxDEM, 6553.6, 25.6, 0.1, 10000));
-    test('serialized - terrarium', testSerialization(terrariumDEM, 256.0, 1.0, 1.0 / 256.0, 32768.0));
-    test('serialized - custom', testSerialization(customDEM, 1.0, 2.0, 3.0, 4.0));
+    test('serialized - mapbox', expectSerialization(mapboxDEM, 6553.6, 25.6, 0.1, 10000));
+    test('serialized - terrarium', expectSerialization(terrariumDEM, 256.0, 1.0, 1.0 / 256.0, 32768.0));
+    test('serialized - custom', expectSerialization(customDEM, 1.0, 2.0, 3.0, 4.0));
 
-    test('deserialized - mapbox', testDeserialization(mapboxDEM));
-    test('deserialized - terrarium', testDeserialization(terrariumDEM));
-    test('deserialized - custom', testDeserialization(customDEM));
+    test('deserialized - mapbox', expectDeserialization(mapboxDEM));
+    test('deserialized - terrarium', expectDeserialization(terrariumDEM));
+    test('deserialized - custom', expectDeserialization(customDEM));
 });
 
 describe('UnpackVector is correctly returned', () => {
@@ -244,7 +244,7 @@ describe('UnpackVector is correctly returned', () => {
     });
 });
 
-function testGetPixels(dem: DEMData, imageData: RGBAImage) {
+function expectGetPixels(dem: DEMData, imageData: RGBAImage) {
     return () => {
         expect(dem.getPixels()).toEqual(imageData);
     };
@@ -256,9 +256,9 @@ describe('DEMData.getImage', () => {
     const terrariumDEM = new DEMData('0', imageData, 'terrarium');
     const customDEM = new DEMData('0', imageData, 'terrarium');
 
-    test('Image is correctly returned - mapbox', testGetPixels(mapboxDEM, imageData));
-    test('Image is correctly returned - terrarium', testGetPixels(terrariumDEM, imageData));
-    test('Image is correctly returned - custom', testGetPixels(customDEM, imageData));
+    test('Image is correctly returned - mapbox', expectGetPixels(mapboxDEM, imageData));
+    test('Image is correctly returned - terrarium', expectGetPixels(terrariumDEM, imageData));
+    test('Image is correctly returned - custom', expectGetPixels(customDEM, imageData));
 });
 
 describe('DEMData pack and unpack', () => {
@@ -268,7 +268,7 @@ describe('DEMData pack and unpack', () => {
         expect(dem.unpack(123, 177, 215)).toEqual(800645.5);
         expect(dem.pack(800645.5)).toEqual({r: 123, g: 177, b: 215});
 
-        expect(dem.unpack(0, 0, 0)).toEqual(-10000);
+        expect(dem.unpack(0, 0, 0)).toBe(-10000);
         expect(dem.pack(-10000)).toEqual({r: 0, g: 0, b: 0});
 
         expect(dem.unpack(1, 1, 1)).toBeCloseTo(-3420.7);
@@ -283,13 +283,13 @@ describe('DEMData pack and unpack', () => {
     
     test('terrarium', () => {
         const dem = new DEMData('0', imageData, 'terrarium');
-        expect(dem.unpack(123, 177, 215)).toEqual(-1102.16015625);
+        expect(dem.unpack(123, 177, 215)).toBe(-1102.16015625);
         expect(dem.pack(-1102.16015625)).toEqual({r: 123, g: 177, b: 215});
 
-        expect(dem.unpack(0, 0, 0)).toEqual(-32768);
+        expect(dem.unpack(0, 0, 0)).toBe(-32768);
         expect(dem.pack(-32768)).toEqual({r: 0, g: 0, b: 0});
 
-        expect(dem.unpack(1, 1, 1)).toEqual(-32510.99609375);
+        expect(dem.unpack(1, 1, 1)).toBe(-32510.99609375);
         expect(dem.pack(-32510.99609375)).toEqual({r: 1, g: 1, b: 1});
 
         expect(dem.unpack(255, 255, 255)).toEqual(32767.99609375);
@@ -304,7 +304,7 @@ describe('DEMData pack and unpack', () => {
         expect(dem.unpack(123, 177, 215)).toEqual(3526918.75);
         expect(dem.pack(3526918.75)).toEqual({r: 123, g: 177, b: 215});
 
-        expect(dem.unpack(0, 0, 0)).toEqual(-7000);
+        expect(dem.unpack(0, 0, 0)).toBe(-7000);
         expect(dem.pack(-7000)).toEqual({r: 0, g: 0, b: 0});
 
         expect(dem.unpack(1, 1, 1)).toEqual(9448.25);

--- a/src/data/feature_position_map.test.ts
+++ b/src/data/feature_position_map.test.ts
@@ -29,6 +29,6 @@ describe('FeaturePositionMap', () => {
 
         expect(() => {
             featureMap.getPositions(0);
-        }).toThrow();
+        }).toThrow('Trying to get index, but feature positions are not indexed');
     });
 });

--- a/src/data/segment.test.ts
+++ b/src/data/segment.test.ts
@@ -34,7 +34,7 @@ describe('SegmentVector', () => {
         const second = mockUseSegment(segmentVector, vertexBuffer, indexBuffer, 10);
         expect(first).toBeTruthy();
         expect(second).toBeTruthy();
-        expect(first === second).toBe(false);
+        expect(first).not.toBe(second);
         expect(first.vertexLength).toBe(10);
         expect(second.vertexLength).toBe(10);
         expect(segmentVector.segments).toHaveLength(2);
@@ -49,7 +49,7 @@ describe('SegmentVector', () => {
         const second = mockUseSegment(segmentVector, vertexBuffer, indexBuffer, 5);
         expect(first).toBeTruthy();
         expect(second).toBeTruthy();
-        expect(first === second).toBe(true);
+        expect(first).toBe(second);
         expect(first.vertexLength).toBe(10);
     });
 
@@ -66,8 +66,8 @@ describe('SegmentVector', () => {
         expect(first).toBeTruthy();
         expect(second).toBeTruthy();
         expect(third).toBeTruthy();
-        expect(first === second).toBe(false);
-        expect(second === third).toBe(true);
+        expect(first).not.toBe(second);
+        expect(second).toBe(third);
         expect(first.vertexLength).toBe(5);
         expect(third.vertexLength).toBe(10);
     });
@@ -86,8 +86,8 @@ describe('SegmentVector', () => {
         expect(first).toBeTruthy();
         expect(second).toBeTruthy();
         expect(third).toBeTruthy();
-        expect(first === second).toBe(false);
-        expect(second === third).toBe(true);
+        expect(first).not.toBe(second);
+        expect(second).toBe(third);
         expect(first.vertexLength).toBe(5);
         expect(third.vertexLength).toBe(10);
     });
@@ -115,8 +115,8 @@ describe('SegmentVector', () => {
         expect(first).toBeTruthy();
         expect(second).toBeTruthy();
         expect(third).toBeTruthy();
-        expect(first === second).toBe(true);
-        expect(second === third).toBe(true);
+        expect(first).toBe(second);
+        expect(second).toBe(third);
         expect(first.vertexLength).toBe(15);
     });
 
@@ -134,8 +134,8 @@ describe('SegmentVector', () => {
         expect(first).toBeTruthy();
         expect(second).toBeTruthy();
         expect(third).toBeTruthy();
-        expect(first === second).toBe(false);
-        expect(second === third).toBe(true);
+        expect(first).not.toBe(second);
+        expect(second).toBe(third);
         expect(first.vertexLength).toBe(5);
         expect(third.vertexLength).toBe(10);
     });
@@ -152,8 +152,8 @@ describe('SegmentVector', () => {
         expect(first).toBeTruthy();
         expect(second).toBeTruthy();
         expect(third).toBeTruthy();
-        expect(first === second).toBe(false);
-        expect(second === third).toBe(true);
+        expect(first).not.toBe(second);
+        expect(second).toBe(third);
         expect(first.vertexLength).toBe(5);
         expect(second.vertexLength).toBe(10);
         expect(segmentVector.segments).toHaveLength(2);
@@ -170,7 +170,7 @@ describe('SegmentVector', () => {
         const second = mockUseSegment(segmentVector, vertexBuffer, indexBuffer, 5);
         expect(first).toBeTruthy();
         expect(second).toBeTruthy();
-        expect(first === second).toBe(false);
+        expect(first).not.toBe(second);
         expect(first.vertexLength).toBe(5);
         expect(second.vertexLength).toBe(5);
         expect(segmentVector.segments).toHaveLength(2);
@@ -197,7 +197,7 @@ describe('SegmentVector', () => {
         const second = mockUseSegment(segmentVector, vertexBuffer, indexBuffer, 5, 2);
         expect(first).toBeTruthy();
         expect(second).toBeTruthy();
-        expect(first === second).toBe(false);
+        expect(first).not.toBe(second);
         expect(first.vertexLength).toBe(5);
         expect(second.vertexLength).toBe(5);
         expect(segmentVector.segments).toHaveLength(2);

--- a/src/geo/bounds.test.ts
+++ b/src/geo/bounds.test.ts
@@ -21,8 +21,8 @@ describe('Bounds', () => {
         const bounds = new Bounds();
         bounds.extend(new Point(1, 2));
         expect(bounds.empty()).toBeFalsy();
-        expect(bounds.height()).toEqual(0);
-        expect(bounds.width()).toEqual(0);
+        expect(bounds.height()).toBe(0);
+        expect(bounds.width()).toBe(0);
 
         expect(bounds.contains(new Point(1, 2))).toBeTruthy();
         expect(bounds.contains(new Point(2, 2))).toBeFalsy();
@@ -36,8 +36,8 @@ describe('Bounds', () => {
         bounds.extend(new Point(1, 2));
         bounds.extend(new Point(3, 5));
         expect(bounds.empty()).toBeFalsy();
-        expect(bounds.width()).toEqual(2);
-        expect(bounds.height()).toEqual(3);
+        expect(bounds.width()).toBe(2);
+        expect(bounds.height()).toBe(3);
 
         expect(bounds.contains(new Point(1, 2))).toBeTruthy();
         expect(bounds.contains(new Point(3, 2))).toBeTruthy();

--- a/src/geo/lng_lat_bounds.test.ts
+++ b/src/geo/lng_lat_bounds.test.ts
@@ -41,7 +41,7 @@ describe('LngLatBounds', () => {
         const t1 = () => {
             bounds.getCenter();
         };
-        expect(t1).toThrow();
+        expect(t1).toThrow(TypeError);
     });
 
     test('extend with coordinate', () => {

--- a/src/geo/projection/mercator_transform.test.ts
+++ b/src/geo/projection/mercator_transform.test.ts
@@ -110,7 +110,7 @@ describe('transform', () => {
         expect(transform.tileZoom).toBe(5);
     });
 
-    test('set zoom clamps tileZoom to non negative value ', () => {
+    test('set zoom clamps tileZoom to non negative value', () => {
         const transform = new MercatorTransform({minZoom: -2, maxZoom: 22, minPitch: 0, maxPitch: 60});
         transform.setZoom(-2);
         expect(transform.tileZoom).toBe(0);

--- a/src/geo/projection/mercator_utils.test.ts
+++ b/src/geo/projection/mercator_utils.test.ts
@@ -58,25 +58,25 @@ describe('mercator utils', () => {
     describe('tileCoordinatesToMercatorCoordinates', () => {
         const precisionDigits = 10;
 
-        test('Test 0,0', () => {
+        test('0,0', () => {
             const result = tileCoordinatesToMercatorCoordinates(0, 0, new CanonicalTileID(0, 0, 0));
             expect(result.x).toBe(0);
             expect(result.y).toBe(0);
         });
 
-        test('Test tile center', () => {
+        test('tile center', () => {
             const result = tileCoordinatesToMercatorCoordinates(EXTENT / 2, EXTENT / 2, new CanonicalTileID(0, 0, 0));
             expect(result.x).toBeCloseTo(0.5, precisionDigits);
             expect(result.y).toBeCloseTo(0.5, precisionDigits);
         });
 
-        test('Test higher zoom 0,0', () => {
+        test('higher zoom 0,0', () => {
             const result = tileCoordinatesToMercatorCoordinates(0, 0, new CanonicalTileID(3, 0, 0));
             expect(result.x).toBe(0);
             expect(result.y).toBe(0);
         });
 
-        test('Test higher zoom tile center', () => {
+        test('higher zoom tile center', () => {
             const result = tileCoordinatesToMercatorCoordinates(EXTENT / 2, EXTENT / 2, new CanonicalTileID(3, 0, 0));
             expect(result.x).toBeCloseTo(1 / 16, precisionDigits);
             expect(result.y).toBeCloseTo(1 / 16, precisionDigits);
@@ -86,25 +86,25 @@ describe('mercator utils', () => {
     describe('tileCoordinatesToLocation', () => {
         const precisionDigits = 5;
 
-        test('Test 0,0', () => {
+        test('0,0', () => {
             const result = tileCoordinatesToLocation(0, 0, new CanonicalTileID(0, 0, 0));
             expect(result.lng).toBeCloseTo(-180, precisionDigits);
             expect(result.lat).toBeCloseTo(MAX_VALID_LATITUDE, precisionDigits);
         });
 
-        test('Test tile center', () => {
+        test('tile center', () => {
             const result = tileCoordinatesToLocation(EXTENT / 2, EXTENT / 2, new CanonicalTileID(0, 0, 0));
             expect(result.lng).toBeCloseTo(0, precisionDigits);
             expect(result.lat).toBeCloseTo(0, precisionDigits);
         });
 
-        test('Test higher zoom 0,0', () => {
+        test('higher zoom 0,0', () => {
             const result = tileCoordinatesToLocation(0, 0, new CanonicalTileID(3, 0, 0));
             expect(result.lng).toBeCloseTo(-180, precisionDigits);
             expect(result.lat).toBeCloseTo(MAX_VALID_LATITUDE, precisionDigits);
         });
 
-        test('Test higher zoom mercator center', () => {
+        test('higher zoom mercator center', () => {
             const result = tileCoordinatesToLocation(EXTENT, EXTENT, new CanonicalTileID(3, 3, 3));
             expect(result.lng).toBeCloseTo(0, precisionDigits);
             expect(result.lat).toBeCloseTo(0, precisionDigits);

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -3,7 +3,6 @@ import {config} from './util/config.ts';
 import {addProtocol, getWorkerCount, removeProtocol, getVersion} from './index.ts';
 import {getJSON, getArrayBuffer} from './util/ajax.ts';
 import {ImageRequest} from './util/image_request.ts';
-import {isAbortError} from './util/abort_error.ts';
 
 describe('maplibre', () => {
     beforeEach(() => {
@@ -37,7 +36,7 @@ describe('maplibre', () => {
     });
 
     test('addProtocol - getJSON', async () => {
-        const mockProtocol = vi.fn().mockReturnValue(Promise.resolve({data: {'foo': 'bar'}}));
+        const mockProtocol = vi.fn().mockResolvedValue({data: {'foo': 'bar'}});
         addProtocol('custom', mockProtocol);
 
         const response = await getJSON({url: 'custom://test/url/json'}, new AbortController());
@@ -46,7 +45,7 @@ describe('maplibre', () => {
     });
 
     test('addProtocol - getArrayBuffer', async () => {
-        const mockProtocol = vi.fn().mockReturnValue(Promise.resolve({data: new ArrayBuffer(1), cacheControl: 'cache-control', expires: 'expires'}));
+        const mockProtocol = vi.fn().mockResolvedValue({data: new ArrayBuffer(1), cacheControl: 'cache-control', expires: 'expires'});
         addProtocol('custom', mockProtocol);
 
         const response = await getArrayBuffer({url: 'custom://test/url/getArrayBuffer'}, new AbortController());
@@ -57,7 +56,7 @@ describe('maplibre', () => {
     });
 
     test('addProtocol - null response for getArrayBuffer results in empty array buffer', async () => {
-        const mockProtocol = vi.fn().mockReturnValue(Promise.resolve({data: null, cacheControl: 'cache-control', expires: 'expires'}));
+        const mockProtocol = vi.fn().mockResolvedValue({data: null, cacheControl: 'cache-control', expires: 'expires'});
         addProtocol('custom', mockProtocol);
 
         const response = await getArrayBuffer({url: 'custom://test/url/getArrayBuffer'}, new AbortController());
@@ -69,7 +68,7 @@ describe('maplibre', () => {
     });
 
     test('addProtocol - returning ImageBitmap for getImage', async () => {
-        const mockProtocol = vi.fn().mockReturnValue(Promise.resolve({data: new ImageBitmap()}));
+        const mockProtocol = vi.fn().mockResolvedValue({data: new ImageBitmap()});
         addProtocol('custom', mockProtocol);
 
         const img = await ImageRequest.getImage({url: 'custom://test/url/getImage'}, new AbortController());
@@ -78,7 +77,7 @@ describe('maplibre', () => {
     });
 
     test('addProtocol - returning HTMLImageElement for getImage', async () => {
-        const mockProtocol = vi.fn().mockReturnValue(Promise.resolve({data: new Image()}));
+        const mockProtocol = vi.fn().mockResolvedValue({data: new Image()});
         addProtocol('custom', mockProtocol);
 
         const img = await ImageRequest.getImage({url: 'custom://test/url/getImage'}, new AbortController());
@@ -88,7 +87,7 @@ describe('maplibre', () => {
 
     test('addProtocol - error', async () => {
         const mockError = new Error('test error');
-        const mockProtocol = vi.fn().mockReturnValue(Promise.reject(mockError));
+        const mockProtocol = vi.fn().mockRejectedValue(mockError);
         addProtocol('custom', mockProtocol);
 
         const successCallback = vi.fn();
@@ -110,11 +109,7 @@ describe('maplibre', () => {
         const abortController = new AbortController();
         const promise = getJSON({url: 'custom://test/url/json'}, abortController);
         abortController.abort();
-        try {
-            await promise;
-        } catch (err) {
-            expect(isAbortError(err)).toBeTruthy();
-        }
+        await promise;
 
         expect(cancelCalled).toBeTruthy();
     });

--- a/src/render/glyph_manager.test.ts
+++ b/src/render/glyph_manager.test.ts
@@ -208,9 +208,7 @@ describe('GlyphManager', () => {
     test('GlyphManager caches locally generated glyphs', async () => {
 
         const manager = createGlyphManager(true, 'sans-serif');
-        const drawSpy = GlyphManager.TinySDF.prototype.draw = vi.fn().mockImplementation(() => {
-            return {data: new Uint8ClampedArray(60 * 60)} as any;
-        });
+        const drawSpy = GlyphManager.TinySDF.prototype.draw = vi.fn().mockReturnValue({data: new Uint8ClampedArray(60 * 60)} as any);
 
         // Katakana letter te
         const returnedGlyphs = await manager.getGlyphs({'Arial Unicode MS': [0x30c6]});
@@ -220,22 +218,14 @@ describe('GlyphManager', () => {
     });
 
     test('GlyphManager passes no language to TinySDF by default', async () => {
-        const langSpy = GlyphManager.TinySDF = vi.fn().mockImplementation(function () {
-            return {
-                draw: () => GLYPHS[0]
-            };
-        });
+        const langSpy = GlyphManager.TinySDF = vi.fn().mockImplementation(class { draw = () => GLYPHS[0]; } as any);
         const manager = createGlyphManager(true, 'sans-serif');
         await manager.getGlyphs({'Arial Unicode MS': [0x30c6]});
         expect(langSpy).toHaveBeenCalledWith(expect.not.objectContaining({lang: expect.anything()}));
     });
 
     test('GlyphManager sets the language on TinySDF', async () => {
-        const langSpy = GlyphManager.TinySDF = vi.fn().mockImplementation(function () {
-            return {
-                draw: () => GLYPHS[0]
-            };
-        });
+        const langSpy = GlyphManager.TinySDF = vi.fn().mockImplementation(class { draw = () => GLYPHS[0]; } as any);
         const manager = createGlyphManager(true, 'sans-serif', 'zh');
         await manager.getGlyphs({'Arial Unicode MS': [0x30c6]});
         expect(langSpy).toHaveBeenCalledWith(expect.objectContaining({lang: 'zh'}));
@@ -244,9 +234,7 @@ describe('GlyphManager', () => {
     test('awaits document.fonts.load before instantiating TinySDF', async () => {
         const loadSpy = vi.fn(() => Promise.resolve([]));
         Object.defineProperty(document, 'fonts', {configurable: true, value: {load: loadSpy}});
-        const tinySdfSpy = GlyphManager.TinySDF = vi.fn().mockImplementation(function () {
-            return {draw: () => GLYPHS[0]};
-        });
+        const tinySdfSpy = GlyphManager.TinySDF = vi.fn().mockImplementation(class { draw = () => GLYPHS[0]; } as any);
 
         const manager = createGlyphManager(false, 'sans-serif');
         await manager.getGlyphs({'Arial Unicode MS': [0x41]});
@@ -260,9 +248,7 @@ describe('GlyphManager', () => {
         vi.spyOn(console, 'warn').mockImplementation(() => {});
         const loadSpy = vi.fn(() => Promise.reject(new Error('font not found')));
         Object.defineProperty(document, 'fonts', {configurable: true, value: {load: loadSpy}});
-        const tinySdfSpy = GlyphManager.TinySDF = vi.fn().mockImplementation(function () {
-            return {draw: () => GLYPHS[0]};
-        });
+        const tinySdfSpy = GlyphManager.TinySDF = vi.fn().mockImplementation(class { draw = () => GLYPHS[0]; } as any);
 
         const manager = createGlyphManager(false, 'sans-serif');
         const result = await manager.getGlyphs({'Arial Unicode MS': [0x41]});
@@ -275,9 +261,7 @@ describe('GlyphManager', () => {
     test('memoizes document.fonts.load per fontstack', async () => {
         const loadSpy = vi.fn(() => Promise.resolve([]));
         Object.defineProperty(document, 'fonts', {configurable: true, value: {load: loadSpy}});
-        GlyphManager.TinySDF = vi.fn().mockImplementation(function () {
-            return {draw: () => GLYPHS[0]};
-        });
+        GlyphManager.TinySDF = vi.fn().mockImplementation(class { draw = () => GLYPHS[0]; } as any);
 
         const manager = createGlyphManager(false, 'sans-serif');
         await manager.getGlyphs({'Arial Unicode MS': [0x41]});

--- a/src/render/glyph_manager.test.ts
+++ b/src/render/glyph_manager.test.ts
@@ -208,7 +208,7 @@ describe('GlyphManager', () => {
     test('GlyphManager caches locally generated glyphs', async () => {
 
         const manager = createGlyphManager(true, 'sans-serif');
-        const drawSpy = GlyphManager.TinySDF.prototype.draw = vi.fn().mockReturnValue({data: new Uint8ClampedArray(60 * 60)} as any);
+        const drawSpy = vi.spyOn(GlyphManager.TinySDF.prototype, 'draw').mockReturnValue({data: new Uint8ClampedArray(60 * 60)} as any);
 
         // Katakana letter te
         const returnedGlyphs = await manager.getGlyphs({'Arial Unicode MS': [0x30c6]});
@@ -218,14 +218,14 @@ describe('GlyphManager', () => {
     });
 
     test('GlyphManager passes no language to TinySDF by default', async () => {
-        const langSpy = GlyphManager.TinySDF = vi.fn().mockImplementation(class { draw = () => GLYPHS[0]; } as any);
+        const langSpy = vi.spyOn(GlyphManager, 'TinySDF').mockImplementation(class { draw = () => GLYPHS[0]; });
         const manager = createGlyphManager(true, 'sans-serif');
         await manager.getGlyphs({'Arial Unicode MS': [0x30c6]});
         expect(langSpy).toHaveBeenCalledWith(expect.not.objectContaining({lang: expect.anything()}));
     });
 
     test('GlyphManager sets the language on TinySDF', async () => {
-        const langSpy = GlyphManager.TinySDF = vi.fn().mockImplementation(class { draw = () => GLYPHS[0]; } as any);
+        const langSpy = vi.spyOn(GlyphManager, 'TinySDF').mockImplementation(class { draw = () => GLYPHS[0]; });
         const manager = createGlyphManager(true, 'sans-serif', 'zh');
         await manager.getGlyphs({'Arial Unicode MS': [0x30c6]});
         expect(langSpy).toHaveBeenCalledWith(expect.objectContaining({lang: 'zh'}));
@@ -234,7 +234,7 @@ describe('GlyphManager', () => {
     test('awaits document.fonts.load before instantiating TinySDF', async () => {
         const loadSpy = vi.fn(() => Promise.resolve([]));
         Object.defineProperty(document, 'fonts', {configurable: true, value: {load: loadSpy}});
-        const tinySdfSpy = GlyphManager.TinySDF = vi.fn().mockImplementation(class { draw = () => GLYPHS[0]; } as any);
+        const tinySdfSpy = vi.spyOn(GlyphManager, 'TinySDF').mockImplementation(class { draw = () => GLYPHS[0]; });
 
         const manager = createGlyphManager(false, 'sans-serif');
         await manager.getGlyphs({'Arial Unicode MS': [0x41]});
@@ -248,7 +248,7 @@ describe('GlyphManager', () => {
         vi.spyOn(console, 'warn').mockImplementation(() => {});
         const loadSpy = vi.fn(() => Promise.reject(new Error('font not found')));
         Object.defineProperty(document, 'fonts', {configurable: true, value: {load: loadSpy}});
-        const tinySdfSpy = GlyphManager.TinySDF = vi.fn().mockImplementation(class { draw = () => GLYPHS[0]; } as any);
+        const tinySdfSpy = vi.spyOn(GlyphManager, 'TinySDF').mockImplementation(class { draw = () => GLYPHS[0]; });
 
         const manager = createGlyphManager(false, 'sans-serif');
         const result = await manager.getGlyphs({'Arial Unicode MS': [0x41]});
@@ -261,7 +261,7 @@ describe('GlyphManager', () => {
     test('memoizes document.fonts.load per fontstack', async () => {
         const loadSpy = vi.fn(() => Promise.resolve([]));
         Object.defineProperty(document, 'fonts', {configurable: true, value: {load: loadSpy}});
-        GlyphManager.TinySDF = vi.fn().mockImplementation(class { draw = () => GLYPHS[0]; } as any);
+        vi.spyOn(GlyphManager, 'TinySDF').mockImplementation(class { draw = () => GLYPHS[0]; });
 
         const manager = createGlyphManager(false, 'sans-serif');
         await manager.getGlyphs({'Arial Unicode MS': [0x41]});

--- a/src/render/painter.test.ts
+++ b/src/render/painter.test.ts
@@ -46,6 +46,8 @@ describe('render', () => {
 
     test('must not fail with incompletely loaded style', () => {
         painter.render(style, renderOptions);
+
+        expect(painter.renderPass).toBe('translucent');
     });
 
     test('calls terrainDepth but not terrainCoords', () => {

--- a/src/render/subdivision.test.ts
+++ b/src/render/subdivision.test.ts
@@ -224,7 +224,7 @@ describe('Fill subdivision', () => {
                 3, 0
             ]
         ]);
-        checkWindingOrder(result.verticesFlattened, result.indicesTriangles);
+        expectWindingOrder(result.verticesFlattened, result.indicesTriangles);
     });
 
     test('Polygon is unchanged when granularity=1, but winding order is corrected.', () => {
@@ -259,7 +259,7 @@ describe('Fill subdivision', () => {
                 3, 0
             ]
         ]);
-        checkWindingOrder(result.verticesFlattened, result.indicesTriangles);
+        expectWindingOrder(result.verticesFlattened, result.indicesTriangles);
     });
 
     test('Polygon inside cell is unchanged', () => {
@@ -294,7 +294,7 @@ describe('Fill subdivision', () => {
                 3, 0
             ]
         ]);
-        checkWindingOrder(result.verticesFlattened, result.indicesTriangles);
+        expectWindingOrder(result.verticesFlattened, result.indicesTriangles);
     });
 
     test('Subdivide a polygon', () => {
@@ -404,7 +404,7 @@ describe('Fill subdivision', () => {
                 6,   3
             ]
         ]);
-        checkWindingOrder(result.verticesFlattened, result.indicesTriangles);
+        expectWindingOrder(result.verticesFlattened, result.indicesTriangles);
     });
 
     describe('Polygon outline line list is correct', () => {
@@ -419,7 +419,7 @@ describe('Fill subdivision', () => {
             expect(hasDuplicateVertices(result.verticesFlattened)).toBe(false);
             testMeshIntegrity(result.indicesTriangles);
             testPolygonOutlineMatches(result.indicesTriangles, result.indicesLineList);
-            checkWindingOrder(result.verticesFlattened, result.indicesTriangles);
+            expectWindingOrder(result.verticesFlattened, result.indicesTriangles);
         });
 
         test('Small polygon', () => {
@@ -433,7 +433,7 @@ describe('Fill subdivision', () => {
             expect(hasDuplicateVertices(result.verticesFlattened)).toBe(false);
             testMeshIntegrity(result.indicesTriangles);
             testPolygonOutlineMatches(result.indicesTriangles, result.indicesLineList);
-            checkWindingOrder(result.verticesFlattened, result.indicesTriangles);
+            expectWindingOrder(result.verticesFlattened, result.indicesTriangles);
         });
 
         test('Medium polygon', () => {
@@ -447,7 +447,7 @@ describe('Fill subdivision', () => {
             expect(hasDuplicateVertices(result.verticesFlattened)).toBe(false);
             testMeshIntegrity(result.indicesTriangles);
             testPolygonOutlineMatches(result.indicesTriangles, result.indicesLineList);
-            checkWindingOrder(result.verticesFlattened, result.indicesTriangles);
+            expectWindingOrder(result.verticesFlattened, result.indicesTriangles);
         });
 
         test('Large polygon', () => {
@@ -461,7 +461,7 @@ describe('Fill subdivision', () => {
             expect(hasDuplicateVertices(result.verticesFlattened)).toBe(false);
             testMeshIntegrity(result.indicesTriangles);
             testPolygonOutlineMatches(result.indicesTriangles, result.indicesLineList);
-            checkWindingOrder(result.verticesFlattened, result.indicesTriangles);
+            expectWindingOrder(result.verticesFlattened, result.indicesTriangles);
         });
 
         test('Large polygon with hole', () => {
@@ -480,7 +480,7 @@ describe('Fill subdivision', () => {
             expect(hasDuplicateVertices(result.verticesFlattened)).toBe(false);
             testMeshIntegrity(result.indicesTriangles);
             testPolygonOutlineMatches(result.indicesTriangles, result.indicesLineList);
-            checkWindingOrder(result.verticesFlattened, result.indicesTriangles);
+            expectWindingOrder(result.verticesFlattened, result.indicesTriangles);
         });
 
         test('Large polygon with hole, granularity=0', () => {
@@ -499,7 +499,7 @@ describe('Fill subdivision', () => {
             expect(hasDuplicateVertices(result.verticesFlattened)).toBe(false);
             testMeshIntegrity(result.indicesTriangles);
             testPolygonOutlineMatches(result.indicesTriangles, result.indicesLineList);
-            checkWindingOrder(result.verticesFlattened, result.indicesTriangles);
+            expectWindingOrder(result.verticesFlattened, result.indicesTriangles);
         });
 
         test('Large polygon with hole, finer granularity', () => {
@@ -517,7 +517,7 @@ describe('Fill subdivision', () => {
             ], canonicalDefault, EXTENT / 8);
 
             expect(hasDuplicateVertices(result.verticesFlattened)).toBe(false);
-            checkWindingOrder(result.verticesFlattened, result.indicesTriangles);
+            expectWindingOrder(result.verticesFlattened, result.indicesTriangles);
 
             // This polygon subdivision results in at least one edge that is shared among more than 2 triangles.
             // This is not ideal, but it is also an edge case of a weird triangle getting subdivided by a very fine grid.
@@ -586,7 +586,7 @@ describe('Fill subdivision', () => {
                     5, 3
                 ]
             ]);
-            checkWindingOrder(result.verticesFlattened, result.indicesTriangles);
+            expectWindingOrder(result.verticesFlattened, result.indicesTriangles);
         });
 
         test('Polygon with duplicate vertex with hole inside cell', () => {
@@ -640,7 +640,7 @@ describe('Fill subdivision', () => {
                     4, 0
                 ]
             ]);
-            checkWindingOrder(result.verticesFlattened, result.indicesTriangles);
+            expectWindingOrder(result.verticesFlattened, result.indicesTriangles);
         });
 
         test('Polygon with duplicate edge inside cell', () => {
@@ -700,7 +700,7 @@ describe('Fill subdivision', () => {
                     3, 0
                 ]
             ]);
-            checkWindingOrder(result.verticesFlattened, result.indicesTriangles);
+            expectWindingOrder(result.verticesFlattened, result.indicesTriangles);
         });
     });
 
@@ -777,7 +777,7 @@ describe('Fill subdivision', () => {
                 4, 0
             ]
         ]);
-        checkWindingOrder(result.verticesFlattened, result.indicesTriangles);
+        expectWindingOrder(result.verticesFlattened, result.indicesTriangles);
     });
 
     test('Generates pole geometry for north pole only (geometry not bordering other pole)', () => {
@@ -813,7 +813,7 @@ describe('Fill subdivision', () => {
                 2, 3, 3, 0
             ]
         ]);
-        checkWindingOrder(result.verticesFlattened, result.indicesTriangles);
+        expectWindingOrder(result.verticesFlattened, result.indicesTriangles);
     });
 
     test('Generates pole geometry for south pole only (geometry not bordering other pole)', () => {
@@ -849,7 +849,7 @@ describe('Fill subdivision', () => {
                 2, 3, 3, 0
             ]
         ]);
-        checkWindingOrder(result.verticesFlattened, result.indicesTriangles);
+        expectWindingOrder(result.verticesFlattened, result.indicesTriangles);
     });
 
     test('Generates pole geometry for north pole only (tile not bordering other pole)', () => {
@@ -885,7 +885,7 @@ describe('Fill subdivision', () => {
                 2, 3, 3, 0
             ]
         ]);
-        checkWindingOrder(result.verticesFlattened, result.indicesTriangles);
+        expectWindingOrder(result.verticesFlattened, result.indicesTriangles);
     });
 
     test('Generates pole geometry for south pole only (tile not bordering other pole)', () => {
@@ -921,7 +921,7 @@ describe('Fill subdivision', () => {
                 2, 3, 3, 0
             ]
         ]);
-        checkWindingOrder(result.verticesFlattened, result.indicesTriangles);
+        expectWindingOrder(result.verticesFlattened, result.indicesTriangles);
     });
 
     test('Scanline subdivision ring generation case 1', () => {
@@ -951,7 +951,7 @@ describe('Fill subdivision', () => {
         const ring = [0, 1, 2, 3, 4, 5, 6, 7];
         const finalIndices = [];
         scanlineTriangulateVertexRing(vertices, ring, finalIndices);
-        checkWindingOrder(vertices, finalIndices);
+        expectWindingOrder(vertices, finalIndices);
     });
 
     test('Scanline subdivision ring generation case 2', () => {
@@ -960,7 +960,7 @@ describe('Fill subdivision', () => {
         const ring = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
         const finalIndices = [];
         scanlineTriangulateVertexRing(vertices, ring, finalIndices);
-        checkWindingOrder(vertices, finalIndices);
+        expectWindingOrder(vertices, finalIndices);
     });
 });
 
@@ -1075,7 +1075,7 @@ function hasDuplicateVertices(flattened: number[]): boolean {
 /**
  * Passes if all triangles have the correct winding order, otherwise throws.
  */
-function checkWindingOrder(flattened: number[], indices: number[]): void {
+function expectWindingOrder(flattened: number[], indices: number[]): void {
     for (let i = 0; i < indices.length; i += 3) {
         const i0 = indices[i];
         const i1 = indices[i + 1];

--- a/src/render/terrain.test.ts
+++ b/src/render/terrain.test.ts
@@ -364,7 +364,7 @@ describe('Terrain', () => {
         const tileID = new OverscaledTileID(1, 0, 1, 0, 0);
         terrain.getDEMElevation(tileID, EXTENT + 100, 50);
 
-        expect(getSourceTile).toHaveBeenCalledOnce();
+        expect(getSourceTile).toHaveBeenCalledTimes(1);
         const [calledTileID] = getSourceTile.mock.calls[0];
         expect(calledTileID.canonical.x).toBe(1);
         expect(calledTileID.canonical.y).toBe(0);
@@ -395,11 +395,11 @@ describe('Terrain', () => {
             expect(terrain.getElevationForLngLatZoom(new LngLat(0, 88), 0)).toBe(0);
         });
 
-        test('zoom', () => {
+        test('zoom below the minimum', () => {
             expect(terrain.getElevationForLngLatZoom(new LngLat(0, 0), MIN_TILE_ZOOM - 1)).toBe(0);
         });
 
-        test('zoom', () => {
+        test('zoom above the maximum', () => {
             expect(terrain.getElevationForLngLatZoom(new LngLat(0, 0), MAX_TILE_ZOOM + 1)).toBe(0);
         });
     });

--- a/src/source/canvas_source.test.ts
+++ b/src/source/canvas_source.test.ts
@@ -69,7 +69,7 @@ describe('CanvasSource', () => {
         source.onAdd(map);
         await promise;
 
-        expect(typeof source.play).toBe('function');
+        expect(source.play).toBeTypeOf('function');
     });
 
     describe('Validations', () => {

--- a/src/source/geojson_source.test.ts
+++ b/src/source/geojson_source.test.ts
@@ -102,10 +102,11 @@ describe('GeoJSONSource.setData', () => {
         const source = createSource();
         const loadPromise = source.once('data');
         source.load();
-        await loadPromise;
+        await expect(loadPromise).resolves.toBeDefined();
+
         const setDataPromise = source.once('data');
         source.setData({} as GeoJSON.GeoJSON);
-        await setDataPromise;
+        await expect(setDataPromise).resolves.toBeDefined();
     });
 
     test('fires "dataloading" event', async () => {
@@ -545,8 +546,8 @@ describe('GeoJSONSource.update', () => {
         expect(spy.mock.calls[0][0].data.geojsonVtOptions.cluster).toBe(false);
         expect(spy.mock.calls[0][0].data.dataDiff).toEqual(diff);
         expect(spy.mock.calls[1][0].data.geojsonVtOptions.cluster).toBe(true);
-        expect(spy.mock.calls[1][0].data.data).not.toBeDefined();
-        expect(spy.mock.calls[1][0].data.dataDiff).not.toBeDefined();
+        expect(spy.mock.calls[1][0].data.data).toBeUndefined();
+        expect(spy.mock.calls[1][0].data.dataDiff).toBeUndefined();
     });
 
     test('forwards Supercluster options with worker request, ignore max zoom of source', async () => {

--- a/src/source/geojson_source_diff.test.ts
+++ b/src/source/geojson_source_diff.test.ts
@@ -562,7 +562,7 @@ describe('mergeSourceDiffs', () => {
         } satisfies GeoJSONSourceDiff;
 
         const merged = mergeSourceDiffs(diff1, diff2);
-        expect(merged.update.length).toBe(1);
+        expect(merged.update).toHaveLength(1);
         expect(merged.update[0].removeAllProperties).toBe(true);
         expect(merged.update[0].removeProperties).toBeUndefined();
         expect(merged.update[0].addOrUpdateProperties).toEqual([{key: 'fresh', value: 2}]);
@@ -604,7 +604,7 @@ describe('mergeSourceDiffs', () => {
 
         const merged = mergeSourceDiffs(diff1, diff2, 'promoted');
         expect(merged.add).toBeDefined();
-        expect(merged.add.length).toBe(2);
+        expect(merged.add).toHaveLength(2);
     });
 
     test('merges two diffs update feature then remove', () => {

--- a/src/source/geojson_worker_source.test.ts
+++ b/src/source/geojson_worker_source.test.ts
@@ -118,8 +118,7 @@ describe('geojson tile worker source', () => {
 
         await source.loadData({source: 'source', data: geoJson, geojsonVtOptions: {}} as LoadGeoJSONParameters);
 
-        let loadTileSettled = false;
-        const onSettled = () => { loadTileSettled = true; };
+        const onSettled = vi.fn();
         source.loadTile({
             source: 'source',
             uid: 0,
@@ -137,7 +136,7 @@ describe('geojson tile worker source', () => {
             subdivisionGranularity: SubdivisionGranularitySetting.noSubdivision,
         } as any as WorkerTileParameters) as WorkerTileWithData;
 
-        expect(loadTileSettled).toBe(false);
+        expect(onSettled).not.toHaveBeenCalled();
         expect(res).toBeDefined();
         expect(res.rawTileData).toBeDefined();
     });
@@ -190,8 +189,7 @@ describe('geojson tile worker source', () => {
 
         await source.loadData({source: 'source', data: geoJson, geojsonVtOptions: {}} as LoadGeoJSONParameters);
 
-        let loadTileSettled = false;
-        const onSettled = () => { loadTileSettled = true; };
+        const onSettled = vi.fn();
         source.loadTile({
             source: 'source',
             uid: 0,
@@ -216,7 +214,7 @@ describe('geojson tile worker source', () => {
             subdivisionGranularity: SubdivisionGranularitySetting.noSubdivision,
         } as any as WorkerTileParameters) as WorkerTileWithData;
 
-        expect(loadTileSettled).toBe(false);
+        expect(onSettled).not.toHaveBeenCalled();
         expect(res).toBeDefined();
         expect(res.rawTileData).toBeDefined();
     });

--- a/src/source/geojson_worker_source.test.ts
+++ b/src/source/geojson_worker_source.test.ts
@@ -118,12 +118,14 @@ describe('geojson tile worker source', () => {
 
         await source.loadData({source: 'source', data: geoJson, geojsonVtOptions: {}} as LoadGeoJSONParameters);
 
+        let loadTileSettled = false;
+        const onSettled = () => { loadTileSettled = true; };
         source.loadTile({
             source: 'source',
             uid: 0,
             tileID: {overscaledZ: 0, wrap: 0, canonical: {x: 0, y: 0, z: 0, w: 0}},
             subdivisionGranularity: SubdivisionGranularitySetting.noSubdivision,
-        } as any as WorkerTileParameters).then(() => expect(false).toBeTruthy());
+        } as any as WorkerTileParameters).then(onSettled, onSettled);
 
         // allow promise to run
         await sleep(0);
@@ -135,6 +137,7 @@ describe('geojson tile worker source', () => {
             subdivisionGranularity: SubdivisionGranularitySetting.noSubdivision,
         } as any as WorkerTileParameters) as WorkerTileWithData;
 
+        expect(loadTileSettled).toBe(false);
         expect(res).toBeDefined();
         expect(res.rawTileData).toBeDefined();
     });
@@ -187,12 +190,14 @@ describe('geojson tile worker source', () => {
 
         await source.loadData({source: 'source', data: geoJson, geojsonVtOptions: {}} as LoadGeoJSONParameters);
 
+        let loadTileSettled = false;
+        const onSettled = () => { loadTileSettled = true; };
         source.loadTile({
             source: 'source',
             uid: 0,
             tileID: {overscaledZ: 0, wrap: 0, canonical: {x: 0, y: 0, z: 0, w: 0}},
             subdivisionGranularity: SubdivisionGranularitySetting.noSubdivision,
-        } as any as WorkerTileParameters).then(() => expect(false).toBeTruthy());
+        } as any as WorkerTileParameters).then(onSettled, onSettled);
 
         // allow promise to run
         await sleep(0);
@@ -211,6 +216,7 @@ describe('geojson tile worker source', () => {
             subdivisionGranularity: SubdivisionGranularitySetting.noSubdivision,
         } as any as WorkerTileParameters) as WorkerTileWithData;
 
+        expect(loadTileSettled).toBe(false);
         expect(res).toBeDefined();
         expect(res.rawTileData).toBeDefined();
     });
@@ -235,7 +241,7 @@ describe('geojson tile worker source', () => {
             source: 'source',
             uid: 0,
             tileID: {overscaledZ: 0, wrap: 0, canonical: {x: 0, y: 0, z: 0, w: 0}},
-        } as any as WorkerTileParameters)).rejects.toThrowError(/Unable to parse the data into a cluster or geojson/);
+        } as any as WorkerTileParameters)).rejects.toThrow(/Unable to parse the data into a cluster or geojson/);
     });
 
     test('GeoJSONWorkerSource.abortTile aborts tile state', async () => {
@@ -434,8 +440,8 @@ describe('resourceTiming', () => {
             });
             return null;
         });
-        vi.spyOn(performance, 'clearMarks').mockImplementation(() => null);
-        vi.spyOn(performance, 'clearMeasures').mockImplementation(() => null);
+        vi.spyOn(performance, 'clearMarks').mockReturnValue(null);
+        vi.spyOn(performance, 'clearMeasures').mockReturnValue(null);
 
         const layerIndex = new StyleLayerIndex(layers);
         const source = new GeoJSONWorkerSource(actor, layerIndex, []);

--- a/src/source/image_source.test.ts
+++ b/src/source/image_source.test.ts
@@ -35,9 +35,6 @@ describe('ImageSource', () => {
 
     afterEach(() => {
         map.remove();
-    });
-
-    afterEach(() => {
         vi.restoreAllMocks();
     });
 

--- a/src/source/raster_dem_tile_source.test.ts
+++ b/src/source/raster_dem_tile_source.test.ts
@@ -1,4 +1,4 @@
-import {describe, beforeEach, afterEach, test, expect, vi, it} from 'vitest';
+import {describe, beforeEach, afterEach, test, expect, vi} from 'vitest';
 import {fakeServer, type FakeServer} from 'nise';
 import {RasterDEMTileSource} from './raster_dem_tile_source.ts';
 import {OverscaledTileID} from '../tile/tile_id.ts';
@@ -198,7 +198,7 @@ describe('RasterDEMTileSource', () => {
         ]);
     });
 
-    it('serializes options', () => {
+    test('serializes options', () => {
         const source = createSource({
             tiles: ['http://localhost:2900/raster-dem/{z}/{x}/{y}.png'],
             minzoom: 2,

--- a/src/source/raster_tile_source.test.ts
+++ b/src/source/raster_tile_source.test.ts
@@ -1,4 +1,4 @@
-import {describe, beforeEach, afterEach, test, expect, vi, it} from 'vitest';
+import {describe, beforeEach, afterEach, test, expect, vi} from 'vitest';
 import {RasterTileSource} from './raster_tile_source.ts';
 import {OverscaledTileID} from '../tile/tile_id.ts';
 import {RequestManager} from '../util/request_manager.ts';
@@ -216,15 +216,21 @@ describe('RasterTileSource', () => {
         expect(tile.state).toBe('loaded');
     });
 
-    test('supports updating tiles', () => {
+    test('supports updating tiles', async () => {
+        server.respondWith('/source.json', JSON.stringify({
+            minzoom: 0,
+            maxzoom: 22,
+            attribution: 'MapLibre',
+            tiles: ['http://example.com/{z}/{x}/{y}.png'],
+        }));
         const source = createSource({url: '/source.json'});
-        source.setTiles(['http://example.com/{z}/{x}/{y}.png?updated=true']);
 
-        source.on('data', (e) => {
-            if (e.sourceDataType === 'metadata') {
-                expect(source.tiles[0]).toBe('http://example.com/{z}/{x}/{y}.png?updated=true');
-            }
-        });
+        server.respondImmediately = true;
+        const promise = waitForEvent(source, 'data', (e: MapSourceDataEvent) => e.sourceDataType === 'metadata');
+        source.setTiles(['http://example.com/{z}/{x}/{y}.png?updated=true']);
+        await promise;
+
+        expect(source.tiles[0]).toBe('http://example.com/{z}/{x}/{y}.png?updated=true');
     });
 
     test('cancels TileJSON request if removed', async () => {
@@ -256,7 +262,7 @@ describe('RasterTileSource', () => {
 
         await waitForEvent(source, 'data', (e: MapSourceDataEvent) => e.sourceDataType === 'metadata');
 
-        expect(server.requests.length).toBe(2);
+        expect(server.requests).toHaveLength(2);
         expect(server.requests[0].aborted).toBe(true);
         expect(source.serialize()).toEqual({
             type: 'raster',
@@ -265,7 +271,7 @@ describe('RasterTileSource', () => {
         expect(errorHandler).not.toHaveBeenCalled();
     });
 
-    it('serializes options', () => {
+    test('serializes options', () => {
         const source = createSource({
             tiles: ['http://localhost:2900/raster/{z}/{x}/{y}.png'],
             minzoom: 2,

--- a/src/source/rtl_text_plugin_main_thread.test.ts
+++ b/src/source/rtl_text_plugin_main_thread.test.ts
@@ -1,4 +1,4 @@
-import {describe, beforeEach, it, afterEach, expect, vi, type MockInstance} from 'vitest';
+import {describe, beforeEach, afterEach, expect, vi, type MockInstance, test} from 'vitest';
 import {type FakeServer, fakeServer} from 'nise';
 import {rtlMainThreadPluginFactory} from './rtl_text_plugin_main_thread.ts';
 import {sleep} from '../util/test/util.ts';
@@ -20,7 +20,7 @@ describe('RTLMainThreadPlugin', () => {
         global.fetch = null;
         // Reset the singleton instance before each test
         rtlMainThreadPlugin.clearRTLTextPlugin();
-        broadcastSpy = vi.spyOn(Dispatcher.prototype, 'broadcast').mockImplementation(() => Promise.resolve({} as any));
+        broadcastSpy = vi.spyOn(Dispatcher.prototype, 'broadcast').mockResolvedValue({} as any);
     });
 
     function broadcastMockSuccess(message: MessageType, payload: PluginState): Promise<PluginState[]> {
@@ -62,36 +62,36 @@ describe('RTLMainThreadPlugin', () => {
         broadcastSpy.mockRestore();
     });
 
-    it('should get the RTL text plugin status', () => {
+    test('should get the RTL text plugin status', () => {
         const status = rtlMainThreadPlugin.getRTLTextPluginStatus();
         expect(status).toBe('unavailable');
     });
 
-    it('should set the RTL text plugin and download it', async () => {
+    test('should set the RTL text plugin and download it', async () => {
         broadcastSpy = vi.spyOn(Dispatcher.prototype, 'broadcast').mockImplementation(broadcastMockSuccess as any);
         await rtlMainThreadPlugin.setRTLTextPlugin(url);
         expect(rtlMainThreadPlugin.url).toEqual(url);
         expect(rtlMainThreadPlugin.status).toBe('loaded');
     });
 
-    it('should set the RTL text plugin but defer downloading', async () => {
+    test('should set the RTL text plugin but defer downloading', async () => {
         await rtlMainThreadPlugin.setRTLTextPlugin(url, true);
         expect(rtlMainThreadPlugin.status).toBe('deferred');
         expect(broadcastSpy).toHaveBeenCalledWith(SyncRTLPluginStateMessageName, {pluginStatus: 'deferred', pluginURL: url});
     });
 
-    it('should throw if the plugin is already set', async () => {
+    test('should throw if the plugin is already set', async () => {
         await rtlMainThreadPlugin.setRTLTextPlugin(url, true);
         await expect(rtlMainThreadPlugin.setRTLTextPlugin(url)).rejects.toThrow('setRTLTextPlugin cannot be called multiple times.');
     });
 
-    it('should throw if the plugin url is not set', async () => {
-        const spy = vi.spyOn(browser, 'resolveURL').mockImplementation(() => '');
+    test('should throw if the plugin url is not set', async () => {
+        const spy = vi.spyOn(browser, 'resolveURL').mockReturnValue('');
         await expect(rtlMainThreadPlugin.setRTLTextPlugin(null)).rejects.toThrow('requested url null is invalid');
         spy.mockRestore();
     });
 
-    it('should be in error state if download fails', async () => {
+    test('should be in error state if download fails', async () => {
         broadcastSpy = vi.spyOn(Dispatcher.prototype, 'broadcast').mockImplementation(broadcastMockFailure as any);
         const resultPromise = rtlMainThreadPlugin.setRTLTextPlugin(url);
         await expect(resultPromise).rejects.toBe(failedToLoadMessage);
@@ -99,7 +99,7 @@ describe('RTLMainThreadPlugin', () => {
         expect(rtlMainThreadPlugin.status).toBe('error');
     });
 
-    it('should lazy load the plugin if deferred', async () => {
+    test('should lazy load the plugin if deferred', async () => {
         // use success spy to make sure test case does not throw exception
         const deferredSpy = vi.spyOn(Dispatcher.prototype, 'broadcast').mockImplementation(broadcastMockSuccessDefer as any);
         await rtlMainThreadPlugin.setRTLTextPlugin(url, true);
@@ -129,12 +129,12 @@ describe('RTLMainThreadPlugin', () => {
         expect(broadcastSpy).toHaveBeenCalledTimes(1);
     });
 
-    it('should set status to requested if RTL plugin was not set', async () => {
+    test('should set status to requested if RTL plugin was not set', async () => {
         rtlMainThreadPlugin.lazyLoad();
         expect(rtlMainThreadPlugin.status).toBe('requested');
     });
 
-    it('should immediately download if RTL plugin was already requested, ignoring deferred:true', async () => {
+    test('should immediately download if RTL plugin was already requested, ignoring deferred:true', async () => {
         broadcastSpy = vi.spyOn(Dispatcher.prototype, 'broadcast').mockImplementation(broadcastMockSuccess as any);
         rtlMainThreadPlugin.lazyLoad();
         expect(rtlMainThreadPlugin.status).toBe('requested');
@@ -146,14 +146,14 @@ describe('RTLMainThreadPlugin', () => {
         expect(broadcastSpy).toHaveBeenCalledWith(SyncRTLPluginStateMessageName, {pluginStatus: 'loading', pluginURL: url});
     });
 
-    it('should allow multiple calls to lazyLoad', async () => {
+    test('should allow multiple calls to lazyLoad', async () => {
         rtlMainThreadPlugin.lazyLoad();
         expect(rtlMainThreadPlugin.status).toBe('requested');
         rtlMainThreadPlugin.lazyLoad();
         expect(rtlMainThreadPlugin.status).toBe('requested');
     });
 
-    it('should be in error state if lazyLoad fails', async () => {
+    test('should be in error state if lazyLoad fails', async () => {
         broadcastSpy = vi.spyOn(Dispatcher.prototype, 'broadcast').mockImplementation(broadcastMockSuccessDefer);
         const resultPromise = rtlMainThreadPlugin.setRTLTextPlugin(url, true);
         await expect(resultPromise).resolves.toBeUndefined();

--- a/src/source/source.test.ts
+++ b/src/source/source.test.ts
@@ -27,18 +27,18 @@ describe('addSourceType', () => {
         await addSourceType('foo2', sourceType);
         expect(spy).not.toHaveBeenCalled();
 
-        expect(() => create('id', {type: 'foo2'} as any, null, null)).toThrow();
+        expect(() => create('id', {type: 'foo2'} as any, null, null)).toThrow('Expected Source id to be id instead of undefined');
         expect(sourceType).toHaveBeenCalled();
     });
 
     test('refuses to add new type over existing name', async () => {
         const sourceType = function () {} as any as SourceClass;
-        await expect(addSourceType('canvas', sourceType)).rejects.toThrow();
-        await expect(addSourceType('geojson', sourceType)).rejects.toThrow();
-        await expect(addSourceType('image', sourceType)).rejects.toThrow();
-        await expect(addSourceType('raster', sourceType)).rejects.toThrow();
-        await expect(addSourceType('raster-dem', sourceType)).rejects.toThrow();
-        await expect(addSourceType('vector', sourceType)).rejects.toThrow();
-        await expect(addSourceType('video', sourceType)).rejects.toThrow();
+        await expect(addSourceType('canvas', sourceType)).rejects.toThrow('A source type called "canvas" already exists.');
+        await expect(addSourceType('geojson', sourceType)).rejects.toThrow('A source type called "geojson" already exists.');
+        await expect(addSourceType('image', sourceType)).rejects.toThrow('A source type called "image" already exists.');
+        await expect(addSourceType('raster', sourceType)).rejects.toThrow('A source type called "raster" already exists.');
+        await expect(addSourceType('raster-dem', sourceType)).rejects.toThrow('A source type called "raster-dem" already exists.');
+        await expect(addSourceType('vector', sourceType)).rejects.toThrow('A source type called "vector" already exists.');
+        await expect(addSourceType('video', sourceType)).rejects.toThrow('A source type called "video" already exists.');
     });
 });

--- a/src/source/vector_tile_source.test.ts
+++ b/src/source/vector_tile_source.test.ts
@@ -454,7 +454,7 @@ describe('VectorTileSource', () => {
 
         await waitForEvent(source, 'data', (e: MapSourceDataEvent) => e.sourceDataType === 'metadata');
 
-        expect(server.requests.length).toBe(2);
+        expect(server.requests).toHaveLength(2);
         expect(server.requests[0].aborted).toBe(true);
         expect(source.serialize()).toEqual({
             type: 'vector',

--- a/src/source/vector_tile_worker_source.test.ts
+++ b/src/source/vector_tile_worker_source.test.ts
@@ -66,7 +66,7 @@ describe('vector tile worker source', () => {
 
     test('VectorTileWorkerSource.reloadTile reloads a previously-loaded tile', async () => {
         const source = new VectorTileWorkerSource(actor, new StyleLayerIndex(), []);
-        const parse = vi.fn().mockReturnValue(Promise.resolve({} as WorkerTileResult));
+        const parse = vi.fn().mockResolvedValue({});
 
         source.tileState.loaded = {
             '0': {
@@ -144,13 +144,15 @@ describe('vector tile worker source', () => {
             request.respond(200, {'Content-Type': 'application/pbf'}, rawTileData as any);
         });
 
+        let loadTileSettled = false;
+        const onSettled = () => { loadTileSettled = true; };
         source.loadTile({
             source: 'source',
             uid: 0,
             tileID: {overscaledZ: 0, wrap: 0, canonical: {x: 0, y: 0, z: 0, w: 0}},
             request: {url: 'http://localhost:2900/faketile.pbf'},
             subdivisionGranularity: SubdivisionGranularitySetting.noSubdivision,
-        } as any as WorkerTileParameters).then(() => expect(false).toBeTruthy());
+        } as any as WorkerTileParameters).then(onSettled, onSettled);
 
         server.respond();
 
@@ -163,6 +165,7 @@ describe('vector tile worker source', () => {
             tileID: {overscaledZ: 0, wrap: 0, canonical: {x: 0, y: 0, z: 0, w: 0}},
             subdivisionGranularity: SubdivisionGranularitySetting.noSubdivision,
         } as any as WorkerTileParameters) as WorkerTileWithData;
+        expect(loadTileSettled).toBe(false);
         expect(res).toBeDefined();
         expect(res.rawTileData).toBeDefined();
         expect(res.rawTileData).toStrictEqual(rawTileData);
@@ -391,7 +394,7 @@ describe('vector tile worker source', () => {
         server.respond();
 
         expect(parse).not.toHaveBeenCalled();
-        expect(await promise).toBeNull();
+        await expect(promise).resolves.toBeNull();
     });
 
     test('VectorTileWorkerSource.returns a good error message when failing to parse a tile', async () => {
@@ -412,7 +415,7 @@ describe('vector tile worker source', () => {
         server.respond();
 
         expect(parse).not.toHaveBeenCalled();
-        await expect(loadTilePromise).rejects.toThrowError(/Unable to parse the tile at/);
+        await expect(loadTilePromise).rejects.toThrow(/Unable to parse the tile at/);
     });
 
     test('VectorTileWorkerSource.returns a good error message when failing to parse a gzipped tile', async () => {
@@ -431,7 +434,7 @@ describe('vector tile worker source', () => {
         server.respond();
 
         expect(parse).not.toHaveBeenCalled();
-        await expect(loadTilePromise).rejects.toThrowError(/gzipped/);
+        await expect(loadTilePromise).rejects.toThrow(/gzipped/);
     });
 
     test('VectorTileWorkerSource provides resource timing information', async () => {

--- a/src/source/vector_tile_worker_source.test.ts
+++ b/src/source/vector_tile_worker_source.test.ts
@@ -144,8 +144,7 @@ describe('vector tile worker source', () => {
             request.respond(200, {'Content-Type': 'application/pbf'}, rawTileData as any);
         });
 
-        let loadTileSettled = false;
-        const onSettled = () => { loadTileSettled = true; };
+        const onSettled = vi.fn();
         source.loadTile({
             source: 'source',
             uid: 0,
@@ -165,7 +164,7 @@ describe('vector tile worker source', () => {
             tileID: {overscaledZ: 0, wrap: 0, canonical: {x: 0, y: 0, z: 0, w: 0}},
             subdivisionGranularity: SubdivisionGranularitySetting.noSubdivision,
         } as any as WorkerTileParameters) as WorkerTileWithData;
-        expect(loadTileSettled).toBe(false);
+        expect(onSettled).not.toHaveBeenCalled();
         expect(res).toBeDefined();
         expect(res.rawTileData).toBeDefined();
         expect(res.rawTileData).toStrictEqual(rawTileData);

--- a/src/source/worker.test.ts
+++ b/src/source/worker.test.ts
@@ -97,7 +97,7 @@ describe('Worker generic testing', () => {
     test('worker source messages dispatched to the correct map instance', () => {
         const externalSourceName = 'test';
 
-        const sendAsyncSpy = vi.fn().mockReturnValue(Promise.resolve({} as any));
+        const sendAsyncSpy = vi.fn().mockResolvedValue({} as any);
         worker.actor.sendAsync = sendAsyncSpy;
 
         _self.registerWorkerSource(externalSourceName, WorkerSourceMock);

--- a/src/source/worker_tile.test.ts
+++ b/src/source/worker_tile.test.ts
@@ -299,9 +299,12 @@ describe('worker tile', () => {
         const actorMock = {
             sendAsync
         };
-        tile.parse(data, layerIndex, ['hello'], actorMock, SubdivisionGranularitySetting.noSubdivision).then(() => expect(false).toBeTruthy());
-        tile.parse(data, layerIndex, ['hello'], actorMock, SubdivisionGranularitySetting.noSubdivision).then(() => expect(false).toBeTruthy());
+        let supersededSettled = 0;
+        const onSettled = () => { supersededSettled++; };
+        tile.parse(data, layerIndex, ['hello'], actorMock, SubdivisionGranularitySetting.noSubdivision).then(onSettled, onSettled);
+        tile.parse(data, layerIndex, ['hello'], actorMock, SubdivisionGranularitySetting.noSubdivision).then(onSettled, onSettled);
         const result = await tile.parse(data, layerIndex, ['hello'], actorMock, SubdivisionGranularitySetting.noSubdivision);
+        expect(supersededSettled).toBe(0);
         expect(result).toBeDefined();
         expect(cancelCount).toBe(6);
         expect(sendAsync).toHaveBeenCalledTimes(9);

--- a/src/source/worker_tile.test.ts
+++ b/src/source/worker_tile.test.ts
@@ -299,12 +299,11 @@ describe('worker tile', () => {
         const actorMock = {
             sendAsync
         };
-        let supersededSettled = 0;
-        const onSettled = () => { supersededSettled++; };
+        const onSettled = vi.fn();
         tile.parse(data, layerIndex, ['hello'], actorMock, SubdivisionGranularitySetting.noSubdivision).then(onSettled, onSettled);
         tile.parse(data, layerIndex, ['hello'], actorMock, SubdivisionGranularitySetting.noSubdivision).then(onSettled, onSettled);
         const result = await tile.parse(data, layerIndex, ['hello'], actorMock, SubdivisionGranularitySetting.noSubdivision);
-        expect(supersededSettled).toBe(0);
+        expect(onSettled).not.toHaveBeenCalled();
         expect(result).toBeDefined();
         expect(cancelCount).toBe(6);
         expect(sendAsync).toHaveBeenCalledTimes(9);

--- a/src/style/load_glyph_range.test.ts
+++ b/src/style/load_glyph_range.test.ts
@@ -33,10 +33,10 @@ test('loadGlyphRange', async ()  => {
 
         expect(glyph.id).toBe(Number(id));
         expect(glyph.metrics).toBeTruthy();
-        expect(typeof glyph.metrics.width).toBe('number');
-        expect(typeof glyph.metrics.height).toBe('number');
-        expect(typeof glyph.metrics.top).toBe('number');
-        expect(typeof glyph.metrics.advance).toBe('number');
+        expect(glyph.metrics.width).toBeTypeOf('number');
+        expect(glyph.metrics.height).toBeTypeOf('number');
+        expect(glyph.metrics.top).toBeTypeOf('number');
+        expect(glyph.metrics.advance).toBeTypeOf('number');
     }
     expect(server.requests[0].url).toBe('https://localhost/fonts/v1/Arial Unicode MS/0-255.pbf');
 });
@@ -64,10 +64,10 @@ test('loadGlyphRange with async transformRequest', async () => {
 
         expect(glyph.id).toBe(Number(id));
         expect(glyph.metrics).toBeTruthy();
-        expect(typeof glyph.metrics.width).toBe('number');
-        expect(typeof glyph.metrics.height).toBe('number');
-        expect(typeof glyph.metrics.top).toBe('number');
-        expect(typeof glyph.metrics.advance).toBe('number');
+        expect(glyph.metrics.width).toBeTypeOf('number');
+        expect(glyph.metrics.height).toBeTypeOf('number');
+        expect(glyph.metrics.top).toBeTypeOf('number');
+        expect(glyph.metrics.advance).toBeTypeOf('number');
     }
     expect(server.requests[0].url).toBe('https://localhost/fonts/v1/Arial Unicode MS/0-255.pbf');
     expect(server.requests[0].requestHeaders.Authorization).toBe('Bearer token');

--- a/src/style/load_sprite.test.ts
+++ b/src/style/load_sprite.test.ts
@@ -28,7 +28,7 @@ describe('normalizeSpriteURL', () => {
         ).toBe('http://www.foo.com/bar@2x.png?fresh=true');
     });
 
-    test('test relative URL', () => {
+    test('relative URL', () => {
         expect(
             () => normalizeSpriteURL('/bar?fresh=true', '@2x', '.png')
         ).toThrow(/Invalid/i);

--- a/src/style/style.test.ts
+++ b/src/style/style.test.ts
@@ -598,7 +598,7 @@ describe('Style.loadJSON', () => {
         layer.recalculate({} as EvaluationParameters, []);
         const paint = layer.paint as PossiblyEvaluated<CirclePaintProps, CirclePaintPropsPossiblyEvaluated>;
         expect(paint.get('circle-color').evaluate({} as Feature, {})).toEqual(new Color(1, 0, 0, 1));
-        expect(paint.get('circle-radius').evaluate({} as Feature, {})).toEqual(12);
+        expect(paint.get('circle-radius').evaluate({} as Feature, {})).toBe(12);
     });
 
     test('does not throw if request is pending when removed', async () => {
@@ -778,7 +778,7 @@ describe('Style.update', () => {
 
         await style.once('style.load');
 
-        const spy = vi.fn().mockReturnValue(Promise.resolve({}));
+        const spy = vi.fn().mockResolvedValue({});
         style.dispatcher.broadcast = spy;
 
         // Add multiple images — should NOT broadcast setImages immediately
@@ -806,7 +806,7 @@ describe('Style.update', () => {
 
         await style.once('style.load');
 
-        const spy = vi.fn().mockReturnValue(Promise.resolve({}));
+        const spy = vi.fn().mockResolvedValue({});
         style.dispatcher.broadcast = spy;
 
         // Trigger an update that changes layers but not images
@@ -826,7 +826,7 @@ describe('Style.update', () => {
 
         await style.once('style.load');
 
-        const spy = vi.fn().mockReturnValue(Promise.resolve({}));
+        const spy = vi.fn().mockResolvedValue({});
         style.dispatcher.broadcast = spy;
 
         // Trigger both image and layer changes in the same frame
@@ -853,7 +853,7 @@ describe('Style.update', () => {
         style.addImage('img2', {data: new RGBAImage({width: 1, height: 1}, new Uint8Array(4)), pixelRatio: 1, sdf: false});
         style.update({} as EvaluationParameters);
 
-        const spy = vi.fn().mockReturnValue(Promise.resolve({}));
+        const spy = vi.fn().mockResolvedValue({});
         style.dispatcher.broadcast = spy;
 
         style.removeImage('img1');
@@ -877,7 +877,7 @@ describe('Style.update', () => {
         style.addImage('img1', {data: new RGBAImage({width: 1, height: 1}, new Uint8Array(4)), pixelRatio: 1, sdf: false});
         style.update({} as EvaluationParameters);
 
-        const spy = vi.fn().mockReturnValue(Promise.resolve({}));
+        const spy = vi.fn().mockResolvedValue({});
         style.dispatcher.broadcast = spy;
 
         style.updateImage('img1', {data: new RGBAImage({width: 1, height: 1}, new Uint8Array(4)), pixelRatio: 1, sdf: false});
@@ -1300,7 +1300,7 @@ describe('Style.addSource', () => {
             style.addSource('source-id', source);
             style.update({} as EvaluationParameters);
         });
-        await dataPromise;
+        await expect(dataPromise).resolves.toBeDefined();
     });
 
     test('throws on duplicates', async () => {
@@ -1370,7 +1370,7 @@ describe('Style.removeSource', () => {
             style.removeSource('source-id');
             style.update({} as EvaluationParameters);
         });
-        await dataPromise;
+        await expect(dataPromise).resolves.toBeDefined();
     });
 
     test('clears tiles', async () => {
@@ -2474,7 +2474,7 @@ describe('Style.addLayer', () => {
             style.addLayer(layer);
             style.update({} as EvaluationParameters);
         });
-        await dataPromise;
+        await expect(dataPromise).resolves.toBeDefined();
     });
 
     test('emits error on duplicates', async () => {
@@ -2592,7 +2592,7 @@ describe('Style.removeLayer', () => {
             style.update({} as EvaluationParameters);
         });
 
-        await dataPromise;
+        await expect(dataPromise).resolves.toBeDefined();
     });
 
     test('tears down layer event forwarding', async () => {
@@ -2604,9 +2604,8 @@ describe('Style.removeLayer', () => {
             }]
         }));
 
-        style.on('error', () => {
-            throw new Error('test failed');
-        });
+        const styleErrorListener = vi.fn();
+        style.on('error', styleErrorListener);
 
         await style.once('style.load');
         const layer = style._layers.background;
@@ -2616,6 +2615,8 @@ describe('Style.removeLayer', () => {
         layer.on('error', () => {});
 
         layer.fire(new Event('error', {mapLibre: true}));
+
+        expect(styleErrorListener).not.toHaveBeenCalled();
     });
 
     test('fires an error on non-existence', async () => {
@@ -2682,7 +2683,7 @@ describe('Style.moveLayer', () => {
             style.moveLayer('background');
             style.update({} as EvaluationParameters);
         });
-        await dataPromise;
+        await expect(dataPromise).resolves.toBeDefined();
     });
 
     test('fires an error on non-existence', async () => {
@@ -2984,7 +2985,7 @@ describe('Style.setFilter', () => {
         const style = createStyle();
 
         await style.once('style.load');
-        const spy = vi.fn().mockReturnValue(Promise.resolve({}));
+        const spy = vi.fn().mockResolvedValue({});
         style.dispatcher.broadcast = spy;
 
         style.setFilter('symbol', ['==', 'id', 1]);
@@ -3018,7 +3019,7 @@ describe('Style.setFilter', () => {
         style.setFilter('symbol', filter);
         style.update({} as EvaluationParameters); // flush pending operations
 
-        const spy = vi.fn().mockReturnValue(Promise.resolve({}));
+        const spy = vi.fn().mockResolvedValue({});
         style.dispatcher.broadcast = spy;
         filter[2] = 2;
         style.setFilter('symbol', filter);
@@ -3067,7 +3068,7 @@ describe('Style.setFilter', () => {
         const style = createStyle();
 
         await style.once('style.load');
-        const spy = vi.fn().mockReturnValue(Promise.resolve({}));
+        const spy = vi.fn().mockResolvedValue({});
         style.dispatcher.broadcast = spy;
 
         style.setFilter('symbol', 'notafilter' as any as FilterSpecification, {validate: false});
@@ -3119,7 +3120,7 @@ describe('Style.setLayerZoomRange', () => {
         const style = createStyle();
 
         await style.once('style.load');
-        const spy = vi.fn().mockReturnValue(Promise.resolve({}));
+        const spy = vi.fn().mockResolvedValue({});
         style.dispatcher.broadcast = spy;
         style.setLayerZoomRange('symbol', 5, 12);
         expect(style.getLayer('symbol').minzoom).toBe(5);
@@ -3474,7 +3475,7 @@ describe('Style.query*Features', () => {
         expect(onError.mock.calls[0][0].error.message).toMatch(/queryRenderedFeatures\.filter/);
     });
 
-    test('querySourceFeatures not raise validation errors if validation was disabled', () => {
+    test('queryRenderedFeatures not raise validation errors if validation was disabled', () => {
         let errors = 0;
         vi.spyOn(style, 'fire').mockImplementation((event) => {
             if (event['error']) {
@@ -3781,12 +3782,12 @@ describe('Style.serialize', () => {
         expect(result['4,2,true']).toBeDefined();
 
         // Verify the entries have the expected atlas properties
-        expect(typeof result['2,1,false'].width).toBe('number');
-        expect(typeof result['2,1,false'].height).toBe('number');
-        expect(typeof result['2,1,false'].y).toBe('number');
-        expect(typeof result['4,2,true'].width).toBe('number');
-        expect(typeof result['4,2,true'].height).toBe('number');
-        expect(typeof result['4,2,true'].y).toBe('number');
+        expect(result['2,1,false'].width).toBeTypeOf('number');
+        expect(result['2,1,false'].height).toBeTypeOf('number');
+        expect(result['2,1,false'].y).toBeTypeOf('number');
+        expect(result['4,2,true'].width).toBeTypeOf('number');
+        expect(result['4,2,true'].height).toBeTypeOf('number');
+        expect(result['4,2,true'].y).toBeTypeOf('number');
     });
 });
 

--- a/src/style/style_layer.test.ts
+++ b/src/style/style_layer.test.ts
@@ -171,7 +171,8 @@ describe('StyleLayer.setPaintProperty', () => {
         layer.updateTransitions({} as TransitionParameters);
         layer.recalculate({zoom: 0, zoomHistory: {}} as EvaluationParameters, undefined);
 
-        expect(layer.paint.get('fill-outline-color').value).toMatchObject({kind: 'constant', value: {r: 1, g: 0, b: 0, a: 1}});
+        const outlineColor = layer.paint.get('fill-outline-color');
+        expect(outlineColor.value).toMatchObject({kind: 'constant', value: {r: 1, g: 0, b: 0, a: 1}});
     });
 
     test('sets null property value', () => {

--- a/src/style/style_layer.test.ts
+++ b/src/style/style_layer.test.ts
@@ -171,8 +171,7 @@ describe('StyleLayer.setPaintProperty', () => {
         layer.updateTransitions({} as TransitionParameters);
         layer.recalculate({zoom: 0, zoomHistory: {}} as EvaluationParameters, undefined);
 
-        layer.paint.get('fill-outline-color');
-
+        expect(layer.paint.get('fill-outline-color').value).toMatchObject({kind: 'constant', value: {r: 1, g: 0, b: 0, a: 1}});
     });
 
     test('sets null property value', () => {
@@ -508,54 +507,7 @@ describe('StyleLayer.serialize', () => {
 
 });
 
-describe('StyleLayer.serialize', () => {
-
-    function createSymbolLayer(layer?) {
-        return extend({
-            id: 'symbol',
-            type: 'symbol',
-            paint: {
-                'text-color': 'blue'
-            },
-            layout: {
-                'text-transform': 'uppercase'
-            }
-        }, layer);
-    }
-
-    test('serializes layers', () => {
-        expect(createStyleLayer(createSymbolLayer(), {}).serialize()).toEqual(createSymbolLayer());
-    });
-
-    test('serializes functions', () => {
-        const layerPaint = {
-            'text-color': {
-                base: 2,
-                stops: [[0, 'red'], [1, 'blue']]
-            }
-        };
-
-        expect(createStyleLayer(createSymbolLayer({paint: layerPaint}), {}).serialize().paint).toEqual(layerPaint);
-    });
-
-    test('serializes added paint properties', () => {
-        const layer = createStyleLayer(createSymbolLayer(), {});
-        layer.setPaintProperty('text-halo-color', 'orange');
-
-        expect(layer.serialize().paint['text-halo-color']).toBe('orange');
-        expect(layer.serialize().paint['text-color']).toBe('blue');
-
-    });
-
-    test('serializes added layout properties', () => {
-        const layer = createStyleLayer(createSymbolLayer(), {});
-        layer.setLayoutProperty('text-size', 20);
-
-        expect(layer.serialize().layout['text-transform']).toBe('uppercase');
-        expect(layer.serialize().layout['text-size']).toBe(20);
-
-    });
-
+describe('StyleLayer.paint', () => {
     test('layer.paint is never undefined', () => {
         const layer = createStyleLayer({type: 'fill'} as LayerSpecification, {});
         // paint is never undefined

--- a/src/style/style_layer/color_relief_style_layer.test.ts
+++ b/src/style/style_layer/color_relief_style_layer.test.ts
@@ -20,7 +20,7 @@ describe('ColorReliefStyleLayer', () => {
         const layer = createStyleLayer(layerSpec, {});
         expect(layer).toBeInstanceOf(ColorReliefStyleLayer);
         const colorReliefStyleLayer = layer as ColorReliefStyleLayer;
-        expect(colorReliefStyleLayer.paint.get('color-relief-opacity')).toEqual(1);
+        expect(colorReliefStyleLayer.paint.get('color-relief-opacity')).toBe(1);
         const colorRamp = colorReliefStyleLayer._createColorRamp(256);
         expect(colorRamp.elevationStops).toEqual([0,1]);
         expect(colorRamp.colorStops).toEqual([Color.transparent,Color.transparent]);

--- a/src/style/style_layer/raster_style_layer.test.ts
+++ b/src/style/style_layer/raster_style_layer.test.ts
@@ -18,7 +18,7 @@ describe('RasterStyleLayer correctly handles "resampling" and "raster-resampling
         const layer = createStyleLayer(layerSpec, {});
     
         const rasterResampling = layer.getPaintProperty('raster-resampling');
-        expect(rasterResampling).toEqual(undefined);
+        expect(rasterResampling).toBeUndefined();
     });
 
     test('"resampling" is undefined when instantiated with "raster-resampling"', () => {
@@ -26,7 +26,7 @@ describe('RasterStyleLayer correctly handles "resampling" and "raster-resampling
         const layer = createStyleLayer(layerSpec, {});
     
         const resampling = layer.getPaintProperty('resampling');
-        expect(resampling).toEqual(undefined);
+        expect(resampling).toBeUndefined();
     });
 
 });

--- a/src/symbol/collision_index.test.ts
+++ b/src/symbol/collision_index.test.ts
@@ -10,7 +10,7 @@ describe('CollisionIndex', () => {
         const transform = new MercatorTransform({minZoom: 0, maxZoom: 22, minPitch: 0, maxPitch: 60, renderWorldCopies: true});
         transform.resize(200, 200);
         const tile = new UnwrappedTileID(0, new CanonicalTileID(0, 0, 0));
-        vi.spyOn(transform, 'calculatePosMatrix').mockImplementation(() => createIdentityMat4f64());
+        vi.spyOn(transform, 'calculatePosMatrix').mockReturnValue(createIdentityMat4f64());
 
         const ci = new CollisionIndex(transform);
         expect(ci.projectAndGetPerspectiveRatio(x, y, tile, null).x).toBeCloseTo(10000212.3456, 10);

--- a/src/symbol/grid_index.test.ts
+++ b/src/symbol/grid_index.test.ts
@@ -86,7 +86,7 @@ describe('GridIndex', () => {
         // differs from y_boundary_a by less than 1e-10 (1-2 ULPs)
         const y_boundary_b = 406.2043266199999;
         // y_boundary_b < y_boundary_a, so strict >= would fail
-        expect(y_boundary_b >= y_boundary_a).toBe(false);
+        expect(y_boundary_b).toBeLessThan(y_boundary_a);
 
         // Despite the floating-point difference, hitTest should detect overlap
         expect(grid.hitTest(660, 366, y_boundary_b, y_boundary_b, 'never')).toBeFalsy();

--- a/src/tile/terrain_tile_manager.test.ts
+++ b/src/tile/terrain_tile_manager.test.ts
@@ -1,4 +1,4 @@
-import {describe, beforeAll, afterAll, test, expect, vi, type Mock} from 'vitest';
+import {describe, beforeAll, afterAll, test, expect, vi} from 'vitest';
 import {TerrainTileManager} from './terrain_tile_manager.ts';
 import {Style} from '../style/style.ts';
 import {RequestManager} from '../util/request_manager.ts';
@@ -248,7 +248,7 @@ describe('TerrainTileManager', () => {
 
             tsc.releaseAllRTT();
 
-            expect((painter.releaseRTT as Mock<typeof painter.releaseRTT>).mock.calls.length).toBe(Object.keys(tiles).length);
+            expect((vi.mocked(painter.releaseRTT))).toHaveBeenCalledTimes(Object.keys(tiles).length);
             for (const key in rttObjects) {
                 expect(painter.releaseRTT).toHaveBeenCalledWith(rttObjects[key]);
                 expect(tiles[key].getRTT(0)).toBeUndefined();

--- a/src/tile/tile_id.test.ts
+++ b/src/tile/tile_id.test.ts
@@ -7,16 +7,16 @@ describe('CanonicalTileID', () => {
     test('constructor', () => {
         expect(() => {
             new CanonicalTileID(MIN_TILE_ZOOM - 1, 0, 0);
-        }).toThrow();
+        }).toThrow(`x=0, y=0, z=${MIN_TILE_ZOOM - 1} outside of bounds`);
         expect(() => {
             new CanonicalTileID(MAX_TILE_ZOOM + 1, 0, 0);
-        }).toThrow();
+        }).toThrow(`x=0, y=0, z=${MAX_TILE_ZOOM + 1} outside of bounds`);
         expect(() => {
             new CanonicalTileID(2, 4, 0);
-        }).toThrow();
+        }).toThrow('x=4, y=0, z=2 outside of bounds');
         expect(() => {
             new CanonicalTileID(2, 0, 4);
-        }).toThrow();
+        }).toThrow('x=0, y=4, z=2 outside of bounds');
     });
 
     test('.key', () => {
@@ -67,7 +67,7 @@ describe('OverscaledTileID', () => {
     });
 
     test('constructor - deeper canonicalZ than overscaledZ disallowed', () => {
-        expect(() => new OverscaledTileID(7, 0, 8, 0, 0)).toThrow();
+        expect(() => new OverscaledTileID(7, 0, 8, 0, 0)).toThrow('overscaledZ should be >= z; overscaledZ = 7; z = 8');
     });
 
     test('.key', () => {

--- a/src/tile/tile_manager.test.ts
+++ b/src/tile/tile_manager.test.ts
@@ -2328,11 +2328,9 @@ describe('tile manager loaded', () => {
 
         const sourceLoadedPromise = waitForEvent(tileManager, 'data', () => tileManager.loaded());
 
-        const loadedBeforeIdle: boolean[] = [];
         tileManager.on('data', (e) => {
-            if (e.sourceDataType !== 'idle') {
-                loadedBeforeIdle.push(tileManager.loaded());
-            }
+            if (e.sourceDataType === 'idle') return;
+            expect(tileManager.loaded()).toBe(false);
         });
 
         tileManager.onAdd(undefined);
@@ -2341,8 +2339,6 @@ describe('tile manager loaded', () => {
         tr.resize(512, 512);
         tileManager.update(tr);
         await sourceLoadedPromise;
-
-        expect(loadedBeforeIdle).not.toContain(true);
     });
 });
 

--- a/src/tile/tile_manager.test.ts
+++ b/src/tile/tile_manager.test.ts
@@ -343,16 +343,24 @@ describe('TileManager.removeTile', () => {
 
     });
 
-    test('_tileLoaded after _removeTile skips tile.added', () => {
+    test('_tileLoaded after _removeTile skips tile.added', async () => {
         const tileID = new OverscaledTileID(0, 0, 0, 0, 0);
 
         const tileManager = createTileManager();
+        let releaseLoad: () => void;
+        const tileRegistered = new Promise<void>((resolve) => { releaseLoad = resolve; });
         tileManager._source.loadTile = async () => {
+            await tileRegistered;
             tileManager._removeTile(tileID.key);
         };
         tileManager.map = {painter: {crossTileSymbolIndex: '', tileExtentVAO: {}}} as any;
 
-        tileManager._addTile(tileID);
+        const abortPromise = tileManager.once('dataabort');
+        const tile = tileManager._addTile(tileID);
+        releaseLoad();
+        await abortPromise;
+
+        expect(tile.aborted).toBe(true);
     });
 
     test('fires dataabort event', async () => {
@@ -454,8 +462,11 @@ describe('TileManager / Source lifecycle', () => {
 
     test('suppress 404 errors', () => {
         const tileManager = createTileManager({status: 404, message: 'Not found'});
-        tileManager.on('error', () => { throw new Error('test failed: error event fired'); });
+        const errorListener = vi.fn();
+        tileManager.on('error', errorListener);
         tileManager.onAdd(undefined);
+
+        expect(errorListener).not.toHaveBeenCalled();
     });
 
     test('loaded() true after source error', async () => {
@@ -801,7 +812,7 @@ describe('TileManager.update', () => {
         ]);
     });
 
-    test('retains children tiles for pending parents', () => {
+    test('retains children tiles for pending parents', async () => {
         const transform = new GlobeTransform();
         transform.resize(511, 511);
         transform.setZoom(1);
@@ -812,29 +823,28 @@ describe('TileManager.update', () => {
             tile.state = (tile.tileID.key === new OverscaledTileID(0, 1, 0, 0, 0).key) ? 'loading' : 'loaded';
         };
 
-        tileManager.on('data', (e) => {
-            if (e.sourceDataType === 'metadata') {
-                tileManager.update(transform);
-                expect(tileManager.getIds()).toEqual([
-                    new OverscaledTileID(1, 1, 1, 1, 1).key,
-                    new OverscaledTileID(1, 1, 1, 0, 1).key,
-                    new OverscaledTileID(1, 1, 1, 1, 0).key,
-                    new OverscaledTileID(1, 1, 1, 0, 0).key
-                ]);
-
-                transform.setZoom(0);
-                tileManager.update(transform);
-
-                expect(tileManager.getIds()).toEqual([
-                    new OverscaledTileID(0, 1, 0, 0, 0).key,
-                    new OverscaledTileID(1, 1, 1, 1, 1).key,
-                    new OverscaledTileID(1, 1, 1, 0, 1).key,
-                    new OverscaledTileID(1, 1, 1, 1, 0).key,
-                    new OverscaledTileID(1, 1, 1, 0, 0).key
-                ]);
-            }
-        });
+        const metadataPromise = waitForEvent(tileManager, 'data', e => e.sourceDataType === 'metadata');
         tileManager.onAdd(undefined);
+        await metadataPromise;
+
+        tileManager.update(transform);
+        expect(tileManager.getIds()).toEqual([
+            new OverscaledTileID(1, 1, 1, 1, 1).key,
+            new OverscaledTileID(1, 1, 1, 0, 1).key,
+            new OverscaledTileID(1, 1, 1, 1, 0).key,
+            new OverscaledTileID(1, 1, 1, 0, 0).key
+        ]);
+
+        transform.setZoom(0);
+        tileManager.update(transform);
+
+        expect(tileManager.getIds()).toEqual([
+            new OverscaledTileID(0, 1, 0, 0, 0).key,
+            new OverscaledTileID(1, 1, 1, 1, 1).key,
+            new OverscaledTileID(1, 1, 1, 0, 1).key,
+            new OverscaledTileID(1, 1, 1, 1, 0).key,
+            new OverscaledTileID(1, 1, 1, 0, 0).key
+        ]);
     });
 
     test('retains overscaled loaded children', async () => {
@@ -1136,7 +1146,7 @@ describe('TileManager._updateRetainedTiles', () => {
         const secondGeneration = idealTile
             .children(10)
             .flatMap(child => child.children(10));
-        expect(secondGeneration.length).toEqual(16);
+        expect(secondGeneration).toHaveLength(16);
 
         for (const id of secondGeneration) {
             tileManager._inViewTiles.setTile(id.key, new Tile(id, undefined));
@@ -1774,7 +1784,7 @@ describe('TileManager.tilesIn', () => {
         expect(round(tiles[1].queryGeometry)).toEqual([{x: -4096, y: 4050}, {x: 4096, y: 8146}]);
     });
 
-    test('reparsed overscaled tiles', () => {
+    test('reparsed overscaled tiles', async () => {
         const tileManager = createTileManager({
             reparseOverscaled: true,
             minzoom: 1,
@@ -1785,44 +1795,42 @@ describe('TileManager.tilesIn', () => {
             tile.state = 'loaded';
         };
 
-        tileManager.on('data', (e) => {
-            if (e.sourceDataType === 'metadata') {
-                const transform = new MercatorTransform();
-                transform.resize(1024, 1024);
-                transform.setZoom(2);
-                transform.setCenter(new LngLat(0, 1));
-                tileManager.update(transform);
-
-                expect(tileManager.getIds()).toEqual([
-                    new OverscaledTileID(2, 0, 1, 1, 1).key,
-                    new OverscaledTileID(2, 0, 1, 0, 1).key,
-                    new OverscaledTileID(2, 0, 1, 1, 0).key,
-                    new OverscaledTileID(2, 0, 1, 0, 0).key
-                ]);
-
-                const tiles = tileManager.tilesIn([
-                    new Point(0, 0),
-                    new Point(1024, 512)
-                ], 1, true);
-
-                tiles.sort((a, b) => { return a.tile.tileID.canonical.x - b.tile.tileID.canonical.x; });
-                for (const result of tiles) {
-                    delete result.tile.uid;
-                }
-
-                expect(tiles[0].tile.tileID.key).toBe('012');
-                expect(tiles[0].tile.tileSize).toBe(1024);
-                expect(tiles[0].scale).toBe(1);
-                expect(round(tiles[0].queryGeometry)).toEqual([{x: 4096, y: 4050}, {x: 12288, y: 8146}]);
-
-                expect(tiles[1].tile.tileID.key).toBe('112');
-                expect(tiles[1].tile.tileSize).toBe(1024);
-                expect(tiles[1].scale).toBe(1);
-                expect(round(tiles[1].queryGeometry)).toEqual([{x: -4096, y: 4050}, {x: 4096, y: 8146}]);
-
-            }
-        });
+        const metadataPromise = waitForEvent(tileManager, 'data', e => e.sourceDataType === 'metadata');
         tileManager.onAdd(undefined);
+        await metadataPromise;
+
+        const transform = new MercatorTransform();
+        transform.resize(1024, 1024);
+        transform.setZoom(2);
+        transform.setCenter(new LngLat(0, 1));
+        tileManager.update(transform);
+
+        expect(tileManager.getIds()).toEqual([
+            new OverscaledTileID(2, 0, 1, 1, 1).key,
+            new OverscaledTileID(2, 0, 1, 0, 1).key,
+            new OverscaledTileID(2, 0, 1, 1, 0).key,
+            new OverscaledTileID(2, 0, 1, 0, 0).key
+        ]);
+
+        const tiles = tileManager.tilesIn([
+            new Point(0, 0),
+            new Point(1024, 512)
+        ], 1, true);
+
+        tiles.sort((a, b) => { return a.tile.tileID.canonical.x - b.tile.tileID.canonical.x; });
+        for (const result of tiles) {
+            delete result.tile.uid;
+        }
+
+        expect(tiles[0].tile.tileID.key).toBe('012');
+        expect(tiles[0].tile.tileSize).toBe(1024);
+        expect(tiles[0].scale).toBe(1);
+        expect(round(tiles[0].queryGeometry)).toEqual([{x: 4096, y: 4050}, {x: 12288, y: 8146}]);
+
+        expect(tiles[1].tile.tileID.key).toBe('112');
+        expect(tiles[1].tile.tileSize).toBe(1024);
+        expect(tiles[1].scale).toBe(1);
+        expect(round(tiles[1].queryGeometry)).toEqual([{x: -4096, y: 4050}, {x: 4096, y: 8146}]);
     });
 
     test('overscaled tiles', async () => {
@@ -1843,6 +1851,13 @@ describe('TileManager.tilesIn', () => {
         transform.resize(512, 512);
         transform.setZoom(2.0);
         tileManager.update(transform);
+
+        expect(tileManager.getIds()).toEqual([
+            new OverscaledTileID(1, 0, 1, 1, 1).key,
+            new OverscaledTileID(1, 0, 1, 0, 1).key,
+            new OverscaledTileID(1, 0, 1, 1, 0).key,
+            new OverscaledTileID(1, 0, 1, 0, 0).key
+        ]);
     });
 
     test('globe wrap', async () => {
@@ -2283,7 +2298,7 @@ describe('tile manager loaded', () => {
         tileManager.update(tr);
 
         await sourceLoadedPromise;
-        expect(spy.mock.calls.length).toBe(5); // 4 tiles + 1 source loaded
+        expect(spy).toHaveBeenCalledTimes(5); // 4 tiles + 1 source loaded
     });
 
     test('TileManager.loaded (tiles outside bounds, idle)', async () => {
@@ -2313,10 +2328,10 @@ describe('tile manager loaded', () => {
 
         const sourceLoadedPromise = waitForEvent(tileManager, 'data', () => tileManager.loaded());
 
+        const loadedBeforeIdle: boolean[] = [];
         tileManager.on('data', (e) => {
             if (e.sourceDataType !== 'idle') {
-                expect(tileManager.loaded()).toBeFalsy();
-                // 'idle' emission when source bounds are outside of viewport bounds
+                loadedBeforeIdle.push(tileManager.loaded());
             }
         });
 
@@ -2326,6 +2341,8 @@ describe('tile manager loaded', () => {
         tr.resize(512, 512);
         tileManager.update(tr);
         await sourceLoadedPromise;
+
+        expect(loadedBeforeIdle).not.toContain(true);
     });
 });
 
@@ -2518,7 +2535,7 @@ describe('TileManager::refreshTiles', () => {
 
         tileManager._addTile(coord);
         tileManager.refreshTiles([new CanonicalTileID(1, 0, 1)]);
-        expect(spy).toHaveBeenCalledOnce();
+        expect(spy).toHaveBeenCalledTimes(1);
         expect(spy.mock.calls[0][1]).toBe('expired');
     });
 
@@ -2549,7 +2566,7 @@ describe('TileManager::refreshTiles', () => {
 
         tileManager._addTile(coord);
         tileManager.refreshTiles([new CanonicalTileID(1, 0, 1)]);
-        expect(spy).toHaveBeenCalledOnce();
+        expect(spy).toHaveBeenCalledTimes(1);
         expect(spy.mock.calls[0][1]).toBe('expired');
     });
 
@@ -2565,7 +2582,7 @@ describe('TileManager::refreshTiles', () => {
 
         tileManager._addTile(coord);
         tileManager.refreshTiles([new CanonicalTileID(1, 0, 1)]);
-        expect(spy).toHaveBeenCalledOnce();
+        expect(spy).toHaveBeenCalledTimes(1);
         expect(spy.mock.calls[0][1]).toBe('expired');
     });
 

--- a/src/tile/tile_manager_in_view_tiles.test.ts
+++ b/src/tile/tile_manager_in_view_tiles.test.ts
@@ -81,7 +81,7 @@ describe('InViewTiles', () => {
         inViewTiles.handleWrapJump(1);
 
         const tiles = inViewTiles.getAllTiles();
-        expect(tiles.length).toBe(1);
+        expect(tiles).toHaveLength(1);
         expect(tiles[0].tileID.wrap).toBe(1);
         expect(inViewTiles.getTileById(tiles[0].tileID.key)).toBe(tiles[0]);
     });
@@ -96,7 +96,7 @@ describe('InViewTiles', () => {
         inViewTiles.handleWrapJump(-1);
 
         const tiles = inViewTiles.getAllTiles();
-        expect(tiles.length).toBe(2);
+        expect(tiles).toHaveLength(2);
         
         const updatedTile1 = tiles.find(t => t.uid === tile1.uid);
         const updatedTile2 = tiles.find(t => t.uid === tile2.uid);

--- a/src/ui/camera.test.ts
+++ b/src/ui/camera.test.ts
@@ -126,7 +126,7 @@ describe('calculateCameraOptionsFromTo', () => {
     });
 
     test('same To as From error', () => {
-        expect(() => camera.calculateCameraOptionsFromTo({lng: 0, lat: 0}, 0, {lng: 0, lat: 0}, 0)).toThrow();
+        expect(() => camera.calculateCameraOptionsFromTo({lng: 0, lat: 0}, 0, {lng: 0, lat: 0}, 0)).toThrow('Can\'t calculate camera options with same From and To');
     });
 });
 

--- a/src/ui/camera.test.ts
+++ b/src/ui/camera.test.ts
@@ -1046,14 +1046,14 @@ describe('easeTo', () => {
         const {camera, queue} = createCamera();
         const stub = vi.spyOn(timeControl, 'now');
 
-        stub.mockImplementation(() => 0);
+        stub.mockReturnValue(0);
         camera.easeTo({center: [100, 0], duration: 10});
 
         let promise = camera.once('moveend');
 
         // setTimeout to avoid a synchronous callback
         setTimeout(() => {
-            stub.mockImplementation(() => 10);
+            stub.mockReturnValue(10);
             queue.run();
         }, 0);
 
@@ -1063,7 +1063,7 @@ describe('easeTo', () => {
 
         // setTimeout to avoid a synchronous callback
         setTimeout(() => {
-            stub.mockImplementation(() => 20);
+            stub.mockReturnValue(20);
             queue.run();
         }, 0);
 
@@ -1072,11 +1072,12 @@ describe('easeTo', () => {
         promise = camera.once('moveend');
 
         setTimeout(() => {
-            stub.mockImplementation(() => 30);
+            stub.mockReturnValue(30);
             queue.run();
         }, 0);
 
         await promise;
+        expect(camera.getCenter().lng).toBeCloseTo(-60);
     });
 
     test('pans eastward across the antimeridian', async () => {
@@ -1094,15 +1095,15 @@ describe('easeTo', () => {
 
         const promise = camera.once('moveend');
 
-        stub.mockImplementation(() => 0);
+        stub.mockReturnValue(0);
         camera.easeTo({center: [-170, 0], duration: 10});
 
         setTimeout(() => {
-            stub.mockImplementation(() => 1);
+            stub.mockReturnValue(1);
             queue.run();
 
             setTimeout(() => {
-                stub.mockImplementation(() => 10);
+                stub.mockReturnValue(10);
                 queue.run();
             }, 0);
         }, 0);
@@ -1137,15 +1138,15 @@ describe('easeTo', () => {
 
         const promise = camera.once('moveend');
 
-        stub.mockImplementation(() => 0);
+        stub.mockReturnValue(0);
         camera.easeTo({center: [170, 0], duration: 10});
 
         setTimeout(() => {
-            stub.mockImplementation(() => 1);
+            stub.mockReturnValue(1);
             queue.run();
 
             setTimeout(() => {
-                stub.mockImplementation(() => 10);
+                stub.mockReturnValue(10);
                 queue.run();
             }, 0);
         }, 0);
@@ -1180,13 +1181,13 @@ describe('easeTo', () => {
         const promise = camera.once('moveend');
 
         setTimeout(() => {
-            stubNow.mockImplementation(() => 0);
+            stubNow.mockReturnValue(0);
             queue.run();
 
             camera.easeTo({center: [100, 0], zoom: 3.2, bearing: 90, duration: 200, essential: true});
 
             setTimeout(() => {
-                stubNow.mockImplementation(() => 200);
+                stubNow.mockReturnValue(200);
                 queue.run();
             }, 0);
         }, 0);
@@ -1286,11 +1287,11 @@ describe('easeTo', () => {
         const {camera, queue} = createCamera({terrain});
         const stubNow = vi.spyOn(timeControl, 'now');
 
-        stubNow.mockImplementation(() => 0);
+        stubNow.mockReturnValue(0);
 
         camera.easeTo({bearing: 97, duration: 500});
 
-        stubNow.mockImplementation(() => 100);
+        stubNow.mockReturnValue(100);
         queue.run();
 
         terrain = {
@@ -1298,10 +1299,10 @@ describe('easeTo', () => {
             getElevationForLngLatZoom: () => 0
         } as any as Terrain;
 
-        stubNow.mockImplementation(() => 500);
+        stubNow.mockReturnValue(500);
         queue.run();
 
-        expect(camera.getBearing()).toEqual(97);
+        expect(camera.getBearing()).toBe(97);
     });
 
     test('respects zoomSnap', () => {
@@ -1361,10 +1362,10 @@ describe('flyTo', () => {
 
         const promise = camera.once('moveend');
 
-        stub.mockImplementation(() => 0);
+        stub.mockReturnValue(0);
         camera.flyTo({zoom: 19, center: pos, duration: 2});
 
-        stub.mockImplementation(() => 3);
+        stub.mockReturnValue(3);
         queue.run();
 
         await promise;
@@ -1552,16 +1553,16 @@ describe('flyTo', () => {
         const promise = camera.once('moveend');
 
         const stub = vi.spyOn(timeControl, 'now');
-        stub.mockImplementation(() => 0);
+        stub.mockReturnValue(0);
 
         camera.flyTo({center: [100, 0], duration: 10}, eventData);
 
         setTimeout(() => {
-            stub.mockImplementation(() => 1);
+            stub.mockReturnValue(1);
             queue.run();
 
             setTimeout(() => {
-                stub.mockImplementation(() => 10);
+                stub.mockReturnValue(10);
                 queue.run();
             }, 0);
         }, 0);
@@ -1595,9 +1596,9 @@ describe('flyTo', () => {
         const stub = vi.spyOn(timeControl, 'now');
 
         const {camera, queue} = createCamera();
-        stub.mockImplementation(() => 0);
+        stub.mockReturnValue(0);
         camera.easeTo({pitch: 10, bearing: 100, duration: 1000});
-        stub.mockImplementation(() => 100);
+        stub.mockReturnValue(100);
         queue.run();
         camera.easeTo({elevation: 1, duration: 0});
         expect(camera.getRoll()).toBe(0);
@@ -1607,9 +1608,9 @@ describe('flyTo', () => {
         const stub = vi.spyOn(timeControl, 'now');
 
         const {camera, queue} = createCamera(null, true);
-        stub.mockImplementation(() => 0);
+        stub.mockReturnValue(0);
         camera.easeTo({pitch: 10, bearing: 100, duration: 1000});
-        stub.mockImplementation(() => 100);
+        stub.mockReturnValue(100);
         queue.run();
         camera.easeTo({elevation: 1, duration: 0});
         expect(camera.getRoll()).toBe(0);
@@ -1619,9 +1620,9 @@ describe('flyTo', () => {
         const stub = vi.spyOn(timeControl, 'now');
 
         const {camera, queue} = createCamera();
-        stub.mockImplementation(() => 0);
+        stub.mockReturnValue(0);
         camera.easeTo({pitch: 10, bearing: 20, roll: 30, duration: 1000});
-        stub.mockImplementation(() => 500);
+        stub.mockReturnValue(500);
         queue.run();
         camera.easeTo({elevation: 1, duration: 0});
         expect(camera.getRoll()).toBeCloseTo(25.041890412598942);
@@ -1633,9 +1634,9 @@ describe('flyTo', () => {
         const stub = vi.spyOn(timeControl, 'now');
 
         const {camera, queue} = createCamera(null, true);
-        stub.mockImplementation(() => 0);
+        stub.mockReturnValue(0);
         camera.easeTo({pitch: 10, bearing: 20, roll: 30, duration: 1000});
-        stub.mockImplementation(() => 500);
+        stub.mockReturnValue(500);
         queue.run();
         camera.easeTo({elevation: 1, duration: 0});
         expect(camera.getRoll()).toBeCloseTo(25.041890412598942);
@@ -1646,21 +1647,21 @@ describe('flyTo', () => {
     test('can be called from within a moveend event handler', async () => {
         const {camera, queue} = createCamera();
         const stub = vi.spyOn(timeControl, 'now');
-        stub.mockImplementation(() => 0);
+        stub.mockReturnValue(0);
 
         camera.flyTo({center: [100, 0], duration: 10});
         let promise = camera.once('moveend');
 
         setTimeout(() => {
-            stub.mockImplementation(() => 10);
+            stub.mockReturnValue(10);
             queue.run();
 
             setTimeout(() => {
-                stub.mockImplementation(() => 20);
+                stub.mockReturnValue(20);
                 queue.run();
 
                 setTimeout(() => {
-                    stub.mockImplementation(() => 30);
+                    stub.mockReturnValue(30);
                     queue.run();
                 }, 0);
             }, 0);
@@ -1671,6 +1672,8 @@ describe('flyTo', () => {
         await promise;
         camera.flyTo({center: [300, 0], duration: 10});
         await camera.once('moveend');
+
+        expect(camera.getCenter().lng).toBeCloseTo(-60);
     });
 
     test('ascends', async () => {
@@ -1687,16 +1690,16 @@ describe('flyTo', () => {
         const promise = camera.once('moveend');
 
         const stub = vi.spyOn(timeControl, 'now');
-        stub.mockImplementation(() => 0);
+        stub.mockReturnValue(0);
 
         camera.flyTo({center: [100, 0], zoom: 18, duration: 10});
 
         setTimeout(() => {
-            stub.mockImplementation(() => 1);
+            stub.mockReturnValue(1);
             queue.run();
 
             setTimeout(() => {
-                stub.mockImplementation(() => 10);
+                stub.mockReturnValue(10);
                 queue.run();
             }, 0);
         }, 0);
@@ -1719,15 +1722,15 @@ describe('flyTo', () => {
 
         const promise = camera.once('moveend');
 
-        stub.mockImplementation(() => 0);
+        stub.mockReturnValue(0);
         camera.flyTo({center: [10, 0], duration: 20});
 
         setTimeout(() => {
-            stub.mockImplementation(() => 1);
+            stub.mockReturnValue(1);
             queue.run();
 
             setTimeout(() => {
-                stub.mockImplementation(() => 20);
+                stub.mockReturnValue(20);
                 queue.run();
             }, 0);
         }, 0);
@@ -1751,15 +1754,15 @@ describe('flyTo', () => {
 
         const promise = camera.once('moveend');
 
-        stub.mockImplementation(() => 0);
+        stub.mockReturnValue(0);
         camera.flyTo({center: [-10, 0], duration: 20});
 
         setTimeout(() => {
-            stub.mockImplementation(() => 1);
+            stub.mockReturnValue(1);
             queue.run();
 
             setTimeout(() => {
-                stub.mockImplementation(() => 20);
+                stub.mockReturnValue(20);
                 queue.run();
             }, 0);
         }, 0);
@@ -1783,15 +1786,15 @@ describe('flyTo', () => {
 
         const promise = camera.once('moveend');
 
-        stub.mockImplementation(() => 0);
+        stub.mockReturnValue(0);
         camera.flyTo({center: [-170, 0], duration: 20});
 
         setTimeout(() => {
-            stub.mockImplementation(() => 1);
+            stub.mockReturnValue(1);
             queue.run();
 
             setTimeout(() => {
-                stub.mockImplementation(() => 20);
+                stub.mockReturnValue(20);
                 queue.run();
             }, 0);
         }, 0);
@@ -1814,15 +1817,15 @@ describe('flyTo', () => {
 
         const promise = camera.once('moveend');
 
-        stub.mockImplementation(() => 0);
+        stub.mockReturnValue(0);
         camera.flyTo({center: [170, 0], duration: 10});
 
         setTimeout(() => {
-            stub.mockImplementation(() => 1);
+            stub.mockReturnValue(1);
             queue.run();
 
             setTimeout(() => {
-                stub.mockImplementation(() => 10);
+                stub.mockReturnValue(10);
                 queue.run();
             }, 0);
         }, 0);
@@ -1845,15 +1848,15 @@ describe('flyTo', () => {
 
         const promise = camera.once('moveend');
 
-        stub.mockImplementation(() => 0);
+        stub.mockReturnValue(0);
         camera.flyTo({center: [-170, 0], duration: 10});
 
         setTimeout(() => {
-            stub.mockImplementation(() => 1);
+            stub.mockReturnValue(1);
             queue.run();
 
             setTimeout(() => {
-                stub.mockImplementation(() => 10);
+                stub.mockReturnValue(10);
                 queue.run();
             }, 0);
         }, 0);
@@ -1877,15 +1880,15 @@ describe('flyTo', () => {
 
         const promise = camera.once('moveend');
 
-        stub.mockImplementation(() => 0);
+        stub.mockReturnValue(0);
         camera.flyTo({center: [170, 0], duration: 10});
 
         setTimeout(() => {
-            stub.mockImplementation(() => 1);
+            stub.mockReturnValue(1);
             queue.run();
 
             setTimeout(() => {
-                stub.mockImplementation(() => 10);
+                stub.mockReturnValue(10);
                 queue.run();
             }, 0);
         }, 0);
@@ -1908,15 +1911,15 @@ describe('flyTo', () => {
 
         const promise = camera.once('moveend');
 
-        stub.mockImplementation(() => 0);
+        stub.mockReturnValue(0);
         camera.flyTo({center: [170, 0], duration: 10});
 
         setTimeout(() => {
-            stub.mockImplementation(() => 1);
+            stub.mockReturnValue(1);
             queue.run();
 
             setTimeout(() => {
-                stub.mockImplementation(() => 10);
+                stub.mockReturnValue(10);
                 queue.run();
             }, 0);
         }, 0);
@@ -1937,7 +1940,7 @@ describe('flyTo', () => {
         const promise = camera.once('moveend');
 
         const duration = 10;
-        stub.mockImplementation(() => 0);
+        stub.mockReturnValue(0);
         camera.flyTo({center: [1, 0], zoom: 20, minZoom, duration});
 
         await simulateAllAnimationFrames(stub, camera, queue, duration);
@@ -1960,7 +1963,7 @@ describe('flyTo', () => {
         const promise = camera.once('moveend');
 
         const duration = 10;
-        stub.mockImplementation(() => 0);
+        stub.mockReturnValue(0);
         camera.flyTo({center: [1, 0], zoom: 20, duration});
 
         await simulateAllAnimationFrames(stub, camera, queue, duration);
@@ -1977,11 +1980,11 @@ describe('flyTo', () => {
         const promise = camera.once('moveend');
 
         const stub = vi.spyOn(timeControl, 'now');
-        stub.mockImplementation(() => 0);
+        stub.mockReturnValue(0);
         camera.flyTo({center: [12, 34], zoom: 30, duration: 10});
 
         setTimeout(() => {
-            stub.mockImplementation(() => 10);
+            stub.mockReturnValue(10);
             queue.run();
         }, 0);
 
@@ -1999,11 +2002,11 @@ describe('flyTo', () => {
         const promise = camera.once('moveend');
 
         const stub = vi.spyOn(timeControl, 'now');
-        stub.mockImplementation(() => 0);
+        stub.mockReturnValue(0);
         camera.flyTo({center: [12, 34], zoom: 1, duration: 10});
 
         setTimeout(() => {
-            stub.mockImplementation(() => 10);
+            stub.mockReturnValue(10);
             queue.run();
         }, 0);
 
@@ -2026,15 +2029,15 @@ describe('flyTo', () => {
 
         const promise = camera.once('moveend');
         const stub = vi.spyOn(timeControl, 'now');
-        stub.mockImplementation(() => 0);
+        stub.mockReturnValue(0);
         camera.flyTo({center: [40, 0], zoom: 10, duration: 10});
 
         await new Promise(resolve => setTimeout(resolve, 0));
-        stub.mockImplementation(() => 5);
+        stub.mockReturnValue(5);
         queue.run();
 
         await new Promise(resolve => setTimeout(resolve, 0));
-        stub.mockImplementation(() => 10);
+        stub.mockReturnValue(10);
         queue.run();
 
         await promise;
@@ -2097,11 +2100,11 @@ describe('flyTo', () => {
         camera.setCenter([-10, 0]);
         const moveEnded = camera.once('moveend');
 
-        stub.mockImplementation(() => 0);
+        stub.mockReturnValue(0);
         camera.flyTo({center: [10, 0], duration: 20, freezeElevation: false});
-        stub.mockImplementation(() => 1);
+        stub.mockReturnValue(1);
         queue.run();
-        stub.mockImplementation(() => 20);
+        stub.mockReturnValue(20);
         queue.run();
         await moveEnded;
         expect(terrainCallbacks.prepare).toBe(1);
@@ -2121,11 +2124,11 @@ describe('flyTo', () => {
         camera.setCenter([-10, 0]);
         const moveEnded = camera.once('moveend');
 
-        stub.mockImplementation(() => 0);
+        stub.mockReturnValue(0);
         camera.flyTo({center: [10, 0], duration: 20, freezeElevation: true});
-        stub.mockImplementation(() => 1);
+        stub.mockReturnValue(1);
         queue.run();
-        stub.mockImplementation(() => 20);
+        stub.mockReturnValue(20);
         queue.run();
         await moveEnded;
         expect(terrainCallbacks.prepare).toBe(1);
@@ -2191,10 +2194,10 @@ describe('isEasing', () => {
         const {camera, queue} = createCamera();
         const promise = camera.once('moveend');
         const stub = vi.spyOn(timeControl, 'now');
-        stub.mockImplementation(() => 0);
+        stub.mockReturnValue(0);
         camera.panTo([100, 0], {duration: 1});
         setTimeout(() => {
-            stub.mockImplementation(() => 1);
+            stub.mockReturnValue(1);
             queue.run();
         }, 0);
 
@@ -2213,10 +2216,10 @@ describe('isEasing', () => {
         const {camera, queue} = createCamera();
         const promise = camera.once('moveend');
         const stub = vi.spyOn(timeControl, 'now');
-        stub.mockImplementation(() => 0);
+        stub.mockReturnValue(0);
         camera.zoomTo(3.2, {duration: 1});
         setTimeout(() => {
-            stub.mockImplementation(() => 1);
+            stub.mockReturnValue(1);
             queue.run();
         }, 0);
 
@@ -2234,10 +2237,10 @@ describe('isEasing', () => {
         const {camera, queue} = createCamera();
         const promise = camera.once('moveend');
         const stub = vi.spyOn(timeControl, 'now');
-        stub.mockImplementation(() => 0);
+        stub.mockReturnValue(0);
         camera.rotateTo(90, {duration: 1});
         setTimeout(() => {
-            stub.mockImplementation(() => 1);
+            stub.mockReturnValue(1);
             queue.run();
         }, 0);
 
@@ -2309,11 +2312,11 @@ describe('stop', () => {
         camera.on('moveend', spy);
 
         const stub = vi.spyOn(timeControl, 'now');
-        stub.mockImplementation(() => 0);
+        stub.mockReturnValue(0);
         camera.panTo([100, 0], {duration: 1}, eventData);
 
         setTimeout(() => {
-            stub.mockImplementation(() => 1);
+            stub.mockReturnValue(1);
             queue.run();
         }, 0);
 
@@ -2605,7 +2608,7 @@ describe('transformCameraUpdate', () => {
     test('invoke transformCameraUpdate callback during easeTo', async () => {
         const {camera, queue} = createCamera();
         const stub = vi.spyOn(timeControl, 'now');
-        stub.mockImplementation(() => 0);
+        stub.mockReturnValue(0);
 
         let callbackCount = 0;
         let eventCount = 0;
@@ -2624,11 +2627,11 @@ describe('transformCameraUpdate', () => {
         camera.easeTo({center: [100, 0], duration: 10});
 
         setTimeout(() => {
-            stub.mockImplementation(() => 1);
+            stub.mockReturnValue(1);
             queue.run();
 
             setTimeout(() => {
-                stub.mockImplementation(() => 10);
+                stub.mockReturnValue(10);
                 queue.run();
             }, 0);
         }, 0);
@@ -2639,7 +2642,7 @@ describe('transformCameraUpdate', () => {
     test('invoke transformCameraUpdate callback during flyTo', async () => {
         const {camera, queue} = createCamera();
         const stub = vi.spyOn(timeControl, 'now');
-        stub.mockImplementation(() => 0);
+        stub.mockReturnValue(0);
 
         let callbackCount = 0;
         let eventCount = 0;
@@ -2658,11 +2661,11 @@ describe('transformCameraUpdate', () => {
         camera.flyTo({center: [100, 0], duration: 10});
 
         setTimeout(() => {
-            stub.mockImplementation(() => 1);
+            stub.mockReturnValue(1);
             queue.run();
 
             setTimeout(() => {
-                stub.mockImplementation(() => 10);
+                stub.mockReturnValue(10);
                 queue.run();
             }, 0);
         }, 0);
@@ -2951,11 +2954,11 @@ describe('easeTo globe projection', () => {
             const stub = vi.spyOn(timeControl, 'now');
             const promise = camera.once('moveend');
 
-            stub.mockImplementation(() => 0);
+            stub.mockReturnValue(0);
 
             camera.easeTo({center: [100, 0], duration: 100, padding: {left: 100}});
 
-            stub.mockImplementation(() => 50);
+            stub.mockReturnValue(50);
             queue.run();
 
             const padding = camera.getPadding();
@@ -2965,7 +2968,7 @@ describe('easeTo globe projection', () => {
             expect(padding.right).toBe(0);
             expect(padding.top).toBe(0);
 
-            stub.mockImplementation(() => 100);
+            stub.mockReturnValue(100);
             queue.run();
 
             await promise;
@@ -3123,15 +3126,15 @@ describe('easeTo globe projection', () => {
 
             const promise = camera.once('moveend');
 
-            stub.mockImplementation(() => 0);
+            stub.mockReturnValue(0);
             camera.easeTo({center: [-170, 0], duration: 10});
 
             setTimeout(() => {
-                stub.mockImplementation(() => 1);
+                stub.mockReturnValue(1);
                 queue.run();
 
                 setTimeout(() => {
-                    stub.mockImplementation(() => 10);
+                    stub.mockReturnValue(10);
                     queue.run();
                 }, 0);
             }, 0);
@@ -3165,15 +3168,15 @@ describe('easeTo globe projection', () => {
 
             const promise = camera.once('moveend');
 
-            stub.mockImplementation(() => 0);
+            stub.mockReturnValue(0);
             camera.easeTo({center: [170, 0], duration: 10});
 
             setTimeout(() => {
-                stub.mockImplementation(() => 1);
+                stub.mockReturnValue(1);
                 queue.run();
 
                 setTimeout(() => {
-                    stub.mockImplementation(() => 10);
+                    stub.mockReturnValue(10);
                     queue.run();
                 }, 0);
             }, 0);
@@ -3256,10 +3259,10 @@ describe('flyTo globe projection', () => {
 
             const promise = camera.once('zoomend');
 
-            stub.mockImplementation(() => 0);
+            stub.mockReturnValue(0);
             camera.flyTo({zoom: 19, center: pos, duration: 2});
 
-            stub.mockImplementation(() => 3);
+            stub.mockReturnValue(3);
             queue.run();
 
             await promise;
@@ -3334,11 +3337,11 @@ describe('flyTo globe projection', () => {
             const stub = vi.spyOn(timeControl, 'now');
             const promise = camera.once('moveend');
 
-            stub.mockImplementation(() => 0);
+            stub.mockReturnValue(0);
 
             camera.flyTo({center: [100, 0], duration: 100, padding: {left: 100}});
 
-            stub.mockImplementation(() => 100);
+            stub.mockReturnValue(100);
             queue.run();
 
             const padding = camera.getPadding();
@@ -3348,7 +3351,7 @@ describe('flyTo globe projection', () => {
             expect(padding.right).toBe(0);
             expect(padding.top).toBe(0);
 
-            stub.mockImplementation(() => 100);
+            stub.mockReturnValue(100);
             queue.run();
 
             await promise;
@@ -3499,16 +3502,16 @@ describe('flyTo globe projection', () => {
             const promise = camera.once('moveend');
 
             const stub = vi.spyOn(timeControl, 'now');
-            stub.mockImplementation(() => 0);
+            stub.mockReturnValue(0);
 
             camera.flyTo({center: [100, 0], duration: 10}, eventData);
 
             setTimeout(() => {
-                stub.mockImplementation(() => 1);
+                stub.mockReturnValue(1);
                 queue.run();
 
                 setTimeout(() => {
-                    stub.mockImplementation(() => 10);
+                    stub.mockReturnValue(10);
                     queue.run();
                 }, 0);
             }, 0);
@@ -3546,16 +3549,16 @@ describe('flyTo globe projection', () => {
             const promise = camera.once('moveend');
 
             const stub = vi.spyOn(timeControl, 'now');
-            stub.mockImplementation(() => 0);
+            stub.mockReturnValue(0);
 
             camera.flyTo({center: [100, 0], zoom: 18, duration: 10});
 
             setTimeout(() => {
-                stub.mockImplementation(() => 1);
+                stub.mockReturnValue(1);
                 queue.run();
 
                 setTimeout(() => {
-                    stub.mockImplementation(() => 10);
+                    stub.mockReturnValue(10);
                     queue.run();
                 }, 0);
             }, 0);
@@ -3579,15 +3582,15 @@ describe('flyTo globe projection', () => {
 
             const promise = camera.once('moveend');
 
-            stub.mockImplementation(() => 0);
+            stub.mockReturnValue(0);
             camera.flyTo({center: [10, 0], duration: 20});
 
             setTimeout(() => {
-                stub.mockImplementation(() => 1);
+                stub.mockReturnValue(1);
                 queue.run();
 
                 setTimeout(() => {
-                    stub.mockImplementation(() => 20);
+                    stub.mockReturnValue(20);
                     queue.run();
                 }, 0);
             }, 0);
@@ -3611,15 +3614,15 @@ describe('flyTo globe projection', () => {
 
             const promise = camera.once('moveend');
 
-            stub.mockImplementation(() => 0);
+            stub.mockReturnValue(0);
             camera.flyTo({center: [-10, 0], duration: 20});
 
             setTimeout(() => {
-                stub.mockImplementation(() => 1);
+                stub.mockReturnValue(1);
                 queue.run();
 
                 setTimeout(() => {
-                    stub.mockImplementation(() => 20);
+                    stub.mockReturnValue(20);
                     queue.run();
                 }, 0);
             }, 0);
@@ -3643,15 +3646,15 @@ describe('flyTo globe projection', () => {
 
             const promise = camera.once('moveend');
 
-            stub.mockImplementation(() => 0);
+            stub.mockReturnValue(0);
             camera.flyTo({center: [-170, 0], duration: 20});
 
             setTimeout(() => {
-                stub.mockImplementation(() => 1);
+                stub.mockReturnValue(1);
                 queue.run();
 
                 setTimeout(() => {
-                    stub.mockImplementation(() => 20);
+                    stub.mockReturnValue(20);
                     queue.run();
                 }, 0);
             }, 0);
@@ -3675,15 +3678,15 @@ describe('flyTo globe projection', () => {
 
             const promise = camera.once('moveend');
 
-            stub.mockImplementation(() => 0);
+            stub.mockReturnValue(0);
             camera.flyTo({center: [170, 0], duration: 10});
 
             setTimeout(() => {
-                stub.mockImplementation(() => 1);
+                stub.mockReturnValue(1);
                 queue.run();
 
                 setTimeout(() => {
-                    stub.mockImplementation(() => 10);
+                    stub.mockReturnValue(10);
                     queue.run();
                 }, 0);
             }, 0);
@@ -3707,15 +3710,15 @@ describe('flyTo globe projection', () => {
 
             const promise = camera.once('moveend');
 
-            stub.mockImplementation(() => 0);
+            stub.mockReturnValue(0);
             camera.flyTo({center: [-170, 0], duration: 10});
 
             setTimeout(() => {
-                stub.mockImplementation(() => 1);
+                stub.mockReturnValue(1);
                 queue.run();
 
                 setTimeout(() => {
-                    stub.mockImplementation(() => 10);
+                    stub.mockReturnValue(10);
                     queue.run();
                 }, 0);
             }, 0);
@@ -3739,15 +3742,15 @@ describe('flyTo globe projection', () => {
 
             const promise = camera.once('moveend');
 
-            stub.mockImplementation(() => 0);
+            stub.mockReturnValue(0);
             camera.flyTo({center: [170, 0], duration: 10});
 
             setTimeout(() => {
-                stub.mockImplementation(() => 1);
+                stub.mockReturnValue(1);
                 queue.run();
 
                 setTimeout(() => {
-                    stub.mockImplementation(() => 10);
+                    stub.mockReturnValue(10);
                     queue.run();
                 }, 0);
             }, 0);
@@ -3770,15 +3773,15 @@ describe('flyTo globe projection', () => {
 
             const promise = camera.once('moveend');
 
-            stub.mockImplementation(() => 0);
+            stub.mockReturnValue(0);
             camera.flyTo({center: [170, 0], duration: 10});
 
             setTimeout(() => {
-                stub.mockImplementation(() => 1);
+                stub.mockReturnValue(1);
                 queue.run();
 
                 setTimeout(() => {
-                    stub.mockImplementation(() => 10);
+                    stub.mockReturnValue(10);
                     queue.run();
                 }, 0);
             }, 0);
@@ -3799,7 +3802,7 @@ describe('flyTo globe projection', () => {
             const promise = camera.once('moveend');
 
             const duration = 10;
-            stub.mockImplementation(() => 0);
+            stub.mockReturnValue(0);
             camera.flyTo({center: [1, 0], zoom: 20, minZoom, duration});
 
             await simulateAllAnimationFrames(stub, camera, queue,duration);
@@ -3822,7 +3825,7 @@ describe('flyTo globe projection', () => {
             const promise = camera.once('moveend');
 
             const duration = 10;
-            stub.mockImplementation(() => 0);
+            stub.mockReturnValue(0);
             camera.flyTo({center: [1, 0], zoom: 20, duration});
 
             await simulateAllAnimationFrames(stub, camera, queue,duration);
@@ -3840,11 +3843,11 @@ describe('flyTo globe projection', () => {
             const promise = camera.once('moveend');
 
             const stub = vi.spyOn(timeControl, 'now');
-            stub.mockImplementation(() => 0);
+            stub.mockReturnValue(0);
             camera.flyTo({center: [12, 34], zoom: 30, duration: 10});
 
             setTimeout(() => {
-                stub.mockImplementation(() => 10);
+                stub.mockReturnValue(10);
                 queue.run();
             }, 0);
 
@@ -3864,11 +3867,11 @@ describe('flyTo globe projection', () => {
             const promise = camera.once('moveend');
 
             const stub = vi.spyOn(timeControl, 'now');
-            stub.mockImplementation(() => 0);
+            stub.mockReturnValue(0);
             camera.flyTo({center: target, zoom: 1, duration: 10});
 
             setTimeout(() => {
-                stub.mockImplementation(() => 10);
+                stub.mockReturnValue(10);
                 queue.run();
             }, 0);
 

--- a/src/ui/control/geolocate_control.test.ts
+++ b/src/ui/control/geolocate_control.test.ts
@@ -3,7 +3,7 @@ import geolocation from 'mock-geolocation';
 import {LngLatBounds} from '../../geo/lng_lat_bounds.ts';
 import {createMap, beforeMapTest, sleep} from '../../util/test/util.ts';
 import {GeolocateControl} from './geolocate_control.ts';
-vi.mock('../../util/geolocation_support', () => (
+vi.mock(import('../../util/geolocation_support'), () => (
     {
         checkGeolocationSupport: vi.fn()
     }
@@ -61,7 +61,7 @@ describe('GeolocateControl with no options', () => {
     beforeEach(() => {
         beforeMapTest();
         map = createMap();
-        (checkGeolocationSupport as unknown as MockInstance).mockImplementationOnce(() => Promise.resolve(true));
+        (checkGeolocationSupport as unknown as MockInstance).mockResolvedValueOnce(true);
         createResizeObserverEntryMock();
     });
 
@@ -70,7 +70,7 @@ describe('GeolocateControl with no options', () => {
     });
 
     test('is disabled when there is no support', async () => {
-        (checkGeolocationSupport as unknown as MockInstance).mockReset().mockImplementationOnce(() => Promise.resolve(false));
+        (checkGeolocationSupport as unknown as MockInstance).mockReset().mockResolvedValueOnce(false);
         const geolocate = new GeolocateControl(undefined);
         const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
         map.addControl(geolocate);
@@ -237,13 +237,13 @@ describe('GeolocateControl with no options', () => {
 
     test('does not throw if removed quickly', () => {
         (checkGeolocationSupport as unknown as MockInstance).mockReset()
-            .mockImplementationOnce(() => {
-                return sleep(10);
-            });
+            .mockReturnValueOnce(sleep(10));
 
         const geolocate = new GeolocateControl(undefined);
         map.addControl(geolocate);
         map.removeControl(geolocate);
+
+        expect(map.hasControl(geolocate)).toBe(false);
     });
 
     test('outofmaxbounds event in waiting active state', async () => {
@@ -832,29 +832,6 @@ describe('GeolocateControl with no options', () => {
         map.zoomTo(18, {duration: 0});
         await zoomendPromise;
         expect(geolocate._circleElement.style.width).toBe('4766.49px');
-    });
-
-    test('shown even if trackUserLocation = false', async () => {
-        const geolocate = new GeolocateControl({
-            trackUserLocation: false,
-            showUserLocation: true,
-            showAccuracyCircle: true,
-        });
-        map.addControl(geolocate);
-        await sleep(0);
-        const click = new window.Event('click');
-
-        const geolocatePromise = geolocate.once('geolocate');
-        geolocate._geolocateButton.dispatchEvent(click);
-        geolocation.send({latitude: 10, longitude: 20, accuracy: 700});
-        await geolocatePromise;
-        map.jumpTo({
-            center: [10, 20]
-        });
-        const zoomendPromise = map.once('zoomend');
-        map.zoomTo(10, {duration: 0});
-        await zoomendPromise;
-        expect(geolocate._circleElement.style.width).toBeTruthy();
     });
 
     test('shown even if trackUserLocation = false', async () => {

--- a/src/ui/handler/dblclick_zoom.test.ts
+++ b/src/ui/handler/dblclick_zoom.test.ts
@@ -191,7 +191,7 @@ describe('dbclick_zoom', () => {
         expect(zoom).not.toHaveBeenCalled();
     });
 
-    test('DoubleClickZoomHandler snaps to nearest zoomSnap', () => {
+    test('DoubleClickZoomHandler snaps to nearest zoomSnap on a non-interactive map', () => {
         const map = createMap({zoom: 9.7, zoomSnap: 1.0});
         const spy = vi.spyOn(map, 'easeTo');
 
@@ -203,7 +203,7 @@ describe('dbclick_zoom', () => {
         map.remove();
     });
 
-    test('DoubleClickZoomHandler double-tap snaps to nearest zoomSnap', async () => {
+    test('DoubleClickZoomHandler double-tap snaps to nearest zoomSnap on a non-interactive map', async () => {
         const map = createMap({zoom: 9.7, zoomSnap: 1.0});
         const spy = vi.spyOn(map, 'easeTo');
 

--- a/src/ui/handler/scroll_zoom.test.ts
+++ b/src/ui/handler/scroll_zoom.test.ts
@@ -359,6 +359,7 @@ describe('ScrollZoomHandler', () => {
 
         const map = createMap();
         map._renderTaskQueue.run();
+        const startZoom = map.getZoom();
 
         simulate.wheel(map.getCanvas(), {deltaY: -1});
         simulate.wheel(map.getCanvas(), {deltaY: -1});
@@ -372,6 +373,7 @@ describe('ScrollZoomHandler', () => {
         timeControlNow.mockReturnValue(now);
         map._renderTaskQueue.run();
 
+        expect(map.getZoom()).toBeCloseTo(startZoom);
         map.remove();
     });
 

--- a/src/ui/handler_manager.test.ts
+++ b/src/ui/handler_manager.test.ts
@@ -1,4 +1,4 @@
-import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import {afterEach, beforeEach, describe, expect, vi, test} from 'vitest';
 import Point from '@mapbox/point-geometry';
 
 import type {HandlerManager, MapControlsScenarioOptions, EventInProgress, EventsInProgress} from './handler_manager.ts';
@@ -25,7 +25,7 @@ afterEach(() => {
 });
 
 describe('HandlerManager terrain scenarios', () => {
-    it('_handleMapControls keeps terrain movement disabled when terrain is not enabled', () => {
+    test('_handleMapControls keeps terrain movement disabled when terrain is not enabled', () => {
         const handleZoom = vi.fn();
         const handlePan = vi.fn();
         map._camera.cameraHelper = {
@@ -73,7 +73,7 @@ describe('HandlerManager terrain scenarios', () => {
         expect(setCenterMock).not.toHaveBeenCalled();
     });
 
-    it('_handleMapControls enables terrain movement for globe terrain handling', () => {
+    test('_handleMapControls enables terrain movement for globe terrain handling', () => {
         const handleZoom = vi.fn();
         const handlePan = vi.fn();
         map._camera.cameraHelper = {
@@ -114,7 +114,7 @@ describe('HandlerManager terrain scenarios', () => {
         expect(handlePan).toHaveBeenCalledWith(options.deltasForHelper, options.tr, options.preZoomAroundLoc);
     });
 
-    it('_handleMapControls keeps terrain movement state when globe terrain is already active', () => {
+    test('_handleMapControls keeps terrain movement state when globe terrain is already active', () => {
         const handleZoom = vi.fn();
         const handlePan = vi.fn();
         map._camera.cameraHelper = {
@@ -155,7 +155,7 @@ describe('HandlerManager terrain scenarios', () => {
         expect(handlePan).toHaveBeenCalledWith(options.deltasForHelper, options.tr, options.preZoomAroundLoc);
     });
 
-    it('_handleMapControls activates terrain movement on first drag in mercator terrain', () => {
+    test('_handleMapControls activates terrain movement on first drag in mercator terrain', () => {
         const handleZoom = vi.fn();
         const handlePan = vi.fn();
         map._camera.cameraHelper = {
@@ -199,7 +199,7 @@ describe('HandlerManager terrain scenarios', () => {
         expect(setCenterMock).not.toHaveBeenCalled();
     });
 
-    it('_handleMapControls drags using transform when already moving in mercator terrain', () => {
+    test('_handleMapControls drags using transform when already moving in mercator terrain', () => {
         const handleZoom = vi.fn();
         const handlePan = vi.fn();
         map._camera.cameraHelper = {
@@ -245,7 +245,7 @@ describe('HandlerManager terrain scenarios', () => {
         expect(handlePan).not.toHaveBeenCalled();
     });
 
-    it('_handleMapControls falls back to helper panning when not dragging in mercator terrain', () => {
+    test('_handleMapControls falls back to helper panning when not dragging in mercator terrain', () => {
         const handleZoom = vi.fn();
         const handlePan = vi.fn();
         map._camera.cameraHelper = {

--- a/src/ui/hash.test.ts
+++ b/src/ui/hash.test.ts
@@ -522,6 +522,7 @@ describe('hash', () => {
 
         map.remove();
 
+        expect(map._removed).toBe(true);
     });
 
     test('hash with URL in other parameter does not change except normalization', () => {

--- a/src/ui/map_tests/map_basic.test.ts
+++ b/src/ui/map_tests/map_basic.test.ts
@@ -96,24 +96,18 @@ describe('Map', () => {
             const map = createMap({style});
 
             await map.once('load');
-            const disagreements: Array<{event: boolean; map: boolean}> = [];
             const promise = new Promise<void>((resolve) => {
                 map.on('data', (e: MapSourceDataEvent) => {
-                    if (e.dataType === 'source' && 'source' in e) {
-                        if (map.isSourceLoaded('geojson') !== e.isSourceLoaded) {
-                            disagreements.push({event: e.isSourceLoaded, map: map.isSourceLoaded('geojson')});
-                        }
-                        if (e.sourceDataType === 'idle') {
-                            resolve();
-                        }
+                    if (e.dataType !== 'source' || !('source' in e)) return;
+                    expect(map.isSourceLoaded('geojson')).toBe(e.isSourceLoaded);
+                    if (e.sourceDataType === 'idle') {
+                        resolve();
                     }
                 });
             });
             map.addSource('geojson', createStyleSource());
             expect(map.isSourceLoaded('geojson')).toBe(false);
             await promise;
-
-            expect(disagreements).toHaveLength(0);
         });
 
         test('Map.isStyleLoaded', async () => {

--- a/src/ui/map_tests/map_basic.test.ts
+++ b/src/ui/map_tests/map_basic.test.ts
@@ -1,6 +1,6 @@
 import {describe, beforeEach, test, expect, vi} from 'vitest';
 import {Map} from '../map.ts';
-import {createMap, beforeMapTest, createStyle, createStyleSource, sleep} from '../../util/test/util.ts';
+import {createMap, beforeMapTest, createStyle, createStyleSource, sleep, waitForEvent} from '../../util/test/util.ts';
 import {Tile} from '../../tile/tile.ts';
 import {OverscaledTileID} from '../../tile/tile_id.ts';
 import {fixedLngLat} from '../../../test/unit/lib/fixed.ts';
@@ -47,14 +47,6 @@ describe('Map', () => {
         );
     });
 
-    test('bad map-specific token breaks map', () => {
-        const container = window.document.createElement('div');
-        Object.defineProperty(container, 'offsetWidth', {value: 512});
-        Object.defineProperty(container, 'offsetHeight', {value: 512});
-        createMap();
-        //t.error();
-    });
-
     describe('setTransformRequest', () => {
         test('returns self', () => {
             const transformRequest = (() => {}) as any as RequestTransformFunction;
@@ -69,6 +61,8 @@ describe('Map', () => {
             const transformRequest = (() => {}) as any as RequestTransformFunction;
             map.setTransformRequest(transformRequest);
             map.setTransformRequest(transformRequest);
+
+            expect(map._requestManager._transformRequestFn).toBe(transformRequest);
         });
 
         test('removes function when called with null', () => {
@@ -89,17 +83,12 @@ describe('Map', () => {
             const map = createMap({style});
 
             await map.once('load');
-            const promise = new Promise<void>((resolve) => {
-                map.on('data', (e) => {
-                    if (e.dataType === 'source' && e.sourceDataType === 'idle') {
-                        expect(map.isSourceLoaded('geojson')).toBe(true);
-                        resolve();
-                    }
-                });
-            });
+            const idlePromise = waitForEvent(map, 'data', (e) => e.dataType === 'source' && e.sourceDataType === 'idle');
             map.addSource('geojson', createStyleSource());
             expect(map.isSourceLoaded('geojson')).toBe(false);
-            await promise;
+
+            await idlePromise;
+            expect(map.isSourceLoaded('geojson')).toBe(true);
         });
 
         test('Map.isSourceLoaded (equivalent to event.isSourceLoaded)', async () => {
@@ -107,10 +96,13 @@ describe('Map', () => {
             const map = createMap({style});
 
             await map.once('load');
+            const disagreements: Array<{event: boolean; map: boolean}> = [];
             const promise = new Promise<void>((resolve) => {
                 map.on('data', (e: MapSourceDataEvent) => {
                     if (e.dataType === 'source' && 'source' in e) {
-                        expect(map.isSourceLoaded('geojson')).toBe(e.isSourceLoaded);
+                        if (map.isSourceLoaded('geojson') !== e.isSourceLoaded) {
+                            disagreements.push({event: e.isSourceLoaded, map: map.isSourceLoaded('geojson')});
+                        }
                         if (e.sourceDataType === 'idle') {
                             resolve();
                         }
@@ -120,6 +112,8 @@ describe('Map', () => {
             map.addSource('geojson', createStyleSource());
             expect(map.isSourceLoaded('geojson')).toBe(false);
             await promise;
+
+            expect(disagreements).toHaveLength(0);
         });
 
         test('Map.isStyleLoaded', async () => {

--- a/src/ui/map_tests/map_calculate_camera_options.test.ts
+++ b/src/ui/map_tests/map_calculate_camera_options.test.ts
@@ -27,7 +27,7 @@ describe('calculateCameraOptionsFromTo', () => {
         const cameraOptions: CameraOptions = map.calculateCameraOptionsFromTo(new LngLat(1, 0), 111200, new LngLat(0, 0));
         expect(cameraOptions).toBeDefined();
         expect(cameraOptions.pitch).toBeCloseTo(90);
-        expect(mockedGetElevation.mock.calls).toHaveLength(1);
+        expect(mockedGetElevation).toHaveBeenCalledTimes(1);
     });
 
     test('pitch 153.435 with terrain', () => {
@@ -44,7 +44,7 @@ describe('calculateCameraOptionsFromTo', () => {
         const cameraOptions: CameraOptions = map.calculateCameraOptionsFromTo(new LngLat(1, 0), 111200, new LngLat(0, 0));
         expect(cameraOptions).toBeDefined();
         expect(cameraOptions.pitch).toBeCloseTo(153.435);
-        expect(mockedGetElevation.mock.calls).toHaveLength(1);
+        expect(mockedGetElevation).toHaveBeenCalledTimes(1);
     });
 
     test('pitch 63 with terrain', () => {
@@ -62,7 +62,7 @@ describe('calculateCameraOptionsFromTo', () => {
         const cameraOptions: CameraOptions = map.calculateCameraOptionsFromTo(new LngLat(0, 0), 111200, new LngLat(1, 0));
         expect(cameraOptions).toBeDefined();
         expect(cameraOptions.pitch).toBeCloseTo(63.435);
-        expect(mockedGetElevation.mock.calls).toHaveLength(1);
+        expect(mockedGetElevation).toHaveBeenCalledTimes(1);
     });
 
     test('zoom distance 1000', () => {
@@ -79,7 +79,7 @@ describe('calculateCameraOptionsFromTo', () => {
 
         expect(cameraOptions).toBeDefined();
         expect(cameraOptions.zoom).toBeCloseTo(expectedZoom);
-        expect(mockedGetElevation.mock.calls).toHaveLength(1);
+        expect(mockedGetElevation).toHaveBeenCalledTimes(1);
     });
 
     test('don\'t call getElevation when altitude supplied', () => {
@@ -94,7 +94,7 @@ describe('calculateCameraOptionsFromTo', () => {
         const cameraOptions = map.calculateCameraOptionsFromTo(new LngLat(0, 0), 0, new LngLat(0, 0), 1000);
 
         expect(cameraOptions).toBeDefined();
-        expect(mockedGetElevation.mock.calls).toHaveLength(0);
+        expect(mockedGetElevation).toHaveBeenCalledTimes(0);
     });
 
     test('don\'t call getElevation when altitude 0 supplied', () => {
@@ -109,6 +109,6 @@ describe('calculateCameraOptionsFromTo', () => {
         const cameraOptions = map.calculateCameraOptionsFromTo(new LngLat(0, 0), 0, new LngLat(1, 0), 0);
 
         expect(cameraOptions).toBeDefined();
-        expect(mockedGetElevation.mock.calls).toHaveLength(0);
+        expect(mockedGetElevation).toHaveBeenCalledTimes(0);
     });
 });

--- a/src/ui/map_tests/map_events.test.ts
+++ b/src/ui/map_tests/map_events.test.ts
@@ -964,7 +964,7 @@ describe('map events', () => {
         map.on('load', loadHandler);
         await sleep(1);
 
-        expect(loadHandler).toThrow();
+        expect(loadHandler).toThrow('Error in load handler');
     });
 
     test('no idle event during move', async () => {

--- a/src/ui/map_tests/map_events.test.ts
+++ b/src/ui/map_tests/map_events.test.ts
@@ -247,7 +247,7 @@ describe('map events', () => {
         expect(handler.onMove).toHaveBeenCalledTimes(1);
     });
 
-    test('Map.on allows a listener to infer the event type ', () => {
+    test('Map.on allows a listener to infer the event type', () => {
         const map = createMap();
 
         const spy = vi.fn();
@@ -411,7 +411,7 @@ describe('map events', () => {
         expect(handler.onMove).toHaveBeenCalledTimes(0);
     });
 
-    test('Map.off allows a listener to infer the event type ', () => {
+    test('Map.off allows a listener to infer the event type', () => {
         const map = createMap();
 
         const spy = vi.fn();
@@ -440,7 +440,7 @@ describe('map events', () => {
         expect(handler.onMoveOnce).toHaveBeenCalledTimes(1);
     });
 
-    test('Map.once allows a listener to infer the event type ', () => {
+    test('Map.once allows a listener to infer the event type', () => {
         const map = createMap();
 
         const spy = vi.fn();
@@ -964,7 +964,7 @@ describe('map events', () => {
         map.on('load', loadHandler);
         await sleep(1);
 
-        expect(loadHandler).toThrowError();
+        expect(loadHandler).toThrow();
     });
 
     test('no idle event during move', async () => {
@@ -981,7 +981,7 @@ describe('map events', () => {
         const map = createMap();
         const sourcePromise = map.once('sourcedataabort');
         map.fire(new EventedEvent('dataabort'));
-        await sourcePromise;
+        await expect(sourcePromise).resolves.toBeDefined();
     });
 
     test('getZoom on moveend is the same as after the map end moving, with terrain on', async () => {

--- a/src/ui/map_tests/map_global_state.test.ts
+++ b/src/ui/map_tests/map_global_state.test.ts
@@ -1,4 +1,4 @@
-import {describe, beforeEach, test, expect, vitest} from 'vitest';
+import {describe, beforeEach, test, expect, vi} from 'vitest';
 import {createMap, beforeMapTest} from '../../util/test/util.ts';
 
 beforeEach(() => {
@@ -27,7 +27,7 @@ describe('setGlobalStateProperty', () => {
         });
 
         await map.once('style.load');
-        map._update = vitest.fn();
+        map._update = vi.fn();
 
         map.setGlobalStateProperty('backgroundColor', 'blue');
 
@@ -56,7 +56,7 @@ describe('setGlobalStateProperty', () => {
         });
 
         await map.once('style.load');
-        map._update = vitest.fn();
+        map._update = vi.fn();
 
         map.setGlobalStateProperty('backgroundColor', 'blue');
 

--- a/src/ui/map_tests/map_images.test.ts
+++ b/src/ui/map_tests/map_images.test.ts
@@ -90,7 +90,7 @@ test('map fires `styleimagemissing` when missing style image resolver returns no
     const generatedImage = await map.style.imageManager.getImages([id]);
     expect(resolver).toHaveBeenCalledWith(id);
     expect(generatedImage[id]).toBeUndefined();
-    expect(missingImageEventSpy).toHaveBeenCalledOnce();
+    expect(missingImageEventSpy).toHaveBeenCalledTimes(1);
     expect(missingImageEventSpy.mock.calls[0][0].id).toBe(id);
     expect(map.hasImage(id)).toBeFalsy();
 });
@@ -245,7 +245,7 @@ test('setImages broadcasts even when getImages is called between addImage and up
 
     await map.once('load');
 
-    const broadcastSpy = vi.fn().mockReturnValue(Promise.resolve({}));
+    const broadcastSpy = vi.fn().mockResolvedValue({});
     map.style.dispatcher.broadcast = broadcastSpy;
 
     map.addImage('new-image', {width: 1, height: 1, data: new Uint8Array(4)});
@@ -271,7 +271,7 @@ test('setImages broadcasts after missing style image resolver adds an image', as
 
     await map.once('load');
 
-    const broadcastSpy = vi.fn().mockReturnValue(Promise.resolve({}));
+    const broadcastSpy = vi.fn().mockResolvedValue({});
     map.style.dispatcher.broadcast = broadcastSpy;
 
     map.setMissingStyleImageResolver((id) => {

--- a/src/ui/map_tests/map_is_moving.test.ts
+++ b/src/ui/map_tests/map_is_moving.test.ts
@@ -69,7 +69,7 @@ describe('Map.isMoving', () => {
 
     test('returns true when drag rotating', async () => {
         // Prevent inertial rotation.
-        vi.spyOn(timeControl, 'now').mockImplementation(() => 0);
+        vi.spyOn(timeControl, 'now').mockReturnValue(0);
 
         map.on('movestart', () => {
             expect(map.isMoving()).toBe(true);

--- a/src/ui/map_tests/map_is_rotating.test.ts
+++ b/src/ui/map_tests/map_is_rotating.test.ts
@@ -40,7 +40,7 @@ describe('Map.isRotating', () => {
 
     test('returns true when drag rotating', async () => {
         // Prevent inertial rotation.
-        vi.spyOn(timeControl, 'now').mockImplementation(() => 0);
+        vi.spyOn(timeControl, 'now').mockReturnValue(0);
 
         map.on('rotatestart', () => {
             expect(map.isRotating()).toBe(true);

--- a/src/ui/map_tests/map_layer.test.ts
+++ b/src/ui/map_tests/map_layer.test.ts
@@ -98,7 +98,8 @@ test('removeLayer restores Map.loaded() to true', async () => {
 
     await map.once('render');
     map.removeLayer('layerId');
-    await waitForEvent(map, 'render', () => map.loaded());
+    await expect(waitForEvent(map, 'render', () => map.loaded())).resolves.toBeDefined();
+
     map.remove();
 });
 

--- a/src/ui/map_tests/map_options.test.ts
+++ b/src/ui/map_tests/map_options.test.ts
@@ -46,22 +46,16 @@ describe('mapOptions', () => {
     });
 
     test('fadeDuration is set after first idle event', async () => {
+        let idleTriggered = false;
         const fadeDuration = 100;
-        const observedFadeDurations: number[] = [];
         const spy = vi.spyOn(Style.prototype, 'update').mockImplementation((parameters: EvaluationParameters) => {
-            observedFadeDurations.push(parameters.fadeDuration);
+            expect(parameters.fadeDuration).toBe(idleTriggered ? fadeDuration : 0);
         });
         const style = createStyle();
         const map = createMap({style, fadeDuration});
         await map.once('idle');
-
-        expect(observedFadeDurations).not.toHaveLength(0);
-        expect(observedFadeDurations.filter(duration => duration !== 0)).toHaveLength(0);
-
-        const updatesBeforeZoom = observedFadeDurations.length;
+        idleTriggered = true;
         map.zoomTo(0.5, {duration: 100});
         spy.mockRestore();
-
-        expect(observedFadeDurations.slice(updatesBeforeZoom).filter(duration => duration !== fadeDuration)).toHaveLength(0);
     });
 });

--- a/src/ui/map_tests/map_options.test.ts
+++ b/src/ui/map_tests/map_options.test.ts
@@ -46,20 +46,22 @@ describe('mapOptions', () => {
     });
 
     test('fadeDuration is set after first idle event', async () => {
-        let idleTriggered = false;
         const fadeDuration = 100;
+        const observedFadeDurations: number[] = [];
         const spy = vi.spyOn(Style.prototype, 'update').mockImplementation((parameters: EvaluationParameters) => {
-            if (!idleTriggered) {
-                expect(parameters.fadeDuration).toBe(0);
-            } else {
-                expect(parameters.fadeDuration).toBe(fadeDuration);
-            }
+            observedFadeDurations.push(parameters.fadeDuration);
         });
         const style = createStyle();
         const map = createMap({style, fadeDuration});
         await map.once('idle');
-        idleTriggered = true;
+
+        expect(observedFadeDurations).not.toHaveLength(0);
+        expect(observedFadeDurations.filter(duration => duration !== 0)).toHaveLength(0);
+
+        const updatesBeforeZoom = observedFadeDurations.length;
         map.zoomTo(0.5, {duration: 100});
         spy.mockRestore();
+
+        expect(observedFadeDurations.slice(updatesBeforeZoom).filter(duration => duration !== fadeDuration)).toHaveLength(0);
     });
 });

--- a/src/ui/map_tests/map_pitch.test.ts
+++ b/src/ui/map_tests/map_pitch.test.ts
@@ -140,8 +140,8 @@ test('fire move and pitch events when pitch is changed due to minPitch change', 
     map.on('pitch', handleEvent);
     map.on('pitchend', handleEvent);
     map.setMinPitch(11);
-    expect(map.getPitch()).toEqual(11);
-    expect(map.getMinPitch()).toEqual(11);
+    expect(map.getPitch()).toBe(11);
+    expect(map.getMinPitch()).toBe(11);
     expect(handleEvent).toHaveBeenCalledTimes(6);
 });
 
@@ -155,7 +155,7 @@ test('fire move and pitch events when pitch is changed due to maxPitch change', 
     map.on('pitch', handleEvent);
     map.on('pitchend', handleEvent);
     map.setMaxPitch(10);
-    expect(map.getPitch()).toEqual(10);
-    expect(map.getMaxPitch()).toEqual(10);
+    expect(map.getPitch()).toBe(10);
+    expect(map.getMaxPitch()).toBe(10);
     expect(handleEvent).toHaveBeenCalledTimes(6);
 });

--- a/src/ui/map_tests/map_pitch.test.ts
+++ b/src/ui/map_tests/map_pitch.test.ts
@@ -31,7 +31,7 @@ test('ignore minPitchs over maxPitch', () => {
     const map = createMap({pitch: 0, maxPitch: 10});
     expect(() => {
         map.setMinPitch(20);
-    }).toThrow();
+    }).toThrow('minPitch must be between 0 and the current maxPitch, inclusive');
     map.setPitch(0);
     expect(map.getPitch()).toBe(0);
 });
@@ -89,7 +89,7 @@ test('ignore maxPitchs over minPitch', () => {
     const map = createMap({minPitch: 10});
     expect(() => {
         map.setMaxPitch(0);
-    }).toThrow();
+    }).toThrow('maxPitch must be greater than the current minPitch');
     map.setPitch(10);
     expect(map.getPitch()).toBe(10);
 });

--- a/src/ui/map_tests/map_refresh_tiles.test.ts
+++ b/src/ui/map_tests/map_refresh_tiles.test.ts
@@ -30,7 +30,7 @@ describe('Map::refreshTiles', () => {
         map.style.tileManagers['source-id1'].refreshTiles = spy;
 
         map.refreshTiles('source-id1', [{x: 1024, y: 1023, z: 11}]);
-        expect(spy).toHaveBeenCalledOnce();
+        expect(spy).toHaveBeenCalledTimes(1);
         expect(spy.mock.calls[0][0]).toEqual([new CanonicalTileID(11, 1024, 1023)]);
     });
 
@@ -43,7 +43,7 @@ describe('Map::refreshTiles', () => {
         map.style.tileManagers['source-id1'].reload = spy;
 
         map.refreshTiles('source-id1');
-        expect(spy).toHaveBeenCalledOnce();
+        expect(spy).toHaveBeenCalledTimes(1);
         expect(spy.mock.calls[0][0]).toBe(true);
     });
 });

--- a/src/ui/map_tests/map_render.test.ts
+++ b/src/ui/map_tests/map_render.test.ts
@@ -87,5 +87,5 @@ test('redraw', async () => {
     const renderPromise = map.once('render');
 
     map.redraw();
-    await renderPromise;
+    await expect(renderPromise).resolves.toBeDefined();
 });

--- a/src/ui/map_tests/map_set_lod_params.test.ts
+++ b/src/ui/map_tests/map_set_lod_params.test.ts
@@ -42,7 +42,7 @@ test('set tile LOD params for a non-existent source', async () => {
 
     expect(map.getSource('source-id1').calculateTileZoom).toBeUndefined();
     expect(map.getSource('source-id2').calculateTileZoom).toBeUndefined();
-    expect(() => {map.setSourceTileLodParams(1, 1, 'non-existent-source-id');}).toThrowError();
+    expect(() => {map.setSourceTileLodParams(1, 1, 'non-existent-source-id');}).toThrow();
     expect(map.getSource('source-id1').calculateTileZoom).toBeUndefined();
     expect(map.getSource('source-id2').calculateTileZoom).toBeUndefined();
 });

--- a/src/ui/map_tests/map_set_lod_params.test.ts
+++ b/src/ui/map_tests/map_set_lod_params.test.ts
@@ -42,7 +42,7 @@ test('set tile LOD params for a non-existent source', async () => {
 
     expect(map.getSource('source-id1').calculateTileZoom).toBeUndefined();
     expect(map.getSource('source-id2').calculateTileZoom).toBeUndefined();
-    expect(() => {map.setSourceTileLodParams(1, 1, 'non-existent-source-id');}).toThrow();
+    expect(() => {map.setSourceTileLodParams(1, 1, 'non-existent-source-id');}).toThrow('There is no source with ID "non-existent-source-id", cannot set LOD parameters');
     expect(map.getSource('source-id1').calculateTileZoom).toBeUndefined();
     expect(map.getSource('source-id2').calculateTileZoom).toBeUndefined();
 });

--- a/src/ui/map_tests/map_style.test.ts
+++ b/src/ui/map_tests/map_style.test.ts
@@ -78,12 +78,14 @@ describe('setStyle', () => {
         ]);
     });
 
-    test('can be called more than once', () => {
+    test('can be called more than once', async () => {
         const map = createMap();
 
         map.setStyle({version: 8, sources: {}, layers: []}, {diff: false});
         map.setStyle({version: 8, sources: {}, layers: []}, {diff: false});
+        await map.once('style.load');
 
+        expect(map.getStyle()).toEqual({version: 8, sources: {}, layers: []});
     });
 
     test('setStyle back to the first style should work', async () => {
@@ -477,12 +479,16 @@ describe('getStyle', () => {
             type: 'background'
         } as LayerSpecification;
         map.addLayer(layer);
+
+        expect(map.getLayer('background')).toBeDefined();
     });
 
     test('a source can be added even if a map is created without a style', () => {
         const map = createMap({deleteStyle: true});
         const source = createStyleSource();
         map.addSource('fill', source);
+
+        expect(map.getSource('fill')).toBeDefined();
     });
 
     test('a layer can be added with an embedded source specification', () => {
@@ -496,6 +502,8 @@ describe('getStyle', () => {
             type: 'symbol',
             source
         });
+
+        expect(map.getLayer('foo')).toBeDefined();
     });
 
     test('returns the style with added source and layer', async () => {

--- a/src/ui/map_tests/map_terrain.test.ts
+++ b/src/ui/map_tests/map_terrain.test.ts
@@ -105,7 +105,7 @@ describe('setTerrain', () => {
             source: {type: 'raster-dem'}
         } as any);
 
-        expect(resetElevationCache).toHaveBeenCalledOnce();
+        expect(resetElevationCache).toHaveBeenCalledTimes(1);
     });
 });
 

--- a/src/ui/map_tests/map_zoom.test.ts
+++ b/src/ui/map_tests/map_zoom.test.ts
@@ -32,7 +32,7 @@ test('ignore minZooms over maxZoom', () => {
     const map = createMap({zoom: 2, maxZoom: 5});
     expect(() => {
         map.setMinZoom(6);
-    }).toThrow();
+    }).toThrow('minZoom must be between -2 and the current maxZoom, inclusive');
     map.setZoom(0);
     expect(map.getZoom()).toBe(0);
 });
@@ -62,7 +62,7 @@ test('ignore maxZooms over minZoom', () => {
     const map = createMap({minZoom: 5});
     expect(() => {
         map.setMaxZoom(4);
-    }).toThrow();
+    }).toThrow('maxZoom must be greater than the current minZoom');
     map.setZoom(5);
     expect(map.getZoom()).toBe(5);
 });

--- a/src/ui/map_tests/map_zoom.test.ts
+++ b/src/ui/map_tests/map_zoom.test.ts
@@ -102,16 +102,16 @@ test('transformCameraUpdate is called after changing min or max zoom', async () 
     map.setMaxZoom(18);
     map.setZoom(18);
     await map.once('style.load');
-    expect(map.getZoom()).toEqual(18);
-    expect(map.getMinZoom()).toEqual(5);
-    expect(map.getMaxZoom()).toEqual(18);
+    expect(map.getZoom()).toBe(18);
+    expect(map.getMinZoom()).toBe(5);
+    expect(map.getMaxZoom()).toBe(18);
     const transformCameraUpdate = vi.fn(t => t);
     map.setTransformCameraUpdate(transformCameraUpdate);
 
     map.setMaxZoom(16);
-    expect(map.getZoom()).toEqual(16);
-    expect(map.getMinZoom()).toEqual(5);
-    expect(map.getMaxZoom()).toEqual(16);
+    expect(map.getZoom()).toBe(16);
+    expect(map.getMinZoom()).toBe(5);
+    expect(map.getMaxZoom()).toBe(16);
     expect(transformCameraUpdate.mock.calls[0][0]).toMatchObject({
         zoom: 16,
         minZoom: 5,
@@ -127,9 +127,9 @@ test('transformCameraUpdate is called after changing min or max zoom', async () 
 
     map.setMinZoom(6);
     map.setTransformCameraUpdate(transformCameraUpdate);
-    expect(map.getZoom()).toEqual(6);
-    expect(map.getMinZoom()).toEqual(6);
-    expect(map.getMaxZoom()).toEqual(16);
+    expect(map.getZoom()).toBe(6);
+    expect(map.getMinZoom()).toBe(6);
+    expect(map.getMaxZoom()).toBe(16);
     expect(transformCameraUpdate.mock.calls[2][0]).toMatchObject({
         zoom: 6,
         minZoom: 6,
@@ -147,8 +147,8 @@ test('fire move and zoom events when zoom is changed due to minZoom change', () 
     map.on('zoom', handleEvent);
     map.on('zoomend', handleEvent);
     map.setMinZoom(11);
-    expect(map.getZoom()).toEqual(11);
-    expect(map.getMinZoom()).toEqual(11);
+    expect(map.getZoom()).toBe(11);
+    expect(map.getMinZoom()).toBe(11);
     expect(handleEvent).toHaveBeenCalledTimes(6);
 });
 
@@ -162,7 +162,7 @@ test('fire move and zoom events when zoom is changed due to maxZoom change', () 
     map.on('zoom', handleEvent);
     map.on('zoomend', handleEvent);
     map.setMaxZoom(10);
-    expect(map.getZoom()).toEqual(10);
-    expect(map.getMaxZoom()).toEqual(10);
+    expect(map.getZoom()).toBe(10);
+    expect(map.getMaxZoom()).toBe(10);
     expect(handleEvent).toHaveBeenCalledTimes(6);
 });

--- a/src/ui/popup.test.ts
+++ b/src/ui/popup.test.ts
@@ -333,7 +333,7 @@ describe('popup', () => {
         expect(popup._pos).toEqual(map.project([5, 0]));
     });
 
-    test('Popup wraps position after map move if it would otherwise go offscreen (right)', () => {
+    test('Popup wraps position after map move if it would otherwise go offscreen (left)', () => {
         const map = createMap({width: 1024}); // longitude bounds: [-360, 360]
 
         const popup = new Popup()
@@ -613,7 +613,7 @@ describe('popup', () => {
         ).toContain('maplibregl-popup-track-pointer');
     });
 
-    test('Pointer-tracked popup with content set later is tagged with right class ', () => {
+    test('Pointer-tracked popup with content set later is tagged with right class', () => {
         const map = createMap();
         const popup = new Popup()
             .trackPointer()
@@ -626,7 +626,7 @@ describe('popup', () => {
         ).toContain('maplibregl-popup-track-pointer');
     });
 
-    test('Pointer-tracked popup that is set afterwards is tagged with right class ', () => {
+    test('Pointer-tracked popup that is set afterwards is tagged with right class', () => {
         const map = createMap();
         const popup = new Popup()
             .addTo(map);

--- a/src/util/actor.test.ts
+++ b/src/util/actor.test.ts
@@ -144,7 +144,7 @@ describe('Actor', () => {
         const worker = await workerFactory() as any as WorkerGlobalScopeInterface & ActorTarget;
         const actor = new Actor(worker, '1');
 
-        const spy = vi.fn().mockReturnValue(Promise.resolve({}));
+        const spy = vi.fn().mockResolvedValue({});
         worker.worker.actor.registerMessageHandler(MessageType.getClusterExpansionZoom, spy);
 
         worker.worker.actor.invoker.trigger = async () => {
@@ -209,7 +209,7 @@ describe('Actor', () => {
 
         worker.worker.actor.mapId = '2';
 
-        const spy = vi.fn().mockReturnValue(Promise.resolve({}));
+        const spy = vi.fn().mockResolvedValue({});
         worker.worker.actor.registerMessageHandler(MessageType.getClusterExpansionZoom, spy);
 
         actor.sendAsync({type: MessageType.getClusterExpansionZoom, data: {} as any, targetMapId: '1'});
@@ -223,7 +223,7 @@ describe('Actor', () => {
         const worker = await workerFactory() as any as WorkerGlobalScopeInterface & ActorTarget;
         const actor = new Actor(worker, '1');
 
-        const spy = vi.fn().mockReturnValue(Promise.resolve({}));
+        const spy = vi.fn().mockResolvedValue({});
         worker.worker.actor.registerMessageHandler(MessageType.getClusterExpansionZoom, spy);
 
         actor.target.postMessage({type: 'getClusterExpansionZoom', data: {} as any, origin: 'https://example.com'});
@@ -237,7 +237,7 @@ describe('Actor', () => {
         const worker = await workerFactory() as any as WorkerGlobalScopeInterface & ActorTarget;
         const actor = new Actor(worker, '1');
 
-        const spy = vi.fn().mockReturnValue(Promise.resolve({}));
+        const spy = vi.fn().mockResolvedValue({});
         worker.worker.actor.registerMessageHandler(MessageType.getClusterExpansionZoom, spy);
 
         actor.target.postMessage({type: MessageType.getClusterExpansionZoom, data: {} as any, origin: 'null'});
@@ -251,7 +251,7 @@ describe('Actor', () => {
         const worker = await workerFactory() as any as WorkerGlobalScopeInterface & ActorTarget;
         const actor = new Actor(worker, '1');
 
-        const spy = vi.fn().mockReturnValue(Promise.resolve({}));
+        const spy = vi.fn().mockResolvedValue({});
         worker.worker.actor.registerMessageHandler(MessageType.getClusterExpansionZoom, spy);
 
         actor.target.postMessage({type: MessageType.getClusterExpansionZoom, data: {} as any, origin: 'file://'});
@@ -265,7 +265,7 @@ describe('Actor', () => {
         const worker = await workerFactory() as any as WorkerGlobalScopeInterface & ActorTarget;
         const actor = new Actor(worker, '1');
 
-        const spy = vi.fn().mockReturnValue(Promise.resolve({}));
+        const spy = vi.fn().mockResolvedValue({});
         worker.worker.actor.registerMessageHandler(MessageType.getClusterExpansionZoom, spy);
 
         actor.target.postMessage({type: MessageType.getClusterExpansionZoom, data: {} as any, origin: 'resource://android'});

--- a/src/util/ajax.test.ts
+++ b/src/util/ajax.test.ts
@@ -20,6 +20,12 @@ function readAsText(blob) {
     });
 }
 
+async function expectRejection(promise: Promise<unknown>): Promise<AJAXError> {
+    const error = await promise.catch((e) => e);
+    expect(error).toBeInstanceOf(Error);
+    return error as AJAXError;
+}
+
 const originalFetch = global.fetch;
 
 describe('ajax', () => {
@@ -37,18 +43,14 @@ describe('ajax', () => {
             request.respond(404, undefined, '404 Not Found');
         });
 
-        try {
-            const promise =  getArrayBuffer({url: 'http://example.com/test.bin'}, new AbortController());
-            server.respond();
-            await promise;
-        } catch (error) {
-            const ajaxError = error as AJAXError;
-            const body = await readAsText(ajaxError.body);
-            expect(ajaxError.status).toBe(404);
-            expect(ajaxError.statusText).toBe('Not Found');
-            expect(ajaxError.url).toBe('http://example.com/test.bin');
-            expect(body).toBe('404 Not Found');
-        }
+        const promise = getArrayBuffer({url: 'http://example.com/test.bin'}, new AbortController());
+        server.respond();
+
+        const ajaxError = await expectRejection(promise);
+        expect(ajaxError.status).toBe(404);
+        expect(ajaxError.statusText).toBe('Not Found');
+        expect(ajaxError.url).toBe('http://example.com/test.bin');
+        await expect(readAsText(ajaxError.body)).resolves.toBe('404 Not Found');
     });
 
     test('getJSON', async () => {
@@ -68,11 +70,8 @@ describe('ajax', () => {
         });
         const promise = getJSON({url: ''}, new AbortController());
         server.respond();
-        try {
-            await promise;
-        } catch (error) {
-            expect(error).toBeTruthy();
-        }
+
+        await expect(promise).rejects.toThrow();
     });
 
     test('getJSON, 404', async () => {
@@ -82,16 +81,11 @@ describe('ajax', () => {
         const promise = getJSON({url: 'http://example.com/test.json'}, new AbortController());
         server.respond();
 
-        try {
-            await promise;
-        } catch (error) {
-            const ajaxError = error as AJAXError;
-            const body = await readAsText(ajaxError.body);
-            expect(ajaxError.status).toBe(404);
-            expect(ajaxError.statusText).toBe('Not Found');
-            expect(ajaxError.url).toBe('http://example.com/test.json');
-            expect(body).toBe('404 Not Found');
-        }
+        const ajaxError = await expectRejection(promise);
+        expect(ajaxError.status).toBe(404);
+        expect(ajaxError.statusText).toBe('Not Found');
+        expect(ajaxError.url).toBe('http://example.com/test.json');
+        await expect(readAsText(ajaxError.body)).resolves.toBe('404 Not Found');
     });
 
     test('getJSON, aborted', async () => {
@@ -103,12 +97,9 @@ describe('ajax', () => {
         abortController.abort();
         server.respond();
 
-        try {
-            await promise;
-        } catch (error) {
-            expect(ensureError(error).name).toBe('AbortError');
-            expect(isAbortError(error)).toBe(true);
-        }
+        const error = await expectRejection(promise);
+        expect(ensureError(error).name).toBe('AbortError');
+        expect(isAbortError(error)).toBe(true);
     });
 
     test('getJSON with fetch, aborted', async () => {
@@ -126,12 +117,9 @@ describe('ajax', () => {
         abortController.abort();
         server.respond();
 
-        try {
-            await promise;
-        } catch (error) {
-            expect(ensureError(error).name).toBe('AbortError');
-            expect(isAbortError(error)).toBe(true);
-        }
+        const error = await expectRejection(promise);
+        expect(ensureError(error).name).toBe('AbortError');
+        expect(isAbortError(error)).toBe(true);
     });
 
     test('getReferrer method (outside Worker), same origin https URL', () => {

--- a/src/util/ajax.test.ts
+++ b/src/util/ajax.test.ts
@@ -71,7 +71,7 @@ describe('ajax', () => {
         const promise = getJSON({url: ''}, new AbortController());
         server.respond();
 
-        await expect(promise).rejects.toThrow();
+        await expect(promise).rejects.toThrow(SyntaxError);
     });
 
     test('getJSON, 404', async () => {

--- a/src/util/browser.test.ts
+++ b/src/util/browser.test.ts
@@ -1,6 +1,7 @@
 import {describe, test, expect, beforeEach, vi, afterEach} from 'vitest';
 import {beforeMapTest, createMap as globalCreateMap} from './test/util.ts';
 import {browser} from './browser.ts';
+import {AbortError} from './abort_error.ts';
 
 describe('browser', () => {
     describe('frame',() => {
@@ -142,7 +143,7 @@ describe('browser', () => {
             const abortController = new AbortController();
             const promise = browser.frameAsync(abortController);
             abortController.abort();
-            await expect(promise).rejects.toThrow();
+            await expect(promise).rejects.toThrow(AbortError);
         });
     });
 

--- a/src/util/browser.test.ts
+++ b/src/util/browser.test.ts
@@ -1,4 +1,4 @@
-import {describe, test, expect, beforeEach, vi, afterEach, type Mock} from 'vitest';
+import {describe, test, expect, beforeEach, vi, afterEach} from 'vitest';
 import {beforeMapTest, createMap as globalCreateMap} from './test/util.ts';
 import {browser} from './browser.ts';
 
@@ -56,7 +56,7 @@ describe('browser', () => {
 
             expect(fn).toHaveBeenCalledTimes(1);
             const callArg = fn.mock.calls[0][0];
-            expect(typeof callArg).toBe('number');
+            expect(callArg).toBeTypeOf('number');
 
             expect(window.cancelAnimationFrame).not.toHaveBeenCalled();
             expect(reject).not.toHaveBeenCalled();
@@ -69,11 +69,8 @@ describe('browser', () => {
         test('when AbortController is aborted before frame fires, calls cancelAnimationFrame and reject', () => {
             // We override the default mock so that the callback is NOT called immediately
             // giving us time to abort.
-            (window.requestAnimationFrame as Mock).mockImplementation(
-                () => {
-                    // Return ID but do not invoke cb
-                    return 42;
-                }
+            (vi.mocked(window.requestAnimationFrame)).mockReturnValue(
+                42
             );
 
             const abortController = new AbortController();
@@ -177,6 +174,6 @@ describe('browser', () => {
     });
 
     test('hardwareConcurrency', () => {
-        expect(typeof browser.hardwareConcurrency).toBe('number');
+        expect(browser.hardwareConcurrency).toBeTypeOf('number');
     });
 });

--- a/src/util/create_tile_mesh.test.ts
+++ b/src/util/create_tile_mesh.test.ts
@@ -12,8 +12,8 @@ describe('create_tile_mesh', () => {
         const options: CreateTileMeshOptions = {};
         createTileMeshWithBuffers(contextMock, options);
 
-        expect(createVertexBufferSpy.mock.calls[0][0].length).toBe(4);
-        expect(createIndexBufferSpy.mock.calls[0][0].length).toBe(2);
+        expect(createVertexBufferSpy.mock.calls[0][0]).toHaveLength(4);
+        expect(createIndexBufferSpy.mock.calls[0][0]).toHaveLength(2);
     });
 
     test('createTileMesh 32bit', () => {

--- a/src/util/dispatcher.test.ts
+++ b/src/util/dispatcher.test.ts
@@ -60,7 +60,7 @@ describe('Dispatcher', () => {
     test('remove destroys actors', async () => {
         const actorsRemoved = [];
         const mapId = 1;
-        Actor.prototype.remove = vi.fn().mockImplementation(() => {
+        vi.spyOn(Actor.prototype, 'remove').mockImplementation(() => {
             actorsRemoved.push(this);
         });
         WorkerPool.workerCount = 4;

--- a/src/util/evented.test.ts
+++ b/src/util/evented.test.ts
@@ -120,10 +120,13 @@ describe('Evented', () => {
 
     test('does not immediately call listeners added within another listener', () => {
         const evented = new StubbedEvented();
+        const nestedListener = vi.fn();
         evented.on('a', () => {
-            evented.on('a', () => { throw new Error('fail'); });
+            evented.on('a', nestedListener);
         });
         evented.fire(new Event('a'));
+
+        expect(nestedListener).not.toHaveBeenCalled();
     });
 
     test('has backward compatibility for fire(string, object) API', () => {

--- a/src/util/fast_maths.test.ts
+++ b/src/util/fast_maths.test.ts
@@ -2,7 +2,7 @@ import {describe, test, expect} from 'vitest';
 import {mat4, vec3, quat} from 'gl-matrix';
 import {fastInvertTransformMat4, fastInvertProjMat4, fastInvertSkewMat4} from './fast_maths.ts';
 
-function compare_matrix(mat: mat4, matRef: mat4){
+function expectMatricesClose(mat: mat4, matRef: mat4){
     for (let i=0; i<16; ++i){
         expect(mat[i]).toBeCloseTo(matRef[i], 6);
     }
@@ -74,7 +74,7 @@ describe('fast_maths', () => {
             // compute ref:
             mat4.invert(mInvRef, m);
 
-            compare_matrix(mInv, mInvRef);
+            expectMatricesClose(mInv, mInvRef);
         };
     });
 
@@ -114,7 +114,7 @@ describe('fast_maths', () => {
             fastInvertProjMat4(mInv, m);
             // compute ref:
             mat4.invert(mInvRef, m);
-            compare_matrix(mInv, mInvRef);
+            expectMatricesClose(mInv, mInvRef);
         };
     });
 
@@ -171,7 +171,7 @@ describe('fast_maths', () => {
             // compute ref:
             mat4.invert(mInvRef, m);
 
-            compare_matrix(mInv, mInvRef);
+            expectMatricesClose(mInv, mInvRef);
         };
     });
 });

--- a/src/util/image_request.test.ts
+++ b/src/util/image_request.test.ts
@@ -55,17 +55,15 @@ describe('ImageRequest', () => {
     test('Cancel: getImage cancelling frees up request for maxParallelImageRequests', async () => {
         const maxRequests = config.MAX_PARALLEL_IMAGE_REQUESTS;
 
-        const abortedRequests: Array<Promise<unknown>> = [];
+        const abortedRequests: Array<Promise<void>> = [];
         for (let i = 0; i < maxRequests + 1; i++) {
             const abortController = new AbortController();
-            abortedRequests.push(ImageRequest.getImage({url: ''}, abortController));
+            abortedRequests.push(expect(ImageRequest.getImage({url: ''}, abortController)).rejects.toSatisfy(isAbortError));
             abortController.abort();
             await sleep(0);
         }
         expect(server.requests).toHaveLength(maxRequests + 1);
-        for (const request of abortedRequests) {
-            await expect(request).rejects.toSatisfy(isAbortError);
-        }
+        await Promise.all(abortedRequests);
     });
 
     test('Cancel: getImage requests that were once queued are still abortable', async () => {
@@ -145,7 +143,7 @@ describe('ImageRequest', () => {
 
         server.respond();
 
-        await expect(promise).rejects.toThrow();
+        await expect(promise).rejects.toThrow('error');
     });
 
     test('getImage uses HTMLImageElement when createImageBitmap is not supported', async () => {

--- a/src/util/image_request.test.ts
+++ b/src/util/image_request.test.ts
@@ -55,15 +55,14 @@ describe('ImageRequest', () => {
     test('Cancel: getImage cancelling frees up request for maxParallelImageRequests', async () => {
         const maxRequests = config.MAX_PARALLEL_IMAGE_REQUESTS;
 
-        const abortedRequests: Array<Promise<void>> = [];
         for (let i = 0; i < maxRequests + 1; i++) {
             const abortController = new AbortController();
-            abortedRequests.push(expect(ImageRequest.getImage({url: ''}, abortController)).rejects.toSatisfy(isAbortError));
+            const request = ImageRequest.getImage({url: ''}, abortController);
             abortController.abort();
+            await expect(request).rejects.toSatisfy(isAbortError);
             await sleep(0);
         }
         expect(server.requests).toHaveLength(maxRequests + 1);
-        await Promise.all(abortedRequests);
     });
 
     test('Cancel: getImage requests that were once queued are still abortable', async () => {

--- a/src/util/image_request.test.ts
+++ b/src/util/image_request.test.ts
@@ -55,13 +55,17 @@ describe('ImageRequest', () => {
     test('Cancel: getImage cancelling frees up request for maxParallelImageRequests', async () => {
         const maxRequests = config.MAX_PARALLEL_IMAGE_REQUESTS;
 
+        const abortedRequests: Array<Promise<unknown>> = [];
         for (let i = 0; i < maxRequests + 1; i++) {
             const abortController = new AbortController();
-            ImageRequest.getImage({url: ''}, abortController).catch((e) => expect(isAbortError(e)).toBeTruthy());
+            abortedRequests.push(ImageRequest.getImage({url: ''}, abortController));
             abortController.abort();
             await sleep(0);
         }
         expect(server.requests).toHaveLength(maxRequests + 1);
+        for (const request of abortedRequests) {
+            await expect(request).rejects.toSatisfy(isAbortError);
+        }
     });
 
     test('Cancel: getImage requests that were once queued are still abortable', async () => {
@@ -79,7 +83,7 @@ describe('ImageRequest', () => {
 
         const queuedURL = 'this-is-the-queued-request';
         const abortController = new AbortController();
-        ImageRequest.getImage({url: queuedURL}, abortController).catch((e) => expect(isAbortError(e)).toBeTruthy());
+        const queuedRequestPromise = ImageRequest.getImage({url: queuedURL}, abortController);
 
         // the new requests is queued because the limit is reached
         expect(server.requests).toHaveLength(maxRequests);
@@ -95,6 +99,7 @@ describe('ImageRequest', () => {
         expect((queuedRequest as any).aborted).toBeUndefined();
         abortController.abort();
         expect((queuedRequest as any).aborted).toBe(true);
+        await expect(queuedRequestPromise).rejects.toSatisfy(isAbortError);
     });
 
     test('getImage sends accept/webp header', async () => {

--- a/src/util/struct_array.test.ts
+++ b/src/util/struct_array.test.ts
@@ -87,8 +87,8 @@ describe('StructArray', () => {
         // Typed views should no longer reference the original buffer
         expect(array.uint8.buffer).not.toBe(originalBuffer);
         expect(array.int16.buffer).not.toBe(originalBuffer);
-        expect(array.uint8.length).toBe(0);
-        expect(array.int16.length).toBe(0);
+        expect(array.uint8).toHaveLength(0);
+        expect(array.int16).toHaveLength(0);
     });
 });
 

--- a/src/util/task_queue.test.ts
+++ b/src/util/task_queue.test.ts
@@ -85,7 +85,7 @@ describe('TaskQueue', () => {
     test('TaskQueue.run() throws on attempted re-entrance', () => {
         const q = new TaskQueue();
         q.add(() => q.run());
-        expect(() => q.run()).toThrow();
+        expect(() => q.run()).toThrow('Attempting to run(), but is already running.');
     });
 
     test('TaskQueue.clear() prevents queued task from being executed', () => {

--- a/src/util/time_control.test.ts
+++ b/src/util/time_control.test.ts
@@ -26,7 +26,7 @@ describe('time_control', () => {
     describe('now()', () => {
         test('returns a valid number when not frozen', () => {
             const currentTime = now();
-            expect(typeof currentTime).toBe('number');
+            expect(currentTime).toBeTypeOf('number');
             expect(currentTime).toBeGreaterThanOrEqual(0);
         });
 
@@ -133,7 +133,7 @@ describe('time_control', () => {
             expect(isTimeFrozen()).toBe(false);
 
             const time = now();
-            expect(typeof time).toBe('number');
+            expect(time).toBeTypeOf('number');
             expect(time).toBeGreaterThanOrEqual(0);
         });
     });

--- a/src/util/transferable_grid_index.test.ts
+++ b/src/util/transferable_grid_index.test.ts
@@ -40,7 +40,7 @@ describe('TransferableGridIndex', () => {
         expect(grid.query(-6, 0, -7, 100)).toEqual([2]);
         expect(grid.query(-Infinity, -Infinity, Infinity, Infinity).sort()).toEqual([0, 1, 2]);
 
-        expect(() => grid.insert(3, 0, 0, 0, 0)).toThrow();
+        expect(() => grid.insert(3, 0, 0, 0, 0)).toThrow('Cannot insert into a GridIndex created from an ArrayBuffer.');
     });
 
     test('serialize round trip', () => {

--- a/src/util/util.test.ts
+++ b/src/util/util.test.ts
@@ -7,16 +7,30 @@ import {expectToBeCloseToArray} from './test/util.ts';
 import {vec3, type vec4} from 'gl-matrix';
 
 describe('util', () => {
-    expect(easeCubicInOut(0)).toBe(0);
-    expect(easeCubicInOut(0.2)).toBe(0.03200000000000001);
-    expect(easeCubicInOut(0.5)).toBe(0.5);
-    expect(easeCubicInOut(1)).toBe(1);
-    expect(keysDifference({a: 1}, {})).toEqual(['a']);
-    expect(keysDifference({a: 1}, {a: 1})).toEqual([]);
-    expect(extend({a: 1}, {b: 2})).toEqual({a: 1, b: 2});
-    expect(pick({a: 1, b: 2, c: 3}, ['a', 'c'])).toEqual({a: 1, c: 3});
-    expect(pick({a: 1, b: 2, c: 3}, ['a', 'c', 'd'] as any)).toEqual({a: 1, c: 3});
-    expect(typeof uniqueId() === 'number').toBeTruthy();
+    test('easeCubicInOut', () => {
+        expect(easeCubicInOut(0)).toBe(0);
+        expect(easeCubicInOut(0.2)).toBe(0.03200000000000001);
+        expect(easeCubicInOut(0.5)).toBe(0.5);
+        expect(easeCubicInOut(1)).toBe(1);
+    });
+
+    test('keysDifference', () => {
+        expect(keysDifference({a: 1}, {})).toEqual(['a']);
+        expect(keysDifference({a: 1}, {a: 1})).toEqual([]);
+    });
+
+    test('extend', () => {
+        expect(extend({a: 1}, {b: 2})).toEqual({a: 1, b: 2});
+    });
+
+    test('pick', () => {
+        expect(pick({a: 1, b: 2, c: 3}, ['a', 'c'])).toEqual({a: 1, c: 3});
+        expect(pick({a: 1, b: 2, c: 3}, ['a', 'c', 'd'] as any)).toEqual({a: 1, c: 3});
+    });
+
+    test('uniqueId', () => {
+        expect(uniqueId()).toBeTypeOf('number');
+    });
 
     test('isPowerOfTwo', () => {
         expect(isPowerOfTwo(1)).toBe(true);
@@ -38,7 +52,7 @@ describe('util', () => {
         expect(nextPowerOfTwo(42)).toBe(64);
     });
 
-    test('nextPowerOfTwo', () => {
+    test('nextPowerOfTwo always returns a power of two', () => {
         expect(isPowerOfTwo(nextPowerOfTwo(1))).toBe(true);
         expect(isPowerOfTwo(nextPowerOfTwo(2))).toBe(true);
         expect(isPowerOfTwo(nextPowerOfTwo(256))).toBe(true);
@@ -590,7 +604,7 @@ describe('util getAngleDelta', () => {
         expect(getAngleDelta(lastPoint, currentPoint, center)).toBe(90);
     });
 
-    test('positive direction', () => {
+    test('negative direction', () => {
         const lastPoint = new Point(1, 0);
         const currentPoint = new Point(0, 1);
         const center = new Point(0, 0);

--- a/src/util/util.test.ts
+++ b/src/util/util.test.ts
@@ -449,7 +449,7 @@ describe('util readImageUsingVideoFrame', () => {
 
     test('ignore bad format', async () => {
         format = 'OTHER';
-        await expect(readImageUsingVideoFrame(canvas, 0, 0, 2, 2)).rejects.toThrow();
+        await expect(readImageUsingVideoFrame(canvas, 0, 0, 2, 2)).rejects.toThrow('Unrecognized format OTHER');
         expect(frame.close).toHaveBeenCalledTimes(1);
     });
 

--- a/src/util/verticalize_punctuation.test.ts
+++ b/src/util/verticalize_punctuation.test.ts
@@ -3,13 +3,13 @@ import {verticalizePunctuation} from './verticalize_punctuation.ts';
 
 describe('verticalizePunctuation', () => {
     test('preserves characters without fullwidth variants', () => {
-        expect(verticalizePunctuation('ABC123')).toEqual('ABC123');
+        expect(verticalizePunctuation('ABC123')).toBe('ABC123');
     });
     test('replaces punctuation marks with fullwidth variants', () => {
-        expect(verticalizePunctuation('!?')).toEqual('︕︖');
+        expect(verticalizePunctuation('!?')).toBe('︕︖');
     });
     test('replaces rotatable punctuation marks', () => {
-        expect(verticalizePunctuation('(…)')).toEqual('︵︙︶');
-        expect(verticalizePunctuation('（⋯）')).toEqual('︵︙︶');
+        expect(verticalizePunctuation('(…)')).toBe('︵︙︶');
+        expect(verticalizePunctuation('（⋯）')).toBe('︵︙︶');
     });
 });

--- a/src/util/web_worker_transfer.test.ts
+++ b/src/util/web_worker_transfer.test.ts
@@ -119,7 +119,7 @@ describe('web worker transfer', () => {
         const trySerialize = () => {
             serialize(new BadClass());
         };
-        expect(trySerialize).toThrow();
+        expect(trySerialize).toThrow('can\'t serialize object of unregistered class BadClass');
     });
     test('serialize can not used reserved property #name', () => {
         class BadClass {
@@ -133,7 +133,7 @@ describe('web worker transfer', () => {
         const badObject = new BadClass();
         expect(() => {
             serialize(badObject);
-        }).toThrow();
+        }).toThrow('$name property is reserved for worker serialization logic.');
     });
     test('deserialize Object has $name', () => {
         const badObject = {
@@ -142,18 +142,18 @@ describe('web worker transfer', () => {
         const tryDeserialize = () => {
             deserialize(badObject);
         };
-        expect(tryDeserialize).toThrow();
+        expect(tryDeserialize).toThrow('can\'t deserialize unregistered class foo');
     });
 
     test('some objects can not be serialized', () => {
         expect(() => {
             serialize(BigInt(123));
-        }).toThrow();
+        }).toThrow('can\'t serialize object of type bigint');
     });
     test('some objects can not be deserialized', () => {
         expect(() => {
             deserialize(BigInt(123) as unknown);
-        }).toThrow();
+        }).toThrow('can\'t deserialize object of type bigint');
     });
 
     test('"has" filter returns false for undefined or missing properties after serialization', () => {

--- a/src/webgl/draw/draw_custom.test.ts
+++ b/src/webgl/draw/draw_custom.test.ts
@@ -1,4 +1,4 @@
-import {describe, test, expect, vi, type Mock} from 'vitest';
+import {describe, test, expect, vi} from 'vitest';
 import {OverscaledTileID} from '../../tile/tile_id.ts';
 import {TileManager} from '../../tile/tile_manager.ts';
 import {Tile} from '../../tile/tile.ts';
@@ -11,16 +11,16 @@ import {MercatorProjection} from '../../geo/projection/mercator_projection.ts';
 import {type CustomRenderMethodInput} from '../../style/style_layer/custom_style_layer.ts';
 import {expectToBeCloseToArray} from '../../util/test/util.ts';
 
-vi.mock('../../render/painter');
-vi.mock('../program');
-vi.mock('../../tile/tile_manager');
-vi.mock('../../tile/tile');
-vi.mock('../../data/bucket/symbol_bucket', () => {
+vi.mock(import('../../render/painter'));
+vi.mock(import('../program'));
+vi.mock(import('../../tile/tile_manager'));
+vi.mock(import('../../tile/tile'));
+vi.mock(import('../../data/bucket/symbol_bucket'), () => {
     return {
         SymbolBucket: vi.fn()
-    };
+    } as any;
 });
-vi.mock('../../symbol/projection');
+vi.mock(import('../../symbol/projection'));
 
 describe('drawCustom', () => {
     test('should return custom render method inputs', () => {
@@ -53,7 +53,7 @@ describe('drawCustom', () => {
             bind: () => { }
         } as any;
         const tileManagerMock = new TileManager(null, null, null);
-        (tileManagerMock.getTile as Mock).mockReturnValue(tile);
+        (vi.mocked(tileManagerMock.getTile)).mockReturnValue(tile);
         tileManagerMock.map = {showCollisionBoxes: false} as any as Map;
 
         let result: {
@@ -82,10 +82,10 @@ describe('drawCustom', () => {
         expectToBeCloseToArray(result.args.defaultProjectionData.tileMercatorCoords, [0, 0, 1, 1]);
         expect(result.args.defaultProjectionData.mainMatrix).toBeInstanceOf(Float64Array);
         expect(result.args.defaultProjectionData.fallbackMatrix).toBeInstanceOf(Float64Array);
-        expect(result.args.defaultProjectionData.mainMatrix[0]).toEqual(1536);
-        expect(result.args.defaultProjectionData.mainMatrix[5]).toEqual(-1512.6647086267515);
+        expect(result.args.defaultProjectionData.mainMatrix[0]).toBe(1536);
+        expect(result.args.defaultProjectionData.mainMatrix[5]).toBe(-1512.6647086267515);
         expect(result.args.defaultProjectionData.mainMatrix[15]).toEqual(794.4539334827342);
-        expect(result.args.defaultProjectionData.projectionTransition).toEqual(0);
+        expect(result.args.defaultProjectionData.projectionTransition).toBe(0);
         expect(result.args.defaultProjectionData.mainMatrix).toEqual(result.args.defaultProjectionData.fallbackMatrix);
         const tileProjectionData = result.args.getProjectionData({
             tileID: {
@@ -103,7 +103,7 @@ describe('drawCustom', () => {
         expect(tileProjectionData.mainMatrix[0]).toBeCloseTo(0.09375, 6);
         expect(tileProjectionData.mainMatrix[5]).toBeCloseTo(-0.09232572466135025, 6);
         expect(tileProjectionData.mainMatrix[15]).toBeCloseTo(794.4539184570312, 6);
-        expect(tileProjectionData.projectionTransition).toEqual(0);
+        expect(tileProjectionData.projectionTransition).toBe(0);
         expect(tileProjectionData.mainMatrix).toEqual(tileProjectionData.fallbackMatrix);
     });
 });

--- a/src/webgl/draw/draw_debug.test.ts
+++ b/src/webgl/draw/draw_debug.test.ts
@@ -6,7 +6,7 @@ import {FillStyleLayer} from '../../style/style_layer/fill_style_layer.ts';
 import {RasterStyleLayer} from '../../style/style_layer/raster_style_layer.ts';
 import {selectDebugSource} from './draw_debug.ts';
 
-vi.mock('../../style/style');
+vi.mock(import('../../style/style'));
 
 const zoom = 14;
 

--- a/src/webgl/draw/draw_fill.test.ts
+++ b/src/webgl/draw/draw_fill.test.ts
@@ -1,4 +1,4 @@
-import {describe, test, expect, vi, type Mock} from 'vitest';
+import {describe, test, expect, vi} from 'vitest';
 import {mat4} from 'gl-matrix';
 import {OverscaledTileID} from '../../tile/tile_id.ts';
 import {TileManager} from '../../tile/tile_manager.ts';
@@ -18,17 +18,17 @@ import {type ProgramConfiguration, type ProgramConfigurationSet} from '../../dat
 import type {ProjectionData} from '../../geo/projection/projection_data.ts';
 import {createIdentityMat4f32} from '../../util/util.ts';
 
-vi.mock('../../render/painter');
-vi.mock('../program');
-vi.mock('../../tile/tile_manager');
-vi.mock('../../tile/tile');
+vi.mock(import('../../render/painter'));
+vi.mock(import('../program'));
+vi.mock(import('../../tile/tile_manager'));
+vi.mock(import('../../tile/tile'));
 
-vi.mock('../../data/bucket/symbol_bucket', () => {
+vi.mock(import('../../data/bucket/symbol_bucket'), () => {
     return {
         SymbolBucket: vi.fn()
-    };
+    } as any;
 });
-vi.mock('../../symbol/projection');
+vi.mock(import('../../symbol/projection'));
 
 describe('drawFill', () => {
     test('should call programConfiguration.setConstantPatternPositions for transitioning fill-pattern', () => {
@@ -37,12 +37,12 @@ describe('drawFill', () => {
         const layer: FillStyleLayer = constructMockLayer();
 
         const programMock = new Program(null, null, null, null, null, null, null, null);
-        (painterMock.useProgram as Mock).mockReturnValue(programMock);
+        (vi.mocked(painterMock.useProgram)).mockReturnValue(programMock);
 
         const mockTile = constructMockTile(layer);
 
         const tileManagerMock = new TileManager(null, null, null);
-        (tileManagerMock.getTile as Mock).mockReturnValue(mockTile);
+        (vi.mocked(tileManagerMock.getTile)).mockReturnValue(mockTile);
         tileManagerMock.map = {showCollisionBoxes: false} as any as Map;
 
         const renderOptions: RenderOptions = {isRenderingToTexture: false, isRenderingGlobe: false};
@@ -140,8 +140,8 @@ describe('drawFill', () => {
 
         const bucketMock = constructMockBucket(layer);
 
-        (tile.getBucket as Mock).mockReturnValue(bucketMock);
-        (tile.patternsLoaded as Mock).mockReturnValue(true);
+        (vi.mocked(tile.getBucket)).mockReturnValue(bucketMock);
+        (vi.mocked(tile.patternsLoaded)).mockReturnValue(true);
         return tile;
     }
 

--- a/src/webgl/draw/draw_symbol.test.ts
+++ b/src/webgl/draw/draw_symbol.test.ts
@@ -1,4 +1,4 @@
-import {describe, test, expect, vi, type Mock} from 'vitest';
+import {describe, test, expect, vi} from 'vitest';
 import {mat4} from 'gl-matrix';
 import {OverscaledTileID} from '../../tile/tile_id.ts';
 import {SymbolBucket} from '../../data/bucket/symbol_bucket.ts';
@@ -19,18 +19,18 @@ import {MercatorProjection} from '../../geo/projection/mercator_projection.ts';
 import type {ProjectionData} from '../../geo/projection/projection_data.ts';
 import {createIdentityMat4f32} from '../../util/util.ts';
 
-vi.mock('../../render/painter');
-vi.mock('../program');
-vi.mock('../../tile/tile_manager');
-vi.mock('../../tile/tile');
-vi.mock('../../data/bucket/symbol_bucket', () => {
+vi.mock(import('../../render/painter'));
+vi.mock(import('../program'));
+vi.mock(import('../../tile/tile_manager'));
+vi.mock(import('../../tile/tile'));
+vi.mock(import('../../data/bucket/symbol_bucket'), () => {
     return {
         SymbolBucket: vi.fn()
-    };
+    } as any;
 });
 
-vi.mock('../../symbol/projection');
-(symbolProjection.getPitchedLabelPlaneMatrix as Mock).mockReturnValue(mat4.create());
+vi.mock(import('../../symbol/projection'));
+(vi.mocked(symbolProjection.getPitchedLabelPlaneMatrix)).mockReturnValue(mat4.create());
 
 function createMockTransform() {
     return {
@@ -94,7 +94,7 @@ describe('drawSymbol', () => {
         const tileId = new OverscaledTileID(1, 0, 1, 0, 0);
         tileId.terrainRttPosMatrix32f = createIdentityMat4f32();
         const programMock = new Program(null, null, null, null, null, null, null, null);
-        (painterMock.useProgram as Mock).mockReturnValue(programMock);
+        (vi.mocked(painterMock.useProgram)).mockReturnValue(programMock);
         const bucketMock = new SymbolBucket(null);
         bucketMock.icon = {
             programConfigurations: {
@@ -157,7 +157,7 @@ describe('drawSymbol', () => {
         const tileId = new OverscaledTileID(1, 0, 1, 0, 0);
         tileId.terrainRttPosMatrix32f = createIdentityMat4f32();
         const programMock = new Program(null, null, null, null, null, null, null, null);
-        (painterMock.useProgram as Mock).mockReturnValue(programMock);
+        (vi.mocked(painterMock.useProgram)).mockReturnValue(programMock);
         const bucketMock = new SymbolBucket(null);
         bucketMock.icon = {
             programConfigurations: {
@@ -177,9 +177,9 @@ describe('drawSymbol', () => {
         tile.imageAtlasTexture = {
             bind: () => { }
         } as any;
-        (tile.getBucket as Mock).mockReturnValue(bucketMock);
+        (vi.mocked(tile.getBucket)).mockReturnValue(bucketMock);
         const tileManagerMock = new TileManager(null, null, null);
-        (tileManagerMock.getTile as Mock).mockReturnValue(tile);
+        (vi.mocked(tileManagerMock.getTile)).mockReturnValue(tile);
         tileManagerMock.map = {showCollisionBoxes: false} as any as Map;
         painterMock.style = {
             map: {},
@@ -224,7 +224,7 @@ describe('drawSymbol', () => {
         const tileId = new OverscaledTileID(1, 0, 1, 0, 0);
         tileId.terrainRttPosMatrix32f = createIdentityMat4f32();
         const programMock = new Program(null, null, null, null, null, null, null, null);
-        (painterMock.useProgram as Mock).mockReturnValue(programMock);
+        (vi.mocked(painterMock.useProgram)).mockReturnValue(programMock);
         const bucketMock = new SymbolBucket(null);
         bucketMock.icon = {
             programConfigurations: {
@@ -244,9 +244,9 @@ describe('drawSymbol', () => {
         tile.imageAtlasTexture = {
             bind: () => { }
         } as any;
-        (tile.getBucket as Mock).mockReturnValue(bucketMock);
+        (vi.mocked(tile.getBucket)).mockReturnValue(bucketMock);
         const tileManagerMock = new TileManager(null, null, null);
-        (tileManagerMock.getTile as Mock).mockReturnValue(tile);
+        (vi.mocked(tileManagerMock.getTile)).mockReturnValue(tile);
         tileManagerMock.map = {showCollisionBoxes: false} as any as Map;
 
         const renderOptions: RenderOptions = {isRenderingToTexture: false, isRenderingGlobe: false};

--- a/src/webgl/render_to_texture.test.ts
+++ b/src/webgl/render_to_texture.test.ts
@@ -1,4 +1,4 @@
-import {beforeEach, describe, test, expect, vi, type Mock} from 'vitest';
+import {beforeEach, describe, test, expect, vi} from 'vitest';
 import {RenderToTexture} from './render_to_texture.ts';
 import type {Painter, RTTObject} from '../render/painter.ts';
 import type {LineStyleLayer} from '../style/style_layer/line_style_layer.ts';
@@ -155,8 +155,8 @@ describe('render to texture', () => {
         tile.rttObjects[0] = obj;
 
         const otherTileID = new OverscaledTileID(3, 0, 2, 2, 2);
-        (terrain.tileManager.getTerrainCoords as Mock).mockReturnValueOnce({[tile.tileID.key]: otherTileID});
-        (painter.releaseRTT as Mock).mockClear();
+        (vi.mocked(terrain.tileManager.getTerrainCoords)).mockReturnValueOnce({[tile.tileID.key]: otherTileID});
+        (vi.mocked(painter.releaseRTT)).mockClear();
 
         rtt.prepareForRender(style, 0);
 
@@ -218,7 +218,7 @@ describe('render to texture', () => {
 
     test('should clear tile cache on source state update', () => {
         const state = {revision: 0};
-        (style.tileManagers['maine'].getState as Mock).mockReturnValue(state);
+        (vi.mocked(style.tileManagers['maine'].getState)).mockReturnValue(state as any);
 
         tile.rttObjects[0] = {texture: {}, size: 512} as unknown as RTTObject;
         tile.rttFingerprint = {maine: '923#0'};
@@ -289,7 +289,7 @@ describe('render to texture', () => {
             }
         } as any as Style;
 
-        (terrain.tileManager.getTerrainCoords as Mock).mockClear();
+        (vi.mocked(terrain.tileManager.getTerrainCoords)).mockClear();
         rtt.prepareForRender(testStyle, 0);
 
         expect(maineTileManager.getVisibleCoordinates).toHaveBeenCalledTimes(1);

--- a/src/webgl/state.test.ts
+++ b/src/webgl/state.test.ts
@@ -20,7 +20,7 @@ describe('Value classes', () => {
             const v = new Constructor(context);
             expect(v).toBeTruthy();
             const currentV = v.get();
-            expect(typeof currentV).not.toBe('undefined');
+            expect(currentV).not.toBeTypeOf('undefined');
         });
 
         test('set', () => {

--- a/src/webgl/texture.test.ts
+++ b/src/webgl/texture.test.ts
@@ -15,7 +15,7 @@ describe('Texture', () => {
             return new Context(createNullGL());
         }
 
-        function checkPixelStoreState(context: Context): void {
+        function expectPixelStoreState(context: Context): void {
             expect(context.pixelStoreUnpack.current).toEqual(context.pixelStoreUnpack.default);
             expect(context.pixelStoreUnpackFlipY.current).toEqual(context.pixelStoreUnpackFlipY.default);
             expect(context.pixelStoreUnpackPremultiplyAlpha.current).toEqual(context.pixelStoreUnpackPremultiplyAlpha.default);
@@ -26,7 +26,7 @@ describe('Texture', () => {
             // We test the Texture constructor's side effects
             // eslint-disable-next-line @typescript-eslint/no-unused-vars
             const _texture = new Texture(context, testImage, context.gl.RGBA, {premultiply: false});
-            checkPixelStoreState(context);
+            expectPixelStoreState(context);
         });
 
         test('premultiply=true', () => {
@@ -34,7 +34,7 @@ describe('Texture', () => {
             // We test the Texture constructor's side effects
             // eslint-disable-next-line @typescript-eslint/no-unused-vars
             const _texture = new Texture(context, testImage, context.gl.RGBA, {premultiply: true});
-            checkPixelStoreState(context);
+            expectPixelStoreState(context);
         });
     });
 

--- a/src/webgl/vertex_buffer.test.ts
+++ b/src/webgl/vertex_buffer.test.ts
@@ -71,7 +71,7 @@ describe('VertexBuffer', () => {
 
         expect(array.arrayBuffer.byteLength).toBe(0);
         expect(array.int16.buffer).not.toBe(originalBuffer);
-        expect(array.int16.length).toBe(0);
+        expect(array.int16).toHaveLength(0);
     });
 
     test('dynamic buffer preserves StructArray data after upload', () => {

--- a/test/build/esm.test.ts
+++ b/test/build/esm.test.ts
@@ -14,11 +14,11 @@ const loadEsm = (relPath: string) => import(pathToFileURL(path.resolve(relPath))
 describe('ESM build', () => {
     test('main bundle exports the public API', async () => {
         const mod = await loadEsm('dist/maplibre-gl-dev.mjs');
-        expect(typeof mod.Map).toBe('function');
-        expect(typeof mod.Marker).toBe('function');
-        expect(typeof mod.Popup).toBe('function');
-        expect(typeof mod.setWorkerUrl).toBe('function');
-        expect(typeof mod.getWorkerUrl).toBe('function');
+        expect(mod.Map).toBeTypeOf('function');
+        expect(mod.Marker).toBeTypeOf('function');
+        expect(mod.Popup).toBeTypeOf('function');
+        expect(mod.setWorkerUrl).toBeTypeOf('function');
+        expect(mod.getWorkerUrl).toBeTypeOf('function');
     });
 
     test('worker bundle loads as an ES module', async () => {
@@ -34,8 +34,8 @@ describe('ESM build', () => {
     test('production main bundle exports the public API (if built)', async () => {
         if (!fs.existsSync('dist/maplibre-gl.mjs')) return;
         const mod = await loadEsm('dist/maplibre-gl.mjs');
-        expect(typeof mod.Map).toBe('function');
-        expect(typeof mod.setWorkerUrl).toBe('function');
+        expect(mod.Map).toBeTypeOf('function');
+        expect(mod.setWorkerUrl).toBeTypeOf('function');
     });
 
     test('production worker bundle loads as an ES module (if built)', async () => {

--- a/test/build/examples.test.ts
+++ b/test/build/examples.test.ts
@@ -13,49 +13,38 @@ describe('Example HTML files', () => {
         const content = fs.readFileSync(exampleFile, 'utf-8');
         test(`${exampleFile} has og:created meta tag`, () => {
             const createdMatch = content.match(/<meta\s+property=["']og:created["']\s+content=["']([^"']*)["']/);
-            if (!createdMatch) {
-                expect.fail('missing `og:created` meta tag');
-            } else if (!/^\d{4}-\d{2}-\d{2}$/.test(createdMatch[1])) {
-                expect.fail(`\`og:created\` has invalid date format "${createdMatch[1]}" use YYYY-MM-DD format.`);
-            }
+            expect(createdMatch, 'missing `og:created` meta tag').not.toBeNull();
+            expect(createdMatch[1], '`og:created` must use the YYYY-MM-DD format').toMatch(/^\d{4}-\d{2}-\d{2}$/);
         });
-    
+
         test(`${exampleFile} has og:description meta tag`, () => {
             const descriptionMatch = content.match(/<meta\s+property=["']og:description["']\s+content=["']([^"']*)["']/);
-            if (!descriptionMatch) {
-                expect.fail('missing `og:description` meta tag');
-            } else if (!descriptionMatch[1].trim()) {
-                expect.fail('`og:description` content is empty');
-            }
+            expect(descriptionMatch, 'missing `og:description` meta tag').not.toBeNull();
+            expect(descriptionMatch[1].trim(), '`og:description` content is empty').not.toBe('');
         });
 
         test(`${exampleFile} has a valid og:category meta tag`, () => {
             const categoryMatch = content.match(/<meta\s+property=["']og:category["']\s+content=["']([^"']*)["']/);
-            if (!categoryMatch) {
-                expect.fail('missing `og:category` meta tag');
-            } else if (!EXAMPLE_CATEGORIES.includes(categoryMatch[1])) {
-                expect.fail(`unknown \`og:category\` "${categoryMatch[1]}", valid categories are: ${EXAMPLE_CATEGORIES.join(', ')}.`);
-            }
+            expect(categoryMatch, 'missing `og:category` meta tag').not.toBeNull();
+            expect(EXAMPLE_CATEGORIES, `unknown \`og:category\` "${categoryMatch?.[1]}"`).toContain(categoryMatch[1]);
         });
 
         test(`${exampleFile} has a numeric og:order meta tag if present`, () => {
             const orderMatch = content.match(/<meta\s+property=["']og:order["']\s+content=["']([^"']*)["']/);
-            if (orderMatch && Number.isNaN(Number(orderMatch[1]))) {
-                expect.fail(`\`og:order\` has a non-numeric value "${orderMatch[1]}"`);
-            }
+            const order = orderMatch ? Number(orderMatch[1]) : 0;
+            expect(order, `\`og:order\` has a non-numeric value "${orderMatch?.[1]}"`).not.toBeNaN();
         });
 
         test(`${exampleFile} file name matches the title`, () => {
             const titleMatch = content.match(/<title>([^<]*)<\/title>/);
-            if (!titleMatch) {
-                expect.fail('missing <title> tag');
-            } else if (!titleMatch[1].trim()) {
-                expect.fail('<title> content is empty');
-            } else {
-                const expectedFileName = titleMatch[1].trim().toLowerCase().replace(/\s+/g, '-').replace(/[^a-zA-Z0-9-]/g, '');
-                const actualFileName = basename(exampleFile).replace('.html', '').toLowerCase();
-                expect(actualFileName).toBe(expectedFileName);
-            }
+            expect(titleMatch, 'missing <title> tag').not.toBeNull();
+
+            const title = titleMatch[1].trim();
+            expect(title, '<title> content is empty').not.toBe('');
+
+            const expectedFileName = title.toLowerCase().replace(/\s+/g, '-').replace(/[^a-zA-Z0-9-]/g, '');
+            const actualFileName = basename(exampleFile).replace('.html', '').toLowerCase();
+            expect(actualFileName).toBe(expectedFileName);
         });
     }
 });

--- a/test/build/import.test.ts
+++ b/test/build/import.test.ts
@@ -1,8 +1,8 @@
-import {describe, expect, it} from 'vitest';
+import {describe, expect, test} from 'vitest';
 import {LngLat} from '../../dist/maplibre-gl.mjs';
 
 describe('Importing a class', () => {
-    it('should allow import and contruct', () => {
+    test('should allow import and contruct', () => {
         const ll = new LngLat(1, 2);
         expect(ll.lng).toBe(1);
         expect(ll.lat).toBe(2);

--- a/test/build/node-version.test.ts
+++ b/test/build/node-version.test.ts
@@ -10,10 +10,7 @@ describe('Node.js version', () => {
 
         const expected = nvmrc.split('.')[0];
         for (const image of images) {
-            const major = image.split('.')[0];
-            if (major !== expected) {
-                expect.fail(`docker-compose.yml uses node:${image} but .nvmrc says ${nvmrc}, update both together`);
-            }
+            expect(image.split('.')[0], `docker-compose.yml uses node:${image} but .nvmrc says ${nvmrc}, update both together`).toBe(expected);
         }
     });
 });

--- a/test/integration/render/render.test.ts
+++ b/test/integration/render/render.test.ts
@@ -867,14 +867,6 @@ describe('Render tests', () => {
         await page.waitForFunction(() => (window as any).maplibregl, {timeout: 10000});
     }, 30000);
 
-    afterAll(async () => {
-        await stopCoverageAndReport(page, workers, 'render');
-        printHTMLReport(testStyles);
-        server.close();
-        mvtServer.close();
-        await browser.close();
-    });
-
     beforeEach((ctx) => {
         if (ctx.task.result?.retryCount > 0) {
             console.log(`Retry ${ctx.task.name} with console logging enabled`);
@@ -887,6 +879,14 @@ describe('Render tests', () => {
         page.removeAllListeners('pageerror');
         page.removeAllListeners('response');
         page.removeAllListeners('requestfailed');
+    });
+
+    afterAll(async () => {
+        await stopCoverageAndReport(page, workers, 'render');
+        printHTMLReport(testStyles);
+        server.close();
+        mvtServer.close();
+        await browser.close();
     });
 
     for (const style of testStyles) {


### PR DESCRIPTION
`@vitest/eslint-plugin` was already a devDependency and already registered in `eslint.config.js`. With **no rules enabled**, so it not very usefull 😉.

This turns on 30 of them (the ones where we were mostly consistent plus the throwing lint) and fixes what they found.