### PR TITLE
bug: 'Add an icon to the map' docs shows 'ReferenceError: assignment to undeclared variable image'

### DIFF
--- a/test/examples/add-an-icon-to-the-map.html
+++ b/test/examples/add-an-icon-to-the-map.html
@@ -27,7 +27,7 @@
     });
 
     map.on('load', async () => {
-        image = await map.loadImage('https://upload.wikimedia.org/wikipedia/commons/7/7c/201408_cat.png');
+        const image = await map.loadImage('https://upload.wikimedia.org/wikipedia/commons/7/7c/201408_cat.png');
         map.addImage('cat', image.data);
         map.addSource('point', {
             'type': 'geojson',


### PR DESCRIPTION
Checking the [Add an icon to the map docs](https://maplibre.org/maplibre-gl-js/docs/examples/add-an-icon-to-the-map/) I noticed the image isn't loading, and there is an error in the console. TLDR the variable wasn't declared and needs to be.

## Launch Checklist

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality.
 - [x] Document any changes to public APIs.
 - [x] If you changed code in a file that has a benchmark file next to it (`*.bench.ts`), post before/after results of `npm run bench` (the compare workflow is in `test/bench/README.md`).
 - [ ] Add an entry to `CHANGELOG.md` under the `## main` section.
 - [x] Confirm you have read our AI policy [here](https://github.com/maplibre/maplibre/blob/main/AI_POLICY.md).
<!--
  Add one of:    Assisted-By: | Generated-By:     and the model/version
-->


1. I can't work out how to preview this in the dev docs site because it doesn't show up.
2. I'm unsure if something like this needs to be included in the changelog, but lmk and I'll add it.
