### PR TITLE
fix: declare the loop variables in the HTML clusters example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,6 @@
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes
-- Fix the "Display HTML clusters with custom properties" example, where two loop variables were used without being declared and threw a `ReferenceError` in the module's strict mode, so no cluster marker was ever drawn ([#8193](https://github.com/maplibre/maplibre-gl-js/issues/8193)) (by [@lazerg](https://github.com/lazerg))
 - _...Add new stuff here..._
 
 ## 6.4.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes
+- Fix the "Display HTML clusters with custom properties" example, where two loop variables were used without being declared and threw a `ReferenceError` in the module's strict mode, so no cluster marker was ever drawn ([#8193](https://github.com/maplibre/maplibre-gl-js/issues/8193)) (by [@lazerg](https://github.com/lazerg))
 - _...Add new stuff here..._
 
 ## 6.4.1

--- a/test/examples/display-html-clusters-with-custom-properties.html
+++ b/test/examples/display-html-clusters-with-custom-properties.html
@@ -131,7 +131,7 @@
                 if (!markersOnScreen[id]) marker.addTo(map);
             }
             // for every marker we've added previously, remove those that are no longer visible
-            for (id in markersOnScreen) {
+            for (const id in markersOnScreen) {
                 if (!newMarkers[id]) markersOnScreen[id].remove();
             }
             markersOnScreen = newMarkers;
@@ -181,7 +181,7 @@
                 fontSize
             }px sans-serif; display: block">`;
 
-        for (i = 0; i < counts.length; i++) {
+        for (let i = 0; i < counts.length; i++) {
             html += donutSegment(
                 offsets[i] / total,
                 (offsets[i] + counts[i]) / total,


### PR DESCRIPTION
The "Display HTML clusters with custom properties" example never draws its donut markers. Two loop variables are assigned without ever being declared, and the example runs as a module, so strict mode turns both into errors: `createDonutChart` throws `ReferenceError: i is not defined` on the first cluster it builds, and the `for...in` over `markersOnScreen` would throw on the next map move once markers exist. Declaring both brings the example back: the clusters render on load and keep updating while panning.

Fixes #8193

## Launch Checklist

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] If you changed code in a file that has a benchmark file next to it (`*.bench.ts`), post before/after results of `npm run bench` (the compare workflow is in `test/bench/README.md`).
 - [x] Add an entry to `CHANGELOG.md` under the `## main` section.
 - [x] Confirm you have read our AI policy [here](https://github.com/maplibre/maplibre/blob/main/AI_POLICY.md).
