### PR TITLE
Public getter getCameraTransform() returning map._camera.transform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## main
 ### ✨ Features and improvements
 - _...Add new stuff here..._
+- Add `map.getCameraTransform()`, a public getter returning the current camera transform [#8185](https://github.com/maplibre/maplibre-gl-js/pull/8185) (by [@xavierjs](https://github.com/xavierjs))
 
 ### 🐞 Bug fixes
 - Give custom layers the live globe transition in `CustomRenderMethodInput.defaultProjectionData.projectionTransition`, which was hardcoded to 1 for the whole globe/mercator transition, so a custom layer jumped straight to the fully bent globe while every other layer eased ([#8169](https://github.com/maplibre/maplibre-gl-js/pull/8169)) (by [@mondsichtung](https://github.com/mondsichtung))

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
         "@types/window-or-global": "^1.0.6",
         "@typescript-eslint/eslint-plugin": "^8.67.0",
         "@typescript-eslint/parser": "^8.59.3",
-        "@typescript/native-preview": "*",
+        "@typescript/native-preview": "beta",
         "@unicode/unicode-17.0.0": "^1.6.17",
         "@vitest/coverage-v8": "4.1.10",
         "@vitest/eslint-plugin": "^1.6.27",

--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -1014,6 +1014,13 @@ export class Map extends Evented<MapEventType> {
     }
 
     /**
+     * Returns the map's camera transform.
+     *
+     * @returns The map's current camera transform.
+     */
+    getCameraTransform(): ITransform { return this._camera.transform; }
+
+    /**
      * Sets the callback used to defer camera updates or apply arbitrary constraints.
      * If specified, this Camera instance can be used as a stateless component in React etc.
      */

--- a/src/ui/map_tests/map_covering_tiles.test.ts
+++ b/src/ui/map_tests/map_covering_tiles.test.ts
@@ -36,3 +36,14 @@ describe('Map.coveringTiles', () => {
         expect(tiles.every(tile => tile.canonical.z === 4)).toBeTruthy();
     });
 });
+
+describe('Map.getCameraTransform', () => {
+    test('returns the camera transform', () => {
+        expect(map.getCameraTransform()).toBe(map._camera.transform);
+    });
+
+    test('reflects the current view state', () => {
+        map.setZoom(5);
+        expect(map.getCameraTransform().zoom).toBe(5);
+    });
+});


### PR DESCRIPTION
## Add `map.getCameraTransform()` public getter

Some use cases such as controlled/custom navigation need direct access to the camera transform to read the full view state and drive camera logic. Today the only way to get it is through the internal `map._camera.transform`, which forces consumers to reach into private state. This getter provides a supported, public entry point instead.

With Maplibre 5 this value was accessible with `map.transform` so it was less an issue.

```ts
const transform = map.getCameraTransform();
```

## Launch Checklist


- [X] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
- [X] Briefly describe the changes in this PR.
- [X] Write tests for all new functionality.
- [X] Document any changes to public APIs.
- [X] Add an entry to `CHANGELOG.md` under the `## main` section.
- [X] Confirm you have read our AI policy [here](https://github.com/maplibre/maplibre/blob/main/AI_POLICY.md).
