### PR TITLE
Render test concurrency

### DIFF
--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -138,6 +138,7 @@ jobs:
         run: npm run test-render
         env:
           CURRENT_SPLIT_INDEX: ${{ matrix.split }}
+          RENDER_TEST_CONCURRENCY: 2
       - name: Move files
         if: runner.os == 'Linux'
         run: |

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -138,7 +138,6 @@ jobs:
         run: npm run test-render
         env:
           CURRENT_SPLIT_INDEX: ${{ matrix.split }}
-          RENDER_TEST_CONCURRENCY: 2
       - name: Move files
         if: runner.os == 'Linux'
         run: |

--- a/test/integration/README.md
+++ b/test/integration/README.md
@@ -34,7 +34,7 @@ To run the render tests:
 npm run test-render
 ```
 
-By default the render tests run one at a time, as CI does. Locally you can run several at once, each in its own browser tab, for example:
+By default the render tests run one at a time, as CI does. Locally you can run several at once, each in its own headless browser, for example:
 
 ```sh
 RENDER_TEST_CONCURRENCY=4 npm run test-render

--- a/test/integration/README.md
+++ b/test/integration/README.md
@@ -34,7 +34,7 @@ To run the render tests:
 npm run test-render
 ```
 
-By default the render tests run one at a time, as CI does. Locally you can run several at once, each in its own headless browser, for example:
+By default the render tests run one at a time, but if you have multiple cores you can add concurrency with:
 
 ```sh
 RENDER_TEST_CONCURRENCY=4 npm run test-render

--- a/test/integration/README.md
+++ b/test/integration/README.md
@@ -34,6 +34,12 @@ To run the render tests:
 npm run test-render
 ```
 
+By default the render tests run one at a time, as CI does. Locally you can run several at once, each in its own browser tab, for example:
+
+```sh
+RENDER_TEST_CONCURRENCY=4 npm run test-render
+```
+
 To run the integration tests (except the render tests):
 
 ```sh

--- a/test/integration/lib/puppeteer_config.ts
+++ b/test/integration/lib/puppeteer_config.ts
@@ -28,9 +28,10 @@ export async function startCoverage(page: Page): Promise<WebWorker[]> {
     return workers;
 }
 
