### PR TITLE
perf(terrain): avoid allocating tile IDs and matrices that are then discarded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## main
 ### ✨ Features and improvements
+- Stop `TerrainTileManager._getTerrainCoordsForRegularTile` allocating a tile ID and a matrix for every renderable terrain tile before discarding most of them; the matrix is now a reused scratch and the clone happens only for tiles that are kept ([#XXXX](https://github.com/maplibre/maplibre-gl-js/pull/XXXX))
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes

--- a/src/tile/terrain_tile_manager.bench.ts
+++ b/src/tile/terrain_tile_manager.bench.ts
@@ -1,0 +1,69 @@
+import {bench, describe} from 'vitest';
+import {TerrainTileManager} from './terrain_tile_manager.ts';
+import {OverscaledTileID} from './tile_id.ts';
+import {Tile} from './tile.ts';
+import type {TileManager} from './tile_manager.ts';
+
+/**
+ * Builds a manager holding `count` renderable terrain tiles that are siblings at one zoom, so for any
+ * one of them used as the queried tile exactly one entry is kept and the rest hit the `continue`.
+ * That is the shape measured on a live map: the kept count tracks the call count almost exactly.
+ */
+function makeManager(count: number): {manager: TerrainTileManager; visible: OverscaledTileID[]} {
+    const manager = new TerrainTileManager({
+        _source: {tileSize: 512},
+        usedForTerrain: false,
+        tileSize: null,
+    } as any as TileManager);
+
+    const visible: OverscaledTileID[] = [];
+    manager._tiles = {};
+    manager._renderableTilesKeys = [];
+    for (let i = 0; i < count; i++) {
+        const tileID = new OverscaledTileID(8, 0, 8, 40 + i, 90);
+        manager._tiles[tileID.key] = new Tile(tileID, 256);
+        manager._renderableTilesKeys.push(tileID.key);
+        visible.push(tileID);
+    }
+    return {manager, visible};
+}
+
+/**
+ * Consumed so neither arm can be optimised away for having an unused result, and checked once so a
+ * variant that returned nothing could not read as "fast".
+ *
+ * Each sweep is one frame's worth of calls for a single draped source, which is the whole cost model:
+ * `_renderableTilesKeys` belongs to the one TerrainTileManager and is rebuilt per frame rather than
+ * per source, so additional draped sources lengthen the caller's outer loop without changing `count`
+ * or the per-call cost.
+ */
+let sink = 0;
+
+function makeSweep(count: number): () => void {
+    const {manager, visible} = makeManager(count);
+
+    const kept = Object.keys(manager._getTerrainCoordsForRegularTile(visible[0])).length;
+    if (kept !== 1) {
+        throw new Error(`fixture is wrong: expected exactly 1 kept coord per call, got ${kept}`);
+    }
+
+    return () => {
+        for (const tileID of visible) {
+            sink += Object.keys(manager._getTerrainCoordsForRegularTile(tileID)).length;
+        }
+    };
+}
+
+describe('TerrainTileManager#_getTerrainCoordsForRegularTile', () => {
+    // 15 and 27 are the renderable-tiles-per-call figures measured on a live globe with terrain at
+    // pitch 0 and pitch 60.
+    const sweep15 = makeSweep(15);
+    const sweep27 = makeSweep(27);
+    const sweep64 = makeSweep(64);
+
+    bench('15 renderable tiles', sweep15);
+    bench('27 renderable tiles', sweep27);
+    bench('64 renderable tiles', sweep64);
+});
+
+export {sink};

--- a/src/tile/terrain_tile_manager.test.ts
+++ b/src/tile/terrain_tile_manager.test.ts
@@ -135,6 +135,42 @@ describe('TerrainTileManager', () => {
                 expect(result[terrainRenderableTile.key]).toBeTruthy();
                 expect(result[terrainNonRenderableTile.key]).toBeFalsy();
             });
+
+            test('builds the right matrix for each relationship', () => {
+                // All four terrain tiles go through a single call, so a matrix left over from an
+                // earlier iteration would surface here rather than in a one-tile fixture.
+                const testTile = new OverscaledTileID(2, 0, 2, 1, 1);
+                const terrainChildTile = new OverscaledTileID(3, 0, 3, 3, 2);
+                const terrainParentTile = new OverscaledTileID(1, 0, 1, 0, 0);
+                const terrainSameTile = new OverscaledTileID(2, 0, 2, 1, 1);
+                const terrainNonOverlappingTile = new OverscaledTileID(3, 0, 3, 0, 0);
+
+                tsc._tiles = {
+                    [terrainChildTile.key]: new Tile(terrainChildTile, 256),
+                    [terrainParentTile.key]: new Tile(terrainParentTile, 256),
+                    [terrainSameTile.key]: new Tile(terrainSameTile, 256),
+                    [terrainNonOverlappingTile.key]: new Tile(terrainNonOverlappingTile, 256),
+                };
+                tsc._renderableTilesKeys = [
+                    terrainChildTile.key,
+                    terrainParentTile.key,
+                    terrainSameTile.key,
+                    terrainNonOverlappingTile.key
+                ];
+
+                const result = tsc.getTerrainCoords(testTile);
+
+                expect(Array.from(result[terrainSameTile.key].terrainRttPosMatrix32f)).toEqual([
+                    0.000244140625, 0, 0, 0, 0, -0.000244140625, 0, 0, 0, 0, -2, 0, -1, 1, -1, 1
+                ]);
+                expect(Array.from(result[terrainChildTile.key].terrainRttPosMatrix32f)).toEqual([
+                    0.00048828125, 0, 0, 0, 0, -0.00048828125, 0, 0, 0, 0, -2, 0, -3, 1, -1, 1
+                ]);
+                expect(Array.from(result[terrainParentTile.key].terrainRttPosMatrix32f)).toEqual([
+                    // index 10 is a signed zero: the parent branch scales z by 0, so -2 becomes -0.
+                    0.0001220703125, 0, 0, 0, 0, -0.0001220703125, 0, 0, 0, 0, -0, 0, 0, 0, -1, 1
+                ]);
+            });
         });
 
         describe('tile with custom range', () => {

--- a/src/tile/terrain_tile_manager.ts
+++ b/src/tile/terrain_tile_manager.ts
@@ -9,7 +9,7 @@ import type {Source} from '../source/source.ts';
 import {type Terrain} from '../render/terrain.ts';
 import {now} from '../util/time_control.ts';
 import {coveringTiles} from '../geo/projection/covering_tiles.ts';
-import {createMat4f64} from '../util/util.ts';
+import {createMat4f64, type Mat4f64} from '../util/util.ts';
 import {type CanonicalTileRange} from '../source/image_source.ts';
 
 /**
@@ -59,6 +59,11 @@ export class TerrainTileManager extends Evented {
      * used to determine whether depth & coord framebuffers need updating
      */
     _lastTilesetChange: number = now();
+    /**
+     * scratch matrix reused by {@link _getTerrainCoordsForRegularTile}. Only the Float32Array copy
+     * of it escapes that loop, so it never needs to be allocated per tile.
+     */
+    _scratchMat: Mat4f64 = createMat4f64();
 
     constructor(tileManager: TileManager) {
         super();
@@ -186,10 +191,9 @@ export class TerrainTileManager extends Evented {
      */
     _getTerrainCoordsForRegularTile(tileID: OverscaledTileID): Record<string, OverscaledTileID> {
         const coords: Record<string, OverscaledTileID> = {};
+        const mat = this._scratchMat;
         for (const key of this._renderableTilesKeys) {
             const terrainTileID = this._tiles[key].tileID;
-            const coord = tileID.clone();
-            const mat = createMat4f64();
             if (terrainTileID.canonical.equals(tileID.canonical)) {
                 mat4.ortho(mat, 0, EXTENT, EXTENT, 0, 0, 1);
             } else if (terrainTileID.canonical.isChildOf(tileID.canonical)) {
@@ -210,6 +214,7 @@ export class TerrainTileManager extends Evented {
             } else {
                 continue;
             }
+            const coord = tileID.clone();
             coord.terrainRttPosMatrix32f = new Float32Array(mat);
             coords[key] = coord;
         }


### PR DESCRIPTION
When using terrain, the tile manager is allocating a tile ID and a 16-element matrix for _every_ renderable terrain tile, but most of it is wasted compute that adds up.

```mermaid
flowchart TD
    subgraph after["After — decide, then allocate"]
        A1[next terrain tile] --> A2{same, child<br/>or parent?}
        A2 -->|no| A3[continue<br/>nothing allocated]
        A2 -->|yes| A4[clone tile ID<br/>copy scratch matrix]
        A3 --> A1
        A4 --> A1
    end
    subgraph before["Before — allocate, then decide"]
        B1[next terrain tile] --> B2[clone tile ID<br/>allocate Float64Array 16]
        B2 --> B3{same, child<br/>or parent?}
        B3 -->|no| B4[continue<br/>both discarded]
        B3 -->|yes| B5[keep]
        B4 --> B1
        B5 --> B1
    end
```

After applying the fix, every frame should save about 0.15-1.05ms of compute (which is about 1-7% of a 60FPS budget).

Bench results:

| renderable tiles | before (hz) | after (hz) | ratio |
|---|---|---|---|
| 15 | 8,076 | 221,123 | **27.4×** |
| 27 | 2,386 | 105,658 | **44.3×** |
| 64 | 373 | 27,834 | **74.6×** |

The factors seem big, but they're only in-function improvements, and this function isn't called very many times for a frame, so effective improvement is still only the range noted above.

---

Related to:
- #5072
  - Same category of fix applied here
- #5368
  - Same linear loop count affecting the number of calls per frame
- #7699 
  - Fixed by #8048, but this PR touches the same call path

## Launch Checklist

 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [x] Write tests for all new functionality.
 - [x] If you changed code in a file that has a benchmark file next to it (`*.bench.ts`), post before/after results of `npm run bench` (the compare workflow is in `test/bench/README.md`).
 - [x] Add an entry to `CHANGELOG.md` under the `## main` section.
 - [x] Confirm you have read our AI policy [here](https://github.com/maplibre/maplibre/blob/main/AI_POLICY.md).

Assisted-By: Claude Opus 5