### PR TITLE
fix(types): keep `Evented` a supertype of its subclasses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes
+- Fix `Map`, `Marker` and `Popup` no longer being assignable to `Evented` when compiling with `strict: true` ([#8072](https://github.com/maplibre/maplibre-gl-js/pull/8072))
 - Fix `project()` and `queryTerrainElevation` disagreeing with the rendered terrain surface when the elevation lookup sampled a different DEM zoom than the drawn mesh ([#8212](https://github.com/maplibre/maplibre-gl-js/issues/8212))
 - Draw numbers (e.g. “21” in “반포대로21길”) and short uppercase codes (e.g. “A1”) upright in vertical line labels instead of rotating them along the line ([#5404](https://github.com/maplibre/maplibre-gl-js/issues/5404)) (by [@NEKOYASAN](https://github.com/NEKOYASAN))
 - Fix the camera jumping at the end of a pan or zoom gesture on terrain by sampling the center elevation from the rendered terrain surface ([#7989](https://github.com/maplibre/maplibre-gl-js/issues/7989), [#3982](https://github.com/maplibre/maplibre-gl-js/issues/3982))

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -42,6 +42,7 @@ export default [
                         'build/generate-*.ts',
                         'build/eslint-rules/*.js',
                         'test/build/*.ts',
+                        'test/types/*.ts',
                         'eslint.config.js',
                         'postcss.config.js',
                     ],

--- a/src/util/evented.ts
+++ b/src/util/evented.ts
@@ -20,7 +20,9 @@ export type EventNames<EventType extends EventTypeMap> = Extract<keyof EventType
  */
 export type EventedParentData = Record<string, unknown>;
 
-type Listeners<EventType extends EventTypeMap> = {[K in keyof EventType]?: Array<Listener<EventType[K]>>};
+type Listeners<EventType extends EventTypeMap> = {
+    [K in keyof EventType]?: Array<{bivariant(event: EventType[K]): unknown}['bivariant']>
+};
 
 function _addEventListener<T extends EventTypeMap, K extends EventNames<T>>(type: K, listener: Listener<T[K]>, listenerList: Listeners<T>) {
     const listenerExists = listenerList[type]?.includes(listener);

--- a/test/types/evented-assignability.ts
+++ b/test/types/evented-assignability.ts
@@ -1,0 +1,13 @@
+/**
+ * `Evented` is exported as the base of every evented class, so `Map`, `Marker`
+ * and `Popup` must be assignable to it.
+ */
+import type {Evented, Map, Marker, Popup} from '../../dist/maplibre-gl';
+
+declare const map: Map;
+declare const marker: Marker;
+declare const popup: Popup;
+
+export const eventedMap: Evented = map;
+export const eventedMarker: Evented = marker;
+export const eventedPopup: Evented = popup;

--- a/tsconfig.dist.json
+++ b/tsconfig.dist.json
@@ -8,7 +8,8 @@
     ]
   },
   "include": [
-    "dist/maplibre-gl.d.ts"
+    "dist/maplibre-gl.d.ts",
+    "test/types/**/*"
   ],
   "exclude": []
 }


### PR DESCRIPTION
## The problem

`Evented` is exported as the base of every evented class, so consumers write the bare form. Since #8072 that does not type-check:

```ts
import type {Evented, Map} from 'maplibre-gl';
declare const map: Map;
const evented: Evented = map;   // TS2322
```


```
Type 'Map' is not assignable to type 'Evented<EventTypeMap>'.
  Types of property '_listeners' are incompatible.
    Property 'error' is incompatible with index signature.
      Type 'Listener<ErrorEvent>' is not assignable to 'Listener<Event<string>>'.
```

`Map` extends `Evented<MapEventType>`, whose values are `Event` subclasses. `Listeners<T>` put that value type in a contravariant position, so a specific map was not assignable to `Record<string, Event>`. `Marker` and `Popup` failed the same way. First released in v6.3.0. Bisected to f950bf6f1 (#8072).

## Why CI did not catch it

`tsconfig.json` sets `strict: false`. With `strictFunctionTypes` off, parameter bivariance already applies, so no check against `src` sees the failure. Only a consumer with `strict: true` sees it.

`tsconfig.dist.json` is `strict: true` and already reads the published `d.ts`, so the type tests join it. `npm run typecheck` runs them.

## The change

TypeScript exempts method declarations from `strictFunctionTypes`, so the method-shorthand form restores the assignability. The default type argument and every explicit `Evented<Specific>` stay as they are.

The first commit adds the test and fails. The second commit is 3 lines and makes it pass.

## Rejected

- `protected` fields: `src/ui/map.ts:4157` reads `_listeners` across classes.
- `Listeners<EventTypeMap>` storage: 15 errors in `src`.
- `Record<string, any>` default: brings back `any`, and the exported symbol fails `generate-docs`.
- `Record<string, never>` default: 137 errors, and does not fix the problem.
- `Record<string, unknown>`: does not satisfy the constraint.
- A vitest build test that spawns the compiler: 25 lines, duplicates the compiler flags, and needs platform-specific handling of the bin.

## Verified

`npm run typecheck`, `npm run generate-docs` and eslint. Checked out on its own, the test commit fails `npm run typecheck`.

Cowritten by Claude

## Launch Checklist


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues/commits.
 - [x] Write tests for all new functionality.
 - [x] Add an entry to `CHANGELOG.md` under the `## main` section.
 - [x] Confirm you have read our AI policy [here](https://github.com/maplibre/maplibre/blob/main/AI_POLICY.md).

Assisted-By: Claude