-/** Harvest page + worker coverage, close the page, and write a monocart report to `coverage/<outputDir>`. */
-export async function stopCoverageAndReport(page: Page, workers: WebWorker[], outputDir: string): Promise<void> {
-    const coverage = await page.coverage.stopJSCoverage();
+/** Harvest page + worker coverage, close the page(s), and write a monocart report to `coverage/<outputDir>`. */
+export async function stopCoverageAndReport(pageOrPages: Page | Page[], workers: WebWorker[], outputDir: string): Promise<void> {
+    const pages = Array.isArray(pageOrPages) ? pageOrPages : [pageOrPages];
+    const coverage = (await Promise.all(pages.map((page) => page.coverage.stopJSCoverage()))).flat();
 
     const workerCoverageEntries: any[] = [];
     for (const worker of workers) {
@@ -40,7 +41,7 @@ export async function stopCoverageAndReport(page: Page, workers: WebWorker[], ou
         } catch {}
     }
 
-    await page.close();
+    await Promise.all(pages.map((page) => page.close()));
 
     const rawV8CoverageData: any[] = coverage.map((it) => {
         const entry: any = {source: it.text, ...it.rawScriptCoverage};

--- a/test/integration/render/render.test.ts
+++ b/test/integration/render/render.test.ts
@@ -34,7 +34,7 @@ const DEFAULT_TEST_TIMEOUT = 60000;
  */
 const HOOK_TIMEOUT = 180000;
 
-/** How many tests run at the same time, each in its own browser; 1 is the serial run CI does. */
+/** How many tests run at the same time, each in its own browser; 1 is serial / default. */
 const TEST_CONCURRENCY = Math.max(1, +process.env.RENDER_TEST_CONCURRENCY || 1);
 
 type RenderTestContext = TestContext & {page: Page};

--- a/test/integration/render/render.test.ts
+++ b/test/integration/render/render.test.ts
@@ -13,7 +13,7 @@ import {localizeURLs} from '../lib/localize-urls.ts';
 import {launchPuppeteer, startCoverage, stopCoverageAndReport} from '../lib/puppeteer_config.ts';
 import type {MapLibreMap, CanvasSource, PointLike, StyleSpecification, MapEventType} from '../../../dist/maplibre-gl';
 import type * as MapLibreGL from '../../../dist/maplibre-gl';
-import {afterAll, afterEach, beforeAll, beforeEach, describe, expect, test} from 'vitest';
+import {afterAll, beforeAll, describe, expect, test, vi} from 'vitest';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 let maplibregl: typeof MapLibreGL;
@@ -33,6 +33,9 @@ const DEFAULT_TEST_TIMEOUT = 60000;
  * run once per split, so a generous value costs nothing when everything is healthy.
  */
 const HOOK_TIMEOUT = 180000;
+
+/** How many tests run at the same time, each in its own browser; 1 is the serial run CI does. */
+const TEST_CONCURRENCY = Math.max(1, +process.env.RENDER_TEST_CONCURRENCY || 1);
 
 type TestData = {
     id: string;
@@ -873,11 +876,13 @@ function printHTMLReport(testStyles: StyleWithTestData[]) {
 }
 
 describe('Render tests', () => {
-    let browser: Browser;
+    let browsers: Browser[] = [];
     let server: http.Server;
     let mvtServer: http.Server;
-    let page: Page;
-    let workers: WebWorker[];
+    let pages: Page[] = [];
+    const freePages: Page[] = [];
+    const workers: WebWorker[][] = [];
+    vi.setConfig({maxConcurrency: TEST_CONCURRENCY});
 
     const directory = path.join(__dirname);
     let testStyles = getTestStyles(directory);
@@ -889,47 +894,53 @@ describe('Render tests', () => {
 
     beforeAll(async () => {
         const setupStart = Date.now();
-        browser = await launchPuppeteer(true);
+        browsers = await Promise.all(Array.from({length: TEST_CONCURRENCY}, () => launchPuppeteer(true)));
         ({server, mvtServer} = await createServer());
         const serverPort = (server.address() as any).port;
-        page = await browser.newPage();
-        workers = await startCoverage(page);
-        await page.goto(`http://localhost:${serverPort}/test-page.html`, {waitUntil: 'load'});
-        await page.waitForFunction(() => (window as any).maplibregl, {timeout: 10000});
+        pages = await Promise.all(browsers.map(async (browser) => {
+            const page = await browser.newPage();
+            workers.push(await startCoverage(page));
+            await page.goto(`http://localhost:${serverPort}/test-page.html`, {waitUntil: 'load'});
+            await page.waitForFunction(() => (window as any).maplibregl, {timeout: 10000});
+            return page;
+        }));
+        freePages.push(...pages);
         console.log(`Render test setup took ${Date.now() - setupStart}ms`);
     }, HOOK_TIMEOUT);
 
-    beforeEach((ctx) => {
-        if (ctx.task.result?.retryCount > 0) {
-            console.log(`Retry ${ctx.task.name} with console logging enabled`);
-            addConsoleLogging(page);
-        }
-    });
-
-    afterEach(async () => {
-        page.removeAllListeners('console');
-        page.removeAllListeners('pageerror');
-        page.removeAllListeners('response');
-        page.removeAllListeners('requestfailed');
-    });
-
     afterAll(async () => {
-        if (page) {
-            await stopCoverageAndReport(page, workers, 'render');
+        if (pages.length > 0) {
+            await stopCoverageAndReport(pages, workers.flat(), 'render');
         }
         printHTMLReport(testStyles);
         server?.close();
         mvtServer?.close();
-        await browser?.close();
+        await Promise.all(browsers.map((browser) => browser.close()));
     }, HOOK_TIMEOUT);
 
     for (const style of testStyles) {
-        test(style.metadata.test.id, {retry: 1, timeout: style.metadata.test.timeout || DEFAULT_TEST_TIMEOUT}, async () => {
-            const serverPort = (server.address() as any).port;
-            localizeURLs(style, serverPort, path.join(__dirname, '../'));
-            const data = await getImageFromStyle(style, page);
-            compareRenderResults(directory, style.metadata.test, data);
-            expect(style.metadata.test.ok).toBe(true);
+        test.concurrent(style.metadata.test.id, {retry: 1, timeout: style.metadata.test.timeout || DEFAULT_TEST_TIMEOUT}, async (ctx) => {
+            const page = freePages.pop();
+            if (!page) {
+                throw new Error('More tests running at once than pages');
+            }
+            try {
+                if (ctx.task.result?.retryCount > 0) {
+                    console.log(`Retry ${ctx.task.name} with console logging enabled`);
+                    addConsoleLogging(page);
+                }
+                const serverPort = (server.address() as any).port;
+                localizeURLs(style, serverPort, path.join(__dirname, '../'));
+                const data = await getImageFromStyle(style, page);
+                compareRenderResults(directory, style.metadata.test, data);
+                expect(style.metadata.test.ok).toBe(true);
+            } finally {
+                page.removeAllListeners('console');
+                page.removeAllListeners('pageerror');
+                page.removeAllListeners('response');
+                page.removeAllListeners('requestfailed');
+                freePages.push(page);
+            }
         });
     }
 });

--- a/test/integration/render/render.test.ts
+++ b/test/integration/render/render.test.ts
@@ -13,7 +13,7 @@ import {localizeURLs} from '../lib/localize-urls.ts';
 import {launchPuppeteer, startCoverage, stopCoverageAndReport} from '../lib/puppeteer_config.ts';
 import type {MapLibreMap, CanvasSource, PointLike, StyleSpecification, MapEventType} from '../../../dist/maplibre-gl';
 import type * as MapLibreGL from '../../../dist/maplibre-gl';
-import {afterAll, beforeAll, describe, expect, test, vi} from 'vitest';
+import {afterAll, afterEach, beforeAll, beforeEach, describe, expect, test, vi} from 'vitest';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 let maplibregl: typeof MapLibreGL;
@@ -36,6 +36,12 @@ const HOOK_TIMEOUT = 180000;
 
 /** How many tests run at the same time, each in its own browser; 1 is the serial run CI does. */
 const TEST_CONCURRENCY = Math.max(1, +process.env.RENDER_TEST_CONCURRENCY || 1);
+
+declare module 'vitest' {
+    export interface TestContext {
+        page: Page;
+    }
+}
 
 type TestData = {
     id: string;
@@ -908,6 +914,22 @@ describe('Render tests', () => {
         console.log(`Render test setup took ${Date.now() - setupStart}ms`);
     }, HOOK_TIMEOUT);
 
+    beforeEach((ctx) => {
+        ctx.page = freePages.pop();
+        if (ctx.task.result?.retryCount > 0) {
+            console.log(`Retry ${ctx.task.name} with console logging enabled`);
+            addConsoleLogging(ctx.page);
+        }
+    });
+
+    afterEach(async (ctx) => {
+        ctx.page.removeAllListeners('console');
+        ctx.page.removeAllListeners('pageerror');
+        ctx.page.removeAllListeners('response');
+        ctx.page.removeAllListeners('requestfailed');
+        freePages.push(ctx.page);
+    });
+
     afterAll(async () => {
         if (pages.length > 0) {
             await stopCoverageAndReport(pages, workers.flat(), 'render');
@@ -919,28 +941,12 @@ describe('Render tests', () => {
     }, HOOK_TIMEOUT);
 
     for (const style of testStyles) {
-        test.concurrent(style.metadata.test.id, {retry: 1, timeout: style.metadata.test.timeout || DEFAULT_TEST_TIMEOUT}, async (ctx) => {
-            const page = freePages.pop();
-            if (!page) {
-                throw new Error('More tests running at once than pages');
-            }
-            try {
-                if (ctx.task.result?.retryCount > 0) {
-                    console.log(`Retry ${ctx.task.name} with console logging enabled`);
-                    addConsoleLogging(page);
-                }
-                const serverPort = (server.address() as any).port;
-                localizeURLs(style, serverPort, path.join(__dirname, '../'));
-                const data = await getImageFromStyle(style, page);
-                compareRenderResults(directory, style.metadata.test, data);
-                expect(style.metadata.test.ok).toBe(true);
-            } finally {
-                page.removeAllListeners('console');
-                page.removeAllListeners('pageerror');
-                page.removeAllListeners('response');
-                page.removeAllListeners('requestfailed');
-                freePages.push(page);
-            }
+        test.concurrent(style.metadata.test.id, {retry: 1, timeout: style.metadata.test.timeout || DEFAULT_TEST_TIMEOUT}, async ({page}) => {
+            const serverPort = (server.address() as any).port;
+            localizeURLs(style, serverPort, path.join(__dirname, '../'));
+            const data = await getImageFromStyle(style, page);
+            compareRenderResults(directory, style.metadata.test, data);
+            expect(style.metadata.test.ok).toBe(true);
         });
     }
 });

--- a/test/integration/render/render.test.ts
+++ b/test/integration/render/render.test.ts
@@ -13,7 +13,7 @@ import {localizeURLs} from '../lib/localize-urls.ts';
 import {launchPuppeteer, startCoverage, stopCoverageAndReport} from '../lib/puppeteer_config.ts';
 import type {MapLibreMap, CanvasSource, PointLike, StyleSpecification, MapEventType} from '../../../dist/maplibre-gl';
 import type * as MapLibreGL from '../../../dist/maplibre-gl';
-import {afterAll, afterEach, beforeAll, beforeEach, describe, expect, test, vi} from 'vitest';
+import {afterAll, afterEach, beforeAll, beforeEach, describe, expect, test, vi, type TestContext} from 'vitest';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 let maplibregl: typeof MapLibreGL;
@@ -37,11 +37,7 @@ const HOOK_TIMEOUT = 180000;
 /** How many tests run at the same time, each in its own browser; 1 is the serial run CI does. */
 const TEST_CONCURRENCY = Math.max(1, +process.env.RENDER_TEST_CONCURRENCY || 1);
 
-declare module 'vitest' {
-    export interface TestContext {
-        page: Page;
-    }
-}
+type RenderTestContext = TestContext & {page: Page};
 
 type TestData = {
     id: string;
@@ -914,7 +910,7 @@ describe('Render tests', () => {
         console.log(`Render test setup took ${Date.now() - setupStart}ms`);
     }, HOOK_TIMEOUT);
 
-    beforeEach((ctx) => {
+    beforeEach((ctx: RenderTestContext) => {
         ctx.page = freePages.pop();
         if (ctx.task.result?.retryCount > 0) {
             console.log(`Retry ${ctx.task.name} with console logging enabled`);
@@ -922,7 +918,7 @@ describe('Render tests', () => {
         }
     });
 
-    afterEach(async (ctx) => {
+    afterEach(async (ctx: RenderTestContext) => {
         ctx.page.removeAllListeners('console');
         ctx.page.removeAllListeners('pageerror');
         ctx.page.removeAllListeners('response');
@@ -941,7 +937,7 @@ describe('Render tests', () => {
     }, HOOK_TIMEOUT);
 
     for (const style of testStyles) {
-        test.concurrent(style.metadata.test.id, {retry: 1, timeout: style.metadata.test.timeout || DEFAULT_TEST_TIMEOUT}, async ({page}) => {
+        test.concurrent(style.metadata.test.id, {retry: 1, timeout: style.metadata.test.timeout || DEFAULT_TEST_TIMEOUT}, async ({page}: RenderTestContext) => {
             const serverPort = (server.address() as any).port;
             localizeURLs(style, serverPort, path.join(__dirname, '../'));
             const data = await getImageFromStyle(style, page);


### PR DESCRIPTION
Right now the render tests run one at a time through a single Puppeteer page, which takes about 7 minutes locally. CI splits the suite over 6 runners, but there is nothing equivalent for a local run.

Vitest can run the tests in a file concurrently: `test.concurrent` marks them, and `maxConcurrency` caps how many are in flight. This PR uses that, and adds the browser side: `RENDER_TEST_CONCURRENCY` launches that many headless browsers with one page each, and every test borrows a free page from that pool. For me the full suite goes from 7 minutes to 80 seconds with 12.

The default concurrency is 1, so CI is unchanged. I tried 2 on the CI runners: the Linux splits got a bit faster, but the Windows ones took more than twice as long, so CI stays serial for now. One browser per page is deliberate: pages sharing a browser also share its GPU process, and that was slower than the serial run.


## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items that are not relevant. -->


 - [X] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [X] Briefly describe the changes in this PR.
 - [ ] Link to related issues.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality.
 - [X] Document any changes to public APIs.
 - [ ] If you changed code in a file that has a benchmark file next to it (`*.bench.ts`), post before/after results of `npm run bench` (the compare workflow is in `test/bench/README.md`).
 - [ ] Add an entry to `CHANGELOG.md` under the `## main` section.
 - [X] Confirm you have read our AI policy [here](https://github.com/maplibre/maplibre/blob/main/AI_POLICY.md).
<!--
  Add one of:    Assisted-By: | Generated-By:     and the model/version
-->