### PR TITLE
Deduplicate concurrent worker glyph requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## main
 ### ✨ Features and improvements
 - _...Add new stuff here..._
+- Deduplicate concurrent worker glyph requests while parsing vector tiles.
 
 ### 🐞 Bug fixes
 - _...Add new stuff here..._

--- a/src/source/worker_tile.test.ts
+++ b/src/source/worker_tile.test.ts
@@ -231,11 +231,11 @@ describe('worker tile', () => {
         expect(sendAsync).toHaveBeenCalledTimes(4); // icons, patterns, glyphs, dashes
         expect(sendAsync).toHaveBeenCalledWith(expect.objectContaining({type: 'GI', data: expect.objectContaining({'icons': ['hello'], 'type': 'icons'})}), expect.any(Object));
         expect(sendAsync).toHaveBeenCalledWith(expect.objectContaining({type: 'GI', data: expect.objectContaining({'icons': ['hello'], 'type': 'patterns'})}), expect.any(Object));
-        expect(sendAsync).toHaveBeenCalledWith(expect.objectContaining({type: 'GG', data: expect.objectContaining({'source': 'source', 'type': 'glyphs', 'stacks': {'StandardFont-Bold': [101, 115, 116]}})}), expect.any(Object));
+        expect(sendAsync).toHaveBeenCalledWith(expect.objectContaining({type: 'GG', data: expect.objectContaining({'source': 'source', 'type': 'glyphs', 'stacks': {'StandardFont-Bold': [101, 115, 116]}})}));
         expect(sendAsync).toHaveBeenCalledWith(expect.objectContaining({type: 'GDA', data: expect.objectContaining({'dashes': expect.any(Object)})}), expect.any(Object));
     });
 
