### PR TITLE
fix: snapshot attributes in DOM.removeAttributes to avoid skipping them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes
+- Fix `DOM.sanitize` leaving dangerous attributes behind when multiple consecutive attributes are present. Iterating the live `NamedNodeMap` from `elem.attributes` while calling `removeAttribute` skipped the attribute directly after a removed one, so a second dangerous attribute (for example an `ontoggle` on a `<details open>` element) could survive sanitisation and later execute ([#NNNN](https://github.com/maplibre/maplibre-gl-js/pull/NNNN)) (by [@0xKirisame](https://github.com/0xKirisame))
 - Give custom layers the live globe transition in `CustomRenderMethodInput.defaultProjectionData.projectionTransition`, which was hardcoded to 1 for the whole globe/mercator transition, so a custom layer jumped straight to the fully bent globe while every other layer eased ([#8169](https://github.com/maplibre/maplibre-gl-js/pull/8169)) (by [@mondsichtung](https://github.com/mondsichtung))
 - _...Add new stuff here..._
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes
-- Fix `DOM.sanitize` leaving dangerous attributes behind when multiple consecutive attributes are present. Iterating the live `NamedNodeMap` from `elem.attributes` while calling `removeAttribute` skipped the attribute directly after a removed one, so a second dangerous attribute (for example an `ontoggle` on a `<details open>` element) could survive sanitisation and later execute ([#NNNN](https://github.com/maplibre/maplibre-gl-js/pull/NNNN)) (by [@0xKirisame](https://github.com/0xKirisame))
+- Fix `DOM.sanitize` leaving dangerous attributes behind when multiple consecutive attributes are present. Iterating the live `NamedNodeMap` from `elem.attributes` while calling `removeAttribute` skipped the attribute directly after a removed one, so a second dangerous attribute (for example an `ontoggle` on a `<details open>` element) could survive sanitisation and later execute ([#8189](https://github.com/maplibre/maplibre-gl-js/pull/8189)) (by [@0xKirisame](https://github.com/0xKirisame))
 - Give custom layers the live globe transition in `CustomRenderMethodInput.defaultProjectionData.projectionTransition`, which was hardcoded to 1 for the whole globe/mercator transition, so a custom layer jumped straight to the fully bent globe while every other layer eased ([#8169](https://github.com/maplibre/maplibre-gl-js/pull/8169)) (by [@mondsichtung](https://github.com/mondsichtung))
 - _...Add new stuff here..._
 

--- a/src/util/dom.test.ts
+++ b/src/util/dom.test.ts
@@ -39,5 +39,18 @@ describe('DOM', () => {
             const output = DOM.sanitize(input);
             expect(output).toBe('<div><a>click me</a></div>');
         });
+
+        test('should remove multiple consecutive dangerous attributes', () => {
+            const input = '<details open onload="1" ontoggle="alert(1)">x</details>';
+            const output = DOM.sanitize(input);
+            expect(output).not.toContain('onload');
+            expect(output).not.toContain('ontoggle');
+        });
+
+        test('should remove dangerous attributes that follow a removed attribute', () => {
+            const input = '<a href=\'javascript:alert(1)\' onclick=\'alert(1)\'>click me</a>';
+            const output = DOM.sanitize(input);
+            expect(output).toBe('<a>click me</a>');
+        });
     });
 });

--- a/src/util/dom.ts
+++ b/src/util/dom.ts
@@ -131,7 +131,7 @@ export class DOM {
 	 * @param elem - The element
 	 */
     private static removeAttributes(elem: Element) {
-        for (const {name, value} of elem.attributes) {
+        for (const {name, value} of Array.from(elem.attributes)) {
             if (!DOM.isPossiblyDangerous(name, value)) continue;
             elem.removeAttribute(name);
         }


### PR DESCRIPTION
## Launch Checklist

- [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license)
- [x] Briefly describe the changes in this PR.
- [x] Link to related issues.
- [x] Write tests for all new functionality.
- [x] Add an entry to `CHANGELOG.md` under the `## main` section.
- [x] Confirm you have read our AI policy [here](https://github.com/maplibre/maplibre/blob/main/AI_POLICY.md).

## What

Fixes a bug in `DOM.removeAttributes` where iterating the **live** `NamedNodeMap` from `elem.attributes` while calling `elem.removeAttribute(name)` skips the attribute directly after a removed one. When two dangerous attributes are consecutive, the first is removed and the second survives into the sanitised output of `DOM.sanitize`.

This is exploitable in the attribution control: style-supplied attribution strings pass through `DOM.sanitize` before being assigned to `innerHTML` (`src/ui/control/attribution_control.ts:177`). A payload such as `<details open onload="1" ontoggle="alert(1)">x</details>` keeps `ontoggle`, and the `toggle` event fires on insertion, so the handler executes with no user interaction.

## Why

The current unit tests in `src/util/dom.test.ts` only exercise a single dangerous attribute per element, which is why the skip was never caught.

## How

- Snapshot the attribute collection with `Array.from(elem.attributes)` before iterating, so removals no longer affect iteration order.
- Added two regression tests covering multiple consecutive dangerous attributes, verified to fail on the old code and pass with the fix.

## Out of scope

Found and verified with an autonomous logic-audit harness I built. All testing was against local builds of this library; no MapLibre-operated service was touched. Coordinated disclosure in progress with the security team, hence the separate report; happy to share details once the fix is released.

- Assisted-By: opencode (deepseek-v4-flash-free) for the audit harness; the one-line fix and regression tests were reviewed and committed by a human.
