### PR TITLE
fix(map): resize when a hidden container becomes visible before the first resize observation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@
 
 ### 🐞 Bug fixes
 
+- Fix a map created inside a hidden container staying at the `400x300` fallback size when the container is shown before the resize observer's first notification is delivered ([#8277](https://github.com/maplibre/maplibre-gl-js/issues/8277)) (by [@spliffone](https://github.com/spliffone))
+- Fix `project()` and `queryTerrainElevation` disagreeing with the rendered terrain surface when the elevation lookup sampled a different DEM zoom than the drawn mesh ([#8212](https://github.com/maplibre/maplibre-gl-js/issues/8212))
 - Fix a marker's popup jumping to another world copy when the marker is moved across the antimeridian on a zoomed-out map ([#5655](https://github.com/maplibre/maplibre-gl-js/issues/5655), [#8326](https://github.com/maplibre/maplibre-gl-js/pull/8326), continues [#5956](https://github.com/maplibre/maplibre-gl-js/pull/5956)) (by [@yuiseki](https://github.com/yuiseki))
 - Fix terrain drape textures not being refreshed after zoom changes, causing stale rendering at the new zoom level ([#8251](https://github.com/maplibre/maplibre-gl-js/issues/8251)) (by [@patte](https://github.com/patte))
 - Fix a gap between the sky and the ground at high pitch while globe transitions to mercator ([#7382](https://github.com/maplibre/maplibre-gl-js/issues/7382)) (by [@birkskyum](https://github.com/birkskyum))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### 🐞 Bug fixes
 - Fix queued GeoJSON `updateData` property removals throwing after geometry-only updates or retaining previously updated values ([#8372](https://github.com/maplibre/maplibre-gl-js/pull/8372)) (by [@jokrasno](https://github.com/jokrasno))
 - Treat camera options passed as `undefined` as not given in `jumpTo`, `easeTo` and `flyTo`; they were coerced to NaN ([#8373](https://github.com/maplibre/maplibre-gl-js/pull/8373)) (by [@vlumi](https://github.com/vlumi))
+- Fix a map created inside a hidden container staying at the `400x300` fallback size when the container is shown before the resize observer's first notification is delivered ([#8277](https://github.com/maplibre/maplibre-gl-js/issues/8277)) (by [@spliffone](https://github.com/spliffone))
 - _...Add new stuff here..._
 
 ## 6.8.0
@@ -21,8 +22,6 @@
 
 ### 🐞 Bug fixes
 
-- Fix a map created inside a hidden container staying at the `400x300` fallback size when the container is shown before the resize observer's first notification is delivered ([#8277](https://github.com/maplibre/maplibre-gl-js/issues/8277)) (by [@spliffone](https://github.com/spliffone))
-- Fix `project()` and `queryTerrainElevation` disagreeing with the rendered terrain surface when the elevation lookup sampled a different DEM zoom than the drawn mesh ([#8212](https://github.com/maplibre/maplibre-gl-js/issues/8212))
 - Fix a marker's popup jumping to another world copy when the marker is moved across the antimeridian on a zoomed-out map ([#5655](https://github.com/maplibre/maplibre-gl-js/issues/5655), [#8326](https://github.com/maplibre/maplibre-gl-js/pull/8326), continues [#5956](https://github.com/maplibre/maplibre-gl-js/pull/5956)) (by [@yuiseki](https://github.com/yuiseki))
 - Fix terrain drape textures not being refreshed after zoom changes, causing stale rendering at the new zoom level ([#8251](https://github.com/maplibre/maplibre-gl-js/issues/8251)) (by [@patte](https://github.com/patte))
 - Fix a gap between the sky and the ground at high pitch while globe transitions to mercator ([#7382](https://github.com/maplibre/maplibre-gl-js/issues/7382)) (by [@birkskyum](https://github.com/birkskyum))

--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -1554,8 +1554,10 @@ export class Map extends Evented<MapEventType> {
      * `container` element.
      *
      * Checks if the map container size changed and updates the map if it has changed.
-     * This method must be called after the map's `container` is resized programmatically
-     * or when the map is shown after being initially hidden with CSS.
+     * With the default `trackResize: true`, container size changes are picked up automatically,
+     * including a container that becomes visible after being hidden with CSS. Call this method
+     * explicitly when `trackResize` is `false`, or when the map's size changes in a way the
+     * container's `ResizeObserver` cannot observe.
      *
      * Triggers the following events: `movestart`, `move`, `moveend`, and `resize`.
      *
@@ -1563,10 +1565,10 @@ export class Map extends Evented<MapEventType> {
      * events that get triggered as a result of resize. This can be useful for differentiating the
      * source of an event (for example, user-initiated or programmatically-triggered events).
      * @example
-     * Resize the map when the map container is shown after being initially hidden with CSS.
+     * Resize a map with `trackResize` disabled when its container is shown after being hidden with CSS.
      * ```ts
      * let mapDiv = document.getElementById('map');
-     * if (mapDiv.style.visibility === true) map.resize();
+     * if (mapDiv.style.visibility === 'visible') map.resize();
      * ```
      */
     resize(eventData?: any, constrainTransform = true): this {
@@ -4066,6 +4068,19 @@ export class Map extends Evented<MapEventType> {
     }
 
     /**
+     * Determines if the initial resize event should be handled based on the container's dimensions.
+     *
+     * @returns `true` if the initial resize event should be handled, `false` otherwise.
+     */
+    _shouldHandleInitialResize(): boolean {
+        if (!this._container?.clientWidth || !this._container.clientHeight) {
+            return false;
+        }
+        const [width, height] = this._containerDimensions();
+        return width !== this._camera.transform.width || height !== this._camera.transform.height;
+    }
+
+    /**
      * @internal
      * Sets up the ResizeObserver to track container size changes.
      * Uses the owning window's ResizeObserver for cross-window support.
@@ -4083,7 +4098,9 @@ export class Map extends Evented<MapEventType> {
         this._resizeObserver = new ResizeObserverClass((entries: ResizeObserverEntry[]) => {
             if (!initialResizeEventCaptured) {
                 initialResizeEventCaptured = true;
-                return;
+                if (!this._shouldHandleInitialResize()) {
+                    return;
+                }
             }
             throttledResizeCallback(entries);
         });

--- a/test/integration/browser/browser.test.ts
+++ b/test/integration/browser/browser.test.ts
@@ -114,6 +114,43 @@ describe('Browser tests', () => {
         expect(firstFiredEvent).toBe('load');
     });
 
+    test('Map created in a hidden container resizes when shown, see #8277', {retry: 3, timeout: 20000}, async () => {
+        const dimensions = await page.evaluate(async () => {
+            const host = document.createElement('div');
+            host.style.display = 'none';
+
+            const container = document.createElement('div');
+            container.style.cssText = 'width: 640px; height: 480px';
+            host.append(container);
+            document.body.append(host);
+
+            const hiddenMap = new maplibregl.Map({
+                container,
+                style: {version: 8, sources: {}, layers: []}
+            });
+            const canvas = hiddenMap.getCanvas();
+
+            host.style.display = 'block';
+            await new Promise((resolve) => setTimeout(resolve, 300));
+
+            const result = {
+                containerWidth: container.clientWidth,
+                containerHeight: container.clientHeight,
+                canvasWidth: canvas.clientWidth,
+                canvasHeight: canvas.clientHeight
+            };
+
+            hiddenMap.remove();
+            host.remove();
+            return result;
+        });
+
+        expect(dimensions.containerWidth).toBe(640);
+        expect(dimensions.containerHeight).toBe(480);
+        expect(dimensions.canvasWidth).toBe(640);
+        expect(dimensions.canvasHeight).toBe(480);
+    });
+
     test('Should continue zooming from last mouse position after scroll and flyto, see #2709', {retry: 3, timeout: 20000}, async () => {
         const finalZoom = await page.evaluate(() => {
             return new Promise<number>((resolve, _reject) => {


### PR DESCRIPTION
Fixes #8277

## Summary

A map constructed inside a hidden container stayed at the `400x300` fallback size after the container was shown, until either a further size change or an explicit `map.resize()` call.

Two behaviours combine to cause it:

- `Map._containerDimensions()` substitutes `400x300` when the container reports zero `clientWidth`/`clientHeight`, so a map built while hidden is laid out at the fallback size.
- `Map._setupResizeObserver()` unconditionally discarded the observer's first notification. That skip exists to keep `resize`/`moveend` from firing before `load` (#2551, fixed in #2552), since a `ResizeObserver` invokes its callback as soon as it starts observing.

When the container becomes visible before the browser delivers that first notification, the notification carries the real dimensions — and was thrown away. Absent any further size change there is no second notification, so the canvas stayed at `400x300` indefinitely.

## Change

The first notification is now discarded only when it carries nothing new. `Map._shouldHandleInitialResize()` returns `false` — preserving the old behaviour — when either:

- the container is still unmeasurable (zero `clientWidth`/`clientHeight`), so `_containerDimensions()` would only return the fallback and there is nothing to catch up to; or
- the container's dimensions already match the ones the map is using.

Otherwise the notification is processed and the map resizes to the real container size.

The comparison reads its values from `_containerDimensions()` rather than re-deriving them, so the `400x300` fallback stays defined in exactly one place. It is compared against `transform.width`/`transform.height`, which store the raw dimensions last applied and are carried across projection migration by `TransformHelper.apply()`.

| scenario | first notification |
| --- | --- |
| visible container, size unchanged | ignored (#2551 behaviour preserved) |
| container still hidden | ignored |
| hidden at construction, shown before delivery | **handled** → resizes to the real size |
| visible at construction, hidden before delivery | ignored (no shrink to the fallback) |

### Behaviour note

In the hidden-then-shown case, `movestart`/`move`/`resize`/`moveend` can now fire before `load`. That is required for the canvas to reach the correct size, and it is scoped to that case only — a normal initial delivery on an unchanged container is still ignored, so the #2551 guarantee is intact and remains covered by the existing tests.

## Tests

- `test/integration/browser/browser.test.ts` — a real-Chromium regression test mirroring the reproduction from the issue. This is the one that actually exercises `ResizeObserver` delivery timing; the unit tests drive a mocked callback and can only cover the branch logic. It asserts on `clientWidth`/`clientHeight` because the harness runs at `deviceScaleFactor: 2`.

The existing `do resize if trackResize is true (default)` test continues to guard the #2551 ordering, and `Load should fire before resize and moveend` covers it end to end.

## Docs

`Map.resize()`'s documentation claimed the method "must be called ... when the map is shown after being initially hidden with CSS". With the default `trackResize: true` that is now handled automatically, so the text is rescoped to `trackResize: false` and to size changes the container's `ResizeObserver` cannot observe. The accompanying example compared `mapDiv.style.visibility === true`, which is never true for a string-valued property; corrected to `=== 'visible'`.

## Possible follow-up

Not included here, but worth considering separately: comparing against the last applied dimensions on *every* notification would subsume the first-notification special case entirely and also skip redundant resizes from spurious observer callbacks. It changes behaviour for all subsequent notifications and would invalidate the deliberate assertion in `do resize if trackResize is true (default)`, so it seemed out of scope for a bug fix.

## Launch Checklist

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [x] ~~Include before/after visuals or gifs if this PR includes visual changes.~~ No visual changes.
 - [x] Write tests for all new functionality.
 - [x] Document any changes to public APIs.
 - [x] ~~If you changed code in a file that has a benchmark file next to it (`*.bench.ts`), post before/after results of `npm run bench`.~~ No benchmark file next to `src/ui/map.ts`, and the change adds one comparison on a single observer notification.
 - [x] Add an entry to `CHANGELOG.md` under the `## main` section.
 - [x] Confirm you have read our AI policy [here](https://github.com/maplibre/maplibre/blob/main/AI_POLICY.md).

Assisted-By: claude-opus-5 (opencode)
