### PR TITLE
Measure gesture inertia from the movement the gesture ended with

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Let an abort reach an image or raster tile load that is still awaiting its `transformRequest`, so `ImageSource.updateImage` no longer loses the image it was just handed and an aborted tile is no longer fetched ([#8071](https://github.com/maplibre/maplibre-gl-js/pull/8071)) (by [@mondsichtung](https://github.com/mondsichtung))
 - Fix raster tiles fading in again when they are reloaded, briefly flashing the map background, most visibly when switching projection ([#8106](https://github.com/maplibre/maplibre-gl-js/pull/8106)) (by [@mondsichtung](https://github.com/mondsichtung))
 - Fix globe panning inverting and stalling near and across the poles by rotating the globe with a versor, keeping the drag direction consistent at every latitude. Panning also eases off as the cursor approaches the edge of the globe and continues past it, instead of stopping. The bearing is preserved while panning, as before ([#5296](https://github.com/maplibre/maplibre-gl-js/issues/5296)) (by [@jcolot](https://github.com/jcolot))
+- Fix a gesture which was slowed down or held still before being released still flinging the map with the velocity it had earlier: inertia is now measured from the movement the gesture ended with and over the time up to the release ([#1303](https://github.com/maplibre/maplibre-gl-js/issues/1303)) (by [@zdila](https://github.com/zdila))
 - _...Add new stuff here..._
 
 ## 6.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 - Let an abort reach an image or raster tile load that is still awaiting its `transformRequest`, so `ImageSource.updateImage` no longer loses the image it was just handed and an aborted tile is no longer fetched ([#8071](https://github.com/maplibre/maplibre-gl-js/pull/8071)) (by [@mondsichtung](https://github.com/mondsichtung))
 - Fix raster tiles fading in again when they are reloaded, briefly flashing the map background, most visibly when switching projection ([#8106](https://github.com/maplibre/maplibre-gl-js/pull/8106)) (by [@mondsichtung](https://github.com/mondsichtung))
 - Fix globe panning inverting and stalling near and across the poles by rotating the globe with a versor, keeping the drag direction consistent at every latitude. Panning also eases off as the cursor approaches the edge of the globe and continues past it, instead of stopping. The bearing is preserved while panning, as before ([#5296](https://github.com/maplibre/maplibre-gl-js/issues/5296)) (by [@jcolot](https://github.com/jcolot))
-- Fix a gesture which was slowed down or held still before being released still flinging the map with the velocity it had earlier: inertia is now measured from the movement the gesture ended with and over the time up to the release ([#1303](https://github.com/maplibre/maplibre-gl-js/issues/1303)) (by [@zdila](https://github.com/zdila))
+- Fix a gesture which was held still before being released still flinging the map ([#1303](https://github.com/maplibre/maplibre-gl-js/issues/1303)) (by [@zdila](https://github.com/zdila))
 - _...Add new stuff here..._
 
 ## 6.3.0

--- a/src/ui/handler/two_fingers_touch.test.ts
+++ b/src/ui/handler/two_fingers_touch.test.ts
@@ -97,9 +97,7 @@ describe('touch zoom rotate', () => {
         map.on('rotate',      rotate);
         map.on('rotateend',   rotateend);
 
-        // Frozen time, so that the inertia of the gesture does not depend on how long the
-        // test itself takes: without it a pause longer than the inertia buffer keeps the
-        // rotation from continuing.
+        // Frozen time, so that the inertia does not depend on how long the test itself takes.
         setNow(1000);
         onTestFinished(restoreNow);
         simulate.touchstart(map.getCanvas(), {touches: [{target, identifier: 0, clientX: 0, clientY: -50}, {target, identifier: 1, clientX: 0, clientY: 50}]});
@@ -126,8 +124,8 @@ describe('touch zoom rotate', () => {
         simulate.touchend(map.getCanvas(), {touches: []});
         map._renderTaskQueue.run();
 
-        // incremented because inertia starts a second rotation: the gesture was rotating
-        // when it ended, even though it ended at the bearing it started from
+        // incremented because inertia starts a second rotation: the gesture was still
+        // rotating when it ended, even though it ended at the bearing it started from
         expect(rotatestart).toHaveBeenCalledTimes(2);
         map._renderTaskQueue.run();
         expect(rotate).toHaveBeenCalledTimes(3);

--- a/src/ui/handler/two_fingers_touch.test.ts
+++ b/src/ui/handler/two_fingers_touch.test.ts
@@ -1,9 +1,10 @@
-import {describe, beforeEach, test, expect, vi} from 'vitest';
+import {describe, beforeEach, test, expect, vi, onTestFinished} from 'vitest';
 import {Map} from '../map.ts';
 import {Marker} from '../marker.ts';
 import {DOM} from '../../util/dom.ts';
 import simulate from '../../../test/unit/lib/simulate_interaction.ts';
 import {beforeMapTest} from '../../util/test/util.ts';
+import {restoreNow, setNow} from '../../util/time_control.ts';
 
 function createMap() {
     return new Map({container: DOM.create('div', '', window.document.body)});
@@ -96,28 +97,40 @@ describe('touch zoom rotate', () => {
         map.on('rotate',      rotate);
         map.on('rotateend',   rotateend);
 
+        // Frozen time, so that the inertia of the gesture does not depend on how long the
+        // test itself takes: without it a pause longer than the inertia buffer keeps the
+        // rotation from continuing.
+        setNow(1000);
+        onTestFinished(restoreNow);
         simulate.touchstart(map.getCanvas(), {touches: [{target, identifier: 0, clientX: 0, clientY: -50}, {target, identifier: 1, clientX: 0, clientY: 50}]});
         map._renderTaskQueue.run();
         expect(rotatestart).toHaveBeenCalledTimes(0);
         expect(rotate).toHaveBeenCalledTimes(0);
         expect(rotateend).toHaveBeenCalledTimes(0);
 
+        setNow(1016);
         simulate.touchmove(map.getCanvas(), {touches: [{target, identifier: 0, clientX: -50, clientY: 0}, {target, identifier: 1, clientX: 50, clientY: 0}]});
         map._renderTaskQueue.run();
         expect(rotatestart).toHaveBeenCalledTimes(1);
         expect(rotate).toHaveBeenCalledTimes(1);
         expect(rotateend).toHaveBeenCalledTimes(0);
 
+        setNow(1032);
         simulate.touchmove(map.getCanvas(), {touches: [{target, identifier: 0, clientX: 0, clientY: -50}, {target, identifier: 1, clientX: 0, clientY: 50}]});
         map._renderTaskQueue.run();
         expect(rotatestart).toHaveBeenCalledTimes(1);
         expect(rotate).toHaveBeenCalledTimes(2);
         expect(rotateend).toHaveBeenCalledTimes(0);
 
+        setNow(1048);
         simulate.touchend(map.getCanvas(), {touches: []});
         map._renderTaskQueue.run();
-        expect(rotatestart).toHaveBeenCalledTimes(1);
-        expect(rotate).toHaveBeenCalledTimes(2);
+
+        // incremented because inertia starts a second rotation: the gesture was rotating
+        // when it ended, even though it ended at the bearing it started from
+        expect(rotatestart).toHaveBeenCalledTimes(2);
+        map._renderTaskQueue.run();
+        expect(rotate).toHaveBeenCalledTimes(3);
         expect(rotateend).toHaveBeenCalledTimes(1);
 
         map.remove();

--- a/src/ui/handler_inertia.test.ts
+++ b/src/ui/handler_inertia.test.ts
@@ -1,0 +1,128 @@
+import {describe, beforeEach, afterEach, test, expect} from 'vitest';
+import Point from '@mapbox/point-geometry';
+import {DOM} from '../util/dom.ts';
+import {beforeMapTest} from '../util/test/util.ts';
+import {restoreNow, setNow} from '../util/time_control.ts';
+import {Map} from './map.ts';
+import type {EaseToOptions} from './camera.ts';
+import {HandlerInertia} from './handler_inertia.ts';
+
+function createMap() {
+    return new Map({container: DOM.create('div', '', window.document.body)});
+}
+
+type PanGesture = {
+    /**
+     * Pixels panned in each recorded frame, oldest first. `null` records a frame without any
+     * delta, which is what a terrain gesture does while the camera is not moving.
+     */
+    frames: Array<number | null>;
+    /**
+     * Milliseconds between the recorded frames.
+     */
+    frameTime?: number;
+    /**
+     * Milliseconds the gesture is held still between the last recorded frame and the release.
+     */
+    holdTime?: number;
+    /**
+     * Milliseconds passing between the previous gesture and this one.
+     */
+    gap?: number;
+};
+
+/**
+ * The clock the recorded gestures run on, so that consecutive gestures share a timeline.
+ */
+let clock: number;
+
+/**
+ * Records a horizontal pan gesture and returns the inertial ease it produces, if any.
+ */
+function panAndRelease(inertia: HandlerInertia, {frames, frameTime = 16, holdTime = 0, gap = 0}: PanGesture) {
+    clock += gap;
+    setNow(clock);
+    for (const pixels of frames) {
+        clock += frameTime;
+        setNow(clock);
+        inertia.record(pixels === null ? {} : {panDelta: new Point(pixels, 0)});
+    }
+    clock += holdTime;
+    setNow(clock);
+    return inertia._onMoveEnd();
+}
+
+/**
+ * The horizontal distance the map keeps panning after the gesture ended.
+ */
+function panOnDistance(ease: EaseToOptions) {
+    return (ease.offset as Point).x;
+}
+
+describe('HandlerInertia', () => {
+    let map: Map;
+    let inertia: HandlerInertia;
+
+    beforeEach(() => {
+        beforeMapTest();
+        map = createMap();
+        inertia = new HandlerInertia(map);
+        clock = 1000;
+    });
+
+    afterEach(() => {
+        restoreNow();
+        map.remove();
+    });
+
+    test('pans on when the gesture is released while still moving', () => {
+        const ease = panAndRelease(inertia, {frames: [20, 20, 20, 20, 20]});
+
+        expect(panOnDistance(ease)).toBeGreaterThan(50);
+        expect(ease.duration).toBeGreaterThan(0);
+    });
+
+    test('barely pans on when the gesture is held still before being released', () => {
+        const ease = panAndRelease(inertia, {frames: [20, 20, 20, 20, 20], holdTime: 100});
+
+        expect(Math.abs(panOnDistance(ease))).toBeLessThan(5);
+    });
+
+    test('does not pan on when the gesture is held still for longer than the buffer cutoff', () => {
+        const ease = panAndRelease(inertia, {frames: [20, 20, 20, 20, 20], holdTime: 200});
+
+        expect(ease).toBeUndefined();
+    });
+
+    test('measures the velocity the gesture ended with, not the one it started with', () => {
+        const slowdown = panAndRelease(inertia, {frames: [40, 40, 40, 30, 20, 10, 3]});
+        const steady = panAndRelease(inertia, {frames: [40, 40, 40, 40, 40, 40, 40]});
+
+        expect(panOnDistance(slowdown)).toBeLessThan(0.25 * panOnDistance(steady));
+    });
+
+    test('pans on at frame rates too low for two frames to fit into the velocity window', () => {
+        const ease = panAndRelease(inertia, {frames: [80, 80, 80], frameTime: 80});
+
+        expect(panOnDistance(ease)).toBeGreaterThan(20);
+    });
+
+    test('does not pan on when a single frame was recorded', () => {
+        const ease = panAndRelease(inertia, {frames: [20]});
+
+        expect(ease).toBeUndefined();
+    });
+
+    test('does not ease when the recorded frames hold no movement', () => {
+        const ease = panAndRelease(inertia, {frames: [20, 20, 20, null, null, null, null]});
+
+        expect(ease).toBeUndefined();
+    });
+
+    test('does not measure a gesture from the frames left over by the previous one', () => {
+        // A gesture too short to be eased must not leave a frame behind which the next
+        // gesture is then measured from.
+        expect(panAndRelease(inertia, {frames: [20]})).toBeUndefined();
+        expect(panAndRelease(inertia, {frames: [20], gap: 100})).toBeUndefined();
+    });
+});

--- a/src/ui/handler_inertia.test.ts
+++ b/src/ui/handler_inertia.test.ts
@@ -7,54 +7,28 @@ import {Map} from './map.ts';
 import type {EaseToOptions} from './camera.ts';
 import {HandlerInertia} from './handler_inertia.ts';
 
-function createMap() {
-    return new Map({container: DOM.create('div', '', window.document.body)});
-}
-
 type PanGesture = {
-    /**
-     * Pixels panned in each recorded frame, oldest first. `null` records a frame without any
-     * delta, which is what a terrain gesture does while the camera is not moving.
-     */
+    // Pixels panned in each recorded frame, oldest first. `null` records a frame without any
+    // delta, which is what a terrain gesture does while the camera is not moving.
     frames: Array<number | null>;
-    /**
-     * Milliseconds between the recorded frames.
-     */
     frameTime?: number;
-    /**
-     * Milliseconds the gesture is held still between the last recorded frame and the release.
-     */
+    // Milliseconds the gesture is held still between the last recorded frame and the release.
     holdTime?: number;
-    /**
-     * Milliseconds passing between the previous gesture and this one.
-     */
-    gap?: number;
 };
 
-/**
- * The clock the recorded gestures run on, so that consecutive gestures share a timeline.
- */
-let clock: number;
-
-/**
- * Records a horizontal pan gesture and returns the inertial ease it produces, if any.
- */
-function panAndRelease(inertia: HandlerInertia, {frames, frameTime = 16, holdTime = 0, gap = 0}: PanGesture) {
-    clock += gap;
-    setNow(clock);
+// Records a horizontal pan gesture and returns the inertial ease it produces, if any.
+function panAndRelease(inertia: HandlerInertia, {frames, frameTime = 16, holdTime = 0}: PanGesture) {
+    let time = 1000;
+    setNow(time);
     for (const pixels of frames) {
-        clock += frameTime;
-        setNow(clock);
+        setNow(time += frameTime);
         inertia.record(pixels === null ? {} : {panDelta: new Point(pixels, 0)});
     }
-    clock += holdTime;
-    setNow(clock);
+    setNow(time + holdTime);
     return inertia._onMoveEnd();
 }
 
-/**
- * The horizontal distance the map keeps panning after the gesture ended.
- */
+// The horizontal distance the map keeps panning after the gesture ended.
 function panOnDistance(ease: EaseToOptions) {
     return (ease.offset as Point).x;
 }
@@ -65,9 +39,8 @@ describe('HandlerInertia', () => {
 
     beforeEach(() => {
         beforeMapTest();
-        map = createMap();
+        map = new Map({container: DOM.create('div', '', window.document.body)});
         inertia = new HandlerInertia(map);
-        clock = 1000;
     });
 
     afterEach(() => {
@@ -79,7 +52,6 @@ describe('HandlerInertia', () => {
         const ease = panAndRelease(inertia, {frames: [20, 20, 20, 20, 20]});
 
         expect(panOnDistance(ease)).toBeGreaterThan(50);
-        expect(ease.duration).toBeGreaterThan(0);
     });
 
     test('barely pans on when the gesture is held still before being released', () => {
@@ -88,41 +60,21 @@ describe('HandlerInertia', () => {
         expect(Math.abs(panOnDistance(ease))).toBeLessThan(5);
     });
 
-    test('does not pan on when the gesture is held still for longer than the buffer cutoff', () => {
-        const ease = panAndRelease(inertia, {frames: [20, 20, 20, 20, 20], holdTime: 200});
-
-        expect(ease).toBeUndefined();
-    });
-
-    test('measures the velocity the gesture ended with, not the one it started with', () => {
-        const slowdown = panAndRelease(inertia, {frames: [40, 40, 40, 30, 20, 10, 3]});
-        const steady = panAndRelease(inertia, {frames: [40, 40, 40, 40, 40, 40, 40]});
-
-        expect(panOnDistance(slowdown)).toBeLessThan(0.25 * panOnDistance(steady));
-    });
-
     test('pans on at frame rates too low for two frames to fit into the velocity window', () => {
         const ease = panAndRelease(inertia, {frames: [80, 80, 80], frameTime: 80});
 
         expect(panOnDistance(ease)).toBeGreaterThan(20);
     });
 
-    test('does not pan on when a single frame was recorded', () => {
-        const ease = panAndRelease(inertia, {frames: [20]});
-
-        expect(ease).toBeUndefined();
+    test('does not pan on when a single frame was recorded, twice in a row', () => {
+        expect(panAndRelease(inertia, {frames: [20]})).toBeUndefined();
+        // the frame left over by the first gesture must not be measured as part of the second
+        expect(panAndRelease(inertia, {frames: [20]})).toBeUndefined();
     });
 
     test('does not ease when the recorded frames hold no movement', () => {
         const ease = panAndRelease(inertia, {frames: [20, 20, 20, null, null, null, null]});
 
         expect(ease).toBeUndefined();
-    });
-
-    test('does not measure a gesture from the frames left over by the previous one', () => {
-        // A gesture too short to be eased must not leave a frame behind which the next
-        // gesture is then measured from.
-        expect(panAndRelease(inertia, {frames: [20]})).toBeUndefined();
-        expect(panAndRelease(inertia, {frames: [20], gap: 100})).toBeUndefined();
     });
 });

--- a/src/ui/handler_inertia.test.ts
+++ b/src/ui/handler_inertia.test.ts
@@ -8,15 +8,24 @@ import type {EaseToOptions} from './camera.ts';
 import {HandlerInertia} from './handler_inertia.ts';
 
 type PanGesture = {
-    // Pixels panned in each recorded frame, oldest first. `null` records a frame without any
-    // delta, which is what a terrain gesture does while the camera is not moving.
+    /**
+     * The pixels panned in each recorded frame, oldest first. `null` records a frame without
+     * any delta, which is what a terrain gesture does while the camera is not moving.
+     */
     frames: Array<number | null>;
+    /**
+     * The milliseconds between the recorded frames.
+     */
     frameTime?: number;
-    // Milliseconds the gesture is held still between the last recorded frame and the release.
+    /**
+     * The milliseconds the gesture is held still between the last recorded frame and the release.
+     */
     holdTime?: number;
 };
 
-// Records a horizontal pan gesture and returns the inertial ease it produces, if any.
+/**
+ * Records a horizontal pan gesture and returns the inertial ease it produces, if any.
+ */
 function panAndRelease(inertia: HandlerInertia, {frames, frameTime = 16, holdTime = 0}: PanGesture) {
     let time = 1000;
     setNow(time);
@@ -28,7 +37,9 @@ function panAndRelease(inertia: HandlerInertia, {frames, frameTime = 16, holdTim
     return inertia._onMoveEnd();
 }
 
-// The horizontal distance the map keeps panning after the gesture ended.
+/**
+ * Returns the horizontal distance the map keeps panning after the gesture ended.
+ */
 function panOnDistance(ease: EaseToOptions) {
     return (ease.offset as Point).x;
 }

--- a/src/ui/handler_inertia.ts
+++ b/src/ui/handler_inertia.ts
@@ -43,22 +43,10 @@ export type InertiaOptions = {
     maxSpeed: number;
 };
 
-/**
- * Maximum age of a recorded gesture update, in milliseconds. Older entries are dropped.
- */
-const bufferCutoff = 160;
+const bufferCutoff = 160;   //msec
+const velocityWindow = 60;  //msec
 
-/**
- * The gesture velocity is measured over this time window, in milliseconds, ending at the
- * moment the gesture was released. Keeping the window short makes the estimate follow the
- * velocity the gesture actually had when it was released, so that slowing down or stopping
- * right before the release does not fling the map. At least the last two recorded updates
- * are always used, so that inertia also works at frame rates where fewer than two updates
- * fit into the window - their age is accounted for by the measured duration.
- */
-const velocityWindow = 60;
-
-export type InertiaBufferEntry = {
+type InertiaBufferEntry = {
     time: number;
     settings: any;
 };
@@ -89,10 +77,8 @@ export class HandlerInertia {
             inertia.shift();
     }
 
-    /**
-     * Returns the buffer entries the velocity is measured from: everything recorded within
-     * {@link velocityWindow} before now, but never fewer than the last two entries.
-     */
+    // Everything recorded within velocityWindow before now, but never fewer than the last
+    // two entries, so that inertia also works below two recorded updates per window.
     _getVelocityEntries(): InertiaBufferEntry[] {
         const inertia = this._inertiaBuffer;
         const windowStart = now() - velocityWindow;
@@ -108,7 +94,6 @@ export class HandlerInertia {
     _onMoveEnd(panInertiaOptions?: DragPanOptions | boolean): EaseToOptions {
         this._drainInertiaBuffer();
         const entries = this._getVelocityEntries();
-        // The gesture is over, so whatever is left in the buffer must not leak into the next one.
         if (entries.length < 2) {
             this.clear();
             return;
@@ -124,16 +109,14 @@ export class HandlerInertia {
             around: undefined
         };
 
-        // Unlike the deltas, an anchor describes the state at the moment its entry was
-        // recorded, so it counts even when it comes from the entry the interval starts at.
+        // Unlike a delta, an anchor describes the state at the moment of its entry.
         for (const {settings} of entries) {
             if (settings.around) deltas.around = settings.around;
             if (settings.pinchAround) deltas.pinchAround = settings.pinchAround;
         }
 
-        // The delta of an entry describes the movement which happened before it was recorded,
-        // so the first entry only marks the start of the measured interval and its delta
-        // belongs to the time before it.
+        // The delta of an entry happened before it was recorded, so the first entry only
+        // marks the start of the measured interval.
         for (const {settings} of entries.slice(1)) {
             deltas.zoom += settings.zoomDelta || 0;
             deltas.bearing += settings.bearingDelta || 0;
@@ -142,17 +125,14 @@ export class HandlerInertia {
             if (settings.panDelta) deltas.pan._add(settings.panDelta);
         }
 
-        // Entries without any delta are recorded during terrain gestures, so the measured
-        // interval can hold no movement at all. Returning ease options for that would start a
-        // camera animation which moves nothing and only delays `moveend`.
+        // Terrain gestures record entries without any delta, which would ease nowhere.
         if (!deltas.pan.mag() && !deltas.zoom && !deltas.bearing && !deltas.pitch && !deltas.roll) {
             this.clear();
             return;
         }
 
-        // Measure up to the moment of the release and not up to the last recorded movement:
-        // a gesture which was held still before being released has a longer duration and
-        // therefore a lower velocity, down to no inertia at all.
+        // Up to the release and not up to the last recorded movement, so that a gesture held
+        // still before being released has a lower velocity.
         const duration = now() - entries[0].time;
 
         const easeOptions = {} as any;

--- a/src/ui/handler_inertia.ts
+++ b/src/ui/handler_inertia.ts
@@ -3,6 +3,7 @@ import {bezier, clamp, extend, evaluateZoomSnap} from '../util/util.ts';
 import Point from '@mapbox/point-geometry';
 
 import type {DragPanOptions} from './handler/shim/drag_pan.ts';
+import type {HandlerResult} from './handler_manager.ts';
 import type {EaseToOptions} from './camera.ts';
 import type {Map} from './map.ts';
 
@@ -43,12 +44,19 @@ export type InertiaOptions = {
     maxSpeed: number;
 };
 
-const bufferCutoff = 160;   //msec
-const velocityWindow = 60;  //msec
+/**
+ * The maximum age of a recorded gesture update, in milliseconds.
+ */
+const BUFFER_CUTOFF = 160;
+
+/**
+ * The time window the gesture velocity is measured over, in milliseconds.
+ */
+const VELOCITY_WINDOW = 60;
 
 type InertiaBufferEntry = {
     time: number;
-    settings: any;
+    settings: HandlerResult;
 };
 
 export class HandlerInertia {
@@ -64,7 +72,7 @@ export class HandlerInertia {
         this._inertiaBuffer = [];
     }
 
-    record(settings: any): void {
+    record(settings: HandlerResult): void {
         this._drainInertiaBuffer();
         this._inertiaBuffer.push({time: now(), settings});
     }
@@ -73,15 +81,18 @@ export class HandlerInertia {
         const inertia = this._inertiaBuffer,
             currentTime = now();
 
-        while (inertia.length > 0 && currentTime - inertia[0].time > bufferCutoff)
+        while (inertia.length > 0 && currentTime - inertia[0].time > BUFFER_CUTOFF)
             inertia.shift();
     }
 
-    // Everything recorded within velocityWindow before now, but never fewer than the last
-    // two entries, so that inertia also works below two recorded updates per window.
+    /**
+     * Returns the entries the velocity is measured from: everything recorded within
+     * {@link VELOCITY_WINDOW} before now, but never fewer than the last two, so that
+     * inertia also works below two recorded updates per window.
+     */
     _getVelocityEntries(): InertiaBufferEntry[] {
         const inertia = this._inertiaBuffer;
-        const windowStart = now() - velocityWindow;
+        const windowStart = now() - VELOCITY_WINDOW;
 
         let firstIndex = Math.max(0, inertia.length - 2);
         while (firstIndex > 0 && inertia[firstIndex - 1].time >= windowStart) {
@@ -91,6 +102,19 @@ export class HandlerInertia {
         return inertia.slice(firstIndex);
     }
 
+    /**
+     * Returns the ease which continues the gesture that has just ended.
+     *
+     * The velocity is measured over the time up to the release and not up to the last
+     * recorded movement, so that a gesture held still before being released has a lower
+     * velocity, down to no inertia at all. The delta of an entry happened before it was
+     * recorded, so the first entry only marks the start of the measured interval; anchors
+     * are the exception, as they describe the state at the moment of their entry.
+     *
+     * @param panInertiaOptions - overrides for the pan inertia defaults
+     * @returns the ease options, or `undefined` when the measured interval holds no
+     * movement, which terrain gestures produce by recording updates without any delta
+     */
     _onMoveEnd(panInertiaOptions?: DragPanOptions | boolean): EaseToOptions {
         this._drainInertiaBuffer();
         const entries = this._getVelocityEntries();
@@ -109,14 +133,11 @@ export class HandlerInertia {
             around: undefined
         };
 
-        // Unlike a delta, an anchor describes the state at the moment of its entry.
         for (const {settings} of entries) {
             if (settings.around) deltas.around = settings.around;
             if (settings.pinchAround) deltas.pinchAround = settings.pinchAround;
         }
 
-        // The delta of an entry happened before it was recorded, so the first entry only
-        // marks the start of the measured interval.
         for (const {settings} of entries.slice(1)) {
             deltas.zoom += settings.zoomDelta || 0;
             deltas.bearing += settings.bearingDelta || 0;
@@ -125,14 +146,11 @@ export class HandlerInertia {
             if (settings.panDelta) deltas.pan._add(settings.panDelta);
         }
 
-        // Terrain gestures record entries without any delta, which would ease nowhere.
         if (!deltas.pan.mag() && !deltas.zoom && !deltas.bearing && !deltas.pitch && !deltas.roll) {
             this.clear();
             return;
         }
 
-        // Up to the release and not up to the last recorded movement, so that a gesture held
-        // still before being released has a lower velocity.
         const duration = now() - entries[0].time;
 
         const easeOptions = {} as any;

--- a/src/ui/handler_inertia.ts
+++ b/src/ui/handler_inertia.ts
@@ -43,12 +43,29 @@ export type InertiaOptions = {
     maxSpeed: number;
 };
 
+/**
+ * Maximum age of a recorded gesture update, in milliseconds. Older entries are dropped.
+ */
+const bufferCutoff = 160;
+
+/**
+ * The gesture velocity is measured over this time window, in milliseconds, ending at the
+ * moment the gesture was released. Keeping the window short makes the estimate follow the
+ * velocity the gesture actually had when it was released, so that slowing down or stopping
+ * right before the release does not fling the map. At least the last two recorded updates
+ * are always used, so that inertia also works at frame rates where fewer than two updates
+ * fit into the window - their age is accounted for by the measured duration.
+ */
+const velocityWindow = 60;
+
+export type InertiaBufferEntry = {
+    time: number;
+    settings: any;
+};
+
 export class HandlerInertia {
     _map: Map;
-    _inertiaBuffer: Array<{
-        time: number;
-        settings: any;
-    }>;
+    _inertiaBuffer: InertiaBufferEntry[];
 
     constructor(map: Map) {
         this._map = map;
@@ -66,16 +83,34 @@ export class HandlerInertia {
 
     _drainInertiaBuffer(): void {
         const inertia = this._inertiaBuffer,
-            currentTime = now(),
-            cutoff = 160;   //msec
+            currentTime = now();
 
-        while (inertia.length > 0 && currentTime - inertia[0].time > cutoff)
+        while (inertia.length > 0 && currentTime - inertia[0].time > bufferCutoff)
             inertia.shift();
+    }
+
+    /**
+     * Returns the buffer entries the velocity is measured from: everything recorded within
+     * {@link velocityWindow} before now, but never fewer than the last two entries.
+     */
+    _getVelocityEntries(): InertiaBufferEntry[] {
+        const inertia = this._inertiaBuffer;
+        const windowStart = now() - velocityWindow;
+
+        let firstIndex = Math.max(0, inertia.length - 2);
+        while (firstIndex > 0 && inertia[firstIndex - 1].time >= windowStart) {
+            firstIndex--;
+        }
+
+        return inertia.slice(firstIndex);
     }
 
     _onMoveEnd(panInertiaOptions?: DragPanOptions | boolean): EaseToOptions {
         this._drainInertiaBuffer();
-        if (this._inertiaBuffer.length < 2) {
+        const entries = this._getVelocityEntries();
+        // The gesture is over, so whatever is left in the buffer must not leak into the next one.
+        if (entries.length < 2) {
+            this.clear();
             return;
         }
 
@@ -89,18 +124,36 @@ export class HandlerInertia {
             around: undefined
         };
 
-        for (const {settings} of this._inertiaBuffer) {
+        // Unlike the deltas, an anchor describes the state at the moment its entry was
+        // recorded, so it counts even when it comes from the entry the interval starts at.
+        for (const {settings} of entries) {
+            if (settings.around) deltas.around = settings.around;
+            if (settings.pinchAround) deltas.pinchAround = settings.pinchAround;
+        }
+
+        // The delta of an entry describes the movement which happened before it was recorded,
+        // so the first entry only marks the start of the measured interval and its delta
+        // belongs to the time before it.
+        for (const {settings} of entries.slice(1)) {
             deltas.zoom += settings.zoomDelta || 0;
             deltas.bearing += settings.bearingDelta || 0;
             deltas.pitch += settings.pitchDelta || 0;
             deltas.roll += settings.rollDelta || 0;
             if (settings.panDelta) deltas.pan._add(settings.panDelta);
-            if (settings.around) deltas.around = settings.around;
-            if (settings.pinchAround) deltas.pinchAround = settings.pinchAround;
         }
 
-        const lastEntry = this._inertiaBuffer[this._inertiaBuffer.length - 1];
-        const duration = (lastEntry.time - this._inertiaBuffer[0].time);
+        // Entries without any delta are recorded during terrain gestures, so the measured
+        // interval can hold no movement at all. Returning ease options for that would start a
+        // camera animation which moves nothing and only delays `moveend`.
+        if (!deltas.pan.mag() && !deltas.zoom && !deltas.bearing && !deltas.pitch && !deltas.roll) {
+            this.clear();
+            return;
+        }
+
+        // Measure up to the moment of the release and not up to the last recorded movement:
+        // a gesture which was held still before being released has a longer duration and
+        // therefore a lower velocity, down to no inertia at all.
+        const duration = now() - entries[0].time;
 
         const easeOptions = {} as any;
 

--- a/test/build/bundle_size.json
+++ b/test/build/bundle_size.json
@@ -1,7 +1,7 @@
 {
     "dist/maplibre-gl.mjs": {
-        "raw": 566389,
-        "gzip": 142269
+        "raw": 566911,
+        "gzip": 142498
     },
     "dist/maplibre-gl-worker.mjs": {
         "raw": 18592,


### PR DESCRIPTION
Fixes #1303.

**Try it side by side: https://zdila.github.io/maplibre-gl-js/** — the same build twice, `main` on the left and this branch on the right. Drag either map, stop moving the mouse, then release; each drag is logged with how long the pointer was held still and how far the map kept panning.

`HandlerInertia` estimated the release velocity as *(sum of all pan deltas in the buffer) / (time between the first and the last recorded update)*. Two things are wrong with that:

1. The first entry's delta accrued *before* its own timestamp, so the numerator covered one interval more than the denominator.
2. The duration ended at the last recorded update, not at the release. Updates are only recorded when the camera actually changes, so holding the pointer still records nothing: the buffer keeps shrinking from the front while the duration shrinks faster than the deltas do. Holding still made the fling *stronger*.

Measured in Chrome, dragging 8 frames × 20 px, then holding, then releasing:

| held still before release | before | after |
| --- | --- | --- |
| 0 ms | 108 px | 105 px |
| 60 ms | 142 px | 3 px |
| 120 ms | **348 px** | 1 px |
| 250 ms | 0 px | 0 px |

### What changed

- The velocity is measured over the last 60 ms **ending at the release** instead of ending at the last recorded update, so a pause before the release damps the speed continuously down to nothing. Leaflet gets the same effect from its 50 ms prune window.
- The first entry contributes only its timestamp, so numerator and denominator cover the same interval — the accounting Leaflet does with `lastPos - positions[0]`.
- At least the last two entries are always used, so inertia still works at frame rates where fewer than two updates fit into the window; their age is accounted for by the measured duration.
- `_onMoveEnd` returns nothing when the measured interval holds no movement, and clears the buffer on its early-return paths. The first one is reachable on `main` too: terrain gestures record zero-delta entries every frame, and an all-zero result was still truthy, so the caller started a 500 ms `easeTo` which moved nothing and only delayed `moveend`.

### Behaviour change worth a look

A pinch that rotates 90° out and back now gets rotation inertia where it got none before: the deltas cancelled over the whole buffer, but the gesture *was* rotating when it ended. That is the changed expectation in `two_fingers_touch.test.ts`. The same applies to hand jitter just before the release, which used to cancel itself out.

The 60 ms window is the single knob behind this trade-off — shorter follows the moment of release more faithfully, longer averages away noise at low frame rates. Glad to expose it as an option if you would rather have it configurable.

### Testing

New `handler_inertia.test.ts` drives the buffer on a frozen clock; both guards above are covered by cases that fail without them. Full unit suite passes, and the `Drag to the left` browser test is unaffected. The numbers in the table come from a page driven with programmatic mouse events at exact 16 ms frames and re-checked with real (CDP) mouse input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
