### PR TITLE
fix: prevent one missing image resolver rejection from failing the batch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes
+- Prevent a rejected missing style image resolver from blocking successfully resolved images in the same batch ([#8146](https://github.com/maplibre/maplibre-gl-js/pull/8146/)) (by @birkskyum)
 - _...Add new stuff here..._
 
 ## 6.3.0

--- a/src/render/image_manager.ts
+++ b/src/render/image_manager.ts
@@ -237,7 +237,7 @@ export class ImageManager extends Evented<ImageManagerEventType> {
         const resolver = this.missingImageResolver;
 
         if (resolver) {
-            await Promise.all(Array.from(unresolvedIds, (id) => resolver(id)));
+            await Promise.allSettled(Array.from(unresolvedIds, (id) => resolver(id)));
         }
 
         const response: GetImagesResponse = {};

--- a/src/ui/map_tests/map_images.test.ts
+++ b/src/ui/map_tests/map_images.test.ts
@@ -95,6 +95,32 @@ test('map fires `styleimagemissing` when missing style image resolver returns no
     expect(map.hasImage(id)).toBeFalsy();
 });
 
+test('map preserves resolved images when missing style image resolver rejects another image', async () => {
+    const map = createMap();
+
+    const resolvedId = 'resolved-style-image';
+    const rejectedId = 'rejected-style-image';
+    const sampleImage = {width: 2, height: 1, data: new Uint8Array(8)};
+    const missingImageEventSpy = vi.fn();
+
+    map.setMissingStyleImageResolver(async (imageId) => {
+        if (imageId === rejectedId) {
+            throw new Error('Failed to resolve image');
+        }
+        map.addImage(imageId, sampleImage);
+    });
+    map.on('styleimagemissing', missingImageEventSpy);
+
+    const generatedImages = await map.style.imageManager.getImages([resolvedId, rejectedId]);
+
+    expect(generatedImages[resolvedId].data.width).toEqual(sampleImage.width);
+    expect(generatedImages[rejectedId]).toBeUndefined();
+    expect(missingImageEventSpy).toHaveBeenCalledTimes(1);
+    expect(missingImageEventSpy.mock.calls[0][0].id).toBe(rejectedId);
+    expect(map.hasImage(resolvedId)).toBeTruthy();
+    expect(map.hasImage(rejectedId)).toBeFalsy();
+});
+
 test('map keeps missing style image resolver after replacing the style', async () => {
     const map = createMap();
 


### PR DESCRIPTION
This PR hardens a bit the `setMissingStyleImageResolver` introduced in:
- https://github.com/maplibre/maplibre-gl-js/pull/7850

This missing style image resolvers load iamges concurrently. Previously, one rejected resolver caused the entire batch to reject, preventing successfully resolved images from being returned.

This changes `Promise.all` to `Promise.allSettled`, allowing successful images to be returned while failed images follow the existing missing-image path. `Promise.allSettled` has been available since ES2020, and we're targeting ES2022.

Added a small unit test.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items that are not relevant. -->


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [ ] Link to related issues.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] If you changed code in a file that has a benchmark file next to it (`*.bench.ts`), post before/after results of `npm run bench` (the compare workflow is in `test/bench/README.md`).
 - [x] Add an entry to `CHANGELOG.md` under the `## main` section.
 - [ ] Confirm you have read our AI policy [here](https://github.com/maplibre/maplibre/blob/main/AI_POLICY.md).
<!--
  Add one of:    Assisted-By: | Generated-By:     and the model/version
-->
