### PR TITLE
Emit an error for invalid queryRenderedFeatures geometry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes
+- Emit an error event when `Map#queryRenderedFeatures` receives more than two screen points ([#5685](https://github.com/maplibre/maplibre-gl-js/issues/5685)) (by [@isjiajia01](https://github.com/isjiajia01))
 - _...Add new stuff here..._
 
 ## 6.2.0

--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -2549,6 +2549,10 @@ export class Map extends Evented<MapEventType> {
      * @see [Get features under the mouse pointer](https://maplibre.org/maplibre-gl-js/docs/examples/get-features-under-the-mouse-pointer/)
      */
     queryRenderedFeatures(geometryOrOptions?: PointLike | [PointLike, PointLike] | QueryRenderedFeaturesOptions, options?: QueryRenderedFeaturesOptions): MapGeoJSONFeature[] {
+        if (Array.isArray(geometryOrOptions) && typeof geometryOrOptions[0] !== 'number' && geometryOrOptions.length > 2) {
+            this.fire(new ErrorEvent(new Error('queryRenderedFeatures only accepts a single point or a bounding box of two points.')));
+            return [];
+        }
         if (!this.style) {
             return [];
         }

--- a/src/ui/map_tests/map_query_rendered_features.test.ts
+++ b/src/ui/map_tests/map_query_rendered_features.test.ts
@@ -72,6 +72,33 @@ describe('queryRenderedFeatures', () => {
         expect(spy.mock.calls[0][0]).toEqual([{x: 612, y: 100}]);
     });
 
+    test('fires an error when geometry contains more than two points', async () => {
+        const map = createMap();
+        await map.once('load');
+        const errorListener = vi.fn();
+        const queryListener = vi.spyOn(map.style, 'queryRenderedFeatures');
+        map.on('error', errorListener);
+
+        const result = map.queryRenderedFeatures([[0, 0], [10, 10], [20, 20]] as any);
+
+        expect(result).toEqual([]);
+        expect(errorListener).toHaveBeenCalledTimes(1);
+        expect(errorListener.mock.calls[0][0].error.message).toBe('queryRenderedFeatures only accepts a single point or a bounding box of two points.');
+        expect(queryListener).not.toHaveBeenCalled();
+    });
+
+    test('fires an error for more than two points when no style is loaded', () => {
+        const map = createMap({style: undefined});
+        const errorListener = vi.fn();
+        map.on('error', errorListener);
+
+        const result = map.queryRenderedFeatures([[0, 0], [10, 10], [20, 20]] as any);
+
+        expect(result).toEqual([]);
+        expect(errorListener).toHaveBeenCalledTimes(1);
+        expect(errorListener.mock.calls[0][0].error.message).toBe('queryRenderedFeatures only accepts a single point or a bounding box of two points.');
+    });
+
     test('returns an empty array when no style is loaded', () => {
         const map = createMap({style: undefined});
         expect(map.queryRenderedFeatures()).toEqual([]);


### PR DESCRIPTION
Fixes #5685.

`Map#queryRenderedFeatures` previously accepted arrays containing more than two screen points and silently treated the first two points as a bounding box. This change reports that invalid input through an `ErrorEvent` and returns an empty array before querying the style.

The validation also runs when the map has no loaded style. Existing single-point and two-point bounding-box queries continue through the existing query path.

## Verification

- `npm run test-unit -- src/ui/map_tests/map_query_rendered_features.test.ts` (8 passed)
- `npm run typecheck`
- `npm run lint -- src/ui/map.ts src/ui/map_tests/map_query_rendered_features.test.ts`
- `npm run spellcheck -- CHANGELOG.md`
- Safari 27 road-test against the development bundle with real WebGL contexts:
  - loaded and styleless maps each returned an empty array and emitted exactly one `ErrorEvent` with the expected message;
  - the invalid loaded-map query did not call `style.queryRenderedFeatures`;
  - valid single-point and two-point bounding-box inputs continued to call the style query.

## Launch Checklist

- [x] Confirm these changes do not include backports from Mapbox projects.
- [x] Briefly describe the changes in this PR.
- [x] Link to the related issue.
- [x] Write tests for the new behavior.
- [x] Document the public API behavior change.
- [x] Add an entry to `CHANGELOG.md` under the `## main` section.
- [x] Confirm the MapLibre AI policy has been read.

Generated-By: Codex (`relay-openai/gpt-5.6-sol`)

Codex was prompted to implement MapLibre GL JS issue #5685 with a frozen regression test and a minimal production change. It generated the validation code, regression tests, and changelog entry, and ran the automated and browser verification described above. Jiajia reviewed the changed lines and manually road-tested the behavior before submission.