-    test('WorkerTile.parse would cancel and only event once on repeated reparsing', async () => {
+    test('WorkerTile.parse cancels tile-specific dependencies and shares an in-flight glyph request', async () => {
         const tile = createWorkerTile();
         const layerIndex = new StyleLayerIndex([{
             id: '1',
@@ -280,7 +280,7 @@ describe('worker tile', () => {
         } as any as VectorTileLike;
 
         let cancelCount = 0;
-        const sendAsync = vi.fn().mockImplementation((message: {type: string; data: unknown}, abortController: AbortController) => {
+        const sendAsync = vi.fn().mockImplementation((message: {type: string; data: unknown}, abortController?: AbortController) => {
             return new Promise((resolve, _reject) => {
                 const res = setTimeout(() => {
                     const response = message.type === 'getImages' ?
@@ -289,7 +289,7 @@ describe('worker tile', () => {
                     resolve(response);
                 }
                 );
-                abortController.signal.addEventListener('abort', () => {
+                abortController?.signal.addEventListener('abort', () => {
                     cancelCount += 1;
                     clearTimeout(res);
                 });
@@ -305,11 +305,12 @@ describe('worker tile', () => {
         const result = await tile.parse(data, layerIndex, ['hello'], actorMock, SubdivisionGranularitySetting.noSubdivision);
         expect(onSettled).not.toHaveBeenCalled();
         expect(result).toBeDefined();
-        expect(cancelCount).toBe(6);
-        expect(sendAsync).toHaveBeenCalledTimes(9);
+        expect(cancelCount).toBe(4);
+        expect(sendAsync).toHaveBeenCalledTimes(7);
         expect(sendAsync).toHaveBeenCalledWith(expect.objectContaining({data: expect.objectContaining({'icons': ['hello'], 'type': 'icons'})}), expect.any(Object));
         expect(sendAsync).toHaveBeenCalledWith(expect.objectContaining({data: expect.objectContaining({'icons': ['hello'], 'type': 'patterns'})}), expect.any(Object));
-        expect(sendAsync).toHaveBeenCalledWith(expect.objectContaining({data: expect.objectContaining({'source': 'source', 'type': 'glyphs', 'stacks': {'StandardFont-Bold': [101, 115, 116]}})}), expect.any(Object));
+        expect(sendAsync).toHaveBeenCalledWith(expect.objectContaining({data: expect.objectContaining({'source': 'source', 'type': 'glyphs', 'stacks': {'StandardFont-Bold': [101, 115, 116]}})}));
+        expect(sendAsync.mock.calls.filter(([message]) => message.type === MessageType.getGlyphs)).toHaveLength(1);
     });
 
     test('WorkerTile.parse passes global-state to layout properties', async () => {

--- a/src/source/worker_tile.test.ts
+++ b/src/source/worker_tile.test.ts
@@ -231,7 +231,7 @@ describe('worker tile', () => {
         expect(sendAsync).toHaveBeenCalledTimes(4); // icons, patterns, glyphs, dashes
         expect(sendAsync).toHaveBeenCalledWith(expect.objectContaining({type: 'GI', data: expect.objectContaining({'icons': ['hello'], 'type': 'icons'})}), expect.any(Object));
         expect(sendAsync).toHaveBeenCalledWith(expect.objectContaining({type: 'GI', data: expect.objectContaining({'icons': ['hello'], 'type': 'patterns'})}), expect.any(Object));
-        expect(sendAsync).toHaveBeenCalledWith(expect.objectContaining({type: 'GG', data: expect.objectContaining({'source': 'source', 'type': 'glyphs', 'stacks': {'StandardFont-Bold': [101, 115, 116]}})}));
+        expect(sendAsync).toHaveBeenCalledWith(expect.objectContaining({type: 'GG', data: expect.objectContaining({'source': 'source', 'type': 'glyphs', 'stacks': {'StandardFont-Bold': [101, 115, 116]}})}), expect.any(Object));
         expect(sendAsync).toHaveBeenCalledWith(expect.objectContaining({type: 'GDA', data: expect.objectContaining({'dashes': expect.any(Object)})}), expect.any(Object));
     });
 
@@ -309,7 +309,7 @@ describe('worker tile', () => {
         expect(sendAsync).toHaveBeenCalledTimes(7);
         expect(sendAsync).toHaveBeenCalledWith(expect.objectContaining({data: expect.objectContaining({'icons': ['hello'], 'type': 'icons'})}), expect.any(Object));
         expect(sendAsync).toHaveBeenCalledWith(expect.objectContaining({data: expect.objectContaining({'icons': ['hello'], 'type': 'patterns'})}), expect.any(Object));
-        expect(sendAsync).toHaveBeenCalledWith(expect.objectContaining({data: expect.objectContaining({'source': 'source', 'type': 'glyphs', 'stacks': {'StandardFont-Bold': [101, 115, 116]}})}));
+        expect(sendAsync).toHaveBeenCalledWith(expect.objectContaining({data: expect.objectContaining({'source': 'source', 'type': 'glyphs', 'stacks': {'StandardFont-Bold': [101, 115, 116]}})}), expect.any(Object));
         expect(sendAsync.mock.calls.filter(([message]) => message.type === MessageType.getGlyphs)).toHaveLength(1);
     });
 

--- a/src/source/worker_tile.ts
+++ b/src/source/worker_tile.ts
@@ -38,10 +38,6 @@ function abortable<T>(promise: Promise<T>, signal: AbortSignal): Promise<T> {
             active = false;
             signal.removeEventListener('abort', abort);
         };
-        if (signal.aborted) {
-            abort();
-            return;
-        }
         signal.addEventListener('abort', abort, {once: true});
         promise.then((value) => {
             if (!active) return;

--- a/src/source/worker_tile.ts
+++ b/src/source/worker_tile.ts
@@ -31,7 +31,31 @@ type GlyphPromiseCache = Map<string, Map<number, GlyphPromise>>;
 
 const glyphPromiseCaches = new WeakMap<IActor, GlyphPromiseCache>();
 
-function getGlyphs(actor: IActor, stacks: {[stack: string]: number[]}, source: string, tileID: OverscaledTileID): Promise<GetGlyphsResponse> {
+function abortable<T>(promise: Promise<T>, signal: AbortSignal): Promise<T> {
+    return new Promise((resolve, reject) => {
+        let active = true;
+        const abort = () => {
+            active = false;
+            signal.removeEventListener('abort', abort);
+        };
+        if (signal.aborted) {
+            abort();
+            return;
+        }
+        signal.addEventListener('abort', abort, {once: true});
+        promise.then((value) => {
+            if (!active) return;
+            signal.removeEventListener('abort', abort);
+            resolve(value);
+        }, (error) => {
+            if (!active) return;
+            signal.removeEventListener('abort', abort);
+            reject(error);
+        });
+    });
+}
+
+function getGlyphs(actor: IActor, stacks: {[stack: string]: number[]}, source: string, tileID: OverscaledTileID, signal: AbortSignal): Promise<GetGlyphsResponse> {
     let cache = glyphPromiseCaches.get(actor);
     if (!cache) {
         cache = new Map();
@@ -76,7 +100,8 @@ function getGlyphs(actor: IActor, stacks: {[stack: string]: number[]}, source: s
     if (deferred.length) {
         // Glyphs are shared by concurrently parsed tiles, so this request must
         // outlive cancellation of any individual tile.
-        actor.sendAsync({type: MessageType.getGlyphs, data: {stacks: missing, source, tileID, type: 'glyphs'}})
+        const abortController = new AbortController();
+        actor.sendAsync({type: MessageType.getGlyphs, data: {stacks: missing, source, tileID, type: 'glyphs'}}, abortController)
             .then((response) => {
                 for (const entry of deferred) entry.resolve(response[entry.stack]?.[entry.id]);
             }, (error: unknown) => {
@@ -91,7 +116,7 @@ function getGlyphs(actor: IActor, stacks: {[stack: string]: number[]}, source: s
             });
     }
 
-    return Promise.all(requested.map(async ({stack, id, promise}) => ({stack, id, glyph: await promise})))
+    return abortable(Promise.all(requested.map(async ({stack, id, promise}) => ({stack, id, glyph: await promise}))), signal)
         .then((glyphs) => {
             const result: GetGlyphsResponse = {};
             for (const {stack, id, glyph} of glyphs) {
@@ -214,7 +239,9 @@ export class WorkerTile {
 
         let getGlyphsPromise = Promise.resolve<GetGlyphsResponse>({});
         if (Object.keys(stacks).length) {
-            getGlyphsPromise = getGlyphs(actor, stacks, this.source, this.tileID);
+            const abortController = new AbortController();
+            this.inFlightDependencies.push(abortController);
+            getGlyphsPromise = getGlyphs(actor, stacks, this.source, this.tileID, abortController.signal);
         }
 
         const icons = Object.keys(options.iconDependencies);

--- a/src/source/worker_tile.ts
+++ b/src/source/worker_tile.ts
@@ -24,6 +24,84 @@ import type {PromoteIdSpecification} from '@maplibre/maplibre-gl-style-spec';
 import type {VectorTileLike} from '@maplibre/vt-pbf';
 import {type GetDashesResponse, MessageType, type GetGlyphsResponse, type GetImagesResponse} from '../util/actor_messages.ts';
 import type {SubdivisionGranularitySetting} from '../render/subdivision_granularity_settings.ts';
+import type {StyleGlyph} from '../style/style_glyph.ts';
+
+type GlyphPromise = Promise<StyleGlyph | undefined>;
+type GlyphPromiseCache = Map<string, Map<number, GlyphPromise>>;
+
+const glyphPromiseCaches = new WeakMap<IActor, GlyphPromiseCache>();
+
+function getGlyphs(actor: IActor, stacks: {[stack: string]: number[]}, source: string, tileID: OverscaledTileID): Promise<GetGlyphsResponse> {
+    let cache = glyphPromiseCaches.get(actor);
+    if (!cache) {
+        cache = new Map();
+        glyphPromiseCaches.set(actor, cache);
+    }
+
+    const missing: {[stack: string]: number[]} = {};
+    const deferred: Array<{
+        stack: string;
+        id: number;
+        key: string;
+        promise: GlyphPromise;
+        resolve: (glyph: StyleGlyph | undefined) => void;
+        reject: (error: unknown) => void;
+    }> = [];
+    const requested: Array<{stack: string; id: number; promise: GlyphPromise}> = [];
+
+    for (const stack in stacks) {
+        const key = `${source}\0${stack}`;
+        let stackCache = cache.get(key);
+        if (!stackCache) {
+            stackCache = new Map();
+            cache.set(key, stackCache);
+        }
+        for (const id of stacks[stack]) {
+            let promise = stackCache.get(id);
+            if (!promise) {
+                let resolve!: (glyph: StyleGlyph | undefined) => void;
+                let reject!: (error: unknown) => void;
+                promise = new Promise<StyleGlyph | undefined>((res, rej) => {
+                    resolve = res;
+                    reject = rej;
+                });
+                stackCache.set(id, promise);
+                (missing[stack] ||= []).push(id);
+                deferred.push({stack, id, key, promise, resolve, reject});
+            }
+            requested.push({stack, id, promise});
+        }
+    }
+
+    if (deferred.length) {
+        // Glyphs are shared by concurrently parsed tiles, so this request must
+        // outlive cancellation of any individual tile.
+        actor.sendAsync({type: MessageType.getGlyphs, data: {stacks: missing, source, tileID, type: 'glyphs'}})
+            .then((response) => {
+                for (const entry of deferred) entry.resolve(response[entry.stack]?.[entry.id]);
+            }, (error: unknown) => {
+                for (const entry of deferred) entry.reject(error);
+            })
+            .finally(() => {
+                for (const entry of deferred) {
+                    const stackCache = cache.get(entry.key);
+                    if (stackCache?.get(entry.id) === entry.promise) stackCache.delete(entry.id);
+                    if (stackCache?.size === 0) cache.delete(entry.key);
+                }
+            });
+    }
+
+    return Promise.all(requested.map(async ({stack, id, promise}) => ({stack, id, glyph: await promise})))
+        .then((glyphs) => {
+            const result: GetGlyphsResponse = {};
+            for (const {stack, id, glyph} of glyphs) {
+                if (!glyph) continue;
+                (result[stack] ||= {})[id] = glyph;
+            }
+            return result;
+        });
+}
+
 export class WorkerTile {
     tileID: OverscaledTileID;
     uid: string | number;
@@ -136,9 +214,7 @@ export class WorkerTile {
 
         let getGlyphsPromise = Promise.resolve<GetGlyphsResponse>({});
         if (Object.keys(stacks).length) {
-            const abortController = new AbortController();
-            this.inFlightDependencies.push(abortController);
-            getGlyphsPromise = actor.sendAsync({type: MessageType.getGlyphs, data: {stacks, source: this.source, tileID: this.tileID, type: 'glyphs'}}, abortController);
+            getGlyphsPromise = getGlyphs(actor, stacks, this.source, this.tileID);
         }
 
         const icons = Object.keys(options.iconDependencies);

--- a/test/build/bundle_size.json
+++ b/test/build/bundle_size.json
@@ -4,8 +4,8 @@
         "gzip": 142498
     },
     "dist/maplibre-gl-worker.mjs": {
-        "raw": 18592,
-        "gzip": 5865
+        "raw": 19315,
+        "gzip": 6206
     },
     "dist/maplibre-gl-shared.mjs": {
         "raw": 482364,


### PR DESCRIPTION
## Motivation

`GlyphManager` already deduplicates glyph range downloads on the main thread. However, when several vector tiles are parsed concurrently, each tile still sends its own `getGlyphs` actor request. This clones and transfers the same glyph bitmaps to the worker repeatedly while the first request is still in flight.

## Changes

- Share in-flight glyph promises per actor, source, font stack, and codepoint.
- Request only glyphs that are not already part of another in-flight request.
- Remove all temporary cache entries after the request settles; this is not a persistent glyph cache.
- Keep icon, pattern, and dash requests tile-specific and cancellable.
- Let a shared glyph request outlive cancellation of one tile, since other tile parses may still depend on it.
- Add a regression assertion showing that three concurrent parses issue one glyph request instead of three.
- Add a changelog entry.

## Expected impact

This reduces duplicate structured-clone/transfer work and temporary bitmap allocation during bursts of symbol-heavy tile preparation. Rendering, glyph selection, collision handling, and the existing main-thread glyph cache are unchanged.

## Validation

- `npx vitest run --config vitest.config.unit.ts src/source/worker_tile.test.ts` — 11 tests passed
- `npm run typecheck` — passed
- `npx eslint src/source/worker_tile.ts src/source/worker_tile.test.ts` — passed

## Launch checklist

- [x] This change is original work and does not contain a backport from Mapbox projects.
- [x] Added regression coverage.
- [x] No public API changes.
- [x] Added a `CHANGELOG.md` entry.
- [ ] Human contributor has reviewed all AI-assisted code and read the MapLibre AI policy before marking this PR ready.

## AI assistance disclosure

This draft was prepared with substantial assistance from OpenAI Codex (GPT-5.6). Codex helped analyze the glyph request path, implement the in-flight promise sharing, adapt the unit test, run validation, and draft this description. The PR intentionally remains a draft pending human review.