### PR TITLE
docs(marker): show keyboard accessibility for custom marker elements

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -237,6 +237,7 @@
     "Utilice",
     "vaos",
     "varyings",
+    "veritiles",
     "versor",
     "verticalizable",
     "verticalized",

--- a/test/examples/create-a-draggable-marker.html
+++ b/test/examples/create-a-draggable-marker.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <title>Create a draggable Marker</title>
-    <meta property="og:description" content="Drag the marker to a new location on a map and populate its coordinates in a display." />
+    <meta property="og:description" content="Drag a marker with the pointer or the keyboard, and make a custom marker element keyboard accessible." />
     <meta property="og:category" content="Markers" />
     <meta property="og:order" content="3" />
     <meta property="og:created" content="2025-06-25" />
@@ -30,6 +30,15 @@
         border-radius: 3px;
         display: none;
     }
+
+    .custom-marker {
+        width: 24px;
+        height: 24px;
+        border-radius: 50%;
+        border: 2px solid #fff;
+        background: #e55e5e;
+        cursor: move;
+    }
 </style>
 
 <div id="map"></div>
@@ -46,18 +55,57 @@
         zoom: 2
     });
 
+    // A default marker with draggable: true is keyboard accessible out of
+    // the box. Tab focuses it, the arrow keys move it 1 screen pixel per
+    // press (10 with Shift), and the usual dragstart/drag/dragend events
+    // fire.
     const marker = new maplibregl.Marker({draggable: true})
         .setLngLat([0, 0])
         .addTo(map);
 
-    function onDragEnd() {
-        const lngLat = marker.getLngLat();
+    function showCoordinates(m) {
+        const lngLat = m.getLngLat();
         coordinates.style.display = 'block';
         coordinates.innerHTML =
             `Longitude: ${lngLat.lng}<br />Latitude: ${lngLat.lat}`;
     }
 
-    marker.on('dragend', onDragEnd);
+    marker.on('dragend', () => showCoordinates(marker));
+
+    // A marker created with a custom element owns its accessibility
+    // completely. The map adds no tabindex, label, or keyboard behavior,
+    // so the application supplies them.
+    const el = document.createElement('div');
+    el.className = 'custom-marker';
+    el.tabIndex = 0;
+    el.setAttribute('role', 'button');
+    el.setAttribute('aria-label', 'Map marker, use arrow keys to move');
+
+    const customMarker = new maplibregl.Marker({element: el, draggable: true})
+        .setLngLat([20, 0])
+        .addTo(map);
+
+    customMarker.on('dragend', () => showCoordinates(customMarker));
+
+    el.addEventListener('keydown', (e) => {
+        const deltas = {
+            ArrowLeft: [-1, 0],
+            ArrowRight: [1, 0],
+            ArrowUp: [0, -1],
+            ArrowDown: [0, 1]
+        };
+        const delta = deltas[e.key];
+        if (!delta) return;
+        e.preventDefault();
+        // The marker element lives inside the canvas container, so without
+        // this the map's KeyboardHandler sees the same keydown and pans the
+        // camera on every press.
+        e.stopPropagation();
+        const pos = map.project(customMarker.getLngLat());
+        customMarker.setLngLat(
+            map.unproject([pos.x + delta[0], pos.y + delta[1]]));
+        showCoordinates(customMarker);
+    });
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Launch Checklist
- [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license).
- [x] Briefly describe the changes in this PR.
- [x] Link to related issues.
- [ ] Include before/after visuals or gifs if this PR includes visual changes.
- [ ] Write tests for all new functionality. (Docs example only.)
- [ ] Document any changes to public APIs. (No API changes.)
- [ ] Post benchmark scores. (Not applicable.)
- [ ] Add an entry to `CHANGELOG.md` under the `## main` section. (Docs example only, no behavior change.)
- [x] Confirm you have read our AI policy [here](https://github.com/maplibre/maplibre/blob/main/AI_POLICY.md).

## Summary

Fixes #8046. Follows the direction from that thread (extend the existing example instead of adding a new page), unblocked now that #8045 is merged.

Extends `test/examples/create-a-draggable-marker.html` with a second marker built from a custom `element`, wired the way an application has to do it since custom elements own their accessibility completely (per #7790 and the boundary #8045 kept):

- `tabindex="0"`, `role="button"`, and an `aria-label`
- a keydown handler mapping the arrow keys to 1 px moves via `map.project`/`map.unproject`
- `stopPropagation()` on the handled keydown, with a comment explaining why: the marker element lives inside the canvas container, so without it the map's `KeyboardHandler` pans the camera on the same press

The default marker in the example is untouched; after #8045 it is keyboard accessible out of the box, so the example now shows both sides of the boundary. The `og:description` is updated to mention keyboard accessibility.

## Manual testing

Built `dist` and road-tested the example in Chromium:

- the custom marker is reachable in tab order, exposes the label, and 3 ArrowRight presses moved it +3.2 px (1 px per press plus subpixel projection rounding) while the default marker's bounding rect moved 0 px, so no camera pan leaked through
- the default marker still moves exactly 1 px per ArrowRight natively (#8045 behavior), with the custom marker unaffected
- both markers update the coordinates readout
- `npx eslint` on the changed file passes

Disclosure per the AI policy: written with AI assistance (Claude); the approach, code, and measurements were reviewed and the road test run on a real browser before pushing.