### PR TITLE
ci: run the micro benchmarks

### DIFF
--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -174,6 +174,20 @@ jobs:
       - run: npm run build-dist
       - run: npm run test-build-ci
 
+  benchmarks:
+    name: Benchmarks
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v4
+        with:
+          node-version-file: '.nvmrc'
+      - run: npm ci
+      - run: npm run bench
+
   merge-and-report:
     name: Merge coverage and report
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items that are not relevant. -->

Following @HarelM's note after #8122: "I don't know if it's worth adding this to CI, but let's try, worst case we revert." https://github.com/maplibre/maplibre-gl-js/pull/8122#issuecomment-5233617539

One job in the Tests workflow, running `npm run bench` over the 11 `*.bench.ts` files. That is all of it.

It compares nothing. No thresholds, no stored baselines, no uploaded numbers. #982 settled that the only comparison worth trusting is same machine, same session, so a runner has nothing useful to say about a delta. It answers the other question: do the benchmarks still run? Fixtures move, APIs drift, and a bench file can break at runtime where typecheck never looks. (The old page failed exactly that way, with three headless runs stalling on network fetches and nothing reporting it).

The suite is node-only and needs no build. The full run takes about 27 seconds on an M2 MacBook Pro; on a runner it is likely a couple of minutes once `npm ci` is counted. The 20 minute timeout is for catching a hang, rather than for bounding the work.

A module or setup error fails the run loudly; this was checked by breaking a bench file on purpose. A throw inside the measured callback is swallowed by `tinybench`. That case shows an empty table instead of a red check.

`npm run bench-e2e` is not included. It would need a dist build and headless Chrome, and its numbers are version comparisons, which is where runner variance would mislead most.

This is the last open CI item from the redesign issue, though whether that closes #982 the issue is your call. If the job flakes, I'd say that's the answer, and the revert is one commit.

- [x] No backports from Mapbox projects
- [x] Related: #982, #8122
- [x] No benchmark scores: CI configuration only
- [x] No CHANGELOG entry, per the CONTRIBUTING rule for benchmark related changes
- [x] Confirm you have read our AI policy [here](https://github.com/maplibre/maplibre/blob/main/AI_POLICY.md)
