### PR TITLE
test: fix some CI flakes: raise Windows test timeouts

### DIFF
--- a/test/integration/bundler/bundlers.test.ts
+++ b/test/integration/bundler/bundlers.test.ts
@@ -18,6 +18,15 @@ const POST_LOAD_WAIT_MS = 3000;
 const TILE_WAIT_MS = 15000;
 const TEST_TIMEOUT_MS = 300000;
 
+// Browser launch can take over a minute on a cold CI Windows runner (see HOOK_TIMEOUT in
+// the render runner).
+const LAUNCH_HOOK_TIMEOUT_MS = process.platform === 'win32' ? 180000 : 60000;
+
+// Navigating to the locally-served example takes under a second on a healthy machine. A cold
+// CI Windows runner, still digesting the example's `npm install` and build, has been seen to
+// take 15+. The per-test timeout still bounds the whole run.
+const NAVIGATION_TIMEOUT_MS = process.platform === 'win32' ? 60000 : 15000;
+
 // Headless-Chrome / SwiftShader quirks that aren't bundler bugs.
 const ENV_NOISE = [
     /webglcontextcreationerror/i,
@@ -42,7 +51,7 @@ const outputDirs = ['dist', 'out'];
 describe('Bundler examples', () => {
     beforeAll(async () => {
         browser = await launchPuppeteer();
-    }, 60000);
+    }, LAUNCH_HOOK_TIMEOUT_MS);
 
     afterAll(async () => {
         if (browser) await browser.close();
@@ -97,7 +106,7 @@ describe('Bundler examples', () => {
                 });
 
                 const url = `http://localhost:${port}/index.html`;
-                await page.goto(url, {timeout: 15000});
+                await page.goto(url, {timeout: NAVIGATION_TIMEOUT_MS});
                 await new Promise((r) => setTimeout(r, POST_LOAD_WAIT_MS));
 
                 const diagnostics = () => [

--- a/test/integration/render/render.test.ts
+++ b/test/integration/render/render.test.ts
@@ -22,15 +22,20 @@ let maplibregl: typeof MapLibreGL;
  * Fallback timeout for a single render test, used when the test does not set `metadata.test.timeout`.
  * It is generous on purpose: the heavier tests (mostly terrain) take ~15-20 seconds on the CI Windows
  * runners, where software rendering makes the run times vary by a factor of two or three.
+ * Windows runs on double the budget, whether a test uses this default or sets its own:
+ * every render-test timeout on main in the 90 days of retained CI logs (May-Aug 2026) was a
+ * terrain-heavy test on a Windows runner, while the Linux shards never timed out once.
  */
 const DEFAULT_TEST_TIMEOUT = 60000;
 
 /**
- * Timeout for the `beforeAll` and `afterAll` hooks, which launch and tear down the browser, the test
+ * Timeout for the test hooks. `beforeAll` and `afterAll` launch and tear down the browser, the test
  * servers and the coverage reporting. Vitest defaults to 10 seconds, which is not enough on the CI
  * Windows runners: setup takes about a second on a warm machine, but a cold Windows runner has been
  * seen to spend more than a minute on the browser launch and the first page load alone. The hooks
  * run once per split, so a generous value costs nothing when everything is healthy.
+ * The per-test hooks get the same budget: their 10 second default killed three runs on main
+ * in Jul-Aug 2026 even though the hooks themselves do trivial work.
  */
 const HOOK_TIMEOUT = 180000;
 
@@ -895,14 +900,14 @@ describe('Render tests', () => {
             console.log(`Retry ${ctx.task.name} with console logging enabled`);
             addConsoleLogging(page);
         }
-    });
+    }, HOOK_TIMEOUT);
 
     afterEach(async () => {
         page.removeAllListeners('console');
         page.removeAllListeners('pageerror');
         page.removeAllListeners('response');
         page.removeAllListeners('requestfailed');
-    });
+    }, HOOK_TIMEOUT);
 
     afterAll(async () => {
         if (page) {
@@ -915,7 +920,8 @@ describe('Render tests', () => {
     }, HOOK_TIMEOUT);
 
     for (const style of testStyles) {
-        test(style.metadata.test.id, {retry: 1, timeout: style.metadata.test.timeout || DEFAULT_TEST_TIMEOUT}, async () => {
+        const timeout = (style.metadata.test.timeout || DEFAULT_TEST_TIMEOUT) * (process.platform === 'win32' ? 2 : 1);
+        test(style.metadata.test.id, {retry: 1, timeout}, async () => {
             const serverPort = (server.address() as any).port;
             localizeURLs(style, serverPort, path.join(__dirname, '../'));
             const data = await getImageFromStyle(style, page);


### PR DESCRIPTION
The Tests workflow failed 11 times in 160 main-branch runs over the 90 days of retained CI logs (2026-05-27 to 2026-08-23). 

2 were the canvas package's native build breaking on windows-latest 
1 is a genuine cross-platform race in the marker-opacity browser test.

The other 8 were timeout flakes, all on Windows runners, where software rendering runs 2-3x slower with a heavy tail.

- four render-test timeouts (terrain/fog twice, terrain/tile-stiching, high-pitch/terrain-pitch95)
- three runs killed by 'Hook timed out in 10000ms' from the render runner's per-test hooks, which do trivial work but were CPU starved while the old screenshot serialization stalled the event loop (https://github.com/maplibre/maplibre-gl-js/pull/8204 removed the stall; the hooks now share HOOK_TIMEOUT so they cannot kill a run either way)
- one esbuild bundler test failing its 15s localhost navigation timeout on a cold Windows runner: navigation and browser-launch budgets raised on Windows only, other platforms keep their current values

The marker-opacity race and the canvas build breakage are separate issues, not timeout shortfalls; this PR addresses only the timeouts to keep review surface small.

No behavior changes; just timeouts and comments.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items that are not relevant. -->


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Confirm you have read our AI policy [here](https://github.com/maplibre/maplibre/blob/main/AI_POLICY.md).
<!--
  Add one of:    Assisted-By: | Generated-By:     and the model/version
-->

Assisted-By: Claude Fable 5 was used to parse CI logs