### PR TITLE
fix: avoid runtime exceptions in Unicode script detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes
+- Avoid probing Unicode script support with caught exceptions during module loading by using generated cursive and right-to-left character sets instead ([#5807](https://github.com/maplibre/maplibre-gl-js/issues/5807)) (by [@fallenmi](https://github.com/fallenmi))
 - _...Add new stuff here..._
 
 ## 6.4.0

--- a/build/generate-unicode-data.ts
+++ b/build/generate-unicode-data.ts
@@ -27,6 +27,63 @@ async function createSet(blocks: string[], scripts: string[]): Promise<regenerat
     return set;
 }
 
+async function isInCursiveScript(): Promise<string> {
+    // In general, cursive scripts are incompatible with letter spacing.
+    const set = await createSet([], [
+        'Arabic',
+        'Duployan',
+        'Mongolian',
+        'Old Uyghur',
+        'Syriac',
+    ]);
+
+    return set.toString();
+}
+
+async function isInRTLScript(): Promise<string> {
+    // Scripts in the existing right-to-left detection heuristic.
+    const set = await createSet([], [
+        'Adlam',
+        'Arabic',
+        'Imperial Aramaic',
+        'Avestan',
+        'Chorasmian',
+        'Cypriot',
+        'Egyptian Hieroglyphs',
+        'Elymaic',
+        'Garay',
+        'Hatran',
+        'Hebrew',
+        'Old Hungarian',
+        'Kharoshthi',
+        'Lydian',
+        'Mandaic',
+        'Manichaean',
+        'Mende Kikakui',
+        'Meroitic Cursive',
+        'Meroitic Hieroglyphs',
+        'Old North Arabian',
+        'Nabataean',
+        'Nko',
+        'Old Turkic',
+        'Palmyrene',
+        'Inscriptional Pahlavi',
+        'Psalter Pahlavi',
+        'Phoenician',
+        'Inscriptional Parthian',
+        'Hanifi Rohingya',
+        'Samaritan',
+        'Old South Arabian',
+        'Old Sogdian',
+        'Syriac',
+        'Thaana',
+        'Todhri',
+        'Yezidi',
+    ]);
+
+    return set.toString();
+}
+
 async function usesLocalIdeographFontFamily(): Promise<string> {
     // Local rendering is preferred for Unicode code blocks that represent
     // writing systems for which TinySDF produces optimal results and greatly
@@ -315,6 +372,21 @@ async function requiresComplexTextShaping(): Promise<string> {
 
 fs.writeFileSync('src/util/unicode_properties.g.ts',
     `// This file is generated. Edit build/generate-unicode-data.ts, then run \`npm run generate-unicode-data\`.
+
+/**
+ * Returns whether the given codepoint belongs to a cursive script.
+ */
+export function codePointIsInCursiveScript(codePoint: number): boolean {
+    return /${await isInCursiveScript()}/gim.test(String.fromCodePoint(codePoint));
+}
+
+/**
+ * Returns whether the given codepoint belongs to a script in the right-to-left
+ * detection heuristic.
+ */
+export function codePointIsInRTLScript(codePoint: number): boolean {
+    return /${await isInRTLScript()}/gim.test(String.fromCodePoint(codePoint));
+}
 
 /**
  * Returns whether the fallback fonts specified by the

--- a/src/util/script_detection.test.ts
+++ b/src/util/script_detection.test.ts
@@ -1,4 +1,4 @@
-import {describe, test, expect} from 'vitest';
+import {describe, test, expect, vi} from 'vitest';
 import {charIsWhitespace, charAllowsLetterSpacing, charInComplexShapingScript, charInRTLScript} from './script_detection.ts';
 
 describe('charIsWhitespace', () => {
@@ -17,7 +17,7 @@ describe('charAllowsLetterSpacing', () => {
         expect(charAllowsLetterSpacing('A'.codePointAt(0))).toBe(true);
     });
 
-    test('disallows ideographic breaking of Arabic text', () => {
+    test('disallows letter spacing of Arabic text', () => {
         // Arabic
         expect(charAllowsLetterSpacing('۳'.codePointAt(0))).toBe(false);
         // Arabic Supplement
@@ -30,6 +30,11 @@ describe('charAllowsLetterSpacing', () => {
         expect(charAllowsLetterSpacing('ﰤ'.codePointAt(0))).toBe(false);
         // Arabic Presentation Forms-B
         expect(charAllowsLetterSpacing('ﺽ'.codePointAt(0))).toBe(false);
+    });
+
+    test('disallows letter spacing in supplementary-plane cursive scripts', () => {
+        expect(charAllowsLetterSpacing(0x1BC00)).toBe(false); // Duployan
+        expect(charAllowsLetterSpacing(0x10F70)).toBe(false); // Old Uyghur
     });
 });
 
@@ -82,5 +87,37 @@ describe('charInRTLScript', () => {
     test('identifies Thaana text as right-to-left', () => {
         // Thaana
         expect(charInRTLScript('ޘ'.codePointAt(0))).toBe(true);
+    });
+
+    test('preserves configured detection for Garay and Todhri', () => {
+        expect(charInRTLScript(0x10D40)).toBe(true); // Garay
+        expect(charInRTLScript(0x105C0)).toBe(true); // Todhri
+    });
+});
+
+describe('module initialization', () => {
+    test('does not probe Unicode script support with RegExp constructors', async () => {
+        const NativeRegExp = globalThis.RegExp;
+        let scriptPropertyAttempts = 0;
+
+        class ScriptPropertyRegExp extends NativeRegExp {
+            constructor(pattern?: string | RegExp, flags?: string) {
+                if (typeof pattern === 'string' && pattern.includes('\\p{sc=')) {
+                    scriptPropertyAttempts++;
+                    throw new SyntaxError('Unicode script property is unsupported');
+                }
+                super(pattern, flags);
+            }
+        }
+
+        vi.resetModules();
+        vi.stubGlobal('RegExp', ScriptPropertyRegExp);
+        try {
+            await import('./script_detection.ts');
+            expect(scriptPropertyAttempts).toBe(0);
+        } finally {
+            vi.unstubAllGlobals();
+            vi.resetModules();
+        }
     });
 });

--- a/src/util/script_detection.ts
+++ b/src/util/script_detection.ts
@@ -2,6 +2,8 @@ import {
     codePointAllowsIdeographicBreaking,
     codePointHasUprightVerticalOrientation,
     codePointHasNeutralVerticalOrientation,
+    codePointIsInCursiveScript,
+    codePointIsInRTLScript,
     codePointRequiresComplexTextShaping
 } from '../util/unicode_properties.g.ts';
 
@@ -30,39 +32,8 @@ export function allowsLetterSpacing(chars: string): boolean {
     return true;
 }
 
-/**
- * Returns a regular expression matching the given script codes, excluding any
- * code that the execution environment lacks support for in regular expressions.
- */
-function sanitizedRegExpFromScriptCodes(scriptCodes: string[]): RegExp {
-    const supportedPropertyEscapes = scriptCodes.map(code => {
-        try {
-            return new RegExp(`\\p{sc=${code}}`, 'u').source;
-        } catch {
-            return null;
-        }
-    }).filter(pe => pe);
-    return new RegExp(supportedPropertyEscapes.join('|'), 'u');
-}
-
-/**
- * ISO 15924 script codes of scripts that disallow letter spacing as of Unicode
- * 16.0.0.
- *
- * In general, cursive scripts are incompatible with letter spacing.
- */
-const cursiveScriptCodes = [
-    'Arab', // Arabic
-    'Dupl', // Duployan
-    'Mong', // Mongolian
-    'Ougr', // Old Uyghur
-    'Syrc', // Syriac
-];
-
-const cursiveScriptRegExp = sanitizedRegExpFromScriptCodes(cursiveScriptCodes);
-
 export function charAllowsLetterSpacing(char: number): boolean {
-    return !cursiveScriptRegExp.test(String.fromCodePoint(char));
+    return !codePointIsInCursiveScript(char);
 }
 
 /**
@@ -83,53 +54,8 @@ export function charInComplexShapingScript(char: number): boolean {
     return /\p{sc=Arab}/u.test(String.fromCodePoint(char));
 }
 
-/**
- * ISO 15924 script codes of scripts that are primarily written horizontally
- * right-to-left according to Unicode 16.0.0.
- */
-const rtlScriptCodes = [
-    'Adlm', // Adlam
-    'Arab', // Arabic
-    'Armi', // Imperial Aramaic
-    'Avst', // Avestan
-    'Chrs', // Chorasmian
-    'Cprt', // Cypriot
-    'Egyp', // Egyptian Hieroglyphs
-    'Elym', // Elymaic
-    'Gara', // Garay
-    'Hatr', // Hatran
-    'Hebr', // Hebrew
-    'Hung', // Old Hungarian
-    'Khar', // Kharoshthi
-    'Lydi', // Lydian
-    'Mand', // Mandaic
-    'Mani', // Manichaean
-    'Mend', // Mende Kikakui
-    'Merc', // Meroitic Cursive
-    'Mero', // Meroitic Hieroglyphs
-    'Narb', // Old North Arabian
-    'Nbat', // Nabataean
-    'Nkoo', // NKo
-    'Orkh', // Old Turkic
-    'Palm', // Palmyrene
-    'Phli', // Inscriptional Pahlavi
-    'Phlp', // Psalter Pahlavi
-    'Phnx', // Phoenician
-    'Prti', // Inscriptional Parthian
-    'Rohg', // Hanifi Rohingya
-    'Samr', // Samaritan
-    'Sarb', // Old South Arabian
-    'Sogo', // Old Sogdian
-    'Syrc', // Syriac
-    'Thaa', // Thaana
-    'Todr', // Todhri
-    'Yezi', // Yezidi
-];
-
-const rtlScriptRegExp = sanitizedRegExpFromScriptCodes(rtlScriptCodes);
-
 export function charInRTLScript(char: number): boolean {
-    return rtlScriptRegExp.test(String.fromCodePoint(char));
+    return codePointIsInRTLScript(char);
 }
 
 export function charInSupportedScript(char: number, canRenderRTL: boolean): boolean {

--- a/test/build/bundle_size.json
+++ b/test/build/bundle_size.json
@@ -8,7 +8,7 @@
         "gzip": 5865
     },
     "dist/maplibre-gl-shared.mjs": {
-        "raw": 482364,
-        "gzip": 134507
+        "raw": 484414,
+        "gzip": 135075
     }
 }


### PR DESCRIPTION
## Summary

- Generate cursive and right-to-left Unicode character predicates at build time.
- Replace runtime `RegExp` feature probing and caught exceptions with the generated predicates.
- Preserve the existing script sets while consistently recognizing newer scripts such as Garay and Todhri.
- Add regression coverage and update the production bundle-size baseline.

Fixes #5807.

## Implementation

`build/generate-unicode-data.ts` now builds the two character sets from the repository's existing Unicode 17 data. `script_detection.ts` calls the generated predicates instead of constructing `\p{sc=...}` regular expressions during module initialization.

An exhaustive comparison found zero differences from the configured source sets across all 1,114,112 Unicode codepoints: 1,838 cursive and 8,425 RTL codepoints.

The implementation was derived from current MapLibre code, the existing `@unicode/unicode-17.0.0` dependency, and the issue discussion. No code was copied or backported from Mapbox projects.

## Bundle impact

Only `dist/maplibre-gl-shared.mjs` changes:

| Encoding | Delta |
|---|---:|
| Raw | +2,050 bytes |
| Gzip | +568 bytes |
| Brotli | +232 bytes |

The main and worker bundles are unchanged.

## Validation

Run with Node 26:

- `npm run codegen`
- Focused unit tests: 11/11
- Full unit suite: 204 files, 3,038 tests
- Focused ESLint: passed with zero warnings
- `npm run typecheck`
- `npm run build-prod`
- Bundle-size tests: 4/4
- Full integration suite: 4 files, 178 tests
- Node 18 production import: no Unicode-property `RegExp` exceptions
- Chrome 151 smoke test: bundle loaded with no page, console, or network errors

## Launch Checklist

- [x] Confirm **your changes do not include backports from Mapbox projects**.
- [x] Briefly describe the changes in this PR.
- [x] Link to related issues.
- [x] Include before/after visuals or gifs if this PR includes visual changes — not applicable; there is no visual change.
- [x] Write tests for all new functionality.
- [x] Document any changes to public APIs — not applicable; there is no public API change.
- [x] If code with an adjacent benchmark was changed, post before/after benchmark results — not applicable; there is no adjacent benchmark.
- [x] Add an entry to `CHANGELOG.md` under `## main`.
- [ ] Confirm you have read the MapLibre AI policy — human contributor review is required before marking this draft ready.

## AI assistance

Generated-By: OpenAI Codex (GPT-5)

Prompts used:

- "Audit MapLibre GL JS issue #5807 on current main, including competing work and contribution policy."
- "Replace runtime Unicode property exception probing with build-time generated predicates while preserving the existing cursive and RTL script sets."
- "Add regression tests and measure raw, gzip, and Brotli bundle impact."

Human review is pending. This draft must not be marked ready until the contributor has read, understood, and can explain every change.