### PR TITLE
GM1.7 Use texelFetch for exact elevation texel lookups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## main
 ### ✨ Features and improvements
+- Use `texelFetch` for exact DEM and color-relief elevation stop lookups instead of normalized texture coordinate arithmetic ([#7640](https://github.com/maplibre/maplibre-gl-js/issues/7640)) (by [@johncarmack1984](https://github.com/johncarmack1984))
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes

--- a/src/shaders/glsl/_prelude.vertex.glsl
+++ b/src/shaders/glsl/_prelude.vertex.glsl
@@ -132,9 +132,9 @@ float calculate_visibility(vec4 pos) {
 }
 
 // grab an elevation value from a raster-dem texture
-float ele(vec2 pos) {
+float ele(ivec2 pos) {
     #ifdef TERRAIN3D
-        vec4 rgb = (texture(u_terrain, pos) * 255.0) * u_terrain_unpack;
+        vec4 rgb = (texelFetch(u_terrain, pos, 0) * 255.0) * u_terrain_unpack;
         return rgb.r + rgb.g + rgb.b - u_terrain_unpack.a;
     #else
         return 0.0;
@@ -151,12 +151,12 @@ float get_elevation(vec2 pos) {
         #endif
         vec2 coord = (u_terrain_matrix * vec4(pos, 0.0, 1.0)).xy * u_terrain_dim + 1.0;
         vec2 f = fract(coord);
-        vec2 c = (floor(coord) + 0.5) / (u_terrain_dim + 2.0); // get the pixel center
-        float d = 1.0 / (u_terrain_dim + 2.0);
-        float tl = ele(c);
-        float tr = ele(c + vec2(d, 0.0));
-        float bl = ele(c + vec2(0.0, d));
-        float br = ele(c + vec2(d, d));
+        ivec2 c = ivec2(floor(coord)); // get the pixel center
+        ivec2 hi = textureSize(u_terrain, 0) - 1;
+        float tl = ele(clamp(c, ivec2(0), hi));
+        float tr = ele(clamp(c + ivec2(1, 0), ivec2(0), hi));
+        float bl = ele(clamp(c + ivec2(0, 1), ivec2(0), hi));
+        float br = ele(clamp(c + ivec2(1, 1), ivec2(0), hi));
         float elevation = mix(mix(tl, tr, f.x), mix(bl, br, f.x), f.y);
         return elevation * u_terrain_exaggeration;
     #else

--- a/src/shaders/glsl/color_relief.fragment.glsl
+++ b/src/shaders/glsl/color_relief.fragment.glsl
@@ -20,8 +20,7 @@ float getElevation(vec2 coord) {
 
 float getElevationStop(int stop) {
     // Convert encoded elevation value to meters
-    float x = (float(stop)+0.5)/float(u_color_ramp_size);
-    vec4 data = texture(u_elevation_stops, vec2(x, 0)) * 255.0;
+    vec4 data = texelFetch(u_elevation_stops, ivec2(stop, 0), 0) * 255.0;
     data.a = -1.0;
     return dot(data, u_unpack);
 }

--- a/src/shaders/glsl/hillshade_prepare.fragment.glsl
+++ b/src/shaders/glsl/hillshade_prepare.fragment.glsl
@@ -10,15 +10,15 @@ uniform vec2 u_dimension;
 uniform float u_zoom;
 uniform vec4 u_unpack;
 
-float getElevation(vec2 coord, float bias) {
+float getElevation(ivec2 texel) {
     // Convert encoded elevation value to meters
-    vec4 data = texture(u_image, coord) * 255.0;
+    vec4 data = texelFetch(u_image, texel, 0) * 255.0;
     data.a = -1.0;
     return dot(data, u_unpack);
 }
 
 void main() {
-    vec2 epsilon = 1.0 / u_dimension;
+    ivec2 pos = ivec2(gl_FragCoord.xy) + ivec2(1);
     float tileSize = u_dimension.x - 2.0;
 
     // queried pixels:
@@ -36,15 +36,15 @@ void main() {
     // |   |   |   |
     // +-----------+
 
-    float a = getElevation(v_pos + vec2(-epsilon.x, -epsilon.y), 0.0);
-    float b = getElevation(v_pos + vec2(0, -epsilon.y), 0.0);
-    float c = getElevation(v_pos + vec2(epsilon.x, -epsilon.y), 0.0);
-    float d = getElevation(v_pos + vec2(-epsilon.x, 0), 0.0);
-    float e = getElevation(v_pos, 0.0);
-    float f = getElevation(v_pos + vec2(epsilon.x, 0), 0.0);
-    float g = getElevation(v_pos + vec2(-epsilon.x, epsilon.y), 0.0);
-    float h = getElevation(v_pos + vec2(0, epsilon.y), 0.0);
-    float i = getElevation(v_pos + vec2(epsilon.x, epsilon.y), 0.0);
+    float a = getElevation(pos + ivec2(-1, -1));
+    float b = getElevation(pos + ivec2(0, -1));
+    float c = getElevation(pos + ivec2(1, -1));
+    float d = getElevation(pos + ivec2(-1, 0));
+    float e = getElevation(pos);
+    float f = getElevation(pos + ivec2(1, 0));
+    float g = getElevation(pos + ivec2(-1, 1));
+    float h = getElevation(pos + ivec2(0, 1));
+    float i = getElevation(pos + ivec2(1, 1));
 
     // Here we divide the x and y slopes by 8 * pixel size
     // where pixel size (aka meters/pixel) is:


### PR DESCRIPTION
Milestone 1.7 in
- #7640

Three sampling sites want one exact texel but go the long way around: take an integer coordinate, add the half-texel, divide by the texture size, and let NEAREST filtering round-trip back to the texel they started from. WebGL2's `texelFetch` takes the integer directly. Converted here: the color relief elevation stops (the coordinate is literally an `int` inside a per-fragment binary search), the hillshade prepare pass's 3×3 DEM neighborhood (nine taps that are `gl_FragCoord` plus the border offset), and the four taps of the terrain elevation bilinear.

Decoded values are bit-identical, so the render tests pass unchanged. The one semantic difference is at the edges: `texelFetch` has no CLAMP_TO_EDGE, and the terrain lookup relied on it for skirt, overzoom, and globe-pole coordinates. That clamp is now explicit, bounded by `textureSize` so the 1×1 empty-DEM fallback stays correct. The hillshade taps never leave the DEM border and the stop index is bounded by its binary search, so neither needs one. Filtered lookups (glyph SDFs, patterns, ramps, gradients) are untouched. Filtering is doing real work there. WGSL's equivalent is `textureLoad`, so these sites now port directly.

This closes out Phase 1. Beyond this milestone: the terrain coords texture could go away entirely. The coordinates it stores can be synthesized arithmetically in the shader, saving a 4 MB texture and its upload.


## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items that are not relevant. -->


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [x] Add an entry to `CHANGELOG.md` under the `## main` section.
 - [x] Confirm you have read our AI policy [here](https://github.com/maplibre/maplibre/blob/main/AI_POLICY.md).
<!--
  Add one of:    Assisted-By: | Generated-By:     and the model/version
-->
