### PR TITLE
feat: allow creating an image source without a url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## main
 ### ✨ Features and improvements
 - Throw `GPUInitializationError` from the `Map` constructor when the WebGL2 context cannot be created, instead of firing an `error` event no listener can catch and returning a partially constructed map ([#8066](https://github.com/maplibre/maplibre-gl-js/issues/8066))
+- Allow adding an image source without a `url`. The source starts empty and makes no network request; call `updateImage({image})` or `updateImage({url})` later to show an image ([#8167](https://github.com/maplibre/maplibre-gl-js/pull/8167))
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@mapbox/unitbezier": "^1.0.0",
         "@mapbox/vector-tile": "^3.0.0",
         "@maplibre/geojson-vt": "^6.1.1",
-        "@maplibre/maplibre-gl-style-spec": "^26.3.0",
+        "@maplibre/maplibre-gl-style-spec": "^26.4.0",
         "@maplibre/mlt": "^1.2.0",
         "@maplibre/vt-pbf": "^4.3.2",
         "@types/geojson": "^7946.0.16",
@@ -2137,9 +2137,9 @@
       }
     },
     "node_modules/@maplibre/maplibre-gl-style-spec": {
-      "version": "26.3.0",
-      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-26.3.0.tgz",
-      "integrity": "sha512-i5qRxjNvktTZ7CR08u7JJpOrVAd0JbYjYlnHypoVpbaqi6INJ7JZ3ZFTKTxK4QFqRdYAozlu3KeOcZp0g9bvdQ==",
+      "version": "26.4.0",
+      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-26.4.0.tgz",
+      "integrity": "sha512-FHR/9P4g2MrO4+yAQvhIWJEQ34vEBwupoTyGXH4OUAPSeApoOq0Mqc53i4tU4UfTOWxr5KxGM74w9oxK+Snklw==",
       "license": "ISC",
       "dependencies": {
         "@mapbox/jsonlint-lines-primitives": "^2.0.3",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@mapbox/unitbezier": "^1.0.0",
     "@mapbox/vector-tile": "^3.0.0",
     "@maplibre/geojson-vt": "^6.1.1",
-    "@maplibre/maplibre-gl-style-spec": "^26.3.0",
+    "@maplibre/maplibre-gl-style-spec": "^26.4.0",
     "@maplibre/mlt": "^1.2.0",
     "@maplibre/vt-pbf": "^4.3.2",
     "@types/geojson": "^7946.0.16",

--- a/src/source/image_source.test.ts
+++ b/src/source/image_source.test.ts
@@ -679,6 +679,59 @@ describe('ImageSource', () => {
         });
     });
 
+    describe('source created without a url', () => {
+        let source: ImageSource;
+        let transformRequest: Mock<(url: string, resourceType?: string) => any>;
+
+        beforeEach(() => {
+            transformRequest = vi.fn((url: string, _resourceType?: string) => ({url}));
+            map.setTransformRequest(transformRequest);
+            source = createSource({eventedParent: map});
+        });
+
+        test('fires metadata without an error or a request', async () => {
+            const errorHandler = vi.fn();
+            source.on('error', errorHandler);
+            const metadata = waitForEvent(source, 'data', (e: MapSourceDataEvent) => e.sourceDataType === 'metadata');
+
+            source.onAdd(map);
+
+            await metadata;
+            expect(source.loaded()).toBe(true);
+            expect(errorHandler).not.toHaveBeenCalled();
+            expect(transformRequest).not.toHaveBeenCalled();
+        });
+
+        test('displays an image handed to updateImage', async () => {
+            source.onAdd(map);
+            const {z, x, y} = source.tileID;
+            const tile = new Tile(new OverscaledTileID(z, 0, z, x, y), 512);
+            await source.loadTile(tile);
+            const image = new ImageData(1, 1);
+
+            source.updateImage({image});
+            source.prepare();
+
+            expect(tile.state).toBe('loaded');
+            expect(tile.texture).toBe(source.texture);
+        });
+
+        test('loads a url handed to updateImage', async () => {
+            source.onAdd(map);
+            server.respondImmediately = true;
+            const metadata = waitForEvent(source, 'data', (e: MapSourceDataEvent) => e.sourceDataType === 'metadata');
+
+            source.updateImage({url: '/image.png'});
+
+            await metadata;
+            expect(transformRequest).toHaveBeenCalledTimes(1);
+        });
+
+        test('serializes without a url key', () => {
+            expect(source.serialize()).not.toHaveProperty('url');
+        });
+    });
+
     describe('terrainTileRanges', () => {
         test('sets tile ranges for all zoom levels', () => {
             const source = createSource({url: '/image.png'});

--- a/src/source/image_source.ts
+++ b/src/source/image_source.ts
@@ -171,6 +171,18 @@ export type CanonicalTileRange = {
  * const bitmap = await createImageBitmap(myCanvas);
  * mySource.updateImage({image: bitmap});
  *
+ * // create an empty source (no url), then feed it entirely via updateImage
+ * map.addSource('empty id', {
+ *    type: 'image',
+ *    coordinates: [
+ *        [-76.54, 39.18],
+ *        [-76.52, 39.18],
+ *        [-76.52, 39.17],
+ *        [-76.54, 39.17]
+ *    ]
+ * });
+ * (map.getSource('empty id') as ImageSource).updateImage({image: bitmap});
+ *
  * map.removeSource('some id');  // remove
  * ```
  */
@@ -229,6 +241,13 @@ export class ImageSource extends Evented<SourceEventType> implements Source {
     }
 
     async load(newCoordinates?: Coordinates): Promise<void> {
+        if (this.options.url === undefined) {
+            // A url-less source starts empty and displays nothing until updateImage provides content.
+            this._loaded = true;
+            this._finishLoading();
+            return;
+        }
+
         this._loaded = false;
         this.fire(new MapSourceDataEvent('dataloading'));
 
@@ -481,11 +500,14 @@ export class ImageSource extends Evented<SourceEventType> implements Source {
     }
 
     serialize(): ImageSourceSpecification | VideoSourceSpecification | CanvasSourceSpecification {
-        return {
+        const spec: ImageSourceSpecification = {
             type: 'image',
-            url: this.options.url,
             coordinates: this.coordinates
         };
+        if (this.options.url !== undefined) {
+            spec.url = this.options.url;
+        }
+        return spec;
     }
 
     hasTransition() {

--- a/src/style/style_layer/symbol_style_layer.ts
+++ b/src/style/style_layer/symbol_style_layer.ts
@@ -48,12 +48,12 @@ export class SymbolStyleLayer extends StyleLayer {
     recalculate(parameters: EvaluationParameters, availableImages: string[]): void {
         super.recalculate(parameters, availableImages);
 
-        if (this.layout.get('icon-rotation-alignment') === 'auto') {
-            if (this.layout.get('symbol-placement') !== 'point') {
-                this.layout._values['icon-rotation-alignment'] = 'map';
-            } else {
-                this.layout._values['icon-rotation-alignment'] = 'viewport';
-            }
+        const iconRotationAlignment = this.layout.get('icon-rotation-alignment');
+        if (iconRotationAlignment.value.kind !== 'constant' || iconRotationAlignment.value.value === 'auto') {
+            this.layout._values['icon-rotation-alignment'] = new PossiblyEvaluatedPropertyValue(
+                iconRotationAlignment.property,
+                {kind: 'constant', value: this.layout.get('symbol-placement') !== 'point' ? 'map' : 'viewport'},
+                iconRotationAlignment.parameters);
         }
 
         if (this.layout.get('text-rotation-alignment') === 'auto') {
@@ -69,7 +69,7 @@ export class SymbolStyleLayer extends StyleLayer {
             this.layout._values['text-pitch-alignment'] = this.layout.get('text-rotation-alignment') === 'map' ? 'map' : 'viewport';
         }
         if (this.layout.get('icon-pitch-alignment') === 'auto') {
-            this.layout._values['icon-pitch-alignment'] = this.layout.get('icon-rotation-alignment');
+            this.layout._values['icon-pitch-alignment'] = this.layout.get('icon-rotation-alignment').constantOr('viewport');
         }
 
         if (this.layout.get('symbol-placement') === 'point') {

--- a/src/symbol/symbol_layout.ts
+++ b/src/symbol/symbol_layout.ts
@@ -316,7 +316,7 @@ function addFeature(bucket: SymbolBucket,
         iconPadding = getIconPadding(layout, feature, canonical, bucket.tilePixelRatio),
         textMaxAngle = layout.get('text-max-angle') / 180 * Math.PI,
         textAlongLine = layout.get('text-rotation-alignment') !== 'viewport' && layout.get('symbol-placement') !== 'point',
-        iconAlongLine = layout.get('icon-rotation-alignment') === 'map' && layout.get('symbol-placement') !== 'point',
+        iconAlongLine = layout.get('icon-rotation-alignment').constantOr('viewport') === 'map' && layout.get('symbol-placement') !== 'point',
         symbolPlacement = layout.get('symbol-placement'),
         textRepeatDistance = symbolMinDistance / 2;
 

--- a/src/webgl/draw/draw_symbol.ts
+++ b/src/webgl/draw/draw_symbol.ts
@@ -86,7 +86,7 @@ export function drawSymbols(painter: Painter, tileManager: TileManager, layer: S
         drawLayerSymbols(painter, tileManager, layer, coords, false,
             layer.paint.get('icon-translate'),
             layer.paint.get('icon-translate-anchor'),
-            layer.layout.get('icon-rotation-alignment'),
+            layer.layout.get('icon-rotation-alignment').constantOr('viewport'),
             layer.layout.get('icon-pitch-alignment'),
             layer.layout.get('icon-keep-upright'),
             stencilMode, colorMode, isRenderingToTexture


### PR DESCRIPTION
### Summary

An image source can now be created with only `type` and `coordinates`. It starts empty, makes no network request, and displays the first content handed to `updateImage`:

```ts
map.addSource('overlay', {
    type: 'image',
    coordinates: [[-76.54, 39.18], [-76.52, 39.18], [-76.52, 39.17], [-76.54, 39.17]]
});

const bitmap = await createImageBitmap(myCanvas);
(map.getSource('overlay') as ImageSource).updateImage({image: bitmap});
```

### Motivation

#7944 made `updateImage({image})` display an already-decoded image with no network involved, but the source could not be *created* without a `url`: the spec required it, and `ImageSource.onAdd` fetched unconditionally, so a `url`-less source fired an `ErrorEvent` for a request nobody asked for. The workaround was a placeholder 1x1 data-URI url. This removes the need for it.

### Changes

- `ImageSource.load()` returns early when the source has no `url`: no fetch, no `dataloading`, no error. The source still fires `metadata` and reports `loaded() === true`, so a later `updateImage({image})` or `updateImage({url})` behaves exactly as on a url-loaded source. `prepare()` already renders nothing while the image is unset.
- `serialize()` omits the `url` key instead of emitting `url: undefined`.
- `CanvasSource` and `VideoSource` override `load()`, `onAdd` and `serialize()`, so they are behaviorally untouched; their specs keep their own required fields.
- Class JSDoc example shows the url-less creation.

Depends on maplibre/maplibre-style-spec#1817

### Public API changes

None in gl-js itself; the `ImageSourceSpecification` type widens (`url?: string`) via the spec dependency bump.

### Tests

New `source created without a url` block in `src/source/image_source.test.ts`: creation fires `metadata` with no error and no request; `updateImage({image})` on an empty source creates the texture and re-points the tile; `updateImage({url})` loads normally; `serialize()` has no `url` key.



 ## Launch Checklist

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [x] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality.
 - [x] Document any changes to public APIs.
 - [x] If you changed code in a file that has a benchmark file next to it (`*.bench.ts`), post before/after results of `npm run bench` (the compare workflow is in `test/bench/README.md`).
 - [x] Add an entry to `CHANGELOG.md` under the `## main` section.
 - [x] Confirm you have read our AI policy [here](https://github.com/maplibre/maplibre/blob/main/AI_POLICY.md).

Assisted-By: Claude Fable 5 (high)
