### PR TITLE
fix: throw GPUInitializationError from Map constructor when WebGL2 context creation fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## main
 ### ✨ Features and improvements
+- Throw `GPUInitializationError` from the `Map` constructor when the WebGL2 context cannot be created, instead of firing an `error` event no listener can catch and returning a partially constructed map ([#8066](https://github.com/maplibre/maplibre-gl-js/issues/8066))
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes

--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -795,8 +795,6 @@ export class Map extends Evented<MapEventType> {
             browser.prefersReducedMotion = resolvedOptions.reduceMotion;
         }
 
-        this._imageQueueHandle = ImageRequest.addThrottleControl(() => this.isMoving());
-
         this._requestManager = new RequestManager(resolvedOptions.transformRequest);
 
         this._container = this._resolveContainer(resolvedOptions.container);
@@ -806,8 +804,13 @@ export class Map extends Evented<MapEventType> {
         }
 
         this._setupContainer();
-        this._setupPainter();
-        if (!this.painter) return;
+        try {
+            this._setupPainter();
+        } catch (error) {
+            this._cleanupContainer();
+            throw error;
+        }
+        this._imageQueueHandle = ImageRequest.addThrottleControl(() => this.isMoving());
 
         this.on('move', () => this._update(false));
         this.on('moveend', () => this._update(false));
@@ -4063,6 +4066,19 @@ export class Map extends Evented<MapEventType> {
         this._container.addEventListener('scroll', this._onMapScroll, false);
     }
 
+    /**
+     * @internal
+     * Reverses the DOM mutations of {@link Map._setupContainer}, returning the container element to its pre-construction state.
+     */
+    _cleanupContainer(): void {
+        this._canvas.removeEventListener('webglcontextrestored', this._contextRestored, false);
+        this._canvas.removeEventListener('webglcontextlost', this._contextLost, false);
+        this._canvasContainer.remove();
+        this._controlContainer.remove();
+        this._container.removeEventListener('scroll', this._onMapScroll, false);
+        this._container.classList.remove('maplibregl-map');
+    }
+
     _resizeCanvas(width: number, height: number, pixelRatio: number): void {
         // Request the required canvas size taking the pixelratio into account.
         this._canvas.width = Math.floor(pixelRatio * width);
@@ -4073,6 +4089,10 @@ export class Map extends Evented<MapEventType> {
         this._canvas.style.height = `${height}px`;
     }
 
+    /**
+     * @internal
+     * Creates the WebGL2 context and the painter. Throws {@link GPUInitializationError} when the context cannot be created.
+     */
     _setupPainter(): void {
 
         // Maplibre WebGL context requires alpha, depth and stencil buffers. It also forces premultipliedAlpha: true.
@@ -4093,8 +4113,7 @@ export class Map extends Evented<MapEventType> {
         const gl: WebGL2RenderingContext | null = this._canvas.getContext('webgl2', attributes);
 
         if (!gl) {
-            this.fire(new ErrorEvent(new GPUInitializationError(attributes, creationEvent)));
-            return;
+            throw new GPUInitializationError(attributes, creationEvent);
         }
 
         this.painter = new Painter(gl, this._camera.transform);
@@ -4164,8 +4183,12 @@ export class Map extends Evented<MapEventType> {
 
         this._lostContextStyle = {style: null, images: null};
 
-        this._setupPainter();
-        if (!this.painter) return;
+        try {
+            this._setupPainter();
+        } catch (error) {
+            this.fire(new ErrorEvent(error));
+            return;
+        }
         this.resize();
         this._update();
         this._resizeInternal();
@@ -4409,12 +4432,7 @@ export class Map extends Evented<MapEventType> {
         this._resizeObserver?.disconnect();
         const extension = this.painter.context.gl.getExtension('WEBGL_lose_context');
         if (extension?.loseContext) extension.loseContext();
-        this._canvas.removeEventListener('webglcontextrestored', this._contextRestored, false);
-        this._canvas.removeEventListener('webglcontextlost', this._contextLost, false);
-        this._canvasContainer.remove();
-        this._controlContainer.remove();
-        this._container.removeEventListener('scroll', this._onMapScroll, false);
-        this._container.classList.remove('maplibregl-map');
+        this._cleanupContainer();
 
         this._removed = true;
         this.fire(new MapLibreEvent('remove'));

--- a/src/ui/map_tests/map_webgl.test.ts
+++ b/src/ui/map_tests/map_webgl.test.ts
@@ -123,7 +123,7 @@ test('a WebGL style image is told to release its GPU resources on context loss, 
     map.remove();
 });
 
-test('WebGL2 context creation error fires ErrorEvent with structured GPUInitializationError', () => {
+test('Map constructor throws a structured GPUInitializationError when WebGL2 context creation fails', () => {
     HTMLCanvasElement.prototype.getContext = function (type: string) {
         if (type === 'webgl2') {
             const errorEvent = new Event('webglcontextcreationerror');
@@ -132,26 +132,56 @@ test('WebGL2 context creation error fires ErrorEvent with structured GPUInitiali
             return null;
         }
     };
-    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-    createMap({canvasContextAttributes: {antialias: true}});
-    const err = consoleErrorSpy.mock.calls[0][0];
-    expect(err.constructor).toBe(GPUInitializationError);
+    const container = window.document.createElement('div');
+    let err: GPUInitializationError;
+    try {
+        createMap({container, canvasContextAttributes: {antialias: true}});
+    } catch (error) {
+        err = error;
+    }
+    expect(err).toBeInstanceOf(GPUInitializationError);
+    expect(container.children).toHaveLength(0);
+    expect(container.classList).not.toContain('maplibregl-map');
     expect(err.message).toBe('WebGL2 is required to display this map. We are sorry, but it seems that your browser does not support WebGL2, a technology for rendering 3D graphics on the web. Read more on https://wiki.openstreetmap.org/wiki/This_map_requires_WebGL');
     expect(err.statusMessage).toBe('mocked webglcontextcreationerror message');
     expect(err.requestedAttributes.antialias).toBe(true);
-    consoleErrorSpy.mockRestore();
 });
 
 test('GPUInitializationError has null statusMessage when no webglcontextcreationerror is dispatched', () => {
     HTMLCanvasElement.prototype.getContext = function (_type: string) {
         return null;
     };
-    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-    createMap();
-    const err = consoleErrorSpy.mock.calls[0][0];
-    expect(err.constructor).toBe(GPUInitializationError);
+    let err: GPUInitializationError;
+    try {
+        createMap();
+    } catch (error) {
+        err = error;
+    }
+    expect(err).toBeInstanceOf(GPUInitializationError);
     expect(err.statusMessage).toBeNull();
-    consoleErrorSpy.mockRestore();
+});
+
+test('context recreation failure after "webglcontextrestored" fires ErrorEvent with GPUInitializationError', async () => {
+    const map = createMap();
+    const canvas = map.getCanvas();
+
+    const contextLostPromise = map.once('webglcontextlost');
+    canvas.dispatchEvent(new window.Event('webglcontextlost'));
+    await contextLostPromise;
+
+    HTMLCanvasElement.prototype.getContext = function (_type: string) {
+        return null;
+    };
+    const errorPromise = map.once('error');
+    const restoredSpy = vi.fn();
+    map.on('webglcontextrestored', restoredSpy);
+    canvas.dispatchEvent(new window.Event('webglcontextrestored'));
+    const {error} = await errorPromise;
+    expect(error).toBeInstanceOf(GPUInitializationError);
+    expect(restoredSpy).not.toHaveBeenCalled();
+
+    HTMLCanvasElement.prototype.getContext = originalGetContext;
+    map.remove();
 });
 
 test('Hit WebGL max drawing buffer limit', () => {

--- a/src/util/gpu_initialization_error.ts
+++ b/src/util/gpu_initialization_error.ts
@@ -1,5 +1,6 @@
 /**
- * Thrown (via the map's `error` event) when a GPU rendering context cannot be created.
+ * Thrown by the `Map` constructor when a GPU rendering context cannot be created,
+ * or fired via the map's `error` event when recreating the context after a `webglcontextrestored` fails.
  *
  * Carries the canvas attributes that were requested and, when the browser provided one,
  * the originating `webglcontextcreationerror` `statusMessage`.

--- a/test/examples/check-if-webgl-is-supported.html
+++ b/test/examples/check-if-webgl-is-supported.html
@@ -20,16 +20,27 @@
 <script type="module">
     import * as maplibregl from '../../dist/maplibre-gl-dev.mjs';
 
-    const map = new maplibregl.Map({
-        container: 'map',
-        style: 'https://demotiles.maplibre.org/style.json',
-        center: [-74.5, 40],
-        zoom: 2
-    });
-    map.on('error', (e) => {
-        if (e.error instanceof maplibregl.GPUInitializationError) {
+    let map;
+    try {
+        map = new maplibregl.Map({
+            container: 'map',
+            style: 'https://demotiles.maplibre.org/style.json',
+            center: [-74.5, 40],
+            zoom: 2
+        });
+    } catch (error) {
+        if (error instanceof maplibregl.GPUInitializationError) {
             // You can also display the error message in the UI
             // This does not have to be an alert..
+            alert(error.message);
+        } else {
+            throw error;
+        }
+    }
+    // Recreating the context after it was lost and restored can also fail;
+    // that failure arrives through the error event since the map already exists.
+    map?.on('error', (e) => {
+        if (e.error instanceof maplibregl.GPUInitializationError) {
             alert(e.error.message);
             return;
         }


### PR DESCRIPTION
Closes #8066.

When WebGL2 context creation fails, `_setupPainter` fired an `ErrorEvent` from inside the constructor — before any caller could attach a listener — and then returned a partially constructed map with no `painter`, no handlers, and missing members like `scrollZoom` (the invalid-object symptom reported in the issue, seen in Sentry across browsers).

Following the direction discussed in the issue, the constructor now throws the existing `GPUInitializationError` instead:

```js
try {
    const map = new Map({...});
} catch (error) {
    if (error instanceof GPUInitializationError) {
        // show a fallback UI
    }
}
```

Since the throw aborts construction before the caller can ever call `remove()`, the constructor also unwinds its side effects on failure: `_cleanupContainer` (extracted from `remove()`, symmetric with `_setupContainer`) restores the container element to its pre-construction state, and the global `ImageRequest` throttle-control registration moved after painter setup so it can't leak.

The `webglcontextrestored` path keeps its event-based delivery: listeners exist by then, so a failed context recreation fires the same `GPUInitializationError` through the `error` event as before, and `webglcontextrestored` is not fired.

Also updated the check-if-webgl-is-supported example: try/catch for the constructor, keeping the `error`-event listener for the context-restore failure case (with the existing guidance to log handled errors).

Tests: the two constructor-failure tests now assert the throw (message, `statusMessage`, `requestedAttributes`), plus a new test that a failed recreation after `webglcontextrestored` delivers the error via the `error` event and suppresses `webglcontextrestored`.

Verified: unit 3098/3098, lint + tsc clean.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items that are not relevant. -->


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [x] Write tests for all new functionality.
 - [x] Document any changes to public APIs.
 - [x] Add an entry to `CHANGELOG.md` under the `## main` section.
 - [x] Confirm you have read our AI policy [here](https://github.com/maplibre/maplibre/blob/main/AI_POLICY.md).
<!--
  Add one of:    Assisted-By: | Generated-By:     and the model/version
-->

Assisted-By: Claude Fable 5 (low effort): research, test harness, check implementation against issue thread discussion