### PR TITLE
chore: improve render test stability

### DIFF
--- a/test/integration/render/render.test.ts
+++ b/test/integration/render/render.test.ts
@@ -18,6 +18,13 @@ import {afterAll, afterEach, beforeAll, beforeEach, describe, expect, test} from
 const __dirname = dirname(fileURLToPath(import.meta.url));
 let maplibregl: typeof MapLibreGL;
 
+/**
+ * Fallback timeout for a single render test, used when the test does not set `metadata.test.timeout`.
+ * It is generous on purpose: the heavier tests (mostly terrain) take ~15-20 seconds on the CI Windows
+ * runners, where software rendering makes the run times vary by a factor of two or three.
+ */
+const DEFAULT_TEST_TIMEOUT = 60000;
+
 type TestData = {
     id: string;
     width: number;
@@ -31,6 +38,10 @@ type TestData = {
     threshold: number;
     ok: boolean;
     difference: number;
+    /**
+     * Timeout of a single test in milliseconds, only needed to deviate from the default
+     * @defaultValue 60000
+     */
     timeout: number;
     addFakeCanvas: {
         id: string;
@@ -853,8 +864,9 @@ describe('Render tests', () => {
     const directory = path.join(__dirname);
     let testStyles = getTestStyles(directory);
     if (process.env.SPLIT_COUNT && process.env.CURRENT_SPLIT_INDEX) {
-        const numberOfTestsForThisPart = Math.ceil(testStyles.length / +process.env.SPLIT_COUNT);
-        testStyles = testStyles.splice(+process.env.CURRENT_SPLIT_INDEX * numberOfTestsForThisPart, numberOfTestsForThisPart);
+        const splitCount = +process.env.SPLIT_COUNT;
+        const currentSplitIndex = +process.env.CURRENT_SPLIT_INDEX;
+        testStyles = testStyles.filter((_, index) => index % splitCount === currentSplitIndex);
     }
 
     beforeAll(async () => {
@@ -887,10 +899,10 @@ describe('Render tests', () => {
         server.close();
         mvtServer.close();
         await browser.close();
-    });
+    }, 60000);
 
     for (const style of testStyles) {
-        test(style.metadata.test.id, {retry: 1, timeout: style.metadata.test.timeout || 40000}, async () => {
+        test(style.metadata.test.id, {retry: 1, timeout: style.metadata.test.timeout || DEFAULT_TEST_TIMEOUT}, async () => {
             const serverPort = (server.address() as any).port;
             localizeURLs(style, serverPort, path.join(__dirname, '../'));
             const data = await getImageFromStyle(style, page);

--- a/test/integration/render/render.test.ts
+++ b/test/integration/render/render.test.ts
@@ -25,6 +25,13 @@ let maplibregl: typeof MapLibreGL;
  */
 const DEFAULT_TEST_TIMEOUT = 60000;
 
+/**
+ * Timeout for the `beforeAll` and `afterAll` hooks, which launch and tear down the browser, the test
+ * servers and the coverage reporting. Vitest defaults to 10 seconds, which is not enough on the CI
+ * Windows runners.
+ */
+const HOOK_TIMEOUT = 60000;
+
 type TestData = {
     id: string;
     width: number;
@@ -877,7 +884,7 @@ describe('Render tests', () => {
         workers = await startCoverage(page);
         await page.goto(`http://localhost:${serverPort}/test-page.html`, {waitUntil: 'load'});
         await page.waitForFunction(() => (window as any).maplibregl, {timeout: 10000});
-    }, 30000);
+    }, HOOK_TIMEOUT);
 
     beforeEach((ctx) => {
         if (ctx.task.result?.retryCount > 0) {
@@ -899,7 +906,7 @@ describe('Render tests', () => {
         server.close();
         mvtServer.close();
         await browser.close();
-    }, 60000);
+    }, HOOK_TIMEOUT);
 
     for (const style of testStyles) {
         test(style.metadata.test.id, {retry: 1, timeout: style.metadata.test.timeout || DEFAULT_TEST_TIMEOUT}, async () => {

--- a/test/integration/render/tests/high-pitch/pitch95-roll135/style.json
+++ b/test/integration/render/tests/high-pitch/pitch95-roll135/style.json
@@ -4,7 +4,6 @@
     "glyphs": "local://glyphs/{fontstack}/{range}.pbf",
     "metadata": {
         "test": {
-            "timeout": 60000,
             "height": 512,
             "width": 512,
             "maxPitch": 95,

--- a/test/integration/render/tests/high-pitch/pitch95/style.json
+++ b/test/integration/render/tests/high-pitch/pitch95/style.json
@@ -4,7 +4,6 @@
     "glyphs": "local://glyphs/{fontstack}/{range}.pbf",
     "metadata": {
         "test": {
-            "timeout": 60000,
             "height": 512,
             "width": 512,
             "maxPitch": 95,

--- a/test/integration/render/tests/high-pitch/terrain-pitch95/style.json
+++ b/test/integration/render/tests/high-pitch/terrain-pitch95/style.json
@@ -5,7 +5,6 @@
       "height": 512,
       "width": 512,
       "maxPitch": 180,
-      "timeout": 60000,
       "operations": [
           ["setCenterClampedToGround", false],
           ["setCenterElevation", 1500],

--- a/test/integration/render/tests/runtime-styling/set-style-glyphs/style.json
+++ b/test/integration/render/tests/runtime-styling/set-style-glyphs/style.json
@@ -4,7 +4,6 @@
     "test": {
       "width": 512,
       "height": 512,
-      "timeout": 60000,
       "allowed": 0.0003,
       "operations": [
         [

--- a/test/integration/render/tests/terrain-shading/default/style.json
+++ b/test/integration/render/tests/terrain-shading/default/style.json
@@ -4,7 +4,6 @@
     "test": {
       "height": 500,
       "width": 500,
-      "timeout": 60000,
       "operations" : [
         ["sleep", 5000]
       ]

--- a/test/integration/render/tests/terrain/fill-extrusion-multiple/style.json
+++ b/test/integration/render/tests/terrain/fill-extrusion-multiple/style.json
@@ -4,7 +4,6 @@
     "test": {
       "height": 500,
       "width": 500,
-      "timeout": 60000,
       "operations": [["wait"]]
     }
   },

--- a/test/integration/render/tests/terrain/fill-extrusion-multipolygon/style.json
+++ b/test/integration/render/tests/terrain/fill-extrusion-multipolygon/style.json
@@ -4,7 +4,6 @@
     "test": {
       "height": 500,
       "width": 500,
-      "timeout": 60000,
       "operations": [
         [
           "sleep",

--- a/test/integration/render/tests/terrain/fog-no-sky-blend-roll/style.json
+++ b/test/integration/render/tests/terrain/fog-no-sky-blend-roll/style.json
@@ -4,7 +4,6 @@
     "glyphs": "local://glyphs/{fontstack}/{range}.pbf",
     "metadata": {
         "test": {
-            "timeout": 60000,
             "height": 512,
             "width": 512,
             "maxPitch": 85,

--- a/test/integration/render/tests/terrain/fog-no-sky-blend/style.json
+++ b/test/integration/render/tests/terrain/fog-no-sky-blend/style.json
@@ -4,7 +4,6 @@
     "glyphs": "local://glyphs/{fontstack}/{range}.pbf",
     "metadata": {
         "test": {
-            "timeout": 60000,
             "height": 512,
             "width": 512,
             "maxPitch": 85,

--- a/test/integration/render/tests/terrain/fog-sky-blend-globe/style.json
+++ b/test/integration/render/tests/terrain/fog-sky-blend-globe/style.json
@@ -2,7 +2,6 @@
     "version": 8,
     "metadata": {
         "test": {
-            "timeout": 60000,
             "height": 256,
             "width": 256,
             "maxPitch": 120,

--- a/test/integration/render/tests/terrain/fog-sky-blend-roll/style.json
+++ b/test/integration/render/tests/terrain/fog-sky-blend-roll/style.json
@@ -4,7 +4,6 @@
     "glyphs": "local://glyphs/{fontstack}/{range}.pbf",
     "metadata": {
         "test": {
-            "timeout": 60000,
             "height": 512,
             "width": 512,
             "maxPitch": 85,

--- a/test/integration/render/tests/terrain/fog-sky-blend/style.json
+++ b/test/integration/render/tests/terrain/fog-sky-blend/style.json
@@ -4,7 +4,6 @@
     "glyphs": "local://glyphs/{fontstack}/{range}.pbf",
     "metadata": {
         "test": {
-            "timeout": 60000,
             "height": 512,
             "width": 512,
             "maxPitch": 85,

--- a/test/integration/render/tests/terrain/fog/style.json
+++ b/test/integration/render/tests/terrain/fog/style.json
@@ -4,7 +4,6 @@
     "glyphs": "local://glyphs/{fontstack}/{range}.pbf",
     "metadata": {
         "test": {
-            "timeout": 60000,
             "height": 512,
             "width": 512,
             "maxPitch": 85,

--- a/test/integration/render/tests/terrain/symbol-add-terrain/style.json
+++ b/test/integration/render/tests/terrain/symbol-add-terrain/style.json
@@ -4,7 +4,6 @@
     "glyphs": "local://glyphs/{fontstack}/{range}.pbf",
     "metadata": {
         "test": {
-            "timeout": 60000,
             "height": 512,
             "width": 512,
             "operations": [

--- a/test/integration/render/tests/zoomed-raster/underzoom/style.json
+++ b/test/integration/render/tests/zoomed-raster/underzoom/style.json
@@ -2,8 +2,7 @@
   "version": 8,
   "metadata": {
     "test": {
-      "height": 256,
-      "timeout": 40000
+      "height": 256
     }
   },
   "center": [


### PR DESCRIPTION
## Launch Checklist

Adds a default longer timeout for the tests.
Add a longer after each timeout.
Round robin the tests to even the time each slice it taking.

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.