### PR TITLE
chore: exclude benchmark files from coverage reports

### DIFF
--- a/vitest.config.integration.ts
+++ b/vitest.config.integration.ts
@@ -15,7 +15,7 @@ const config: ViteUserConfig = defineConfig({
         coverage: {
             provider: 'v8',
             reporter: ['json', 'html'],
-            exclude: ['**/*.test.ts'],
+            exclude: ['**/*.test.ts', '**/*.bench.ts'],
             include: ['src/**/*.{ts,js}'],
             reportsDirectory: './coverage/vitest/integration',
         },

--- a/vitest.config.unit.ts
+++ b/vitest.config.unit.ts
@@ -19,7 +19,7 @@ const config: ViteUserConfig = defineConfig({
         coverage: {
             provider: 'v8',
             reporter: ['json', 'html'],
-            exclude: ['**/*.test.ts'],
+            exclude: ['**/*.test.ts', '**/*.bench.ts'],
             include: ['src/**/*.{ts,js}'],
             reportsDirectory: './coverage/vitest/unit',
         },


### PR DESCRIPTION
With benchmarks living next to the code as `src/**/*.bench.ts`, the coverage config picks them up as source. They only run under `vitest bench`, which collects no coverage, so they can never report anything but 0% — every PR that adds one gets a red patch-coverage comment that no test can fix (#8127 read 0% patch with 88 lines "missing" for exactly this reason, and the bench file is all that keeps #8158's comment red today). This excludes them from the unit and integration coverage reports the same way `**/*.test.ts` already is, so the patch number reflects testable code again.

## Launch Checklist

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [x] Confirm you have read our AI policy [here](https://github.com/maplibre/maplibre/blob/main/AI_POLICY.md).