### PR TITLE
Skip serializing the style when validation is turned off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Allow adding an image source without a `url`. The source starts empty and makes no network request; call `updateImage({image})` or `updateImage({url})` later to show an image ([#8167](https://github.com/maplibre/maplibre-gl-js/pull/8167))
 - Skip symbol re-placement when its inputs are unchanged, so repaints from animated style images or custom layers cost a single frame ([#8208](https://github.com/maplibre/maplibre-gl-js/pull/8208)) (by [@lucaswoj](https://github.com/lucaswoj))
 - Add `Style#triggerSymbolPlacement`, which re-places symbols when something the map cannot see for itself has moved them ([#8208](https://github.com/maplibre/maplibre-gl-js/pull/8208)) (by [@lucaswoj](https://github.com/lucaswoj))
+- Make `{validate: false}` skip the style snapshot the style setters only build as error context, so adding layers one at a time no longer serializes the whole style on every call ([#8259](https://github.com/maplibre/maplibre-gl-js/issues/8259))
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes

--- a/src/style/style.test.ts
+++ b/src/style/style.test.ts
@@ -2350,18 +2350,6 @@ describe('Style.addLayer', () => {
         expect(style.getLayer('custom')).toBeUndefined();
     });
 
-    test('does not serialize the style when validation is off', async () => {
-        const style = new Style(getStubMap());
-        style.loadJSON(createStyleJSON());
-        await style.once('style.load');
-        const serialize = vi.spyOn(style, 'serialize');
-
-        style.addLayer({id: 'background', type: 'background'}, undefined, {validate: false});
-
-        expect(serialize).not.toHaveBeenCalled();
-        expect(style.getLayer('background')).toBeTruthy();
-    });
-
     test('sets up layer event forwarding', async () => {
         const style = new Style(getStubMap());
         style.loadJSON(createStyleJSON());

--- a/src/style/style.test.ts
+++ b/src/style/style.test.ts
@@ -2350,6 +2350,18 @@ describe('Style.addLayer', () => {
         expect(style.getLayer('custom')).toBeUndefined();
     });
 
+    test('does not serialize the style when validation is off', async () => {
+        const style = new Style(getStubMap());
+        style.loadJSON(createStyleJSON());
+        await style.once('style.load');
+        const serialize = vi.spyOn(style, 'serialize');
+
+        style.addLayer({id: 'background', type: 'background'}, undefined, {validate: false});
+
+        expect(serialize).not.toHaveBeenCalled();
+        expect(style.getLayer('background')).toBeTruthy();
+    });
+
     test('sets up layer event forwarding', async () => {
         const style = new Style(getStubMap());
         style.loadJSON(createStyleJSON());

--- a/src/style/style.ts
+++ b/src/style/style.ts
@@ -1755,8 +1755,6 @@ export class Style extends Evented<MapEventType> {
     }
 
     _validate(validate: Validator, key: string, value: any, props: any, options: StyleSetterOptions = {}): boolean {
-        // Checked here as well as in validateAndEmit so that serializing the style, which costs
-        // O(layers) and is only needed as error context, is skipped along with the validation.
         if (options.validate === false) return false;
 
         return validateAndEmit(this, validate, {

--- a/src/style/style.ts
+++ b/src/style/style.ts
@@ -1755,6 +1755,10 @@ export class Style extends Evented<MapEventType> {
     }
 
     _validate(validate: Validator, key: string, value: any, props: any, options: StyleSetterOptions = {}): boolean {
+        // Checked here as well as in validateAndEmit so that serializing the style, which costs
+        // O(layers) and is only needed as error context, is skipped along with the validation.
+        if (options.validate === false) return false;
+
         return validateAndEmit(this, validate, {
             key,
             style: this.serialize(),


### PR DESCRIPTION
`Style._validate` builds the style snapshot as an argument, so `this.serialize()` runs before `validateAndEmit` gets to look at `options.validate`. Passing `{validate: false}` skipped the validation but never the serialize, and since `addLayer` drops the serialized-layer cache on every call, adding N layers one at a time serialized the whole style N times.

Checking the flag in `_validate` before composing the params makes the escape hatch actually cheap. The default path is unchanged, so validation still pays for the snapshot it needs.

Fixes #8259

## Launch Checklist

- [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license)
- [x] Briefly describe the changes in this PR.
- [x] Link to related issues.
- [x] Write tests for all new functionality.
- [x] Add an entry to `CHANGELOG.md` under the `## main` section.
