### PR TITLE
feat: add rasterPixelAlignment map option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## main
 ### ✨ Features and improvements
-- Add a `rasterPixelAlignment` map option to stop raster, hillshade and color-relief layers from snapping to the pixel grid, which prevents them from shifting relative to vector layers and markers when the camera starts or stops moving ([#PR](https://github.com/maplibre/maplibre-gl-js/pull/PR)) (by [@burmatov-step](https://github.com/burmatov-step))
+- Add a `rasterPixelAlignment` map option to stop raster, hillshade and color-relief layers from snapping to the pixel grid, which prevents them from shifting relative to vector layers and markers when the camera starts or stops moving ([#8206](https://github.com/maplibre/maplibre-gl-js/pull/8206)) (by [@burmatov-step](https://github.com/burmatov-step))
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## main
 ### ✨ Features and improvements
+- Add a `rasterPixelAlignment` map option to stop raster, hillshade and color-relief layers from snapping to the pixel grid, which prevents them from shifting relative to vector layers and markers when the camera starts or stops moving ([#PR](https://github.com/maplibre/maplibre-gl-js/pull/PR)) (by [@burmatov-step](https://github.com/burmatov-step))
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes

--- a/src/render/painter.test.ts
+++ b/src/render/painter.test.ts
@@ -15,6 +15,7 @@ describe('render', () => {
     const renderOptions = {
         fadeDuration: 0,
         moving: false,
+        rasterPixelAlignment: true,
         rotating: false,
         showOverdrawInspector: false,
         showPadding: false,
@@ -203,5 +204,25 @@ describe('RTT pool', () => {
         const destroyed = objs.filter(o => o.texture.destroy.mock.calls.length > 0).length;
         expect(destroyed).toBe(10);
         expect(painter._rttSharedFbo).toBeNull();
+    });
+});
+
+describe('shouldAlignRasterToPixelGrid', () => {
+    function createPainter(options: {moving: boolean; rasterPixelAlignment: boolean}): Painter {
+        const gl = createNullGL();
+        const transform = new MercatorTransform({minZoom: 0, maxZoom: 22, minPitch: 0, maxPitch: 60, renderWorldCopies: true});
+        const painter = new Painter(gl, transform);
+        painter.options = {...options} as any;
+        return painter;
+    }
+
+    test('allows the aligned matrix only while the camera is idle', () => {
+        expect(createPainter({moving: false, rasterPixelAlignment: true}).shouldAlignRasterToPixelGrid()).toBe(true);
+        expect(createPainter({moving: true, rasterPixelAlignment: true}).shouldAlignRasterToPixelGrid()).toBe(false);
+    });
+
+    test('never allows the aligned matrix when rasterPixelAlignment is disabled', () => {
+        expect(createPainter({moving: false, rasterPixelAlignment: false}).shouldAlignRasterToPixelGrid()).toBe(false);
+        expect(createPainter({moving: true, rasterPixelAlignment: false}).shouldAlignRasterToPixelGrid()).toBe(false);
     });
 });

--- a/src/render/painter.ts
+++ b/src/render/painter.ts
@@ -61,6 +61,7 @@ type PainterOptions = {
     rotating: boolean;
     zooming: boolean;
     moving: boolean;
+    rasterPixelAlignment: boolean;
     fadeDuration: number;
     anisotropicFilterPitch: number;
 };
@@ -491,6 +492,10 @@ export class Painter {
         } else {
             return ColorMode.alphaBlended;
         }
+    }
+
+    shouldAlignRasterToPixelGrid(): boolean {
+        return this.options.rasterPixelAlignment && !this.options.moving;
     }
 
     getDepthModeForSublayer(n: number, mask: DepthMaskType, func?: DepthFuncType | null): Readonly<DepthMode> {

--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -313,6 +313,13 @@ export type MapOptions = {
      */
     crossSourceCollisions?: boolean;
     /**
+     * If `true`, raster, hillshade and color-relief layers are snapped to the device pixel grid while the camera is idle, which keeps raster tiles crisp at rest.
+     * Because the snapping is disabled while the camera moves, it makes those layers shift by up to half a pixel relative to vector layers and markers
+     * whenever the camera starts or stops moving. Set to `false` to never snap them, trading a little crispness at rest for layers that stay in sync at all times.
+     * @defaultValue true
+     */
+    rasterPixelAlignment?: boolean;
+    /**
      * If `true`, Resource Timing API information will be collected for requests made by GeoJSON and Vector Tile web workers (this information is normally inaccessible from the main Javascript thread). Information will be returned in a `resourceTiming` property of relevant `data` events.
      * @defaultValue false
      */
@@ -539,6 +546,7 @@ const defaultOptions: Readonly<Partial<MapOptions>> = {
     transformConstrain: null,
     fadeDuration: 300,
     crossSourceCollisions: true,
+    rasterPixelAlignment: true,
     clickTolerance: 3,
     localIdeographFontFamily: 'sans-serif',
     pitchWithRotate: true,
@@ -625,6 +633,7 @@ export class Map extends Evented<MapEventType> {
     _delegatedListeners: Record<keyof MapEventType, DelegatedListener[]>;
     _fadeDuration: number;
     _crossSourceCollisions: boolean;
+    _rasterPixelAlignment: boolean;
     _crossFadingFactor = 1;
     _collectResourceTiming: boolean;
     _renderTaskQueue: TaskQueue = new TaskQueue();
@@ -782,6 +791,7 @@ export class Map extends Evented<MapEventType> {
         this._refreshExpiredTiles = resolvedOptions.refreshExpiredTiles === true;
         this._fadeDuration = resolvedOptions.fadeDuration;
         this._crossSourceCollisions = resolvedOptions.crossSourceCollisions === true;
+        this._rasterPixelAlignment = resolvedOptions.rasterPixelAlignment === true;
         this._collectResourceTiming = resolvedOptions.collectResourceTiming === true;
         this._locale = {...defaultLocale, ...resolvedOptions.locale};
         this._clickTolerance = resolvedOptions.clickTolerance;
@@ -4315,6 +4325,7 @@ export class Map extends Evented<MapEventType> {
             rotating: this.isRotating(),
             zooming: this.isZooming(),
             moving: this.isMoving(),
+            rasterPixelAlignment: this._rasterPixelAlignment,
             fadeDuration,
             showPadding: this.showPadding,
             anisotropicFilterPitch: this.getAnisotropicFilterPitch(),

--- a/src/ui/map_tests/map_options.test.ts
+++ b/src/ui/map_tests/map_options.test.ts
@@ -58,4 +58,18 @@ describe('mapOptions', () => {
         map.zoomTo(0.5, {duration: 100});
         spy.mockRestore();
     });
+    test('rasterPixelAlignment: defaults to true and is forwarded to the painter', async () => {
+        const map = createMap();
+        await map.once('load');
+        expect(map._rasterPixelAlignment).toBe(true);
+        expect(map.painter.options.rasterPixelAlignment).toBe(true);
+    });
+
+    test('rasterPixelAlignment: can be disabled via map options', async () => {
+        const map = createMap({rasterPixelAlignment: false});
+        await map.once('load');
+        expect(map._rasterPixelAlignment).toBe(false);
+        expect(map.painter.options.rasterPixelAlignment).toBe(false);
+    });
+
 });

--- a/src/webgl/draw/draw_color_relief.ts
+++ b/src/webgl/draw/draw_color_relief.ts
@@ -54,7 +54,7 @@ function renderColorRelief(
     const transform = painter.transform;
     const gl = context.gl;
     const program = painter.useProgram('colorRelief');
-    const align = !painter.options.moving;
+    const align = painter.shouldAlignRasterToPixelGrid();
 
     const textureFilter = layer.paint.get('resampling') === 'nearest' ?  gl.NEAREST : gl.LINEAR;
 

--- a/src/webgl/draw/draw_custom.test.ts
+++ b/src/webgl/draw/draw_custom.test.ts
@@ -10,6 +10,7 @@ import {MercatorTransform} from '../../geo/projection/mercator_transform.ts';
 import {MercatorProjection} from '../../geo/projection/mercator_projection.ts';
 import {type CustomRenderMethodInput} from '../../style/style_layer/custom_style_layer.ts';
 import {expectToBeCloseToArray} from '../../util/test/util.ts';
+import {LngLat} from '../../geo/lng_lat.ts';
 
 vi.mock(import('../../render/painter'));
 vi.mock(import('../program'));
@@ -34,6 +35,7 @@ describe('drawCustom', () => {
             projection: new MercatorProjection(),
         } as any;
         mockPainter.renderPass = 'translucent';
+        mockPainter.options = {rasterPixelAlignment: true} as any;
         mockPainter.transform = transform;
         mockPainter.context = {
             gl: {},
@@ -105,5 +107,52 @@ describe('drawCustom', () => {
         expect(tileProjectionData.mainMatrix[15]).toBeCloseTo(794.4539184570312, 6);
         expect(tileProjectionData.projectionTransition).toBe(0);
         expect(tileProjectionData.mainMatrix).toEqual(tileProjectionData.fallbackMatrix);
+    });
+    test('rasterPixelAlignment: false makes a custom layer asking for an aligned matrix get the unaligned one', () => {
+        const transform = new MercatorTransform({minZoom: 0, maxZoom: 22, minPitch: 0, maxPitch: 60, renderWorldCopies: true});
+        transform.resize(500, 500);
+        transform.setZoom(4);
+        transform.setCenter(new LngLat(0.0001234, 0.0004321));
+
+        const tileID = {wrap: 0, canonical: {z: 4, x: 8, y: 8}};
+
+        function getMatrices(rasterPixelAlignment: boolean) {
+            const mockPainter = new Painter(null, null);
+            mockPainter.style = {projection: new MercatorProjection()} as any;
+            mockPainter.renderPass = 'translucent';
+            mockPainter.transform = transform;
+            mockPainter.options = {rasterPixelAlignment} as any;
+            mockPainter.context = {
+                gl: {},
+                setColorMode: () => {},
+                setStencilMode: () => {},
+                setDepthMode: () => {},
+                setDirty: () => {},
+                bindFramebuffer: {set: () => {}}
+            } as any;
+
+            let input: CustomRenderMethodInput;
+            const layer = new CustomStyleLayer({
+                id: 'custom-layer',
+                type: 'custom',
+                render(_gl, args) {
+                    input = args;
+                },
+            }, {});
+            const tileManagerMock = new TileManager(null, null, null);
+            tileManagerMock.map = {showCollisionBoxes: false} as any as Map;
+            drawCustom(mockPainter, tileManagerMock, layer, {isRenderingToTexture: false, isRenderingGlobe: false});
+
+            return {
+                aligned: Array.from(input.getProjectionData({tileID, aligned: true}).mainMatrix),
+                unaligned: Array.from(input.getProjectionData({tileID, aligned: false}).mainMatrix),
+            };
+        }
+
+        const enabled = getMatrices(true);
+        expect(enabled.aligned).not.toEqual(enabled.unaligned);
+
+        const disabled = getMatrices(false);
+        expect(disabled.aligned).toEqual(disabled.unaligned);
     });
 });

--- a/src/webgl/draw/draw_custom.ts
+++ b/src/webgl/draw/draw_custom.ts
@@ -37,7 +37,11 @@ export function drawCustom(painter: Painter, tileManager: TileManager, layer: Cu
                     params.tileID.canonical.x,
                     params.tileID.canonical.y,
                 ),
-                aligned: params.aligned,
+                // Custom layers are not gated on `painter.options.moving` the way the raster paths are:
+                // a layer that asks for the aligned matrix keeps getting it while the camera moves, as before.
+                // The `rasterPixelAlignment` map option still turns it off, so a custom layer cannot end up
+                // aligned while the raster layers around it are not.
+                aligned: params.aligned && painter.options.rasterPixelAlignment,
                 applyGlobeMatrix: params.applyGlobeMatrix,
                 applyTerrainMatrix: params.applyTerrainMatrix,
             });

--- a/src/webgl/draw/draw_hillshade.ts
+++ b/src/webgl/draw/draw_hillshade.ts
@@ -62,7 +62,7 @@ function renderHillshade(
 
     const defines = [`#define NUM_ILLUMINATION_SOURCES ${layer.paint.get('hillshade-highlight-color').values.length}`];
     const program = painter.useProgram('hillshade', null, false, defines);
-    const align = !painter.options.moving;
+    const align = painter.shouldAlignRasterToPixelGrid();
 
     for (const coord of coords) {
         const tile = tileManager.getTile(coord);

--- a/src/webgl/draw/draw_raster.test.ts
+++ b/src/webgl/draw/draw_raster.test.ts
@@ -1,0 +1,116 @@
+import {describe, test, expect, vi} from 'vitest';
+import {Painter} from '../../render/painter.ts';
+import {MercatorTransform} from '../../geo/projection/mercator_transform.ts';
+import {MercatorProjection} from '../../geo/projection/mercator_projection.ts';
+import {createNullGL} from '../../util/test/null_gl.ts';
+import {OverscaledTileID} from '../../tile/tile_id.ts';
+import {LngLat} from '../../geo/lng_lat.ts';
+import {drawRaster} from './draw_raster.ts';
+import type {RasterStyleLayer} from '../../style/style_layer/raster_style_layer.ts';
+import type {TileManager} from '../../tile/tile_manager.ts';
+
+const paintValues = {
+    'raster-opacity': 1,
+    'raster-fade-duration': 0,
+    'raster-brightness-min': 0,
+    'raster-brightness-max': 1,
+    'raster-saturation': 0,
+    'raster-contrast': 0,
+    'raster-hue-rotate': 0,
+    'raster-resampling': 'linear',
+    'resampling': 'linear',
+};
+
+function createSetup(options: {moving: boolean; rasterPixelAlignment: boolean}) {
+    const gl = createNullGL();
+    const transform = new MercatorTransform({minZoom: 0, maxZoom: 22, minPitch: 0, maxPitch: 60, renderWorldCopies: true});
+    transform.resize(512, 512);
+    // Put the camera on a fractional pixel so that the aligned and the unaligned matrix actually differ.
+    transform.setCenter(new LngLat(0.0001234, 0.0004321));
+    transform.setZoom(4);
+
+    const painter = new Painter(gl, transform);
+    painter.renderPass = 'translucent';
+    painter.options = {
+        showOverdrawInspector: false,
+        showTileBoundaries: false,
+        showPadding: false,
+        rotating: false,
+        zooming: false,
+        moving: options.moving,
+        rasterPixelAlignment: options.rasterPixelAlignment,
+        fadeDuration: 0,
+        anisotropicFilterPitch: 20,
+    };
+    painter.style = {
+        projection: new MercatorProjection(),
+        map: {terrain: null},
+    } as any;
+    vi.spyOn(painter, 'useProgram').mockReturnValue({draw: vi.fn()} as any);
+
+    const tileID = new OverscaledTileID(4, 0, 4, 8, 8);
+    const tile = {
+        tileID,
+        texture: {bind: () => {}, useMipmap: false},
+    };
+    const tileManager = {
+        getSource: () => ({}),
+        getTile: () => tile,
+        getLoadedTile: () => null,
+    } as any as TileManager;
+
+    const layer = {
+        id: 'raster',
+        paint: {get: (name: string) => paintValues[name]},
+    } as any as RasterStyleLayer;
+
+    const getProjectionData = vi.spyOn(transform, 'getProjectionData');
+
+    return {painter, tileManager, layer, tileID, getProjectionData};
+}
+
+function drawAndGetAlignedFlags(options: {moving: boolean; rasterPixelAlignment: boolean}): boolean[] {
+    const {painter, tileManager, layer, tileID, getProjectionData} = createSetup(options);
+    drawRaster(painter, tileManager, layer, [tileID], {isRenderingToTexture: false, isRenderingGlobe: false});
+    expect(getProjectionData).toHaveBeenCalled();
+    return getProjectionData.mock.calls.map(call => !!call[0].aligned);
+}
+
+describe('drawRaster pixel alignment', () => {
+    test('requests the pixel-aligned matrix while the camera is idle', () => {
+        expect(drawAndGetAlignedFlags({moving: false, rasterPixelAlignment: true})).not.toContain(false);
+    });
+
+    test('requests the unaligned matrix while the camera is moving', () => {
+        expect(drawAndGetAlignedFlags({moving: true, rasterPixelAlignment: true})).not.toContain(true);
+    });
+
+    test('never requests the pixel-aligned matrix when rasterPixelAlignment is disabled', () => {
+        expect(drawAndGetAlignedFlags({moving: false, rasterPixelAlignment: false})).not.toContain(true);
+        expect(drawAndGetAlignedFlags({moving: true, rasterPixelAlignment: false})).not.toContain(true);
+    });
+
+    test('with rasterPixelAlignment disabled the matrix does not change when the camera starts moving', () => {
+        const idle = createSetup({moving: false, rasterPixelAlignment: false});
+        drawRaster(idle.painter, idle.tileManager, idle.layer, [idle.tileID], {isRenderingToTexture: false, isRenderingGlobe: false});
+        const idleMatrix = Array.from(idle.getProjectionData.mock.results[0].value.mainMatrix);
+
+        const moving = createSetup({moving: true, rasterPixelAlignment: false});
+        drawRaster(moving.painter, moving.tileManager, moving.layer, [moving.tileID], {isRenderingToTexture: false, isRenderingGlobe: false});
+        const movingMatrix = Array.from(moving.getProjectionData.mock.results[0].value.mainMatrix);
+
+        expect(idleMatrix).toEqual(movingMatrix);
+    });
+
+    test('with rasterPixelAlignment enabled the matrix jumps when the camera starts moving', () => {
+        const idle = createSetup({moving: false, rasterPixelAlignment: true});
+        drawRaster(idle.painter, idle.tileManager, idle.layer, [idle.tileID], {isRenderingToTexture: false, isRenderingGlobe: false});
+        const idleMatrix = Array.from(idle.getProjectionData.mock.results[0].value.mainMatrix);
+
+        const moving = createSetup({moving: true, rasterPixelAlignment: true});
+        drawRaster(moving.painter, moving.tileManager, moving.layer, [moving.tileID], {isRenderingToTexture: false, isRenderingGlobe: false});
+        const movingMatrix = Array.from(moving.getProjectionData.mock.results[0].value.mainMatrix);
+
+        expect(idleMatrix).not.toEqual(movingMatrix);
+    });
+});

--- a/src/webgl/draw/draw_raster.ts
+++ b/src/webgl/draw/draw_raster.ts
@@ -100,7 +100,7 @@ function drawTiles(
     const projection = painter.style.projection;
 
     const colorMode = painter.colorModeForRenderPass();
-    const align = !painter.options.moving;
+    const align = painter.shouldAlignRasterToPixelGrid();
     const rasterOpacity = layer.paint.get('raster-opacity');
     const useNearest = layer.paint.get('resampling') === 'nearest' || layer.paint.get('raster-resampling') === 'nearest';
     const textureFilter = useNearest ?  gl.NEAREST : gl.LINEAR;


### PR DESCRIPTION


https://github.com/user-attachments/assets/8568da7d-c4c5-4a4d-9d1c-8163f93532a1

**What I ran into.** In my own projects I use raster tiles as the basemap, with markers and vector layers (lines) on top. Every time the camera stops moving — end of a pan, end of a `flyTo`, end of drag inertia — the basemap and the overlays jump relative to each other by a fraction of a pixel. What you see is the markers and the lines twitching against the map. Short slow drags show it best; inertia makes it happen twice per gesture.

**Why it happens.** Raster layers are drawn with a pixel-grid-aligned projection matrix, but only while the map is idle. Every other layer type always uses the unaligned one.

**What this PR does.** Adds a `rasterPixelAlignment` map option, default `true`, which is exactly today's behavior. Set it to `false` and raster, hillshade and color-relief layers never snap to the pixel grid, so nothing shifts relative to anything else.

- [x] No backports from Mapbox projects — this is original code; mapbox-gl-js#7426 is referenced only through this repo's CHANGELOG.
- [x] Read the AI policy. Disclosure: I used Claude Opus 5 (`claude-opus-5[1m]`) via Claude Code to find the code path and draft the tests. I verified all of it and ran the unit, build and render suites locally.
