### PR TITLE
feat: Allow providing initial global state for style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Skip symbol re-placement when its inputs are unchanged, so repaints from animated style images or custom layers cost a single frame ([#8208](https://github.com/maplibre/maplibre-gl-js/pull/8208)) (by [@lucaswoj](https://github.com/lucaswoj))
 - Add `Style#triggerSymbolPlacement`, which re-places symbols when something the map cannot see for itself has moved them ([#8208](https://github.com/maplibre/maplibre-gl-js/pull/8208)) (by [@lucaswoj](https://github.com/lucaswoj))
 - Make `{validate: false}` skip the style snapshot the style setters only build as error context, so adding layers one at a time no longer serializes the whole style on every call ([#8259](https://github.com/maplibre/maplibre-gl-js/issues/8259))
+- Allow calling `setStyle({ globalState: ... })` to provide an initial global state for the map style, overriding the global state defaults from the style ([#7632](https://github.com/maplibre/maplibre-gl-js/issues/7632))
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes

--- a/src/style/style.test.ts
+++ b/src/style/style.test.ts
@@ -565,7 +565,7 @@ describe('Style.loadJSON', () => {
         // by setting globalState property and checking if the new value
         // was used when evaluating the layer
         const globalState = {size: {default: 12}};
-        style.setGlobalState(globalState, null);
+        style.setGlobalState(globalState);
         const layer = style.getLayer('layer-id');
         layer.recalculate({} as EvaluationParameters, []);
         const layout = layer.layout as PossiblyEvaluated<SymbolLayoutProps, SymbolLayoutPropsPossiblyEvaluated>;
@@ -596,7 +596,7 @@ describe('Style.loadJSON', () => {
         // by setting globalState property and checking if the new value
         // was used when evaluating the layer
         const globalState = {color: {default: 'red'}, radius: {default: 12}};
-        style.setGlobalState(globalState, null);
+        style.setGlobalState(globalState);
         const layer = style.getLayer('layer-id');
         layer.recalculate({} as EvaluationParameters, []);
         const paint = layer.paint as PossiblyEvaluated<CirclePaintProps, CirclePaintPropsPossiblyEvaluated>;
@@ -1788,31 +1788,15 @@ describe('Style.setGeoJSONSourceData', () => {
 describe('Style.setGlobalState', () => {
     test('throws before loaded', () => {
         const style = new Style(getStubMap());
-        expect(() => style.setGlobalState({}, null)).toThrow(/load/i);
+        expect(() => style.setGlobalState({})).toThrow(/load/i);
     });
 
     test('sets global state', async () => {
         const style = new Style(getStubMap());
         style.loadJSON(createStyleJSON());
         await style.once('style.load');
-        style.setGlobalState({accentColor: {default: 'yellow'}}, null);
+        style.setGlobalState({accentColor: {default: 'yellow'}});
         expect(style.getGlobalState()).toEqual({accentColor: 'yellow'});
-    });
-
-    test('sets global state, with the state overriding the style defaults', async () => {
-        const style = new Style(getStubMap());
-        style.loadJSON(createStyleJSON());
-        await style.once('style.load');
-        style.setGlobalState({accentColor: {default: 'yellow'}}, {accentColor: 'red'});
-        expect(style.getGlobalState()).toEqual({accentColor: 'red'});
-    });
-
-    test('sets global state, with state properties without a default accepted', async () => {
-        const style = new Style(getStubMap());
-        style.loadJSON(createStyleJSON());
-        await style.once('style.load');
-        style.setGlobalState({accentColor: {default: 'yellow'}}, {other: 'value'});
-        expect(style.getGlobalState()).toEqual({accentColor: 'yellow', other: 'value'});
     });
 
     test('reloads sources when state property is used in filter property', async () => {
@@ -1843,7 +1827,7 @@ describe('Style.setGlobalState', () => {
         style.tileManagers['fill-source-id'].resume = vi.fn();
         style.tileManagers['fill-source-id'].reload = vi.fn();
 
-        style.setGlobalState({showCircles: {default: true}, showFill: {default: false}}, null);
+        style.setGlobalState({showCircles: {default: true}, showFill: {default: false}});
 
         expect(style.tileManagers['circle-source-id'].resume).toHaveBeenCalled();
         expect(style.tileManagers['circle-source-id'].reload).toHaveBeenCalled();
@@ -1871,7 +1855,7 @@ describe('Style.setGlobalState', () => {
         style.tileManagers['line-source-id'].resume = vi.fn();
         style.tileManagers['line-source-id'].reload = vi.fn();
 
-        style.setGlobalState({lineJoin: {default: 'bevel'}}, null);
+        style.setGlobalState({lineJoin: {default: 'bevel'}});
 
         expect(style.tileManagers['line-source-id'].resume).toHaveBeenCalled();
         expect(style.tileManagers['line-source-id'].reload).toHaveBeenCalled();
@@ -1899,7 +1883,7 @@ describe('Style.setGlobalState', () => {
         style.tileManagers['circle-source-id'].resume = vi.fn();
         style.tileManagers['circle-source-id'].reload = vi.fn();
 
-        style.setGlobalState({circleColor: {default: 'red'}}, null);
+        style.setGlobalState({circleColor: {default: 'red'}});
         style.update({} as EvaluationParameters);
 
         expect(style.tileManagers['circle-source-id'].resume).toHaveBeenCalled();
@@ -1931,38 +1915,7 @@ describe('Style.setGlobalState', () => {
         style.tileManagers['circle-source-id'].resume = vi.fn();
         style.tileManagers['circle-source-id'].reload = vi.fn();
 
-        style.setGlobalState({showCircles: {default: true}}, null);
-
-        expect(style.tileManagers['circle-source-id'].resume).not.toHaveBeenCalled();
-        expect(style.tileManagers['circle-source-id'].reload).not.toHaveBeenCalled();
-    });
-
-    test('does not reload sources when state property is set to the same value as current one, but with a different default value', async () => {
-        const style = new Style(getStubMap());
-        style.loadJSON(createStyleJSON({
-            state: {
-                'showCircles': {
-                    default: true
-                }
-            },
-            sources: {
-                'circle-source-id': createGeoJSONSource(),
-                'fill-source-id': createGeoJSONSource()
-            },
-            layers: [{
-                id: 'first-layer-id',
-                type: 'circle',
-                source: 'circle-source-id',
-                filter: ['global-state', 'showCircles']
-            }]
-        }));
-
-        await style.once('style.load');
-
-        style.tileManagers['circle-source-id'].resume = vi.fn();
-        style.tileManagers['circle-source-id'].reload = vi.fn();
-
-        style.setGlobalState({showCircles: {default: false}}, {showCircles: true});
+        style.setGlobalState({showCircles: {default: true}});
 
         expect(style.tileManagers['circle-source-id'].resume).not.toHaveBeenCalled();
         expect(style.tileManagers['circle-source-id'].reload).not.toHaveBeenCalled();
@@ -1990,7 +1943,7 @@ describe('Style.setGlobalState', () => {
         style.tileManagers['circle-source-id'].resume = vi.fn();
         style.tileManagers['circle-source-id'].reload = vi.fn();
 
-        style.setGlobalState({circleColor: {default: 'red'}}, null);
+        style.setGlobalState({circleColor: {default: 'red'}});
         style.update({} as EvaluationParameters);
 
         expect(style.tileManagers['circle-source-id'].resume).not.toHaveBeenCalled();
@@ -2019,7 +1972,7 @@ describe('Style.setGlobalState', () => {
         style.tileManagers['circle-source-id'].resume = vi.fn();
         style.tileManagers['circle-source-id'].reload = vi.fn();
 
-        style.setGlobalState({circleColor: {default: 'red'}}, null);
+        style.setGlobalState({circleColor: {default: 'red'}});
         style.update({} as EvaluationParameters);
 
         expect(style.tileManagers['circle-source-id'].resume).not.toHaveBeenCalled();
@@ -2050,7 +2003,7 @@ describe('Style.setGlobalState', () => {
         style.tileManagers['line-source-id'].resume = vi.fn();
         style.tileManagers['line-source-id'].reload = vi.fn();
 
-        style.setGlobalState({lineColor: {default: 'red'}}, null);
+        style.setGlobalState({lineColor: {default: 'red'}});
 
         expect(style.tileManagers['line-source-id'].resume).not.toHaveBeenCalled();
         expect(style.tileManagers['line-source-id'].reload).not.toHaveBeenCalled();

--- a/src/style/style.test.ts
+++ b/src/style/style.test.ts
@@ -565,7 +565,7 @@ describe('Style.loadJSON', () => {
         // by setting globalState property and checking if the new value
         // was used when evaluating the layer
         const globalState = {size: {default: 12}};
-        style.setGlobalState(globalState);
+        style.setGlobalState(globalState, null);
         const layer = style.getLayer('layer-id');
         layer.recalculate({} as EvaluationParameters, []);
         const layout = layer.layout as PossiblyEvaluated<SymbolLayoutProps, SymbolLayoutPropsPossiblyEvaluated>;
@@ -596,7 +596,7 @@ describe('Style.loadJSON', () => {
         // by setting globalState property and checking if the new value
         // was used when evaluating the layer
         const globalState = {color: {default: 'red'}, radius: {default: 12}};
-        style.setGlobalState(globalState);
+        style.setGlobalState(globalState, null);
         const layer = style.getLayer('layer-id');
         layer.recalculate({} as EvaluationParameters, []);
         const paint = layer.paint as PossiblyEvaluated<CirclePaintProps, CirclePaintPropsPossiblyEvaluated>;
@@ -1788,14 +1788,31 @@ describe('Style.setGeoJSONSourceData', () => {
 describe('Style.setGlobalState', () => {
     test('throws before loaded', () => {
         const style = new Style(getStubMap());
-        expect(() => style.setGlobalState({})).toThrow(/load/i);
+        expect(() => style.setGlobalState({}, null)).toThrow(/load/i);
     });
+
     test('sets global state', async () => {
         const style = new Style(getStubMap());
         style.loadJSON(createStyleJSON());
         await style.once('style.load');
-        style.setGlobalState({accentColor: {default: 'yellow'}});
+        style.setGlobalState({accentColor: {default: 'yellow'}}, null);
         expect(style.getGlobalState()).toEqual({accentColor: 'yellow'});
+    });
+
+    test('sets global state, with the state overriding the style defaults', async () => {
+        const style = new Style(getStubMap());
+        style.loadJSON(createStyleJSON());
+        await style.once('style.load');
+        style.setGlobalState({accentColor: {default: 'yellow'}}, {accentColor: 'red'});
+        expect(style.getGlobalState()).toEqual({accentColor: 'red'});
+    });
+
+    test('sets global state, with state properties without a default accepted', async () => {
+        const style = new Style(getStubMap());
+        style.loadJSON(createStyleJSON());
+        await style.once('style.load');
+        style.setGlobalState({accentColor: {default: 'yellow'}}, {other: 'value'});
+        expect(style.getGlobalState()).toEqual({accentColor: 'yellow', other: 'value'});
     });
 
     test('reloads sources when state property is used in filter property', async () => {
@@ -1826,7 +1843,7 @@ describe('Style.setGlobalState', () => {
         style.tileManagers['fill-source-id'].resume = vi.fn();
         style.tileManagers['fill-source-id'].reload = vi.fn();
 
-        style.setGlobalState({showCircles: {default: true}, showFill: {default: false}});
+        style.setGlobalState({showCircles: {default: true}, showFill: {default: false}}, null);
 
         expect(style.tileManagers['circle-source-id'].resume).toHaveBeenCalled();
         expect(style.tileManagers['circle-source-id'].reload).toHaveBeenCalled();
@@ -1854,7 +1871,7 @@ describe('Style.setGlobalState', () => {
         style.tileManagers['line-source-id'].resume = vi.fn();
         style.tileManagers['line-source-id'].reload = vi.fn();
 
-        style.setGlobalState({lineJoin: {default: 'bevel'}});
+        style.setGlobalState({lineJoin: {default: 'bevel'}}, null);
 
         expect(style.tileManagers['line-source-id'].resume).toHaveBeenCalled();
         expect(style.tileManagers['line-source-id'].reload).toHaveBeenCalled();
@@ -1882,7 +1899,7 @@ describe('Style.setGlobalState', () => {
         style.tileManagers['circle-source-id'].resume = vi.fn();
         style.tileManagers['circle-source-id'].reload = vi.fn();
 
-        style.setGlobalState({circleColor: {default: 'red'}});
+        style.setGlobalState({circleColor: {default: 'red'}}, null);
         style.update({} as EvaluationParameters);
 
         expect(style.tileManagers['circle-source-id'].resume).toHaveBeenCalled();
@@ -1914,7 +1931,38 @@ describe('Style.setGlobalState', () => {
         style.tileManagers['circle-source-id'].resume = vi.fn();
         style.tileManagers['circle-source-id'].reload = vi.fn();
 
-        style.setGlobalState({showCircles: {default: true}});
+        style.setGlobalState({showCircles: {default: true}}, null);
+
+        expect(style.tileManagers['circle-source-id'].resume).not.toHaveBeenCalled();
+        expect(style.tileManagers['circle-source-id'].reload).not.toHaveBeenCalled();
+    });
+
+    test('does not reload sources when state property is set to the same value as current one, but with a different default value', async () => {
+        const style = new Style(getStubMap());
+        style.loadJSON(createStyleJSON({
+            state: {
+                'showCircles': {
+                    default: true
+                }
+            },
+            sources: {
+                'circle-source-id': createGeoJSONSource(),
+                'fill-source-id': createGeoJSONSource()
+            },
+            layers: [{
+                id: 'first-layer-id',
+                type: 'circle',
+                source: 'circle-source-id',
+                filter: ['global-state', 'showCircles']
+            }]
+        }));
+
+        await style.once('style.load');
+
+        style.tileManagers['circle-source-id'].resume = vi.fn();
+        style.tileManagers['circle-source-id'].reload = vi.fn();
+
+        style.setGlobalState({showCircles: {default: false}}, {showCircles: true});
 
         expect(style.tileManagers['circle-source-id'].resume).not.toHaveBeenCalled();
         expect(style.tileManagers['circle-source-id'].reload).not.toHaveBeenCalled();
@@ -1942,7 +1990,7 @@ describe('Style.setGlobalState', () => {
         style.tileManagers['circle-source-id'].resume = vi.fn();
         style.tileManagers['circle-source-id'].reload = vi.fn();
 
-        style.setGlobalState({circleColor: {default: 'red'}});
+        style.setGlobalState({circleColor: {default: 'red'}}, null);
         style.update({} as EvaluationParameters);
 
         expect(style.tileManagers['circle-source-id'].resume).not.toHaveBeenCalled();
@@ -1971,7 +2019,7 @@ describe('Style.setGlobalState', () => {
         style.tileManagers['circle-source-id'].resume = vi.fn();
         style.tileManagers['circle-source-id'].reload = vi.fn();
 
-        style.setGlobalState({circleColor: {default: 'red'}});
+        style.setGlobalState({circleColor: {default: 'red'}}, null);
         style.update({} as EvaluationParameters);
 
         expect(style.tileManagers['circle-source-id'].resume).not.toHaveBeenCalled();
@@ -2002,7 +2050,7 @@ describe('Style.setGlobalState', () => {
         style.tileManagers['line-source-id'].resume = vi.fn();
         style.tileManagers['line-source-id'].reload = vi.fn();
 
-        style.setGlobalState({lineColor: {default: 'red'}});
+        style.setGlobalState({lineColor: {default: 'red'}}, null);
 
         expect(style.tileManagers['line-source-id'].resume).not.toHaveBeenCalled();
         expect(style.tileManagers['line-source-id'].reload).not.toHaveBeenCalled();

--- a/src/style/style.ts
+++ b/src/style/style.ts
@@ -242,6 +242,7 @@ export class Style extends Evented<MapEventType> {
     _layerOrderChanged: boolean;
     _symbolPlacementTriggered: boolean;
     _placedProjectionTransition: number;
+    _initialGlobalState: Record<string, any>;
     _globalState: Record<string, any>;
     crossTileSymbolIndex: CrossTileSymbolIndex;
     pauseablePlacement: PauseablePlacement;
@@ -271,7 +272,7 @@ export class Style extends Evented<MapEventType> {
         this.lineAtlas = new LineAtlas(256, 512);
         this.crossTileSymbolIndex = new CrossTileSymbolIndex();
 
-        this._setInitialValues();
+        this._setInitialValues(options.globalState);
 
         this._resetUpdates();
 
@@ -302,12 +303,13 @@ export class Style extends Evented<MapEventType> {
         });
     }
 
-    private _setInitialValues() {
+    private _setInitialValues(initialGlobalState: Record<string, any>) {
         this._layers = {};
         this._order = [];
         this.tileManagers = {};
         this.zoomHistory = new ZoomHistory();
         this._imagesListDirty = false;
+        this._initialGlobalState = initialGlobalState ?? {};
         this._globalState = {};
         this._serializedLayers = {};
         this.stylesheet = null;
@@ -365,14 +367,15 @@ export class Style extends Evented<MapEventType> {
         return this._globalState;
     }
 
-    setGlobalState(newStylesheetState: StateSpecification, globalState: Record<string, any>): void {
+    setGlobalState(newStylesheetState: StateSpecification): void {
         this._checkLoaded();
 
         const changedGlobalStateRefs = [];
-        const propertyNames = new Set([...Object.keys(newStylesheetState ?? {}), ...Object.keys(globalState ?? {})]);
+        const propertyNames = new Set([...Object.keys(newStylesheetState ?? {}), ...Object.keys(this._initialGlobalState)]);
 
         for (const propertyName of propertyNames) {
-            const propertyValue = globalState[propertyName] ?? newStylesheetState[propertyName]?.default ?? null;
+            // Initial global state has priority over global state defaults defined in the map style
+            const propertyValue = this._initialGlobalState[propertyName] ?? newStylesheetState[propertyName]?.default ?? null;
             const didChange = !deepEqual(this._globalState[propertyName], propertyValue);
 
             if (didChange) {
@@ -501,7 +504,7 @@ export class Style extends Evented<MapEventType> {
         }
 
         this.glyphManager.setURL(nextState.glyphs);
-        this._createLayers(options.globalState);
+        this._createLayers();
 
         this.light = new Light(this.stylesheet.light ?? {}, this._globalState);
         this._setProjectionInternal(this.stylesheet.projection?.type || 'mercator');
@@ -515,10 +518,10 @@ export class Style extends Evented<MapEventType> {
         this.fire(new MapStyleLoadEvent());
     }
 
-    private _createLayers(globalState: Record<string, any>) {
+    private _createLayers() {
         const dereferencedLayers = derefLayers(this.stylesheet.layers);
 
-        this.setGlobalState(this.stylesheet.state ?? null, globalState);
+        this.setGlobalState(this.stylesheet.state ?? null);
 
         // Broadcast layers to workers first, so that expensive style processing (createStyleLayer)
         // can happen in parallel on both main and worker threads.
@@ -863,7 +866,7 @@ export class Style extends Evented<MapEventType> {
         nextState.layers = derefLayers(nextState.layers);
 
         const changes = diffStyles(serializedStyle, nextState);
-        const operations = this._getOperationsToPerform(changes, options.globalState);
+        const operations = this._getOperationsToPerform(changes);
 
         if (operations.unimplemented.length > 0) {
             throw new Error(`Unimplemented: ${operations.unimplemented.join(', ')}.`);
@@ -873,6 +876,7 @@ export class Style extends Evented<MapEventType> {
             return false;
         }
 
+        this._initialGlobalState = options.globalState ?? {};
         for (const styleChangeOperation of operations.operations) {
             styleChangeOperation();
         }
@@ -887,7 +891,7 @@ export class Style extends Evented<MapEventType> {
         return true;
     }
 
-    _getOperationsToPerform(diff: Array<DiffCommand<DiffOperations>>, globalState: Record<string, any>): {operations: Function[]; unimplemented: string[]} {
+    _getOperationsToPerform(diff: Array<DiffCommand<DiffOperations>>): {operations: Function[]; unimplemented: string[]} {
         const operations: Function[] = [];
         const unimplemented: string[] = [];
         for (const op of diff) {
@@ -944,7 +948,7 @@ export class Style extends Evented<MapEventType> {
                     this.setProjection.apply(this, op.args);
                     break;
                 case 'setGlobalState':
-                    operations.push(() => this.setGlobalState.apply(this, [...op.args, globalState]));
+                    operations.push(() => this.setGlobalState.apply(this, op.args));
                     break;
                 case 'setTransition':
                     operations.push(() => {});
@@ -2125,7 +2129,7 @@ export class Style extends Evented<MapEventType> {
         }
 
         // reset internal state
-        this._setInitialValues();
+        this._setInitialValues({});
 
         // Remove event listeners
         this.setEventedParent(null);

--- a/src/style/style.ts
+++ b/src/style/style.ts
@@ -272,7 +272,6 @@ export class Style extends Evented<MapEventType> {
         this.crossTileSymbolIndex = new CrossTileSymbolIndex();
 
         this._setInitialValues();
-        this._globalState = extend({}, this._globalState, options.globalState);
 
         this._resetUpdates();
 
@@ -366,17 +365,19 @@ export class Style extends Evented<MapEventType> {
         return this._globalState;
     }
 
-    setGlobalState(newStylesheetState: StateSpecification): void {
+    setGlobalState(newStylesheetState: StateSpecification, globalState: Record<string, any>): void {
         this._checkLoaded();
 
         const changedGlobalStateRefs = [];
+        const propertyNames = new Set([...Object.keys(newStylesheetState ?? {}), ...Object.keys(globalState ?? {})]);
 
-        for (const propertyName in newStylesheetState) {
-            const didChange = !deepEqual(this._globalState[propertyName], newStylesheetState[propertyName].default);
+        for (const propertyName of propertyNames) {
+            const propertyValue = globalState[propertyName] ?? newStylesheetState[propertyName]?.default ?? null;
+            const didChange = !deepEqual(this._globalState[propertyName], propertyValue);
 
             if (didChange) {
                 changedGlobalStateRefs.push(propertyName);
-                this._globalState[propertyName] = newStylesheetState[propertyName].default;
+                this._globalState[propertyName] = propertyValue;
             }
         }
 
@@ -500,7 +501,7 @@ export class Style extends Evented<MapEventType> {
         }
 
         this.glyphManager.setURL(nextState.glyphs);
-        this._createLayers();
+        this._createLayers(options.globalState);
 
         this.light = new Light(this.stylesheet.light ?? {}, this._globalState);
         this._setProjectionInternal(this.stylesheet.projection?.type || 'mercator');
@@ -514,10 +515,10 @@ export class Style extends Evented<MapEventType> {
         this.fire(new MapStyleLoadEvent());
     }
 
-    private _createLayers() {
+    private _createLayers(globalState: Record<string, any>) {
         const dereferencedLayers = derefLayers(this.stylesheet.layers);
 
-        this.setGlobalState(this.stylesheet.state ?? null);
+        this.setGlobalState(this.stylesheet.state ?? null, globalState);
 
         // Broadcast layers to workers first, so that expensive style processing (createStyleLayer)
         // can happen in parallel on both main and worker threads.
@@ -862,7 +863,7 @@ export class Style extends Evented<MapEventType> {
         nextState.layers = derefLayers(nextState.layers);
 
         const changes = diffStyles(serializedStyle, nextState);
-        const operations = this._getOperationsToPerform(changes);
+        const operations = this._getOperationsToPerform(changes, options.globalState);
 
         if (operations.unimplemented.length > 0) {
             throw new Error(`Unimplemented: ${operations.unimplemented.join(', ')}.`);
@@ -876,7 +877,6 @@ export class Style extends Evented<MapEventType> {
             styleChangeOperation();
         }
 
-        this._globalState = extend({}, this._globalState, options.globalState);
         this.stylesheet = nextState;
 
         // reset serialization field, to be populated only when needed
@@ -887,7 +887,7 @@ export class Style extends Evented<MapEventType> {
         return true;
     }
 
-    _getOperationsToPerform(diff: Array<DiffCommand<DiffOperations>>): {operations: Function[]; unimplemented: string[]} {
+    _getOperationsToPerform(diff: Array<DiffCommand<DiffOperations>>, globalState: Record<string, any>): {operations: Function[]; unimplemented: string[]} {
         const operations: Function[] = [];
         const unimplemented: string[] = [];
         for (const op of diff) {
@@ -944,7 +944,7 @@ export class Style extends Evented<MapEventType> {
                     this.setProjection.apply(this, op.args);
                     break;
                 case 'setGlobalState':
-                    operations.push(() => this.setGlobalState.apply(this, op.args));
+                    operations.push(() => this.setGlobalState.apply(this, [...op.args, globalState]));
                     break;
                 case 'setTransition':
                     operations.push(() => {});

--- a/src/style/style.ts
+++ b/src/style/style.ts
@@ -108,6 +108,10 @@ export type StyleOptions = {
      * Forces a full update.
      */
     localIdeographFontFamily?: string | false;
+    /**
+     * Defines an initial global state for the map style. It overrides the defaults defined in the map style, as if setGlobalStateProperty was called after loading the style.
+     */
+    globalState?: Record<string, any>;
 };
 
 /**
@@ -118,6 +122,10 @@ export type StyleSetterOptions = {
      * Whether to check if the filter conforms to the MapLibre Style Specification. Disabling validation is a performance optimization that should only be used if you have previously validated the values you will be passing to this function.
      */
     validate?: boolean;
+    /**
+     * Defines an initial global state for the map style. It overrides the defaults defined in the map style, as if setGlobalStateProperty was called after loading the style.
+     */
+    globalState?: Record<string, any>;
 };
 
 /**
@@ -264,6 +272,7 @@ export class Style extends Evented<MapEventType> {
         this.crossTileSymbolIndex = new CrossTileSymbolIndex();
 
         this._setInitialValues();
+        this._globalState = extend({}, this._globalState, options.globalState);
 
         this._resetUpdates();
 
@@ -867,6 +876,7 @@ export class Style extends Evented<MapEventType> {
             styleChangeOperation();
         }
 
+        this._globalState = extend({}, this._globalState, options.globalState);
         this.stylesheet = nextState;
 
         // reset serialization field, to be populated only when needed

--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -1503,7 +1503,7 @@ export class Map extends Evented<MapEventType> {
      * @param lngLatLike - `[x, y]` or LngLat coordinates of the location
      * @returns elevation in meters
      */
-    queryTerrainElevation(lngLatLike: LngLatLike): number | null { 
+    queryTerrainElevation(lngLatLike: LngLatLike): number | null {
         if (!this.terrain) {
             return null;
         }
@@ -2650,6 +2650,12 @@ export class Map extends Evented<MapEventType> {
      *           })
      *       ]
      *   })
+     * });
+     *
+     * map.setStyle('https://demotiles.maplibre.org/style.json', {
+     *   globalState: {
+     *     showCircles: true,
+     *   }
      * });
      * ```
      */

--- a/src/ui/map_tests/map_style.test.ts
+++ b/src/ui/map_tests/map_style.test.ts
@@ -195,6 +195,89 @@ describe('setStyle', () => {
         spyWorkerPoolRelease.mockClear();
     });
 
+    test('initial style global state overrides defaults', async () => {
+        const map = createMap({deleteStyle: true});
+        const style = {
+            ...createStyle(),
+            state: {
+                showCircles: {
+                    default: true,
+                },
+            },
+        };
+        map.setStyle(style, {
+            globalState: {
+                showCircles: false,
+            },
+        });
+
+        await map.once('style.load');
+
+        expect(map.getGlobalState()).toEqual({
+            showCircles: false,
+        });
+    });
+
+    test('not setting initial style global state uses defaults', async () => {
+        const map = createMap({deleteStyle: true});
+        const style = {
+            ...createStyle(),
+            state: {
+                showCircles: {
+                    default: true,
+                },
+            },
+        };
+        map.setStyle(style, {
+            globalState: {},
+        });
+
+        await map.once('style.load');
+
+        expect(map.getGlobalState()).toEqual({
+            showCircles: true,
+        });
+    });
+
+    test('allow providing initial style global state that has no defaults defined in the style', async () => {
+        const map = createMap({deleteStyle: true});
+        const style = createStyle();
+        map.setStyle(style, {
+            globalState: {
+                somethingElse: 'something',
+            },
+        });
+
+        await map.once('style.load');
+
+        expect(map.getGlobalState()).toEqual({
+            somethingElse: 'something',
+        });
+    });
+
+    test('setting an initial style global with null value resets to the default', async () => {
+        const map = createMap({deleteStyle: true});
+        const style = {
+            ...createStyle(),
+            state: {
+                showCircles: {
+                    default: true,
+                },
+            },
+        };
+        map.setStyle(style, {
+            globalState: {
+                showCircles: null,
+            },
+        });
+
+        await map.once('style.load');
+
+        expect(map.getGlobalState()).toEqual({
+            showCircles: true,
+        });
+    });
+
     test('transformStyle should copy the source and the layer into next style', async () => {
         const style = extend(createStyle(), {
             sources: {


### PR DESCRIPTION
## API changes

Addition of the field `globalState` to the options for creating a style and setting the style on a map.

For example 
```js
map.setStyle('https://demotiles.maplibre.org/style.json', {
  globalState: {
    showCircles: true,
  }
});
```

I did not add the same property to the map options (like the style validation is both in the map constructor and the style constructor), that could easily be added in the future.

## Implementation changes

When a style is created with this option, the global initial state is stored in the style. The initial global state is then used whenever a style is loaded, either from scratch or from a diff. The initial global state has precedence over the defaults defined in the map style.

Added some tests to ensure the behaviour works as expected.

- This should resolve #7632.

Feedback is welcome about the naming.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items that are not relevant. -->

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [x] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality.
 - [x] Document any changes to public APIs.
 - [x] If you changed code in a file that has a benchmark file next to it (`*.bench.ts`), post before/after results of `npm run bench` (the compare workflow is in `test/bench/README.md`).
 - [x] Add an entry to `CHANGELOG.md` under the `## main` section.
 - [x] Confirm you have read our AI policy [here](https://github.com/maplibre/maplibre/blob/main/AI_POLICY.md).
<!--
  Add one of:    Assisted-By: | Generated-By:     and the model/version
-->

No AI was used to create this pull request.