### PR TITLE
fix: Serialize `state` in map style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Fix `project()` and `queryTerrainElevation` disagreeing with the rendered terrain surface when the elevation lookup sampled a different DEM zoom than the drawn mesh ([#8212](https://github.com/maplibre/maplibre-gl-js/issues/8212))
 - Draw numbers (e.g. “21” in “반포대로21길”) and short uppercase codes (e.g. “A1”) upright in vertical line labels instead of rotating them along the line ([#5404](https://github.com/maplibre/maplibre-gl-js/issues/5404)) (by [@NEKOYASAN](https://github.com/NEKOYASAN))
 - Fix the camera jumping at the end of a pan or zoom gesture on terrain by sampling the center elevation from the rendered terrain surface ([#7989](https://github.com/maplibre/maplibre-gl-js/issues/7989), [#3982](https://github.com/maplibre/maplibre-gl-js/issues/3982))
+- Ensure style state defaults are serialized (by [@hiddewie](https://github.com/hiddewie))
 
 ## 6.6.0
 

--- a/src/style/style.test.ts
+++ b/src/style/style.test.ts
@@ -3810,6 +3810,32 @@ describe('Style.serialize', () => {
         expect(style.serialize().sky).toBeDefined();
     });
 
+    test('include state property for style with state defaults', async () => {
+        const style = new Style(getStubMap());
+        style.loadJSON(createStyleJSON());
+
+        await style.once('style.load');
+        expect(style.serialize().state).toBeUndefined();
+    });
+
+    test('include state property for style with state defaults', async () => {
+        const style = new Style(getStubMap());
+        style.loadJSON(createStyleJSON({
+            state: {
+                showCircles: {
+                    default: true,
+                }
+            }
+        }));
+
+        await style.once('style.load');
+        expect(style.serialize().state).toEqual({
+            showCircles: {
+                default: true,
+            },
+        });
+    });
+
     test('update sky properties after setting the sky on initial load', async () => {
         const sky: SkySpecification = {
             'fog-color': '#FF0000'

--- a/src/style/style.test.ts
+++ b/src/style/style.test.ts
@@ -3810,7 +3810,7 @@ describe('Style.serialize', () => {
         expect(style.serialize().sky).toBeDefined();
     });
 
-    test('include state property for style with state defaults', async () => {
+    test('does not include state property when style has no state defaults', async () => {
         const style = new Style(getStubMap());
         style.loadJSON(createStyleJSON());
 

--- a/src/style/style.ts
+++ b/src/style/style.ts
@@ -1487,9 +1487,10 @@ export class Style extends Evented<MapEventType> {
             glyphs: myStyleSheet.glyphs,
             transition: myStyleSheet.transition,
             projection: myStyleSheet.projection,
+            state: myStyleSheet.state,
             sources,
             layers,
-            terrain
+            terrain,
         },
         (value) => value !== undefined);
     }


### PR DESCRIPTION
## Changes

When the map style is serialized, it should include the entire map style. Currently, the `state` is missing, which contains the defaults used to configure the style's global state.

This pull request adds the serialization of the style state defaults, and adds a few tests to prove that it works.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items that are not relevant. -->


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [x] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality.
 - [x] Document any changes to public APIs.
 - [x] If you changed code in a file that has a benchmark file next to it (`*.bench.ts`), post before/after results of `npm run bench` (the compare workflow is in `test/bench/README.md`).
 - [x] Add an entry to `CHANGELOG.md` under the `## main` section.
 - [x] Confirm you have read our AI policy [here](https://github.com/maplibre/maplibre/blob/main/AI_POLICY.md).
<!--
  Add one of:    Assisted-By: | Generated-By:     and the model/version
-->

No AI was used to create this pull request.