### PR TITLE
Upload the color-relief DEM texture once per tile instead of every frame

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### 🐞 Bug fixes
 - Fix labels briefly appearing too large when zooming out several levels at once (e.g. a scroll-wheel or pinch fling) with a zoom-dependent `text-size`/`icon-size` ([#8175](https://github.com/maplibre/maplibre-gl-js/pull/8175)) (by [@mondsichtung](https://github.com/mondsichtung))
 - Fix globe tile selection measuring distances from the ground point below the camera instead of the camera itself, refining some views past the requested zoom and leaving others coarser ([#8187](https://github.com/maplibre/maplibre-gl-js/pull/8187)) (by [@Alchez](https://github.com/Alchez))
+- Upload the `color-relief` DEM texture once per tile instead of on every frame ([#8209](https://github.com/maplibre/maplibre-gl-js/pull/8209))
 - _...Add new stuff here..._
 
 ## 6.5.0

--- a/src/source/raster_dem_tile_source.ts
+++ b/src/source/raster_dem_tile_source.ts
@@ -93,6 +93,7 @@ export class RasterDEMTileSource extends RasterTileSource implements Source {
                 tile.dem = await tile.actor.sendAsync({type: MessageType.loadDEMTile, data: params});
                 tile.needsHillshadePrepare = true;
                 tile.needsTerrainPrepare = true;
+                tile.needsColorReliefPrepare = true;
                 tile.state = 'loaded';
             }
         } catch (err) {

--- a/src/tile/tile.ts
+++ b/src/tile/tile.ts
@@ -104,6 +104,7 @@ export class Tile {
     aborted: boolean;
     needsHillshadePrepare: boolean;
     needsTerrainPrepare: boolean;
+    needsColorReliefPrepare: boolean;
     abortController: AbortController;
     texture: any;
     fbo: Framebuffer;

--- a/src/tile/tile_manager_raster_dem.ts
+++ b/src/tile/tile_manager_raster_dem.ts
@@ -24,6 +24,7 @@ export function backfillDEM(tile: Tile, inViewTiles: InViewTiles): void {
 function fillBorder(tile: Tile, borderTile: Tile) {
     tile.needsHillshadePrepare = true;
     tile.needsTerrainPrepare = true;
+    tile.needsColorReliefPrepare = true;
     let dx = borderTile.tileID.canonical.x - tile.tileID.canonical.x;
     const dy = borderTile.tileID.canonical.y - tile.tileID.canonical.y;
     const dim = Math.pow(2, tile.tileID.canonical.z);

--- a/src/webgl/draw/draw_color_relief.ts
+++ b/src/webgl/draw/draw_color_relief.ts
@@ -83,19 +83,16 @@ function renderColorRelief(
 
         const textureStride = dem.stride;
 
-        const pixelData = dem.getPixels();
         context.activeTexture.set(gl.TEXTURE0);
 
-        context.pixelStoreUnpackPremultiplyAlpha.set(false);
-        tile.demTexture ||= painter.getTileTexture(textureStride);
-        if (tile.demTexture) {
-            const demTexture = tile.demTexture;
-            demTexture.update(pixelData, {premultiply: false});
-            demTexture.bind(textureFilter, gl.CLAMP_TO_EDGE);
-        } else {
-            tile.demTexture = new Texture(context, pixelData, gl.RGBA, {premultiply: false});
-            tile.demTexture.bind(textureFilter, gl.CLAMP_TO_EDGE);
+        if (!tile.demTexture || tile.needsColorReliefPrepare) {
+            context.pixelStoreUnpackPremultiplyAlpha.set(false);
+            tile.demTexture ||= painter.getTileTexture(textureStride) ??
+                new Texture(context, {width: textureStride, height: textureStride, data: null}, gl.RGBA);
+            tile.demTexture.update(dem.getPixels(), {premultiply: false});
+            tile.needsColorReliefPrepare = false;
         }
+        tile.demTexture.bind(textureFilter, gl.CLAMP_TO_EDGE);
 
         const mesh = projection.getMeshFromTileID(context, coord.canonical, useBorder, true, 'raster');
 


### PR DESCRIPTION
Guards against a full RGBA re-upload of pixels that never change between a tile's reload.
Fixes low FPS for the color relief rendering on bandwidth-poor devices and Safari, especially in combination with terrain and hillshading enabled.

The upload now sits behind a `needsColorReliefPrepare` flag on the tile, similar to the existing `needsHillshadePrepare` for hillshading and `needsTerrainPrepare` for terrain.

No new tests to keep it as close as possible to the hillshading and terrain implementations.

Assisted-By: Claude Fable 5