### PR TITLE
fix: resize a map created in a hidden container on the first observer event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Draw numbers (e.g. “21” in “반포대로21길”) and short uppercase codes (e.g. “A1”) upright in vertical line labels instead of rotating them along the line ([#5404](https://github.com/maplibre/maplibre-gl-js/issues/5404)) (by [@NEKOYASAN](https://github.com/NEKOYASAN))
 - Fix the camera jumping at the end of a pan or zoom gesture on terrain by sampling the center elevation from the rendered terrain surface ([#7989](https://github.com/maplibre/maplibre-gl-js/issues/7989), [#3982](https://github.com/maplibre/maplibre-gl-js/issues/3982))
 - Ensure style state defaults are serialized (by [@hiddewie](https://github.com/hiddewie))
+- Fix a map created inside a hidden container staying at its 400x300 fallback size after the container is shown ([#8277](https://github.com/maplibre/maplibre-gl-js/issues/8277))
 
 ## 6.6.0
 

--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -4009,7 +4009,10 @@ export class Map extends Evented<MapEventType> {
         this._resizeObserver = new ResizeObserverClass((entries: ResizeObserverEntry[]) => {
             if (!initialResizeEventCaptured) {
                 initialResizeEventCaptured = true;
-                return;
+                const [width, height] = this._containerDimensions();
+                if (width === this._camera.transform.width && height === this._camera.transform.height) {
+                    return;
+                }
             }
             throttledResizeCallback(entries);
         });

--- a/src/ui/map_tests/map_resize.test.ts
+++ b/src/ui/map_tests/map_resize.test.ts
@@ -104,6 +104,27 @@ describe('resize', () => {
         expect(redrawSpy).toHaveBeenCalledTimes(2);
     });
 
+    test('do resize on the first observer event if the container was hidden on creation', () => {
+        let observerCallback: Function = null;
+        global.ResizeObserver = vi.fn(class {
+            constructor(c) { observerCallback = c; }
+            observe = () => { };
+        }) as any;
+
+        const container = window.document.createElement('div');
+        const map = createMap({container});
+
+        expect(map._camera.transform.width).toBe(400);
+        expect(map._camera.transform.height).toBe(300);
+
+        Object.defineProperty(container, 'clientWidth', {value: 640, configurable: true});
+        Object.defineProperty(container, 'clientHeight', {value: 480, configurable: true});
+        observerCallback();
+
+        expect(map._camera.transform.width).toBe(640);
+        expect(map._camera.transform.height).toBe(480);
+    });
+
     test('width and height correctly rounded', () => {
         const map = createMap();
         const container = map.getContainer();


### PR DESCRIPTION
A map built inside a `display: none` container falls back to 400x300, because `_containerDimensions()` reads zero from a hidden element. `_setupResizeObserver` then drops its first callback unconditionally, so when the container is shown before the browser delivers that first notification, the real size arrives in the callback that gets thrown away and the canvas is stuck at the fallback until something else resizes it.

The first callback is now only dropped when the container already matches the size the transform is using, which is the normal case the skip was added for in #2552. A first callback carrying different dimensions goes through the usual resize path.

Fixes #8277

## Launch Checklist

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] If you changed code in a file that has a benchmark file next to it (`*.bench.ts`), post before/after results of `npm run bench` (the compare workflow is in `test/bench/README.md`).
 - [x] Add an entry to `CHANGELOG.md` under the `## main` section.
