### PR TITLE
fix: skip terrain drawing until replacement projection is ready

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes
+- Fix `setStyle()` throwing while terrain is still loading because an intermediate render tried to compile a terrain shader before the replacement style initialized its projection ([#6824](https://github.com/maplibre/maplibre-gl-js/issues/6824)) (by [@miakh](https://github.com/miakh))
 - Fix queued GeoJSON `updateData` property removals throwing after geometry-only updates or retaining previously updated values ([#8372](https://github.com/maplibre/maplibre-gl-js/pull/8372)) (by [@jokrasno](https://github.com/jokrasno))
 - Treat camera options passed as `undefined` as not given in `jumpTo`, `easeTo` and `flyTo`; they were coerced to NaN ([#8373](https://github.com/maplibre/maplibre-gl-js/pull/8373)) (by [@vlumi](https://github.com/vlumi))
 - Fix a `Not implemented.` error that broke panning and zooming when the projection was changed while the camera was moving, on maps with terrain enabled or a `transformCameraUpdate` callback ([#8351](https://github.com/maplibre/maplibre-gl-js/issues/8351)) (by [@lazerg](https://github.com/lazerg))

--- a/src/render/painter.ts
+++ b/src/render/painter.ts
@@ -656,7 +656,7 @@ export class Painter {
      * Update the depth framebuffer if the camera has moved or tiles have reloaded.
      */
     maybeDrawDepth(): void {
-        if (!this.style?.map?.terrain) {
+        if (!this.style?.projection || !this.style.map?.terrain) {
             return;
         }
         const prevMatrix = this.terrainFacilitator.matrix;

--- a/src/ui/map_tests/map_style.test.ts
+++ b/src/ui/map_tests/map_style.test.ts
@@ -8,7 +8,7 @@ import {extend} from '../../util/util.ts';
 import {fakeServer, type FakeServer} from 'nise';
 import {Style} from '../../style/style.ts';
 import {LngLatBounds} from '../../geo/lng_lat_bounds.ts';
-import type {GeoJSONSourceSpecification, LayerSpecification} from '@maplibre/maplibre-gl-style-spec';
+import type {GeoJSONSourceSpecification, LayerSpecification, StyleSpecification} from '@maplibre/maplibre-gl-style-spec';
 
 let server: FakeServer;
 
@@ -23,6 +23,58 @@ afterEach(() => {
 });
 
 describe('setStyle', () => {
+    test('replaces a terrain style while terrain is loading', async () => {
+        const terrainStyle: StyleSpecification = {
+            version: 8,
+            sources: {
+                dem: {
+                    type: 'raster-dem',
+                    tiles: ['http://example.com/{z}/{x}/{y}.png']
+                }
+            },
+            terrain: {source: 'dem'},
+            layers: []
+        };
+        const nextTerrainStyle: StyleSpecification = {
+            ...terrainStyle,
+            sources: {nextDem: terrainStyle.sources.dem},
+            terrain: {source: 'nextDem'}
+        };
+        const map = createMap({style: terrainStyle});
+        await map.once('style.load');
+        const styleLoad = map.once('style.load');
+
+        map.setStyle(nextTerrainStyle, {diff: false});
+        map.redraw();
+        await styleLoad;
+
+        expect(map.getTerrain()).toEqual({source: 'nextDem'});
+    });
+
+    test('replaces a loading terrain style with a style without terrain', async () => {
+        const map = createMap({
+            style: {
+                version: 8,
+                sources: {
+                    dem: {
+                        type: 'raster-dem',
+                        tiles: ['http://example.com/{z}/{x}/{y}.png']
+                    }
+                },
+                terrain: {source: 'dem'},
+                layers: []
+            }
+        });
+        await map.once('style.load');
+        const styleLoad = map.once('style.load');
+
+        map.setStyle({version: 8, sources: {}, layers: []}, {diff: false});
+        map.redraw();
+        await styleLoad;
+
+        expect(map.getTerrain()).toBeNull();
+    });
+
     test('returns self', () => {
         const map = new Map({container: window.document.createElement('div')});
         expect(map.setStyle({


### PR DESCRIPTION
- Fixes #6824.

Replacing a style while terrain is loading can trigger an intermediate render before the replacement style has initialized its projection. This skips the terrain depth pass during that transient state and resumes normal rendering once the projection is available.

Regression tests cover both terrain-to-terrain and terrain-to-non-terrain style replacement.

## Validation

- `npm run test-unit -- map_style.test.ts` — 37 tests passed
- `npx eslint src/ui/map_tests/map_style.test.ts` — passed
- `git diff --check origin/main...HEAD` — passed

## Launch checklist

- [x] This change contains no Mapbox backport.
- [x] Tests cover the reported regression.
- [x] A changelog entry is included.
- [x] No public API documentation or benchmark update is required.
- [x] The contributor has personally reviewed the complete diff and read the MapLibre AI policy.

## AI assistance

Generated-By: OpenAI Codex (GPT-5.6-sol)

Codex was used to investigate issue #6824, implement the regression tests and fix, and perform independent standards and specification reviews. The contributor has personally reviewed the complete diff and takes responsibility for the contribution.
