### PR TITLE
Let a Marker be elevated above the ground (#8228)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## main
 ### ✨ Features and improvements
+- Add `heightOffset` and `heightAnchor` options to `Marker`, which raise a marker above the ground the way `symbol-height-offset` and `symbol-height-anchor` raise symbols ([#8228](https://github.com/maplibre/maplibre-gl-js/issues/8228)) (by [@clement-igonet](https://github.com/clement-igonet))
 - Throw `GPUInitializationError` from the `Map` constructor when the WebGL2 context cannot be created, instead of firing an `error` event no listener can catch and returning a partially constructed map ([#8066](https://github.com/maplibre/maplibre-gl-js/issues/8066))
 - _...Add new stuff here..._
 

--- a/src/geo/projection/globe_transform.ts
+++ b/src/geo/projection/globe_transform.ts
@@ -422,6 +422,10 @@ export class GlobeTransform implements ITransform {
         return;
     }
 
+    locationToScreenPointAtElevation(lnglat: LngLat, elevation: number): Point {
+        return this.currentTransform.locationToScreenPointAtElevation(lnglat, elevation);
+    }
+
     locationToScreenPoint(lnglat: LngLat, terrain?: Terrain): Point {
         return this.currentTransform.locationToScreenPoint(lnglat, terrain);
     }

--- a/src/geo/projection/mercator_transform.ts
+++ b/src/geo/projection/mercator_transform.ts
@@ -369,6 +369,10 @@ export class MercatorTransform implements ITransform {
         return this.screenPointToMercatorCoordinate(p, terrain)?.toLngLat();
     }
 
+    locationToScreenPointAtElevation(lnglat: LngLat, elevation: number): Point {
+        return this.coordinatePoint(MercatorCoordinate.fromLngLat(lnglat), elevation, this._pixelMatrix3D);
+    }
+
     screenPointToLocationAtElevation(p: Point, elevation: number): LngLat {
         return this.screenPointToMercatorCoordinateAtZ(p, elevation - this.elevation)?.toLngLat();
     }

--- a/src/geo/projection/vertical_perspective_transform.ts
+++ b/src/geo/projection/vertical_perspective_transform.ts
@@ -756,13 +756,15 @@ export class VerticalPerspectiveTransform implements ITransform {
     }
 
     locationToScreenPoint(lnglat: LngLat, terrain?: Terrain): Point {
-        const pos = angularCoordinatesToSurfaceVector(lnglat);
+        const elevation = terrain ? terrain.getElevationForLngLatZoom(lnglat, this._helper._tileZoom) : 0;
+        return this.locationToScreenPointAtElevation(lnglat, elevation);
+    }
 
-        if (terrain) {
-            const elevation = terrain.getElevationForLngLatZoom(lnglat, this._helper._tileZoom);
+    locationToScreenPointAtElevation(lnglat: LngLat, elevation: number): Point {
+        const pos = angularCoordinatesToSurfaceVector(lnglat);
+        if (elevation) {
             vec3.scale(pos, pos, 1.0 + elevation / earthRadius);
         }
-
         return this._projectSurfacePointToScreen(pos);
     }
 

--- a/src/geo/transform_interface.ts
+++ b/src/geo/transform_interface.ts
@@ -356,6 +356,15 @@ export interface IReadonlyTransform extends ITransformGetters {
     screenPointToLocationAtElevation(p: Point, elevation: number): LngLat;
 
     /**
+     * Given a geographical location and an elevation above the zero elevation datum, returns the
+     * point on screen where it is drawn. The counterpart of {@link screenPointToLocationAtElevation}.
+     * @param lnglat - the location
+     * @param elevation - the elevation in meters above the zero elevation datum
+     * @returns the screen point in pixels
+     */
+    locationToScreenPointAtElevation(lnglat: LngLat, elevation: number): Point;
+
+    /**
      * @internal
      * Given a point on screen, return its mercator coordinate.
      * @param p - the point

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ import {FullscreenControl, FullscreenEvent, type FullscreenControlEventType, typ
 import {TerrainControl} from './ui/control/terrain_control.ts';
 import {GlobeControl} from './ui/control/globe_control.ts';
 import {type Offset, Popup, PopupEvent, type PopupEventType, type PopupOptions} from './ui/popup.ts';
-import {type Alignment, Marker, MarkerDragEvent, MarkerClickEvent, type MarkerEventType, type MarkerOptions} from './ui/marker.ts';
+import {type Alignment, type HeightAnchor, Marker, MarkerDragEvent, MarkerClickEvent, type MarkerEventType, type MarkerOptions} from './ui/marker.ts';
 import {type AddLayerObject, type FeatureIdentifier, Style, type StyleOptions, type StyleSetterOptions, type StyleSwapOptions, type TransformStyleFunction} from './style/style.ts';
 import {LngLat, type LngLatLike} from './geo/lng_lat.ts';
 import {LngLatBounds, type LngLatBoundsLike} from './geo/lng_lat_bounds.ts';
@@ -290,6 +290,7 @@ export {
     type GetResourceResponse,
     type MapGeoJSONFeature,
     type Alignment,
+    type HeightAnchor,
     type AddProtocolAction,
     type SourceClass,
     type IndicesType,

--- a/src/ui/marker.test.ts
+++ b/src/ui/marker.test.ts
@@ -12,6 +12,8 @@ type MapOptions = {
     locale?: Partial<typeof defaultLocale>;
     width?: number;
     renderWorldCopies?: boolean;
+    pitch?: number;
+    zoom?: number;
 };
 
 function createMap(options: MapOptions = {}) {
@@ -1119,6 +1121,43 @@ describe('marker', () => {
         marker.setRotationAlignment('viewport');
         marker.setPitchAlignment('auto');
         expect(marker.getRotationAlignment()).toBe(marker.getPitchAlignment());
+
+        map.remove();
+    });
+
+    test('Marker with a height offset is drawn above its ground position', () => {
+        const map = createMap({pitch: 60, zoom: 12});
+        const ground = new Marker().setLngLat([0, 0]).addTo(map);
+        const raised = new Marker({heightOffset: 5000}).setLngLat([0, 0]).addTo(map);
+
+        expect(raised.getHeightOffset()).toBe(5000);
+        expect(raised.getHeightAnchor()).toBe('ground');
+        expect(raised._pos.y).toBeLessThan(ground._pos.y);
+
+        map.remove();
+    });
+
+    test('Marker height offset is measured from the terrain by default, and from the datum when absolute', () => {
+        const map = createMap();
+        map.terrain = createTerrain();   // 1000 m everywhere
+        const onGround = new Marker({heightOffset: 500}).setLngLat([0, 0]).addTo(map);
+        const absolute = new Marker({heightOffset: 500, heightAnchor: 'absolute'}).setLngLat([0, 0]).addTo(map);
+
+        expect(onGround._elevation()).toBe(1500);
+        expect(absolute._elevation()).toBe(500);
+
+        map.remove();
+    });
+
+    test('setHeightOffset moves an existing marker', () => {
+        const map = createMap({pitch: 60, zoom: 12});
+        const marker = new Marker().setLngLat([0, 0]).addTo(map);
+        const atGround = marker._pos.y;
+
+        marker.setHeightOffset(5000);
+
+        expect(marker._pos.y).toBeLessThan(atGround);
+        expect(marker.getHeightOffset()).toBe(5000);
 
         map.remove();
     });

--- a/src/ui/marker.ts
+++ b/src/ui/marker.ts
@@ -19,6 +19,11 @@ import type {PointLike} from './camera.ts';
 export type Alignment = 'map' | 'viewport' | 'auto';
 
 /**
+ * The datum a marker's height offset is measured from.
+ */
+export type HeightAnchor = 'ground' | 'absolute';
+
+/**
  * Screen-pixel deltas applied when a focused draggable marker is moved with the arrow keys.
  */
 const ARROW_KEY_DELTAS: Partial<Record<KeyboardEvent['key'], [number, number]>> = {
@@ -110,6 +115,18 @@ export type MarkerOptions = {
       * @defaultValue false
       */
     subpixelPositioning?: boolean;
+    /**
+     * Raises the marker above the ground, in meters. Mirrors the `symbol-height-offset`
+     * layout property of symbol layers.
+     * @defaultValue 0
+     */
+    heightOffset?: number;
+    /**
+     * The datum `heightOffset` is measured from: the terrain surface below the marker
+     * (`ground`) or the zero elevation datum (`absolute`). Mirrors `symbol-height-anchor`.
+     * @defaultValue 'ground'
+     */
+    heightAnchor?: HeightAnchor;
 };
 
 /**
@@ -243,6 +260,8 @@ export class Marker extends Evented<MarkerEventType> {
     _opacityWhenCovered: string;
     _opacityTimeout: ReturnType<typeof setTimeout>;
     _subpixelPositioning: boolean;
+    _heightOffset: number;
+    _heightAnchor: HeightAnchor;
     _roleManaged: boolean;
     _tabIndexManaged: boolean;
     _keyboardDragActive: boolean;
@@ -259,6 +278,8 @@ export class Marker extends Evented<MarkerEventType> {
         this._draggable = options?.draggable || false;
         this._clickTolerance = options?.clickTolerance || 0;
         this._subpixelPositioning = options?.subpixelPositioning || false;
+        this._heightOffset = options?.heightOffset || 0;
+        this._heightAnchor = options?.heightAnchor || 'ground';
         this._isDragging = false;
         this._roleManaged = false;
         this._tabIndexManaged = false;
@@ -749,6 +770,22 @@ export class Marker extends Evented<MarkerEventType> {
         this._element.classList.toggle('maplibregl-marker-covered', centerIsInvisible);
     }
 
+    /**
+     * The elevation the marker is drawn at, in meters above the zero elevation datum, or
+     * undefined when it sits on the ground and the ordinary ground projection applies.
+     * `absolute` ignores the terrain below the marker, `ground` adds the offset to it.
+     */
+    _elevation(): number | undefined {
+        if (this._heightAnchor === 'absolute') {
+            return this._heightOffset;
+        }
+        if (!this._heightOffset) {
+            return undefined;
+        }
+        const terrain = this._map.terrain;
+        return this._heightOffset + (terrain ? terrain.getElevationForLngLat(this._lngLat, this._map._camera.transform) : 0);
+    }
+
     _update = (e?: { type: 'move' | 'moveend' | 'terrain' | 'render' }): void => {
         if (!this._map) return;
 
@@ -759,7 +796,9 @@ export class Marker extends Evented<MarkerEventType> {
 
         this._lngLat = smartWrap(this._lngLat, this._flatPos, this._map._camera.transform);
 
-        this._flatPos = this._pos = this._map.project(this._lngLat)._add(this._offset);
+        this._flatPos = this._pos = this._elevation() === undefined ?
+            this._map.project(this._lngLat)._add(this._offset) :
+            this._map._camera.transform.locationToScreenPointAtElevation(this._lngLat, this._elevation())._add(this._offset);
         if (this._map.terrain) {
             // flat position is saved because smartWrap needs non-elevated points
             this._flatPos = this._map._camera.transform.locationToScreenPoint(this._lngLat)._add(this._offset);
@@ -792,6 +831,42 @@ export class Marker extends Evented<MarkerEventType> {
             this._updateOpacity(e?.type === 'moveend');
         }).catch(() => {});
     };
+
+    /**
+     * Sets how far above the ground the marker is drawn, in meters.
+     * @param heightOffset - the height in meters
+     * @param heightAnchor - the datum the height is measured from, `ground` (the default) or `absolute`
+     * @returns `this`
+     * @example
+     * ```ts
+     * // a marker floating 50 m above the terrain
+     * marker.setHeightOffset(50);
+     * // a marker at a fixed altitude, ignoring the terrain below it
+     * marker.setHeightOffset(2000, 'absolute');
+     * ```
+     */
+    setHeightOffset(heightOffset: number, heightAnchor?: HeightAnchor): this {
+        this._heightOffset = heightOffset;
+        if (heightAnchor) this._heightAnchor = heightAnchor;
+        this._update();
+        return this;
+    }
+
+    /**
+     * Get how far above the ground the marker is drawn, in meters.
+     * @returns The marker's height offset.
+     */
+    getHeightOffset(): number {
+        return this._heightOffset;
+    }
+
+    /**
+     * Get the datum the marker's height offset is measured from.
+     * @returns `ground` or `absolute`.
+     */
+    getHeightAnchor(): HeightAnchor {
+        return this._heightAnchor;
+    }
 
     /**
      * Get the marker's offset.

--- a/test/build/bundle_size.json
+++ b/test/build/bundle_size.json
@@ -1,7 +1,7 @@
 {
     "dist/maplibre-gl.mjs": {
-        "raw": 568122,
-        "gzip": 143308
+        "raw": 569288,
+        "gzip": 143562
     },
     "dist/maplibre-gl-worker.mjs": {
         "raw": 18592,


### PR DESCRIPTION
Fixes #8228.

Markers are always projected at ground level, so the elevated placement that symbol layers gained in #7827 has no equivalent for DOM markers.

## Launch Checklist

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality.
 - [x] Document any changes to public APIs.
 - [ ] If you changed code in a file that has a benchmark file next to it (`*.bench.ts`), post before/after results of `npm run bench` (the compare workflow is in `test/bench/README.md`).
 - [x] Add an entry to `CHANGELOG.md` under the `## main` section.
 - [x] Confirm you have read our AI policy [here](https://github.com/maplibre/maplibre/blob/main/AI_POLICY.md).

Assisted-By: Claude (claude-fable-5)
