### PR TITLE
fix: sample elevation lookups from the rendered terrain surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes
-- _...Add new stuff here..._
+- Fix `project()` and `queryTerrainElevation` disagreeing with the rendered terrain surface when the elevation lookup sampled a different DEM zoom than the drawn mesh ([#8212](https://github.com/maplibre/maplibre-gl-js/issues/8212))
 
 ## 6.6.0
 

--- a/src/geo/projection/vertical_perspective_transform.ts
+++ b/src/geo/projection/vertical_perspective_transform.ts
@@ -984,7 +984,7 @@ function globeSampleAt(ray: GlobeRay, t: number): {sample: TerrainSample; radius
     const sample = sampleAt(ray.index, ray.exaggeration, mercator.x, mercator.y);
     // The globe mesh caps the poles at elevation zero, matching the GLOBE branch of get_elevation.
     const elevation = Math.abs(lngLat.lat) > MAX_VALID_LATITUDE ? 0 : sample.elevation;
-    return {sample: {covered: sample.covered, elevation}, radius, mercator};
+    return {sample: {...sample, elevation}, radius, mercator};
 }
 
 function globeIsBelowTerrain(ray: GlobeRay, t: number): boolean {

--- a/src/render/terrain.test.ts
+++ b/src/render/terrain.test.ts
@@ -299,17 +299,11 @@ describe('Terrain', () => {
         expect(terrain.tileManager.getSourceTile).toHaveBeenCalledTimes(2);
     });
 
-    /** Renders z0 tiles over a zoom-3 transform, so the covering tiles are at z3. */
-    function createTwoZoomTerrain() {
+    test('getElevationForLngLat samples the rendered tile where its DEM is loaded', () => {
         const terrain = createFlatTerrain(500);
         terrain.tileManager.minzoom = 0;
         terrain.tileManager.maxzoom = 22;
-        (terrain.painter.transform as MercatorTransform).setZoom(3);
-        return terrain;
-    }
-
-    test('getElevationForLngLat samples the rendered tile where its DEM is loaded', () => {
-        const terrain = createTwoZoomTerrain();
+        (terrain.painter.transform as MercatorTransform).setZoom(3); // renders z0 tiles, covering tiles are z3
         const renderedDEM = createDEM(() => 500);
         const coveringDEM = createDEM(() => 100);
         terrain.tileManager.getSourceTile = (tileID) => ({tileID, dem: tileID.canonical.z === 0 ? renderedDEM : coveringDEM}) as any as Tile;
@@ -318,7 +312,10 @@ describe('Terrain', () => {
     });
 
     test('getElevationForLngLat traverses the covering tiles while the rendered tile\'s DEM is loading', () => {
-        const terrain = createTwoZoomTerrain();
+        const terrain = createFlatTerrain(500);
+        terrain.tileManager.minzoom = 0;
+        terrain.tileManager.maxzoom = 22;
+        (terrain.painter.transform as MercatorTransform).setZoom(3); // renders z0 tiles, covering tiles are z3
         const coveringDEM = createDEM(() => 100);
         terrain.tileManager.getSourceTile = (tileID) => tileID.canonical.z === 0 ? undefined : ({tileID, dem: coveringDEM}) as any as Tile;
 
@@ -326,7 +323,10 @@ describe('Terrain', () => {
     });
 
     test('getElevationForLngLat traverses the covering tiles outside the rendered tiles', () => {
-        const terrain = createTwoZoomTerrain();
+        const terrain = createFlatTerrain(500);
+        terrain.tileManager.minzoom = 0;
+        terrain.tileManager.maxzoom = 22;
+        (terrain.painter.transform as MercatorTransform).setZoom(3); // renders z0 tiles, covering tiles are z3
         const renderedDEM = createDEM(() => 500);
         const coveringDEM = createDEM(() => 100);
         terrain.tileManager.getSourceTile = (tileID) => ({tileID, dem: tileID.canonical.z === 0 ? renderedDEM : coveringDEM}) as any as Tile;

--- a/src/render/terrain.test.ts
+++ b/src/render/terrain.test.ts
@@ -299,6 +299,41 @@ describe('Terrain', () => {
         expect(terrain.tileManager.getSourceTile).toHaveBeenCalledTimes(2);
     });
 
+    function createTwoZoomTerrain(renderedElevation: number, coveringElevation: number | null) {
+        const terrain = createFlatTerrain(renderedElevation);
+        terrain.tileManager.minzoom = 0;
+        terrain.tileManager.maxzoom = 22;
+        (terrain.painter.transform as MercatorTransform).setZoom(3);
+        const renderedDEM = createDEM(() => renderedElevation);
+        const coveringDEM = coveringElevation === null ? null : createDEM(() => coveringElevation);
+        terrain.tileManager.getSourceTile = (tileID) => {
+            const dem = tileID.canonical.z === 0 ? renderedDEM : coveringDEM;
+            return dem ? ({tileID, dem}) as any as Tile : undefined;
+        };
+        return terrain;
+    }
+
+    test('getElevationForLngLat samples the rendered tile where its DEM is loaded', () => {
+        const terrain = createTwoZoomTerrain(500, 100);
+
+        expect(terrain.getElevationForLngLat(new LngLat(0, 40), terrain.painter.transform)).toBeCloseTo(500, 6);
+    });
+
+    test('getElevationForLngLat traverses the covering tiles while the rendered tile\'s DEM is loading', () => {
+        const terrain = createTwoZoomTerrain(500, 100);
+        const renderedTileSourceTile = terrain.tileManager.getSourceTile;
+        terrain.tileManager.getSourceTile = (tileID) => tileID.canonical.z === 0 ? undefined : renderedTileSourceTile(tileID);
+
+        expect(terrain.getElevationForLngLat(new LngLat(0, 40), terrain.painter.transform)).toBeCloseTo(100, 6);
+    });
+
+    test('getElevationForLngLat traverses the covering tiles outside the rendered tiles', () => {
+        const terrain = createTwoZoomTerrain(500, 100);
+        terrain.tileManager.getRenderableTiles = () => [{tileID: new OverscaledTileID(1, 0, 1, 0, 0)}] as any as Tile[];
+
+        expect(terrain.getElevationForLngLat(new LngLat(90, -40), terrain.painter.transform)).toBeCloseTo(100, 6);
+    });
+
     test('getElevationForLngLat uses covering tiles to get the right zoom', () => {
         const zoom = 10;
         const painter = {

--- a/src/render/terrain.test.ts
+++ b/src/render/terrain.test.ts
@@ -299,36 +299,37 @@ describe('Terrain', () => {
         expect(terrain.tileManager.getSourceTile).toHaveBeenCalledTimes(2);
     });
 
-    function createTwoZoomTerrain(renderedElevation: number, coveringElevation: number | null) {
-        const terrain = createFlatTerrain(renderedElevation);
+    /** Renders z0 tiles at 500m over a zoom-3 transform whose covering tiles are at 100m. */
+    function createTwoZoomTerrain(renderedDEMLoaded: boolean) {
+        const terrain = createFlatTerrain(500);
         terrain.tileManager.minzoom = 0;
         terrain.tileManager.maxzoom = 22;
         (terrain.painter.transform as MercatorTransform).setZoom(3);
-        const renderedDEM = createDEM(() => renderedElevation);
-        const coveringDEM = coveringElevation === null ? null : createDEM(() => coveringElevation);
+        const renderedDEM = createDEM(() => 500);
+        const coveringDEM = createDEM(() => 100);
         terrain.tileManager.getSourceTile = (tileID) => {
-            const dem = tileID.canonical.z === 0 ? renderedDEM : coveringDEM;
-            return dem ? ({tileID, dem}) as any as Tile : undefined;
+            if (tileID.canonical.z === 0) {
+                return renderedDEMLoaded ? ({tileID, dem: renderedDEM}) as any as Tile : undefined;
+            }
+            return ({tileID, dem: coveringDEM}) as any as Tile;
         };
         return terrain;
     }
 
     test('getElevationForLngLat samples the rendered tile where its DEM is loaded', () => {
-        const terrain = createTwoZoomTerrain(500, 100);
+        const terrain = createTwoZoomTerrain(true);
 
         expect(terrain.getElevationForLngLat(new LngLat(0, 40), terrain.painter.transform)).toBeCloseTo(500, 6);
     });
 
     test('getElevationForLngLat traverses the covering tiles while the rendered tile\'s DEM is loading', () => {
-        const terrain = createTwoZoomTerrain(500, 100);
-        const renderedTileSourceTile = terrain.tileManager.getSourceTile;
-        terrain.tileManager.getSourceTile = (tileID) => tileID.canonical.z === 0 ? undefined : renderedTileSourceTile(tileID);
+        const terrain = createTwoZoomTerrain(false);
 
         expect(terrain.getElevationForLngLat(new LngLat(0, 40), terrain.painter.transform)).toBeCloseTo(100, 6);
     });
 
     test('getElevationForLngLat traverses the covering tiles outside the rendered tiles', () => {
-        const terrain = createTwoZoomTerrain(500, 100);
+        const terrain = createTwoZoomTerrain(true);
         terrain.tileManager.getRenderableTiles = () => [{tileID: new OverscaledTileID(1, 0, 1, 0, 0)}] as any as Tile[];
 
         expect(terrain.getElevationForLngLat(new LngLat(90, -40), terrain.painter.transform)).toBeCloseTo(100, 6);

--- a/src/render/terrain.test.ts
+++ b/src/render/terrain.test.ts
@@ -299,37 +299,37 @@ describe('Terrain', () => {
         expect(terrain.tileManager.getSourceTile).toHaveBeenCalledTimes(2);
     });
 
-    /** Renders z0 tiles at 500m over a zoom-3 transform whose covering tiles are at 100m. */
-    function createTwoZoomTerrain(renderedDEMLoaded: boolean) {
+    /** Renders z0 tiles over a zoom-3 transform, so the covering tiles are at z3. */
+    function createTwoZoomTerrain() {
         const terrain = createFlatTerrain(500);
         terrain.tileManager.minzoom = 0;
         terrain.tileManager.maxzoom = 22;
         (terrain.painter.transform as MercatorTransform).setZoom(3);
-        const renderedDEM = createDEM(() => 500);
-        const coveringDEM = createDEM(() => 100);
-        terrain.tileManager.getSourceTile = (tileID) => {
-            if (tileID.canonical.z === 0) {
-                return renderedDEMLoaded ? ({tileID, dem: renderedDEM}) as any as Tile : undefined;
-            }
-            return ({tileID, dem: coveringDEM}) as any as Tile;
-        };
         return terrain;
     }
 
     test('getElevationForLngLat samples the rendered tile where its DEM is loaded', () => {
-        const terrain = createTwoZoomTerrain(true);
+        const terrain = createTwoZoomTerrain();
+        const renderedDEM = createDEM(() => 500);
+        const coveringDEM = createDEM(() => 100);
+        terrain.tileManager.getSourceTile = (tileID) => ({tileID, dem: tileID.canonical.z === 0 ? renderedDEM : coveringDEM}) as any as Tile;
 
         expect(terrain.getElevationForLngLat(new LngLat(0, 40), terrain.painter.transform)).toBeCloseTo(500, 6);
     });
 
     test('getElevationForLngLat traverses the covering tiles while the rendered tile\'s DEM is loading', () => {
-        const terrain = createTwoZoomTerrain(false);
+        const terrain = createTwoZoomTerrain();
+        const coveringDEM = createDEM(() => 100);
+        terrain.tileManager.getSourceTile = (tileID) => tileID.canonical.z === 0 ? undefined : ({tileID, dem: coveringDEM}) as any as Tile;
 
         expect(terrain.getElevationForLngLat(new LngLat(0, 40), terrain.painter.transform)).toBeCloseTo(100, 6);
     });
 
     test('getElevationForLngLat traverses the covering tiles outside the rendered tiles', () => {
-        const terrain = createTwoZoomTerrain(true);
+        const terrain = createTwoZoomTerrain();
+        const renderedDEM = createDEM(() => 500);
+        const coveringDEM = createDEM(() => 100);
+        terrain.tileManager.getSourceTile = (tileID) => ({tileID, dem: tileID.canonical.z === 0 ? renderedDEM : coveringDEM}) as any as Tile;
         terrain.tileManager.getRenderableTiles = () => [{tileID: new OverscaledTileID(1, 0, 1, 0, 0)}] as any as Tile[];
 
         expect(terrain.getElevationForLngLat(new LngLat(90, -40), terrain.painter.transform)).toBeCloseTo(100, 6);

--- a/src/render/terrain.ts
+++ b/src/render/terrain.ts
@@ -49,6 +49,8 @@ const MAX_TILE_COORD = EXTENT * (1 - 1e-12);
 
 export type TerrainSample = {
     covered: boolean;
+    /** Whether the elevation comes from loaded DEM data rather than the flat surface rendered while it loads. */
+    demLoaded: boolean;
     elevation: number;
 };
 
@@ -223,11 +225,19 @@ export class Terrain {
 
     /**
      * Get the elevation for given {@link LngLat} in respect of exaggeration.
-     * This will traverse up the zoom levels to find the first tile with data to return.
+     * Where the location is covered by a rendered tile with loaded DEM data this samples the
+     * rendered surface, so the result agrees with what is drawn; elsewhere it traverses up the
+     * zoom levels to find the first tile with data to return.
      * @param lnglat - the location
      * @returns the elevation
      */
     getElevationForLngLat(lnglat: LngLat, transform: IReadonlyTransform): number {
+        const index = this.getCoverageIndex();
+        if (index) {
+            const mercator = MercatorCoordinate.fromLngLat(lnglat);
+            const sample = sampleAt(index, this.exaggeration, mercator.x, mercator.y);
+            if (sample.demLoaded) return sample.elevation;
+        }
         const terrainCoveringTiles = coveringTiles(transform, {maxzoom: this.tileManager.maxzoom, minzoom: this.tileManager.minzoom, tileSize: 512, terrain: this});
         let zoom = 0;
         for (const tile of terrainCoveringTiles) {
@@ -553,7 +563,7 @@ export class Terrain {
     }
 }
 
-const NOT_COVERED: TerrainSample = {covered: false, elevation: 0};
+const NOT_COVERED: TerrainSample = {covered: false, demLoaded: false, elevation: 0};
 
 /**
  * Elevation of the rendered terrain surface at a mercator position, and whether it is covered at all.
@@ -573,10 +583,10 @@ export function sampleAt(index: TerrainCoverageIndex, exaggeration: number, merc
         const key = `${wrap}/${z}/${tileX}/${tileY}`;
         if (!index.samplerPerTile.has(key)) continue;
         const sampler = index.samplerPerTile.get(key);
-        if (!sampler) return {covered: true, elevation: 0};
+        if (!sampler) return {covered: true, demLoaded: false, elevation: 0};
         const x = Math.min((scaledX - tileX) * EXTENT, MAX_TILE_COORD);
         const y = Math.min((scaledY - tileY) * EXTENT, MAX_TILE_COORD);
-        return {covered: true, elevation: sampler(x, y, EXTENT) * exaggeration};
+        return {covered: true, demLoaded: true, elevation: sampler(x, y, EXTENT) * exaggeration};
     }
     return NOT_COVERED;
 }


### PR DESCRIPTION
Closes #8212.

`getElevationForLngLat` picks the highest covering-tile zoom, so `project()` could sample a different DEM tile than the mesh on screen: up to ~20 px of screen error at grazing angles on pitched views (details and demo in #8212).

Now, where a location is covered by a rendered tile whose DEM has loaded, the lookup samples that tile through the coverage index from #8158. That's the same surface the picking raycast hits, so `project()` round-trips `unproject()` exactly. Everywhere else (DEM still loading, off-screen queries, `queryTerrainElevation` on arbitrary coordinates) the covering-tile traversal still applies, and the loading behavior from #6791/#6701 doesn't move.

`project(unproject(p))` on the #1596 harness (21×21 grids, DEM fixtures, terrain-hit probes only):

| scenario | before: p95 / max | after: p95 / max |
|---|---|---|
| z11 pitch 0 | 0.00 / 3.37 px | 0.00 / 0.00 px |
| z11 pitch 60 b30 | 6.10 / 17.26 px | 0.00 / 0.00 px |
| z12 pitch 75 b30 | 7.19 / 25.88 px | 0.00 / 14.65 px |
| z13 pitch 60 b0 | 0.82 / 7.61 px | 0.00 / 0.00 px |

The residual at z12 p75 is three probes on the extreme-grazing top row. One legitimately crosses a ridge (the unprojected point is 3 km away), and the worst round-trips to within 0.1 m geographically. That's screen-space sensitivity at the horizon, not an elevation mismatch.

Small perf bonus: the coverage index is cached, so the common case skips the per-call `coveringTiles` traversal.

Verified: unit 3100/3100, terrain render suite green, lint + tsc clean.

### Before

<img width="900" height="700" alt="8212-released" src="https://github.com/user-attachments/assets/b4665668-b15f-4f28-bcfd-82eff6fa4fdb" />

### After

<img width="900" height="700" alt="8212-fixed" src="https://github.com/user-attachments/assets/3243a3ab-72b8-4f71-938f-5ab94e9cb2d7" />

## Launch Checklist
<!-- Thanks for the PR! Feel free to add or remove items that are not relevant. -->

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [x] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality.
 - [x] Document any changes to public APIs.
 - [x] Add an entry to `CHANGELOG.md` under the `## main` section.
 - [x] Confirm you have read our AI policy [here](https://github.com/maplibre/maplibre/blob/main/AI_POLICY.md).

No bench file sits next to the changed files, but the `sampleAt` change touches the raycast hot path, so I ran `mercator_transform.bench.ts` against a main baseline anyway: 0.99x–1.01x across all nine cases, within noise.


<!--
  Add one of:    Assisted-By: | Generated-By:     and the model/version
-->

Assisted-By: Claude Fable 5 (low effort) for planning, test orchestration, and fact-checking