### PR TITLE
Warn when the canvas is clamped to maxCanvasSize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Link shader programs before reading their compile status, so the driver can overlap the compiles and the main thread waits less on shader compilation ([#8338](https://github.com/maplibre/maplibre-gl-js/pull/8338)) (by [@cherenkov](https://github.com/cherenkov))
 - Build the default `Marker` pin once and clone it per marker, so creating many default markers takes roughly half the constructor time ([#8340](https://github.com/maplibre/maplibre-gl-js/pull/8340)) (by [@cherenkov](https://github.com/cherenkov))
 - Add SDF rendering support for fill patterns, using `fill-color` as the foreground color ([#7747](https://github.com/maplibre/maplibre-gl-js/pull/7747)) (by [@bradymadden97](https://github.com/bradymadden97) and [@deniial00](https://github.com/deniial00))
-- Warn once when the map canvas is clamped to `maxCanvasSize`, which until now reduced the rendered resolution silently — the canvas kept the dimensions that were asked for and held fewer pixels than that implies ([#8200](https://github.com/maplibre/maplibre-gl-js/issues/8200))
+- Warn once when the canvas is clamped to `maxCanvasSize`, which previously lowered the rendered resolution silently ([#8200](https://github.com/maplibre/maplibre-gl-js/issues/8200))
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Link shader programs before reading their compile status, so the driver can overlap the compiles and the main thread waits less on shader compilation ([#8338](https://github.com/maplibre/maplibre-gl-js/pull/8338)) (by [@cherenkov](https://github.com/cherenkov))
 - Build the default `Marker` pin once and clone it per marker, so creating many default markers takes roughly half the constructor time ([#8340](https://github.com/maplibre/maplibre-gl-js/pull/8340)) (by [@cherenkov](https://github.com/cherenkov))
 - Add SDF rendering support for fill patterns, using `fill-color` as the foreground color ([#7747](https://github.com/maplibre/maplibre-gl-js/pull/7747)) (by [@bradymadden97](https://github.com/bradymadden97) and [@deniial00](https://github.com/deniial00))
+- Warn once when the map canvas is clamped to `maxCanvasSize`, which until now reduced the rendered resolution silently — the canvas kept the dimensions that were asked for and held fewer pixels than that implies ([#8200](https://github.com/maplibre/maplibre-gl-js/issues/8200))
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes

--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -389,13 +389,7 @@ export type MapOptions = {
     /**
      * The canvas' `width` and `height` max size. The values are passed as an array where the first element is max width and the second element is max height.
      * You shouldn't set this above WebGl `MAX_TEXTURE_SIZE`.
-     *
-     * A canvas larger than this is not refused: the map lowers its pixel ratio to fit and draws at
-     * that lower resolution instead, so the canvas has the dimensions that were asked for and
-     * fewer pixels behind them. {@link Map#getPixelRatio} keeps reporting the ratio that was
-     * requested rather than the one applied, and a warning is logged once. This matters most when
-     * exporting at print resolution, where the result is a correctly sized image holding a
-     * fraction of the detail.
+     * A larger canvas is not refused: the pixel ratio is lowered to fit and a warning is logged once.
      * @defaultValue [4096, 4096].
      */
     maxCanvasSize?: [number, number];
@@ -1638,6 +1632,8 @@ export class Map extends Evented<MapEventType> {
      * @internal
      * Return the map's pixel ratio eventually scaled down to respect maxCanvasSize.
      * Internally you should use this and not getPixelRatio().
+     * Warns once when the ratio is scaled down. The message carries no sizes: this runs on every
+     * resize and `warnOnce` de-duplicates by message, so sizes would warn on every drag frame.
      */
     _getClampedPixelRatio(width: number, height: number): number {
         const {0: maxCanvasWidth, 1: maxCanvasHeight} = this._maxCanvasSize;
@@ -1651,16 +1647,8 @@ export class Map extends Evented<MapEventType> {
 
         const scaleFactor = Math.min(widthScaleFactor, heightScaleFactor);
 
-        // The message deliberately carries no numbers. `_resize` runs on every resize event and
-        // `warnOnce` de-duplicates by message text, so naming the requested size would make a
-        // fresh key -- and a fresh warning -- for every pixel of a window drag.
         if (scaleFactor < 1) {
-            warnOnce(
-                'The map canvas is larger than maxCanvasSize, so it has been drawn at a lower ' +
-                'pixel ratio to fit. The canvas is the size that was requested and holds fewer ' +
-                'pixels than that implies. Raise the maxCanvasSize map option if you need the ' +
-                'full resolution, keeping it within the WebGL MAX_TEXTURE_SIZE.'
-            );
+            warnOnce('The canvas is larger than maxCanvasSize and is rendered at a lower pixel ratio to fit. Increase maxCanvasSize, within MAX_TEXTURE_SIZE, to render at full resolution.');
         }
 
         return scaleFactor * pixelRatio;

--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -389,6 +389,13 @@ export type MapOptions = {
     /**
      * The canvas' `width` and `height` max size. The values are passed as an array where the first element is max width and the second element is max height.
      * You shouldn't set this above WebGl `MAX_TEXTURE_SIZE`.
+     *
+     * A canvas larger than this is not refused: the map lowers its pixel ratio to fit and draws at
+     * that lower resolution instead, so the canvas has the dimensions that were asked for and
+     * fewer pixels behind them. {@link Map#getPixelRatio} keeps reporting the ratio that was
+     * requested rather than the one applied, and a warning is logged once. This matters most when
+     * exporting at print resolution, where the result is a correctly sized image holding a
+     * fraction of the detail.
      * @defaultValue [4096, 4096].
      */
     maxCanvasSize?: [number, number];
@@ -1642,7 +1649,21 @@ export class Map extends Evented<MapEventType> {
         const widthScaleFactor = canvasWidth > maxCanvasWidth ? (maxCanvasWidth / canvasWidth) : 1;
         const heightScaleFactor = canvasHeight > maxCanvasHeight ? (maxCanvasHeight / canvasHeight) : 1;
 
-        return Math.min(widthScaleFactor, heightScaleFactor) * pixelRatio;
+        const scaleFactor = Math.min(widthScaleFactor, heightScaleFactor);
+
+        // The message deliberately carries no numbers. `_resize` runs on every resize event and
+        // `warnOnce` de-duplicates by message text, so naming the requested size would make a
+        // fresh key -- and a fresh warning -- for every pixel of a window drag.
+        if (scaleFactor < 1) {
+            warnOnce(
+                'The map canvas is larger than maxCanvasSize, so it has been drawn at a lower ' +
+                'pixel ratio to fit. The canvas is the size that was requested and holds fewer ' +
+                'pixels than that implies. Raise the maxCanvasSize map option if you need the ' +
+                'full resolution, keeping it within the WebGL MAX_TEXTURE_SIZE.'
+            );
+        }
+
+        return scaleFactor * pixelRatio;
     }
 
     /**

--- a/src/ui/map_tests/map_canvas.test.ts
+++ b/src/ui/map_tests/map_canvas.test.ts
@@ -8,6 +8,27 @@ beforeEach(() => {
 });
 
 describe('Max Canvas Size option', () => {
+    // First in the file on purpose. `warnOnce` keeps a module-level history keyed by message and
+    // exports no way to clear it, so a later test in this file cannot observe a warning that an
+    // earlier clamping test has already consumed.
+    test('warns once when the canvas is clamped to maxCanvasSize', () => {
+        const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        const container = window.document.createElement('div');
+        Object.defineProperty(container, 'clientWidth', {value: 2048});
+        Object.defineProperty(container, 'clientHeight', {value: 2048});
+        const map = createMap({container, maxCanvasSize: [512, 512], pixelRatio: 4});
+        vi.spyOn(map.painter.context.gl, 'drawingBufferWidth', 'get').mockReturnValue(512);
+        vi.spyOn(map.painter.context.gl, 'drawingBufferHeight', 'get').mockReturnValue(512);
+        map.resize();
+        expect(warn).toHaveBeenCalledWith(expect.stringContaining('maxCanvasSize'));
+        expect(warn).toHaveBeenCalledTimes(1);
+
+        // Resized again, to show that a window drag does not fill the console.
+        map.resize();
+        expect(warn).toHaveBeenCalledTimes(1);
+        warn.mockRestore();
+    });
+
     test('maxCanvasSize width = height', () => {
         const container = window.document.createElement('div');
         Object.defineProperty(container, 'clientWidth', {value: 2048});

--- a/src/ui/map_tests/map_canvas.test.ts
+++ b/src/ui/map_tests/map_canvas.test.ts
@@ -8,10 +8,7 @@ beforeEach(() => {
 });
 
 describe('Max Canvas Size option', () => {
-    // First in the file on purpose. `warnOnce` keeps a module-level history keyed by message and
-    // exports no way to clear it, so a later test in this file cannot observe a warning that an
-    // earlier clamping test has already consumed.
-    test('warns once when the canvas is clamped to maxCanvasSize', () => {
+    test('warns once when clamped, and not again on a second resize (must run before other clamping tests, as warnOnce keeps a module-level history)', () => {
         const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
         const container = window.document.createElement('div');
         Object.defineProperty(container, 'clientWidth', {value: 2048});
@@ -22,8 +19,6 @@ describe('Max Canvas Size option', () => {
         map.resize();
         expect(warn).toHaveBeenCalledWith(expect.stringContaining('maxCanvasSize'));
         expect(warn).toHaveBeenCalledTimes(1);
-
-        // Resized again, to show that a window drag does not fill the console.
         map.resize();
         expect(warn).toHaveBeenCalledTimes(1);
         warn.mockRestore();


### PR DESCRIPTION
Closes #8200.

`maxCanvasSize` clamping is documented but unobservable: a request above it is not refused, the map lowers its pixel ratio to fit, and nothing is logged — so the canvas has the dimensions that were asked for and fewer pixels behind them.

Per the discussion on the issue, the two risk-free parts: `warnOnce` in `_getClampedPixelRatio`, and a line on the option's doc. The accessor idea from the issue is left out.

The message carries no sizes — `_resize` runs on every resize event and `warnOnce` de-duplicates by message text, so sizes would warn on every frame of a drag.

Verified: `vitest run --config vitest.config.unit.ts src/ui` — 59 files, 1225 tests passing; eslint clean; and the test fails without the source change.
