### PR TITLE
docs: condition the benchmark checklist item on touching benchmarked code

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,7 +9,7 @@
  - [ ] Include before/after visuals or gifs if this PR includes visual changes.
  - [ ] Write tests for all new functionality.
  - [ ] Document any changes to public APIs.
- - [ ] Post benchmark scores.
+ - [ ] If you changed code in a file that has a benchmark file next to it (`*.bench.ts`), post before/after results of `npm run bench` (the compare workflow is in `test/bench/README.md`).
  - [ ] Add an entry to `CHANGELOG.md` under the `## main` section.
  - [ ] Confirm you have read our AI policy [here](https://github.com/maplibre/maplibre/blob/main/AI_POLICY.md).
 <!--


### PR DESCRIPTION
## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items that are not relevant. -->

Suggested by @HarelM when merging #8122: https://github.com/maplibre/maplibre-gl-js/pull/8122#issuecomment-5233617539

"Post benchmark scores" asks every PR for output most PRs have no output for, so it gets skipped without a thought. Stating the condition makes it answerable: if you touched a file with a `*.bench.ts` next to it, run `npm run bench` before and after then post the results.

The pointer to `test/bench/README.md` is where the baseline and compare commands live, so the checkbox and the README now say the same thing.

- [x] No backports from Mapbox projects
- [x] Related: #8122
- [x] No benchmark scores: template text only
- [x] No CHANGELOG entry, per the CONTRIBUTING rule for documentation changes
- [x] Confirm you have read our AI policy [here](https://github.com/maplibre/maplibre/blob/main/AI_POLICY.md)
