### PR TITLE
chore: add a instanceof/contains restriction lint

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -126,6 +126,14 @@ export default [
                 {
                     'selector': 'CallExpression[callee.property.name=\'forEach\']',
                     'message': 'Do not use forEach. Use for...of for iteration, map for mapping, or reduce for accumulation instead.'
+                },
+                {
+                    'selector': 'CallExpression[callee.name="expect"][arguments.0.type="BinaryExpression"][arguments.0.operator="instanceof"]',
+                    'message': 'Do not use instanceof inside expect(). Use toBeInstanceOf() instead.'
+                },
+                {
+                    'selector': 'CallExpression[callee.name="expect"][arguments.0.type="CallExpression"][arguments.0.callee.property.name="contains"][arguments.0.callee.object.property.name="classList"], CallExpression[callee.name="expect"][arguments.0.type="UnaryExpression"][arguments.0.operator="!"][arguments.0.argument.type="CallExpression"][arguments.0.argument.callee.property.name="contains"][arguments.0.argument.callee.object.property.name="classList"]',
+                    'message': 'Do not use classList.contains inside expect(). Use toContain() on classList directly instead.'
                 }
             ],
 

--- a/src/data/segment.test.ts
+++ b/src/data/segment.test.ts
@@ -4,13 +4,13 @@ import {SegmentVector} from './segment.ts';
 
 describe('SegmentVector', () => {
     test('constructor', () => {
-        expect(new SegmentVector() instanceof SegmentVector).toBeTruthy();
+        expect(new SegmentVector()).toBeInstanceOf(SegmentVector);
     });
 
     test('simpleSegment', () => {
         SegmentVector.MAX_VERTEX_ARRAY_LENGTH = 16;
         const segmentVector = SegmentVector.simpleSegment(0, 0, 10, 0);
-        expect(segmentVector instanceof SegmentVector).toBeTruthy();
+        expect(segmentVector).toBeInstanceOf(SegmentVector);
         expect(segmentVector.segments).toHaveLength(1);
         expect(segmentVector.segments[0].vertexLength).toBe(10);
     });

--- a/src/geo/edge_insets.test.ts
+++ b/src/geo/edge_insets.test.ts
@@ -4,7 +4,7 @@ import {EdgeInsets} from '../geo/edge_insets.ts';
 describe('EdgeInsets', () => {
     describe('constructor', () => {
         test('creates an object with default values', () => {
-            expect(new EdgeInsets() instanceof EdgeInsets).toBeTruthy();
+            expect(new EdgeInsets()).toBeInstanceOf(EdgeInsets);
         });
 
         test('invalid initialization', () => {

--- a/src/geo/lng_lat.test.ts
+++ b/src/geo/lng_lat.test.ts
@@ -3,7 +3,7 @@ import {LngLat} from '../geo/lng_lat.ts';
 
 describe('LngLat', () => {
     test('constructor', () => {
-        expect(new LngLat(0, 0) instanceof LngLat).toBeTruthy();
+        expect(new LngLat(0, 0)).toBeInstanceOf(LngLat);
 
         expect(() => {
             new LngLat(0, -91);
@@ -15,12 +15,12 @@ describe('LngLat', () => {
     });
 
     test('convert', () => {
-        expect(LngLat.convert([0, 10]) instanceof LngLat).toBeTruthy();
-        expect(LngLat.convert({lng: 0, lat: 10}) instanceof LngLat).toBeTruthy();
-        expect(LngLat.convert({lng: 0, lat: 0}) instanceof LngLat).toBeTruthy();
-        expect(LngLat.convert({lon: 0, lat: 10}) instanceof LngLat).toBeTruthy();
-        expect(LngLat.convert({lon: 0, lat: 0}) instanceof LngLat).toBeTruthy();
-        expect(LngLat.convert(new LngLat(0, 0)) instanceof LngLat).toBeTruthy();
+        expect(LngLat.convert([0, 10])).toBeInstanceOf(LngLat);
+        expect(LngLat.convert({lng: 0, lat: 10})).toBeInstanceOf(LngLat);
+        expect(LngLat.convert({lng: 0, lat: 0})).toBeInstanceOf(LngLat);
+        expect(LngLat.convert({lon: 0, lat: 10})).toBeInstanceOf(LngLat);
+        expect(LngLat.convert({lon: 0, lat: 0})).toBeInstanceOf(LngLat);
+        expect(LngLat.convert(new LngLat(0, 0))).toBeInstanceOf(LngLat);
     });
 
     test('wrap', () => {

--- a/src/geo/lng_lat_bounds.test.ts
+++ b/src/geo/lng_lat_bounds.test.ts
@@ -336,25 +336,25 @@ describe('LngLatBounds', () => {
             test('point is in bounds', () => {
                 const llb = new LngLatBounds([-1, -1], [1, 1]);
                 const ll = {lng: 0, lat: 0};
-                expect(llb.contains(ll)).toBeTruthy();
+                expect(llb).toContain(ll);
             });
 
             test('point is not in bounds', () => {
                 const llb = new LngLatBounds([-1, -1], [1, 1]);
                 const ll = {lng: 3, lat: 3};
-                expect(llb.contains(ll)).toBeFalsy();
+                expect(llb).not.toContain(ll);
             });
 
             test('point is in bounds that spans dateline', () => {
                 const llb = new LngLatBounds([190, -10], [170, 10]);
                 const ll = {lng: 180, lat: 0};
-                expect(llb.contains(ll)).toBeTruthy();
+                expect(llb).toContain(ll);
             });
 
             test('point is not in bounds that spans dateline', () => {
                 const llb = new LngLatBounds([190, -10], [170, 10]);
                 const ll = {lng: 0, lat: 0};
-                expect(llb.contains(ll)).toBeFalsy();
+                expect(llb).not.toContain(ll);
             });
         });
     });

--- a/src/geo/lng_lat_bounds.test.ts
+++ b/src/geo/lng_lat_bounds.test.ts
@@ -336,25 +336,25 @@ describe('LngLatBounds', () => {
             test('point is in bounds', () => {
                 const llb = new LngLatBounds([-1, -1], [1, 1]);
                 const ll = {lng: 0, lat: 0};
-                expect(llb).toContain(ll);
+                expect(llb.contains(ll)).toBe(true);
             });
 
             test('point is not in bounds', () => {
                 const llb = new LngLatBounds([-1, -1], [1, 1]);
                 const ll = {lng: 3, lat: 3};
-                expect(llb).not.toContain(ll);
+                expect(llb.contains(ll)).toBe(false);
             });
 
             test('point is in bounds that spans dateline', () => {
                 const llb = new LngLatBounds([190, -10], [170, 10]);
                 const ll = {lng: 180, lat: 0};
-                expect(llb).toContain(ll);
+                expect(llb.contains(ll)).toBe(true);
             });
 
             test('point is not in bounds that spans dateline', () => {
                 const llb = new LngLatBounds([190, -10], [170, 10]);
                 const ll = {lng: 0, lat: 0};
-                expect(llb).not.toContain(ll);
+                expect(llb.contains(ll)).toBe(false);
             });
         });
     });

--- a/src/geo/mercator_coordinate.test.ts
+++ b/src/geo/mercator_coordinate.test.ts
@@ -4,8 +4,8 @@ import {MercatorCoordinate, mercatorScale} from './mercator_coordinate.ts';
 
 describe('LngLat', () => {
     test('constructor', () => {
-        expect(new MercatorCoordinate(0, 0) instanceof MercatorCoordinate).toBeTruthy();
-        expect(new MercatorCoordinate(0, 0, 0) instanceof MercatorCoordinate).toBeTruthy();
+        expect(new MercatorCoordinate(0, 0)).toBeInstanceOf(MercatorCoordinate);
+        expect(new MercatorCoordinate(0, 0, 0)).toBeInstanceOf(MercatorCoordinate);
     });
 
     test('fromLngLat', () => {

--- a/src/source/raster_dem_tile_worker_source.test.ts
+++ b/src/source/raster_dem_tile_worker_source.test.ts
@@ -14,7 +14,7 @@ describe('loadTile', () => {
             dim: 256
         } as any as WorkerDEMTileParameters);
         expect(Object.keys(source.loaded)).toEqual(['0']);
-        expect(data instanceof DEMData).toBeTruthy();
+        expect(data).toBeInstanceOf(DEMData);
     });
 });
 

--- a/src/style/style.test.ts
+++ b/src/style/style.test.ts
@@ -374,7 +374,7 @@ describe('Style.loadJSON', () => {
         }));
 
         await style.once('style.load');
-        expect(style.tileManagers['mapLibre'] instanceof TileManager).toBeTruthy();
+        expect(style.tileManagers['mapLibre']).toBeInstanceOf(TileManager);
     });
 
     test('creates layers', async () => {
@@ -396,7 +396,7 @@ describe('Style.loadJSON', () => {
         });
 
         await style.once('style.load');
-        expect(style.getLayer('fill') instanceof StyleLayer).toBeTruthy();
+        expect(style.getLayer('fill')).toBeInstanceOf(StyleLayer);
     });
 
     test('transforms sprite json and image URLs before request', async () => {

--- a/src/style/style_layer.test.ts
+++ b/src/style/style_layer.test.ts
@@ -13,7 +13,7 @@ describe('StyleLayer', () => {
     test('instantiates the correct subclass', () => {
         const layer = createStyleLayer({type: 'fill'} as LayerSpecification, {});
 
-        expect(layer instanceof FillStyleLayer).toBeTruthy();
+        expect(layer).toBeInstanceOf(FillStyleLayer);
     });
 });
 

--- a/src/symbol/anchor.test.ts
+++ b/src/symbol/anchor.test.ts
@@ -3,8 +3,8 @@ import {Anchor} from './anchor.ts';
 
 describe('Anchor', () => {
     test('constructor', () => {
-        expect(new Anchor(0, 0, 0) instanceof Anchor).toBeTruthy();
-        expect(new Anchor(0, 0, 0, 0) instanceof Anchor).toBeTruthy();
+        expect(new Anchor(0, 0, 0)).toBeInstanceOf(Anchor);
+        expect(new Anchor(0, 0, 0, 0)).toBeInstanceOf(Anchor);
     });
     test('clone', () => {
         const a = new Anchor(1, 2, 3);

--- a/src/tile/tile_id.test.ts
+++ b/src/tile/tile_id.test.ts
@@ -63,7 +63,7 @@ describe('CanonicalTileID', () => {
 
 describe('OverscaledTileID', () => {
     test('constructor', () => {
-        expect(new OverscaledTileID(0, 0, 0, 0, 0) instanceof OverscaledTileID).toBeTruthy();
+        expect(new OverscaledTileID(0, 0, 0, 0, 0)).toBeInstanceOf(OverscaledTileID);
     });
 
     test('constructor - deeper canonicalZ than overscaledZ disallowed', () => {

--- a/src/ui/control/fullscreen_control.test.ts
+++ b/src/ui/control/fullscreen_control.test.ts
@@ -45,15 +45,15 @@ describe('FullscreenControl', () => {
 
         const click = new window.Event('click');
 
-        expect(mapContainer.classList.contains('maplibregl-pseudo-fullscreen')).toBe(false);
+        expect(mapContainer.classList).not.toContain('maplibregl-pseudo-fullscreen');
 
         fullscreen._fullscreenButton.dispatchEvent(click);
 
-        expect(mapContainer.classList.contains('maplibregl-pseudo-fullscreen')).toBe(true);
+        expect(mapContainer.classList).toContain('maplibregl-pseudo-fullscreen');
 
         fullscreen._fullscreenButton.dispatchEvent(click);
 
-        expect(mapContainer.classList.contains('maplibregl-pseudo-fullscreen')).toBe(false);
+        expect(mapContainer.classList).not.toContain('maplibregl-pseudo-fullscreen');
     });
 
     test('start and end events fire for fullscreen button clicks', () => {
@@ -129,11 +129,11 @@ describe('FullscreenControl', () => {
 
         const click = new window.Event('click');
 
-        expect(mapContainer.classList.contains('maplibregl-pseudo-fullscreen')).toBe(false);
+        expect(mapContainer.classList).not.toContain('maplibregl-pseudo-fullscreen');
         fullscreen._fullscreenButton.dispatchEvent(click);
-        expect(mapContainer.classList.contains('maplibregl-pseudo-fullscreen')).toBe(true);
+        expect(mapContainer.classList).toContain('maplibregl-pseudo-fullscreen');
         fullscreen._fullscreenButton.dispatchEvent(click);
-        expect(mapContainer.classList.contains('maplibregl-pseudo-fullscreen')).toBe(false);
+        expect(mapContainer.classList).not.toContain('maplibregl-pseudo-fullscreen');
     });
 
     test('pseudo option forces pseudo fullscreen even when native fullscreen is available', () => {
@@ -151,7 +151,7 @@ describe('FullscreenControl', () => {
         fullscreen._fullscreenButton.dispatchEvent(click);
 
         expect(requestFullscreenSpy).not.toHaveBeenCalled();
-        expect(mapContainer.classList.contains('maplibregl-pseudo-fullscreen')).toBe(true);
+        expect(mapContainer.classList).toContain('maplibregl-pseudo-fullscreen');
     });
 
     test('pseudo fullscreen can be used on custom container', () => {
@@ -166,11 +166,11 @@ describe('FullscreenControl', () => {
 
         const click = new window.Event('click');
 
-        expect(container.classList.contains('maplibregl-pseudo-fullscreen')).toBe(false);
+        expect(container.classList).not.toContain('maplibregl-pseudo-fullscreen');
         fullscreen._fullscreenButton.dispatchEvent(click);
-        expect(container.classList.contains('maplibregl-pseudo-fullscreen')).toBe(true);
+        expect(container.classList).toContain('maplibregl-pseudo-fullscreen');
         expect(fullscreen._container.tagName).toBe('BODY');
         fullscreen._fullscreenButton.dispatchEvent(click);
-        expect(container.classList.contains('maplibregl-pseudo-fullscreen')).toBe(false);
+        expect(container.classList).not.toContain('maplibregl-pseudo-fullscreen');
     });
 });

--- a/src/ui/control/geolocate_control.test.ts
+++ b/src/ui/control/geolocate_control.test.ts
@@ -418,7 +418,7 @@ describe('GeolocateControl with no options', () => {
         geolocate.trigger();
         geolocation.sendError({code: 2, message: 'error message'});
         expect(geolocate._watchState).toBe('ACTIVE_ERROR');
-        expect(geolocate._geolocateButton.classList.contains('maplibregl-ctrl-geolocate-active-error')).toBeTruthy();
+        expect(geolocate._geolocateButton.classList).toContain('maplibregl-ctrl-geolocate-active-error');
     });
 
     test('trigger before added to map', () => {
@@ -549,7 +549,7 @@ describe('GeolocateControl with no options', () => {
         geolocation.changeError({code: 2, message: 'position unavailable'});
         await errorPromise;
         expect(geolocate._userLocationDotMarker._map).toBeTruthy();
-        expect(geolocate._userLocationDotMarker._element.classList.contains('maplibregl-user-location-dot-stale')).toBeTruthy();
+        expect(geolocate._userLocationDotMarker._element.classList).toContain('maplibregl-user-location-dot-stale');
     });
 
     /**

--- a/src/ui/control/geolocate_control.test.ts
+++ b/src/ui/control/geolocate_control.test.ts
@@ -538,9 +538,7 @@ describe('GeolocateControl with no options', () => {
 
         expect(lngLatAsFixed(map.getCenter(), 4)).toEqual({lat: '10.0000', lng: '20.0000'});
         expect(geolocate._userLocationDotMarker._map).toBeTruthy();
-        expect(
-            geolocate._userLocationDotMarker._element.classList.contains('maplibregl-user-location-dot-stale')
-        ).toBeFalsy();
+        expect(geolocate._userLocationDotMarker._element.classList).not.toContain('maplibregl-user-location-dot-stale');
         const secontMoveEnd = map.once('moveend');
         geolocation.change({latitude: 40, longitude: 50, accuracy: 60});
         await secontMoveEnd;

--- a/src/ui/control/globe_control.test.ts
+++ b/src/ui/control/globe_control.test.ts
@@ -73,8 +73,8 @@ describe('GlobeControl', () => {
         test('default without call to setProjection', () => {
             const button = map.getContainer().querySelector('.maplibregl-ctrl-globe');
             expect(map.style.projection.name).toBe('mercator');
-            expect(button.classList.contains('maplibregl-ctrl-globe')).toBeTruthy();
-            expect(button.classList.contains('maplibregl-ctrl-globe-enabled')).toBeFalsy();
+            expect(button.classList).toContain('maplibregl-ctrl-globe');
+            expect(button.classList).not.toContain('maplibregl-ctrl-globe-enabled');
         });
 
         test('setProjection({type: "mercator" -> "globe")', () => {
@@ -85,8 +85,8 @@ describe('GlobeControl', () => {
             const button = map.getContainer().querySelector('.maplibregl-ctrl-globe-enabled');
             expect(map.style.projection.name).toBe('globe');
             expect(button).not.toBeNull();
-            expect(button.classList.contains('maplibregl-ctrl-globe-enabled')).toBeTruthy();
-            expect(button.classList.contains('maplibregl-ctrl-globe')).toBeFalsy();
+            expect(button.classList).toContain('maplibregl-ctrl-globe-enabled');
+            expect(button.classList).not.toContain('maplibregl-ctrl-globe');
         });
 
         test('setProjection({type: "globe" -> "mercator")', () => {
@@ -96,8 +96,8 @@ describe('GlobeControl', () => {
             // mercator = disabled state
             const button = map.getContainer().querySelector('.maplibregl-ctrl-globe');
             expect(map.style.projection.name).toBe('mercator');
-            expect(button.classList.contains('maplibregl-ctrl-globe')).toBeTruthy();
-            expect(button.classList.contains('maplibregl-ctrl-globe-enabled')).toBeFalsy();
+            expect(button.classList).toContain('maplibregl-ctrl-globe');
+            expect(button.classList).not.toContain('maplibregl-ctrl-globe-enabled');
         });
     });
 });

--- a/src/ui/handler/two_fingers_touch.test.ts
+++ b/src/ui/handler/two_fingers_touch.test.ts
@@ -312,11 +312,11 @@ describe('touch zoom rotate', () => {
         const map = createMap();
 
         const className = 'maplibregl-touch-zoom-rotate';
-        expect(map.getCanvasContainer().classList.contains(className)).toBeTruthy();
+        expect(map.getCanvasContainer().classList).toContain(className);
         map.touchZoomRotate.disable();
-        expect(map.getCanvasContainer().classList.contains(className)).toBeFalsy();
+        expect(map.getCanvasContainer().classList).not.toContain(className);
         map.touchZoomRotate.enable();
-        expect(map.getCanvasContainer().classList.contains(className)).toBeTruthy();
+        expect(map.getCanvasContainer().classList).toContain(className);
     });
 
     test('TwoFingersTouchZoomRotateHandler zooms when touching two markers on the same map', () => {

--- a/src/ui/map_tests/map_cross_window.test.ts
+++ b/src/ui/map_tests/map_cross_window.test.ts
@@ -36,8 +36,8 @@ describe('Map cross-window support', () => {
             expect(iframeDocument).not.toBe(window.document);
             expect(iframeWindow).not.toBe(window);
 
-            expect(container instanceof HTMLElement).toBe(false);
-            expect(container instanceof iframeDocument.defaultView.HTMLElement).toBe(true);
+            expect(container).not.toBeInstanceOf( HTMLElement);
+            expect(container).toBeInstanceOf(iframeDocument.defaultView.HTMLElement);
 
             const map = new Map({
                 container,

--- a/src/ui/marker.test.ts
+++ b/src/ui/marker.test.ts
@@ -123,19 +123,19 @@ describe('marker', () => {
     test('Marker provides LngLat accessors', () => {
         expect(new Marker().getLngLat()).toBeUndefined();
 
-        expect(new Marker().setLngLat([1, 2]).getLngLat() instanceof LngLat).toBeTruthy();
+        expect(new Marker().setLngLat([1, 2]).getLngLat()).toBeInstanceOf(LngLat);
         expect(new Marker().setLngLat([1, 2]).getLngLat()).toEqual(new LngLat(1, 2));
 
-        expect(new Marker().setLngLat(new LngLat(1, 2)).getLngLat() instanceof LngLat).toBeTruthy();
+        expect(new Marker().setLngLat(new LngLat(1, 2)).getLngLat()).toBeInstanceOf(LngLat);
         expect(new Marker().setLngLat(new LngLat(1, 2)).getLngLat()).toEqual(new LngLat(1, 2));
 
     });
 
     test('Marker provides offset accessors', () => {
-        expect(new Marker().setOffset([1, 2]).getOffset() instanceof Point).toBeTruthy();
+        expect(new Marker().setOffset([1, 2]).getOffset()).toBeInstanceOf(Point);
         expect(new Marker().setOffset([1, 2]).getOffset()).toEqual(new Point(1, 2));
 
-        expect(new Marker().setOffset(new Point(1, 2)).getOffset() instanceof Point).toBeTruthy();
+        expect(new Marker().setOffset(new Point(1, 2)).getOffset()).toBeInstanceOf(Point);
         expect(new Marker().setOffset(new Point(1, 2)).getOffset()).toEqual(new Point(1, 2));
 
     });

--- a/src/ui/marker.test.ts
+++ b/src/ui/marker.test.ts
@@ -96,20 +96,20 @@ describe('marker', () => {
             .addTo(map);
 
         const markerElement = marker.getElement();
-        expect(markerElement.classList.contains('some')).toBeTruthy();
-        expect(markerElement.classList.contains('classes')).toBeTruthy();
+        expect(markerElement.classList).toContain('some');
+        expect(markerElement.classList).toContain('classes');
 
         marker.addClassName('addedClass');
-        expect(markerElement.classList.contains('addedClass')).toBeTruthy();
+        expect(markerElement.classList).toContain('addedClass');
 
         marker.removeClassName('addedClass');
-        expect(!markerElement.classList.contains('addedClass')).toBeTruthy();
+        expect(!markerElement.classList).toContain('addedClass');
 
         marker.toggleClassName('toggle');
-        expect(markerElement.classList.contains('toggle')).toBeTruthy();
+        expect(markerElement.classList).toContain('toggle');
 
         marker.toggleClassName('toggle');
-        expect(!markerElement.classList.contains('toggle')).toBeTruthy();
+        expect(!markerElement.classList).toContain('toggle');
 
         expect(() => marker.addClassName('should throw exception')).toThrow(window.DOMException);
         expect(() => marker.removeClassName('should throw exception')).toThrow(window.DOMException);
@@ -343,7 +343,7 @@ describe('marker', () => {
             .setLngLat([0, 0])
             .addTo(map);
 
-        expect(marker.getElement().classList.contains('maplibregl-marker-anchor-center')).toBeTruthy();
+        expect(marker.getElement().classList).toContain('maplibregl-marker-anchor-center');
         expect(marker.getElement().style.transform).toMatch(/translate\(-50%,-50%\)/);
 
         map.remove();
@@ -355,7 +355,7 @@ describe('marker', () => {
             .setLngLat([0, 0])
             .addTo(map);
 
-        expect(marker.getElement().classList.contains('maplibregl-marker-anchor-top')).toBeTruthy();
+        expect(marker.getElement().classList).toContain('maplibregl-marker-anchor-top');
         expect(marker.getElement().style.transform).toMatch(/translate\(-50%,0\)/);
 
         map.remove();
@@ -1352,7 +1352,7 @@ describe('marker', () => {
         map.fire('terrain');
         await sleep(100);
 
-        expect(marker.getElement().classList.contains('maplibregl-marker-covered')).toBe(true);
+        expect(marker.getElement().classList).toContain('maplibregl-marker-covered');
         map.remove();
     });
 
@@ -1368,13 +1368,13 @@ describe('marker', () => {
         map.fire('terrain');
         await sleep(100);
 
-        expect(marker.getElement().classList.contains('maplibregl-marker-covered')).toBe(true);
+        expect(marker.getElement().classList).toContain('maplibregl-marker-covered');
 
         map.terrain.depthAtPoint = () => .95; // Terrain no longer blocking marker
         map.fire('moveend');
         await sleep(100);
 
-        expect(marker.getElement().classList.contains('maplibregl-marker-covered')).toBe(false);
+        expect(marker.getElement().classList).not.toContain('maplibregl-marker-covered');
         map.remove();
     });
 
@@ -1389,7 +1389,7 @@ describe('marker', () => {
         map.setProjection({type: 'globe'});
         await sleep(100);
 
-        expect(marker.getElement().classList.contains('maplibregl-marker-covered')).toBe(true);
+        expect(marker.getElement().classList).toContain('maplibregl-marker-covered');
         map.remove();
     });
 
@@ -1404,12 +1404,12 @@ describe('marker', () => {
         map.setProjection({type: 'globe'});
         await sleep(100);
 
-        expect(marker.getElement().classList.contains('maplibregl-marker-covered')).toBe(true);
+        expect(marker.getElement().classList).toContain('maplibregl-marker-covered');
 
         marker.setLngLat([0, 0]);
         await sleep(100);
 
-        expect(marker.getElement().classList.contains('maplibregl-marker-covered')).toBe(false);
+        expect(marker.getElement().classList).not.toContain('maplibregl-marker-covered');
         map.remove();
     });
 });

--- a/src/ui/marker.test.ts
+++ b/src/ui/marker.test.ts
@@ -103,13 +103,13 @@ describe('marker', () => {
         expect(markerElement.classList).toContain('addedClass');
 
         marker.removeClassName('addedClass');
-        expect(!markerElement.classList).toContain('addedClass');
+        expect(markerElement.classList).not.toContain('addedClass');
 
         marker.toggleClassName('toggle');
         expect(markerElement.classList).toContain('toggle');
 
         marker.toggleClassName('toggle');
-        expect(!markerElement.classList).toContain('toggle');
+        expect(markerElement.classList).not.toContain('toggle');
 
         expect(() => marker.addClassName('should throw exception')).toThrow(window.DOMException);
         expect(() => marker.removeClassName('should throw exception')).toThrow(window.DOMException);
@@ -407,51 +407,35 @@ describe('marker', () => {
         Object.defineProperty(marker.getPopup()._container, 'offsetHeight', {value: 100});
 
         // marker should default to above since it has enough space
-        expect(
-            marker.getPopup()._container.classList.contains('maplibregl-popup-anchor-bottom')
-        ).toBeTruthy();
+        expect(marker.getPopup()._container.classList).toContain('maplibregl-popup-anchor-bottom');
 
         // move marker to the top forcing the popup to below
         marker.setLngLat(map.unproject([mapHeight / 2, markerTop]));
-        expect(
-            marker.getPopup()._container.classList.contains('maplibregl-popup-anchor-top')
-        ).toBeTruthy();
+        expect(marker.getPopup()._container.classList).toContain('maplibregl-popup-anchor-top');
 
         // move marker to the right forcing the popup to the left
         marker.setLngLat(map.unproject([mapHeight - markerRight, mapHeight / 2]));
-        expect(
-            marker.getPopup()._container.classList.contains('maplibregl-popup-anchor-right')
-        ).toBeTruthy();
+        expect(marker.getPopup()._container.classList).toContain('maplibregl-popup-anchor-right');
 
         // move marker to the left forcing the popup to the right
         marker.setLngLat(map.unproject([markerRight, mapHeight / 2]));
-        expect(
-            marker.getPopup()._container.classList.contains('maplibregl-popup-anchor-left')
-        ).toBeTruthy();
+        expect(marker.getPopup()._container.classList).toContain('maplibregl-popup-anchor-left');
 
         // move marker to the top left forcing the popup to the bottom right
         marker.setLngLat(map.unproject([markerRight, markerTop]));
-        expect(
-            marker.getPopup()._container.classList.contains('maplibregl-popup-anchor-top-left')
-        ).toBeTruthy();
+        expect(marker.getPopup()._container.classList).toContain('maplibregl-popup-anchor-top-left');
 
         // move marker to the top right forcing the popup to the bottom left
         marker.setLngLat(map.unproject([mapHeight - markerRight, markerTop]));
-        expect(
-            marker.getPopup()._container.classList.contains('maplibregl-popup-anchor-top-right')
-        ).toBeTruthy();
+        expect(marker.getPopup()._container.classList).toContain('maplibregl-popup-anchor-top-right');
 
         // move marker to the bottom left forcing the popup to the top right
         marker.setLngLat(map.unproject([markerRight, mapHeight]));
-        expect(
-            marker.getPopup()._container.classList.contains('maplibregl-popup-anchor-bottom-left')
-        ).toBeTruthy();
+        expect(marker.getPopup()._container.classList).toContain('maplibregl-popup-anchor-bottom-left');
 
         // move marker to the bottom right forcing the popup to the top left
         marker.setLngLat(map.unproject([mapHeight - markerRight, mapHeight]));
-        expect(
-            marker.getPopup()._container.classList.contains('maplibregl-popup-anchor-bottom-right')
-        ).toBeTruthy();
+        expect(marker.getPopup()._container.classList).toContain('maplibregl-popup-anchor-bottom-right');
 
         map.remove();
     });

--- a/src/ui/popup.test.ts
+++ b/src/ui/popup.test.ts
@@ -571,14 +571,14 @@ describe('popup', () => {
         expect(addClassNameMethodPopupInstance).toBeInstanceOf(Popup);
 
         const removeClassNameMethodPopupInstance = popup.removeClassName('addedClass');
-        expect(!popupContainer.classList).toContain('addedClass');
+        expect(popupContainer.classList).not.toContain('addedClass');
         expect(removeClassNameMethodPopupInstance).toBeInstanceOf(Popup);
 
         popup.toggleClassName('toggle');
         expect(popupContainer.classList).toContain('toggle');
 
         popup.toggleClassName('toggle');
-        expect(!popupContainer.classList).toContain('toggle');
+        expect(popupContainer.classList).not.toContain('toggle');
 
         expect(() => popup.addClassName('should throw exception')).toThrow(window.DOMException);
         expect(() => popup.removeClassName('should throw exception')).toThrow(window.DOMException);

--- a/src/ui/popup.test.ts
+++ b/src/ui/popup.test.ts
@@ -258,10 +258,10 @@ describe('popup', () => {
     test('Popup provides LngLat accessors', () => {
         expect(new Popup().getLngLat()).toBeUndefined();
 
-        expect(new Popup().setLngLat([1, 2]).getLngLat() instanceof LngLat).toBeTruthy();
+        expect(new Popup().setLngLat([1, 2]).getLngLat()).toBeInstanceOf(LngLat);
         expect(new Popup().setLngLat([1, 2]).getLngLat()).toEqual(new LngLat(1, 2));
 
-        expect(new Popup().setLngLat(new LngLat(1, 2)).getLngLat() instanceof LngLat).toBeTruthy();
+        expect(new Popup().setLngLat(new LngLat(1, 2)).getLngLat()).toBeInstanceOf(LngLat);
         expect(new Popup().setLngLat(new LngLat(1, 2)).getLngLat()).toEqual(new LngLat(1, 2));
 
     });

--- a/src/ui/popup.test.ts
+++ b/src/ui/popup.test.ts
@@ -32,7 +32,7 @@ describe('popup', () => {
             .addTo(map);
 
         expect(popup.isOpen()).toBeTruthy();
-        expect(popup.getElement().classList.contains('maplibregl-popup')).toBeTruthy();
+        expect(popup.getElement().classList).toContain('maplibregl-popup');
     });
 
     test('Popup.addTo adds a .maplibregl-popup element', () => {
@@ -382,7 +382,7 @@ describe('popup', () => {
             .setText('Test')
             .addTo(map);
 
-        expect(popup.getElement().classList.contains('maplibregl-popup-anchor-top-left')).toBeTruthy();
+        expect(popup.getElement().classList).toContain('maplibregl-popup-anchor-top-left');
     });
 
     const cases =  [
@@ -413,7 +413,7 @@ describe('popup', () => {
             vi.spyOn(map, 'project').mockReturnValue(point);
             popup.setLngLat([0, 0]);
 
-            expect(popup.getElement().classList.contains(`maplibregl-popup-anchor-${anchor}`)).toBeTruthy();
+            expect(popup.getElement().classList).toContain(`maplibregl-popup-anchor-${anchor}`);
         });
 
     const transformCases = cases.map(([anchor, _point, transform]) => [anchor, transform] as const);
@@ -449,7 +449,7 @@ describe('popup', () => {
         vi.spyOn(map, 'project').mockReturnValue(point);
         popup.setLngLat([0, 0]);
 
-        expect(popup.getElement().classList.contains('maplibregl-popup-anchor-top')).toBeTruthy();
+        expect(popup.getElement().classList).toContain('maplibregl-popup-anchor-top');
     });
 
     test('Popup is offset via a PointLike offset option', () => {
@@ -563,22 +563,22 @@ describe('popup', () => {
             .addTo(map);
 
         const popupContainer = popup.getElement();
-        expect(popupContainer.classList.contains('some')).toBeTruthy();
-        expect(popupContainer.classList.contains('classes')).toBeTruthy();
+        expect(popupContainer.classList).toContain('some');
+        expect(popupContainer.classList).toContain('classes');
 
         const addClassNameMethodPopupInstance = popup.addClassName('addedClass');
-        expect(popupContainer.classList.contains('addedClass')).toBeTruthy();
+        expect(popupContainer.classList).toContain('addedClass');
         expect(addClassNameMethodPopupInstance).toBeInstanceOf(Popup);
 
         const removeClassNameMethodPopupInstance = popup.removeClassName('addedClass');
-        expect(!popupContainer.classList.contains('addedClass')).toBeTruthy();
+        expect(!popupContainer.classList).toContain('addedClass');
         expect(removeClassNameMethodPopupInstance).toBeInstanceOf(Popup);
 
         popup.toggleClassName('toggle');
-        expect(popupContainer.classList.contains('toggle')).toBeTruthy();
+        expect(popupContainer.classList).toContain('toggle');
 
         popup.toggleClassName('toggle');
-        expect(!popupContainer.classList.contains('toggle')).toBeTruthy();
+        expect(!popupContainer.classList).toContain('toggle');
 
         expect(() => popup.addClassName('should throw exception')).toThrow(window.DOMException);
         expect(() => popup.removeClassName('should throw exception')).toThrow(window.DOMException);
@@ -1063,8 +1063,8 @@ describe('popup', () => {
                 .trackPointer()
                 .addTo(map);
 
-            expect(popup.getElement().classList.contains('maplibregl-popup-track-pointer')).toBeTruthy();
-            expect(map._canvasContainer.classList.contains('maplibregl-track-pointer')).toBeTruthy();
+            expect(popup.getElement().classList).toContain('maplibregl-popup-track-pointer');
+            expect(map._canvasContainer.classList).toContain('maplibregl-track-pointer');
 
             popup.remove();
         });

--- a/src/util/util.test.ts
+++ b/src/util/util.test.ts
@@ -78,7 +78,7 @@ describe('util', () => {
 
     test('bezier', () => {
         const curve = bezier(0, 0, 0.25, 1);
-        expect(curve instanceof Function).toBeTruthy();
+        expect(curve).toBeInstanceOf(Function);
         expect(curve(0)).toBe(0);
         expect(curve(1)).toBe(1);
         expect(curve(0.5)).toBe(0.8230854638965502);

--- a/src/util/web_worker_transfer.test.ts
+++ b/src/util/web_worker_transfer.test.ts
@@ -39,8 +39,8 @@ describe('web worker transfer', () => {
         const serializableMock = new SerializableMock(10);
         const transferables = [];
         const deserialized = deserialize(serialize(serializableMock, transferables)) as SerializableMock;
-        expect(deserialize(serialize(serializableMock, transferables)) instanceof SerializableMock).toBeTruthy();
-        expect(serializableMock.dataView instanceof DataView).toBeTruthy();
+        expect(deserialize(serialize(serializableMock, transferables))).toBeInstanceOf(SerializableMock);
+        expect(serializableMock.dataView).toBeInstanceOf(DataView);
 
         expect(serializableMock !== deserialized).toBeTruthy();
         expect(deserialized.constructor === SerializableMock).toBeTruthy();
@@ -51,7 +51,7 @@ describe('web worker transfer', () => {
         expect(transferables[1] === serializableMock.dataView.buffer).toBeTruthy();
         expect(deserialized._cached === undefined).toBeTruthy();
         expect(deserialized.squared() === 100).toBeTruthy();
-        expect(deserialized.dataView instanceof DataView).toBeTruthy();
+        expect(deserialized.dataView).toBeInstanceOf(DataView);
         expect(deserialized.array).toEqual(serializableMock.array);
     });
 
@@ -61,7 +61,7 @@ describe('web worker transfer', () => {
         register('Anon', Klass);
         const x = new Klass();
         const deserialized = deserialize(serialize(x));
-        expect(deserialized instanceof Klass).toBeTruthy();
+        expect(deserialized).toBeInstanceOf(Klass);
     });
 
     test('null', () => {
@@ -94,7 +94,7 @@ describe('web worker transfer', () => {
         expect(!customSerialization._deserialized).toBeTruthy();
 
         const deserialized = deserialize(serialize(customSerialization)) as CustomSerialization;
-        expect(deserialize(serialize(customSerialization)) instanceof CustomSerialization).toBeTruthy();
+        expect(deserialize(serialize(customSerialization))).toBeInstanceOf(CustomSerialization);
         expect(deserialized.id).toBe(customSerialization.id);
         expect(deserialized._deserialized).toBeTruthy();
     });


### PR DESCRIPTION
## Launch Checklist

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 
Adds two fairly specificic selectors which are not covered by our current, existing lints.
Primarily motivated by cleaning things up.