### PR TITLE
GM1.6 Unpack the remaining packed vertex data with bitwise operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Make fired/listened map events typed. This means that `map.on("something", ...)` (and `once`, `listens`) will now give you an typescript error and better autocomplete. If you relied on firing/listening custom events via the map, this still works via the escape hatches `map.fire("something" as any)` -> `map.on("something" as any, ...)` ([#8072](https://github.com/maplibre/maplibre-gl-js/issues/8072)) (by [@CommanderStorm](https://github.com/CommanderStorm))
 - Let a `StyleImageInterface` give a `{renderWithWebGL}` callback as its `data`, an escape hatch for plugin developers and advanced users that renders a style image on the GPU instead of moving its pixels through the CPU. Nothing new is possible that pixels could not already express, but an image that changes often, such as an animated icon, gets more performant ([#7954](https://github.com/maplibre/maplibre-gl-js/pull/7954)) (by [@lucaswoj](https://github.com/lucaswoj))
 - Use integer vertex attributes for packed line data instead of float conversion ([#7640](https://github.com/maplibre/maplibre-gl-js/issues/7640)) (by [@johncarmack1984](https://github.com/johncarmack1984))
+- Use integer vertex attributes for packed circle, heatmap, symbol, and fill-extrusion data instead of float conversion ([#7640](https://github.com/maplibre/maplibre-gl-js/issues/7640)) (by [@johncarmack1984](https://github.com/johncarmack1984))
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes

--- a/src/shaders/glsl/_prelude.vertex.glsl
+++ b/src/shaders/glsl/_prelude.vertex.glsl
@@ -26,9 +26,8 @@ vec2 unpack_float(const float packedValue) {
     return vec2(v0, packedIntValue - v0 * 256);
 }
 
-vec2 unpack_opacity(const float packedOpacity) {
-    int intOpacity = int(packedOpacity) / 2;
-    return vec2(float(intOpacity) / 127.0, mod(packedOpacity, 2.0));
+vec2 unpack_opacity(const uint packedOpacity) {
+    return vec2(float(packedOpacity >> 1u) / 127.0, float(packedOpacity & 1u));
 }
 
 // To minimize the number of ins needed, we encode a 4-component

--- a/src/shaders/glsl/circle.vertex.glsl
+++ b/src/shaders/glsl/circle.vertex.glsl
@@ -6,7 +6,7 @@ uniform lowp float u_device_pixel_ratio;
 uniform highp float u_camera_to_center_distance;
 uniform vec2 u_translate;
 
-layout(location = 0) in vec2 a_pos;
+layout(location = 0) in ivec2 a_pos;
 
 out vec3 v_data;
 flat out float v_visibility;
@@ -29,12 +29,12 @@ void main(void) {
     #pragma maplibre: initialize lowp float stroke_opacity
 
     // decode the extrusion vector that we snuck into the a_pos vector
-    vec2 pos_raw = a_pos + 32768.0;
-    vec2 extrude = vec2(mod(pos_raw, 8.0) / 7.0 * 2.0 - 1.0);
+    ivec2 pos_raw = a_pos + 32768;
+    vec2 extrude = vec2(pos_raw & 7) / 7.0 * 2.0 - 1.0;
 
     // Divide a_pos by 8, since we had it * 8 in order to sneak
     // in extrusion data
-    vec2 circle_center = floor(pos_raw / 8.0) + u_translate;
+    vec2 circle_center = vec2(pos_raw >> 3) + u_translate;
     float ele = get_elevation(circle_center);
     v_visibility = calculate_visibility(projectTileWithElevation(circle_center, ele));
 

--- a/src/shaders/glsl/fill_extrusion.vertex.glsl
+++ b/src/shaders/glsl/fill_extrusion.vertex.glsl
@@ -7,7 +7,7 @@ uniform lowp float u_opacity;
 uniform vec2 u_fill_translate;
 
 layout(location = 0) in vec2 a_pos;
-layout(location = 1) in vec4 a_normal_ed;
+layout(location = 1) in ivec4 a_normal_ed;
 
 #ifdef TERRAIN3D
     layout(location = 2) in vec2 a_centroid;
@@ -26,7 +26,7 @@ void main() {
     #pragma maplibre: initialize highp float height
     #pragma maplibre: initialize highp vec4 color
 
-    vec3 normal = a_normal_ed.xyz;
+    vec3 normal = vec3(a_normal_ed.xyz);
 
     #ifdef TERRAIN3D
 	    // Raise the "ceiling" of elements by the elevation of the centroid, in meters.
@@ -44,7 +44,7 @@ void main() {
     base = max(0.0, base) + base_terrain3d_offset;
     height = max(0.0, height) + height_terrain3d_offset;
 
-    float t = mod(normal.x, 2.0);
+    float t = float(a_normal_ed.x & 1);
     float elevation = t > 0.0 ? height : base;
     vec2 posInTile = a_pos + u_fill_translate;
 

--- a/src/shaders/glsl/fill_extrusion_pattern.vertex.glsl
+++ b/src/shaders/glsl/fill_extrusion_pattern.vertex.glsl
@@ -12,7 +12,7 @@ uniform lowp vec3 u_lightpos_globe;
 uniform lowp float u_lightintensity;
 
 layout(location = 0) in vec2 a_pos;
-layout(location = 1) in vec4 a_normal_ed;
+layout(location = 1) in ivec4 a_normal_ed;
 
 #ifdef TERRAIN3D
     layout(location = 2) in vec2 a_centroid;
@@ -50,8 +50,8 @@ void main() {
     float fromScale = u_scale.y;
     float toScale = u_scale.z;
 
-    vec3 normal = a_normal_ed.xyz;
-    float edgedistance = a_normal_ed.w;
+    vec3 normal = vec3(a_normal_ed.xyz);
+    float edgedistance = float(a_normal_ed.w);
 
     vec2 display_size_a = (pattern_br_a - pattern_tl_a) / pixel_ratio_from;
     vec2 display_size_b = (pattern_br_b - pattern_tl_b) / pixel_ratio_to;
@@ -72,7 +72,7 @@ void main() {
     base = max(0.0, base) + base_terrain3d_offset;
     height = max(0.0, height) + height_terrain3d_offset;
 
-    float t = mod(normal.x, 2.0);
+    float t = float(a_normal_ed.x & 1);
     float elevation = t > 0.0 ? height : base;
     vec2 posInTile = a_pos + u_fill_translate;
 
@@ -85,7 +85,7 @@ void main() {
         gl_Position = u_projection_matrix * vec4(posInTile, elevation, 1.0);
     #endif
 
-    vec2 pos = normal.x == 1.0 && normal.y == 0.0 && normal.z == 16384.0
+    vec2 pos = a_normal_ed.x == 1 && a_normal_ed.y == 0 && a_normal_ed.z == 16384
         ? a_pos // extrusion top - note the lack of u_fill_translate, because translation should not affect the pattern
         : vec2(edgedistance, elevation * u_height_factor); // extrusion side
 

--- a/src/shaders/glsl/heatmap.vertex.glsl
+++ b/src/shaders/glsl/heatmap.vertex.glsl
@@ -4,7 +4,7 @@ uniform float u_opacity;
 uniform float u_intensity;
 uniform highp float u_globe_extrude_scale;
 
-layout(location = 0) in vec2 a_pos;
+layout(location = 0) in ivec2 a_pos;
 
 out vec2 v_extrude;
 
@@ -24,8 +24,8 @@ void main(void) {
     #pragma maplibre: initialize mediump float radius
 
     // decode the extrusion vector that we snuck into the a_pos vector
-    vec2 pos_raw = a_pos + 32768.0;
-    vec2 unscaled_extrude = vec2(mod(pos_raw, 8.0) / 7.0 * 2.0 - 1.0);
+    ivec2 pos_raw = a_pos + 32768;
+    vec2 unscaled_extrude = vec2(pos_raw & 7) / 7.0 * 2.0 - 1.0;
 
     // This 'extrude' comes in ranging from [-1, -1], to [1, 1].  We'll use
     // it to produce the vertices of a square mesh framing the point feature
@@ -49,7 +49,7 @@ void main(void) {
 
     // Divide a_pos by 8, since we had it * 8 in order to sneak
     // in extrusion data
-    vec2 circle_center = floor(pos_raw / 8.0);
+    vec2 circle_center = vec2(pos_raw >> 3);
 
 #ifdef GLOBE
     vec2 angles = v_extrude * radius * u_globe_extrude_scale;

--- a/src/shaders/glsl/symbol_icon.vertex.glsl
+++ b/src/shaders/glsl/symbol_icon.vertex.glsl
@@ -2,7 +2,7 @@ layout(location = 0) in vec4 a_pos_offset;
 layout(location = 1) in uvec4 a_data;
 layout(location = 2) in vec4 a_pixeloffset;
 layout(location = 3) in vec3 a_projected_pos;
-layout(location = 4) in float a_fade_opacity;
+layout(location = 4) in uint a_fade_opacity;
 
 uniform bool u_is_size_zoom_constant;
 uniform bool u_is_size_feature_constant;

--- a/src/shaders/glsl/symbol_icon.vertex.glsl
+++ b/src/shaders/glsl/symbol_icon.vertex.glsl
@@ -1,5 +1,5 @@
 layout(location = 0) in vec4 a_pos_offset;
-layout(location = 1) in vec4 a_data;
+layout(location = 1) in uvec4 a_data;
 layout(location = 2) in vec4 a_pixeloffset;
 layout(location = 3) in vec3 a_projected_pos;
 layout(location = 4) in float a_fade_opacity;
@@ -35,10 +35,10 @@ void main() {
     vec2 a_pos = a_pos_offset.xy;
     vec2 a_offset = a_pos_offset.zw;
 
-    vec2 a_tex = a_data.xy;
-    vec2 a_size = a_data.zw;
+    vec2 a_tex = vec2(a_data.xy);
+    vec2 a_size = vec2(a_data.zw);
 
-    float a_size_min = floor(a_size[0] * 0.5);
+    float a_size_min = float(a_data.z >> 1u);
     vec2 a_pxoffset = a_pixeloffset.xy;
     vec2 a_minFontScale = a_pixeloffset.zw / 256.0;
 

--- a/src/shaders/glsl/symbol_sdf.vertex.glsl
+++ b/src/shaders/glsl/symbol_sdf.vertex.glsl
@@ -2,7 +2,7 @@ layout(location = 0) in vec4 a_pos_offset;
 layout(location = 1) in uvec4 a_data;
 layout(location = 2) in vec4 a_pixeloffset;
 layout(location = 3) in vec3 a_projected_pos;
-layout(location = 4) in float a_fade_opacity;
+layout(location = 4) in uint a_fade_opacity;
 
 // contents of a_size vary based on the type of property value
 // used for {text,icon}-size.

--- a/src/shaders/glsl/symbol_sdf.vertex.glsl
+++ b/src/shaders/glsl/symbol_sdf.vertex.glsl
@@ -1,5 +1,5 @@
 layout(location = 0) in vec4 a_pos_offset;
-layout(location = 1) in vec4 a_data;
+layout(location = 1) in uvec4 a_data;
 layout(location = 2) in vec4 a_pixeloffset;
 layout(location = 3) in vec3 a_projected_pos;
 layout(location = 4) in float a_fade_opacity;
@@ -50,10 +50,10 @@ void main() {
     vec2 a_pos = a_pos_offset.xy;
     vec2 a_offset = a_pos_offset.zw;
 
-    vec2 a_tex = a_data.xy;
-    vec2 a_size = a_data.zw;
+    vec2 a_tex = vec2(a_data.xy);
+    vec2 a_size = vec2(a_data.zw);
 
-    float a_size_min = floor(a_size[0] * 0.5);
+    float a_size_min = float(a_data.z >> 1u);
     vec2 a_pxoffset = a_pixeloffset.xy / 16.0;
     vec2 a_minFontScale = a_pixeloffset.zw / 256.0;
 

--- a/src/shaders/glsl/symbol_text_and_icon.vertex.glsl
+++ b/src/shaders/glsl/symbol_text_and_icon.vertex.glsl
@@ -1,5 +1,5 @@
 layout(location = 0) in vec4 a_pos_offset;
-layout(location = 1) in vec4 a_data;
+layout(location = 1) in uvec4 a_data;
 layout(location = 2) in vec3 a_projected_pos;
 layout(location = 3) in float a_fade_opacity;
 
@@ -51,11 +51,11 @@ void main() {
     vec2 a_pos = a_pos_offset.xy;
     vec2 a_offset = a_pos_offset.zw;
 
-    vec2 a_tex = a_data.xy;
-    vec2 a_size = a_data.zw;
+    vec2 a_tex = vec2(a_data.xy);
+    vec2 a_size = vec2(a_data.zw);
 
-    float a_size_min = floor(a_size[0] * 0.5);
-    float is_sdf = a_size[0] - 2.0 * a_size_min;
+    float a_size_min = float(a_data.z >> 1u);
+    float is_sdf = float(a_data.z & 1u);
 
     float ele = get_elevation(a_pos);
     highp float segment_angle = -a_projected_pos[2];

--- a/src/shaders/glsl/symbol_text_and_icon.vertex.glsl
+++ b/src/shaders/glsl/symbol_text_and_icon.vertex.glsl
@@ -1,7 +1,7 @@
 layout(location = 0) in vec4 a_pos_offset;
 layout(location = 1) in uvec4 a_data;
 layout(location = 2) in vec3 a_projected_pos;
-layout(location = 3) in float a_fade_opacity;
+layout(location = 3) in uint a_fade_opacity;
 
 // contents of a_size vary based on the type of property value
 // used for {text,icon}-size.


### PR DESCRIPTION
## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items that are not relevant. -->

Milestone 1.6 in
- #7640

GM1.5 (#8130) made integer attribute delivery a shader-only edit: the declaration alone decides how an attribute arrives. This converts the remaining packed families, one commit each — circle and heatmap positions (`a_pos` as `ivec2`), symbol data (`a_data` as `uvec4`), symbol fade opacity (`a_fade_opacity` as `uint`), and fill extrusion normals (`a_normal_ed` as `ivec4`). The floor/mod float arithmetic becomes shifts and masks.

Buffer layouts and packed formats are unchanged. For the values these buffers hold, the shifts and masks decode to exactly what the float math produced — including `v & 1` against `mod(v, 2.0)` on negative wall normals, where two's complement and GLSL's non-negative residue agree — so the circle, heatmap, symbol, and fill-extrusion render tests pass unchanged. The fill extrusion pattern shader's roof test trades exact float equality for an integer comparison on the same stored values.

Same WebGPU preparation as GM1.5: WGSL has no float auto-conversion for integer vertex formats.

One packed family remains after this: the paint-property color binders, which pack byte pairs into genuinely Float32 buffers. That's a buffer-format change in the binder machinery, not a shader edit, and it belongs with the Phase 2 Drawable work.

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [x] Add an entry to `CHANGELOG.md` under the `## main` section.
 - [x] Confirm you have read our AI policy [here](https://github.com/maplibre/maplibre/blob/main/AI_POLICY.md).

<!--
  Add one of:    Assisted-By: | Generated-By:     and the model/version
-->
