### PR TITLE
fix: use tansform's _unmodified to make the map respect the style parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### 🐞 Bug fixes
 - Fix labels briefly appearing too large when zooming out several levels at once (e.g. a scroll-wheel or pinch fling) with a zoom-dependent `text-size`/`icon-size` ([#8175](https://github.com/maplibre/maplibre-gl-js/pull/8175)) (by [@mondsichtung](https://github.com/mondsichtung))
 - Fix globe tile selection measuring distances from the ground point below the camera instead of the camera itself, refining some views past the requested zoom and leaving others coarser ([#8187](https://github.com/maplibre/maplibre-gl-js/pull/8187)) (by [@Alchez](https://github.com/Alchez))
+- Fix the style's `center`, `zoom`, `bearing`, `pitch` and `roll` being ignored when the map was created with a `minZoom` or `minPitch` option, since applying those limits marked the transform as modified ([#5932](https://github.com/maplibre/maplibre-gl-js/issues/5932))
 - _...Add new stuff here..._
 
 ## 6.5.0

--- a/src/geo/transform_helper.ts
+++ b/src/geo/transform_helper.ts
@@ -139,14 +139,8 @@ export class TransformHelper implements ITransformGetters {
     _pixelPerMeter: number;
     _edgeInsets: EdgeInsets;
     /**
-     * Whether the camera is still where it was initialized and has never been placed somewhere on purpose.
-     * It starts out `true` and is cleared by every setter that moves the camera (center, zoom, bearing,
-     * pitch, roll, fov, padding), whether the move came from the API, a hash or a user gesture.
-     * The map reads it once, when a style finishes loading: only an unmodified transform adopts the
-     * style's `center`, `zoom`, `bearing`, `pitch` and `roll`, so that an explicitly positioned camera
-     * is not thrown away by the style. Updates that merely snap the camera back into a valid range -
-     * constraining, and applying a new min/max zoom or pitch - deliberately preserve the flag, since
-     * they are not the user asking for a particular camera position.
+     * Whether the camera was never deliberately positioned, in which case a loading style may apply its own camera.
+     * Cleared by the setters that move the camera, but not by ones that only snap it into a valid range.
      */
     _unmodified: boolean;
 

--- a/src/geo/transform_helper.ts
+++ b/src/geo/transform_helper.ts
@@ -138,6 +138,16 @@ export class TransformHelper implements ITransformGetters {
     _minElevationForCurrentTile: number;
     _pixelPerMeter: number;
     _edgeInsets: EdgeInsets;
+    /**
+     * Whether the camera is still where it was initialized and has never been placed somewhere on purpose.
+     * It starts out `true` and is cleared by every setter that moves the camera (center, zoom, bearing,
+     * pitch, roll, fov, padding), whether the move came from the API, a hash or a user gesture.
+     * The map reads it once, when a style finishes loading: only an unmodified transform adopts the
+     * style's `center`, `zoom`, `bearing`, `pitch` and `roll`, so that an explicitly positioned camera
+     * is not thrown away by the style. Updates that merely snap the camera back into a valid range -
+     * constraining, and applying a new min/max zoom or pitch - deliberately preserve the flag, since
+     * they are not the user asking for a particular camera position.
+     */
     _unmodified: boolean;
 
     _constraining: boolean;
@@ -254,28 +264,36 @@ export class TransformHelper implements ITransformGetters {
     setMinZoom(zoom: number): void {
         if (this._minZoom === zoom) return;
         this._minZoom = zoom;
+        const unmodified = this._unmodified;
         this.setZoom(this.applyConstrain(this._center, this.zoom).zoom);
+        this._unmodified = unmodified;
     }
 
     get maxZoom(): number { return this._maxZoom; }
     setMaxZoom(zoom: number): void {
         if (this._maxZoom === zoom) return;
         this._maxZoom = zoom;
+        const unmodified = this._unmodified;
         this.setZoom(this.applyConstrain(this._center, this.zoom).zoom);
+        this._unmodified = unmodified;
     }
 
     get minPitch(): number { return this._minPitch; }
     setMinPitch(pitch: number): void {
         if (this._minPitch === pitch) return;
         this._minPitch = pitch;
+        const unmodified = this._unmodified;
         this.setPitch(Math.max(this.pitch, pitch));
+        this._unmodified = unmodified;
     }
 
     get maxPitch(): number { return this._maxPitch; }
     setMaxPitch(pitch: number): void {
         if (this._maxPitch === pitch) return;
         this._maxPitch = pitch;
+        const unmodified = this._unmodified;
         this.setPitch(Math.min(this.pitch, pitch));
+        this._unmodified = unmodified;
     }
 
     get renderWorldCopies(): boolean { return this._renderWorldCopies; }

--- a/src/ui/map_tests/map_pitch.test.ts
+++ b/src/ui/map_tests/map_pitch.test.ts
@@ -13,6 +13,18 @@ test('setMinPitch', () => {
     expect(map.getPitch()).toBe(10);
 });
 
+test('setMinPitch raises the current pitch when it is below the new minimum', () => {
+    const map = createMap({pitch: 5});
+    map.setMinPitch(20);
+    expect(map.getPitch()).toBe(20);
+});
+
+test('setMaxPitch lowers the current pitch when it is above the new maximum', () => {
+    const map = createMap({pitch: 40});
+    map.setMaxPitch(20);
+    expect(map.getPitch()).toBe(20);
+});
+
 test('unset minPitch', () => {
     const map = createMap({minPitch: 20});
     map.setMinPitch(null);

--- a/src/ui/map_tests/map_style.test.ts
+++ b/src/ui/map_tests/map_style.test.ts
@@ -1,5 +1,5 @@
 import {describe, beforeEach, afterEach, test, expect, vi} from 'vitest';
-import {Map, type MapOptions} from '../map.ts';
+import {Map} from '../map.ts';
 import {createMap, beforeMapTest, createStyle, createStyleSource, sleep} from '../../util/test/util.ts';
 import {ErrorEvent} from '../../util/evented.ts';
 import {MapSourceDataEvent, MapStyleDataEvent} from '../events.ts';
@@ -7,8 +7,8 @@ import {fixedLngLat, fixedNum} from '../../../test/unit/lib/fixed.ts';
 import {extend} from '../../util/util.ts';
 import {fakeServer, type FakeServer} from 'nise';
 import {Style} from '../../style/style.ts';
-import {type GeoJSONSourceSpecification, type LayerSpecification} from '@maplibre/maplibre-gl-style-spec';
 import {LngLatBounds} from '../../geo/lng_lat_bounds.ts';
+import type {GeoJSONSourceSpecification, LayerSpecification} from '@maplibre/maplibre-gl-style-spec';
 
 let server: FakeServer;
 
@@ -107,42 +107,66 @@ describe('setStyle', () => {
     });
 
     test('style transform overrides unmodified map transform', async () => {
-        const map = new Map({container: window.document.createElement('div')});
-        map._camera.transform.setMaxBounds(new LngLatBounds([-120, -60], [140, 80]));
-        map._camera.transform.resize(600, 400, true);
-        expect(map._camera.transform.zoom).toBe(0.6983039737971013);
-        expect(map._camera.transform.unmodified).toBeTruthy();
-        map.setStyle(createStyle());
+        const container = window.document.createElement('div');
+        Object.defineProperty(container, 'clientWidth', {value: 600});
+        Object.defineProperty(container, 'clientHeight', {value: 400});
+        const map = createMap({container, deleteStyle: true});
+        map.setMaxBounds(new LngLatBounds([-120, -60], [140, 80]));
+        expect(map.getZoom()).toBeCloseTo(0.6983039737971013, 10);
+        const style = createStyle();
+        map.setStyle(style);
         await map.once('style.load');
-        expect(fixedLngLat(map._camera.transform.center)).toEqual(fixedLngLat({lng: -73.9749, lat: 40.7736}));
-        expect(fixedNum(map._camera.transform.zoom)).toBe(12.5);
-        expect(fixedNum(map._camera.transform.bearing)).toBe(29);
-        expect(fixedNum(map._camera.transform.pitch)).toBe(50);
+        expect(fixedLngLat(map.getCenter())).toEqual({lng: style.center[0], lat: style.center[1]});
+        expect(fixedNum(map.getZoom())).toBe(style.zoom);
+        expect(fixedNum(map.getBearing())).toBe(style.bearing);
+        expect(fixedNum(map.getPitch())).toBe(style.pitch);
+    });
+
+    test('style transform overrides map transform when zoom and pitch limits are set in options', async () => {
+        const map = createMap({deleteStyle: true, minZoom: 1, minPitch: 10});
+        const style = createStyle();
+        map.setStyle(style);
+        await map.once('style.load');
+        expect(fixedLngLat(map.getCenter())).toEqual({lng: style.center[0], lat: style.center[1]});
+        expect(fixedNum(map.getZoom())).toBe(style.zoom);
+        expect(fixedNum(map.getBearing())).toBe(style.bearing);
+        expect(fixedNum(map.getPitch())).toBe(style.pitch);
+    });
+
+    test('style transform overrides map transform when a max zoom limit is set in options', async () => {
+        const map = createMap({deleteStyle: true, maxZoom: -1});
+        const style = createStyle();
+        map.setStyle(style);
+        await map.once('style.load');
+        expect(fixedNum(map.getCenter().lng)).toBe(style.center[0]);
+        expect(fixedNum(map.getBearing())).toBe(style.bearing);
+        expect(fixedNum(map.getPitch())).toBe(style.pitch);
+        // The style's zoom is clamped by the map's maxZoom, and at that zoom the constrain cannot
+        // center on the style's latitude without showing past the pole, so it pulls it back
+        expect(fixedNum(map.getZoom())).toBe(-1);
+        expect(fixedNum(map.getCenter().lat)).toBe(36.5978911823);
     });
 
     test('style transform does not override map transform modified via options', async () => {
-        const map = new Map({container: window.document.createElement('div'), zoom: 10, center: [-77.0186, 38.8888]} as any as MapOptions);
-        expect(map._camera.transform.unmodified).toBeFalsy();
+        const map = createMap({deleteStyle: true, zoom: 10, center: [-77.0186, 38.8888]});
         map.setStyle(createStyle());
         await map.once('style.load');
-        expect(fixedLngLat(map._camera.transform.center)).toEqual(fixedLngLat({lng: -77.0186, lat: 38.8888}));
-        expect(fixedNum(map._camera.transform.zoom)).toBe(10);
-        expect(fixedNum(map._camera.transform.bearing)).toBe(0);
-        expect(fixedNum(map._camera.transform.pitch)).toBe(0);
+        expect(fixedLngLat(map.getCenter())).toEqual(fixedLngLat({lng: -77.0186, lat: 38.8888}));
+        expect(fixedNum(map.getZoom())).toBe(10);
+        expect(fixedNum(map.getBearing())).toBe(0);
+        expect(fixedNum(map.getPitch())).toBe(0);
     });
 
     test('style transform does not override map transform modified via setters', async () => {
-        const map = new Map({container: window.document.createElement('div')});
-        expect(map._camera.transform.unmodified).toBeTruthy();
+        const map = createMap({deleteStyle: true});
         map.setZoom(10);
         map.setCenter([-77.0186, 38.8888]);
-        expect(map._camera.transform.unmodified).toBeFalsy();
         map.setStyle(createStyle());
-        map.once('style.load');
-        expect(fixedLngLat(map._camera.transform.center)).toEqual(fixedLngLat({lng: -77.0186, lat: 38.8888}));
-        expect(fixedNum(map._camera.transform.zoom)).toBe(10);
-        expect(fixedNum(map._camera.transform.bearing)).toBe(0);
-        expect(fixedNum(map._camera.transform.pitch)).toBe(0);
+        await map.once('style.load');
+        expect(fixedLngLat(map.getCenter())).toEqual(fixedLngLat({lng: -77.0186, lat: 38.8888}));
+        expect(fixedNum(map.getZoom())).toBe(10);
+        expect(fixedNum(map.getBearing())).toBe(0);
+        expect(fixedNum(map.getPitch())).toBe(0);
     });
 
     test('passing null removes style', () => {

--- a/src/ui/map_tests/map_style.test.ts
+++ b/src/ui/map_tests/map_style.test.ts
@@ -141,8 +141,6 @@ describe('setStyle', () => {
         expect(fixedNum(map.getCenter().lng)).toBe(style.center[0]);
         expect(fixedNum(map.getBearing())).toBe(style.bearing);
         expect(fixedNum(map.getPitch())).toBe(style.pitch);
-        // The style's zoom is clamped by the map's maxZoom, and at that zoom the constrain cannot
-        // center on the style's latitude without showing past the pole, so it pulls it back
         expect(fixedNum(map.getZoom())).toBe(-1);
         expect(fixedNum(map.getCenter().lat)).toBe(36.5978911823);
     });

--- a/src/ui/map_tests/map_style.test.ts
+++ b/src/ui/map_tests/map_style.test.ts
@@ -106,7 +106,7 @@ describe('setStyle', () => {
         spy.mockRestore();
     });
 
-    test('style transform overrides unmodified map transform', async () => {
+    test('style transform overrides unmodified map transform when max bounds are set for a large area', async () => {
         const container = window.document.createElement('div');
         Object.defineProperty(container, 'clientWidth', {value: 600});
         Object.defineProperty(container, 'clientHeight', {value: 400});

--- a/src/ui/map_tests/map_zoom.test.ts
+++ b/src/ui/map_tests/map_zoom.test.ts
@@ -14,6 +14,18 @@ test('setMinZoom', () => {
     expect(map.getZoom()).toBe(3.5);
 });
 
+test('setMinZoom raises the current zoom when it is below the new minimum', () => {
+    const map = createMap({zoom: 2});
+    map.setMinZoom(5);
+    expect(map.getZoom()).toBe(5);
+});
+
+test('setMaxZoom lowers the current zoom when it is above the new maximum', () => {
+    const map = createMap({zoom: 10});
+    map.setMaxZoom(5);
+    expect(map.getZoom()).toBe(5);
+});
+
 test('unset minZoom', () => {
     const map = createMap({minZoom: 5});
     map.setMinZoom(null);


### PR DESCRIPTION
- Fixes #5932

## Launch Checklist

This uses the `_unmodified` to tell the map it should set the zoom, center etc parameters when the map starts.
This is a regression fix from v4-v5.

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [x] Write tests for all new functionality.
 - [x] Add an entry to `CHANGELOG.md` under the `## main` section.
 - [x] Confirm you have read our AI policy [here](https://github.com/maplibre/maplibre/blob/main/AI_POLICY.md).

Assisted-By: Clause Opus 5.
