### PR TITLE
GM2.3 Move the terrain uniforms into a UBO

### DIFF
--- a/src/render/painter.ts
+++ b/src/render/painter.ts
@@ -917,6 +917,7 @@ export class Painter {
         }
 
         this.context.projectionUniformBuffer.destroy();
+        this.context.terrainUniformBuffer.destroy();
 
         if (this.cache) {
             for (const key in this.cache) {

--- a/src/shaders/glsl/_prelude.vertex.glsl
+++ b/src/shaders/glsl/_prelude.vertex.glsl
@@ -88,11 +88,13 @@ mat3 rotationMatrixFromAxisAngle(vec3 u, float angle) {
 
 #ifdef TERRAIN3D
 uniform sampler2D u_terrain;
-uniform float u_terrain_dim;
-uniform mat4 u_terrain_matrix;
-uniform vec4 u_terrain_unpack;
-uniform float u_terrain_exaggeration;
 uniform highp sampler2D u_depth;
+layout(std140) uniform TerrainUBO {
+    highp mat4 u_terrain_matrix;
+    highp vec4 u_terrain_unpack;
+    highp float u_terrain_dim;
+    highp float u_terrain_exaggeration;
+};
 #endif
 
 // methods for pack/unpack depth value to texture rgba

--- a/src/webgl/context.ts
+++ b/src/webgl/context.ts
@@ -3,6 +3,7 @@ import {IndexBuffer} from './index_buffer.ts';
 import {VertexBuffer} from './vertex_buffer.ts';
 import {Framebuffer} from './framebuffer.ts';
 import {createProjectionUniformBuffer} from './projection_uniform_buffer.ts';
+import {createTerrainUniformBuffer} from './terrain_uniform_buffer.ts';
 import type {UniformBuffer} from './uniform_buffer.ts';
 import {type DepthMode} from './depth_mode.ts';
 import {type StencilMode} from './stencil_mode.ts';
@@ -66,6 +67,7 @@ export class Context {
     pixelStoreUnpackPremultiplyAlpha: PixelStoreUnpackPremultiplyAlpha;
     pixelStoreUnpackFlipY: PixelStoreUnpackFlipY;
     projectionUniformBuffer: UniformBuffer;
+    terrainUniformBuffer: UniformBuffer;
 
     extTextureFilterAnisotropic: EXT_texture_filter_anisotropic | null;
     extTextureFilterAnisotropicMax?: GLfloat;
@@ -116,6 +118,7 @@ export class Context {
         gl.getExtension('EXT_color_buffer_float');
 
         this.projectionUniformBuffer = createProjectionUniformBuffer(this);
+        this.terrainUniformBuffer = createTerrainUniformBuffer(this);
     }
 
     setDefault(): void {
@@ -181,6 +184,7 @@ export class Context {
         this.pixelStoreUnpackPremultiplyAlpha.dirty = true;
         this.pixelStoreUnpackFlipY.dirty = true;
         this.projectionUniformBuffer.bindingDirty = true;
+        this.terrainUniformBuffer.bindingDirty = true;
     }
 
     /**

--- a/src/webgl/program.ts
+++ b/src/webgl/program.ts
@@ -16,6 +16,7 @@ import {terrainPreludeUniforms, type TerrainPreludeUniformsType} from './program
 import type {TerrainData} from '../render/terrain.ts';
 import {applyUBOBindings} from './uniform_buffer.ts';
 import {updateProjectionUniformBuffer} from './projection_uniform_buffer.ts';
+import {updateTerrainUniformBuffer} from './terrain_uniform_buffer.ts';
 import type {ProjectionData} from '../geo/projection/projection_data.ts';
 
 export type DrawMode = WebGLRenderingContextBase['LINES'] | WebGLRenderingContextBase['TRIANGLES'] | WebGL2RenderingContext['LINE_STRIP'];
@@ -216,6 +217,7 @@ export class Program<Us extends UniformBindings> {
             for (const name in this.terrainUniforms) {
                 this.terrainUniforms[name].set(terrain[name]);
             }
+            updateTerrainUniformBuffer(context.terrainUniformBuffer, terrain);
         }
 
         if (projectionData) {

--- a/src/webgl/program/terrain_program.ts
+++ b/src/webgl/program/terrain_program.ts
@@ -1,7 +1,6 @@
 import {
     Uniform1i,
     Uniform1f,
-    Uniform4f,
     UniformMatrix4f,
     UniformColor
 } from '../uniform_binding.ts';
@@ -14,10 +13,6 @@ import {type mat4} from 'gl-matrix';
 export type TerrainPreludeUniformsType = {
     'u_depth': Uniform1i;
     'u_terrain': Uniform1i;
-    'u_terrain_dim': Uniform1f;
-    'u_terrain_matrix': UniformMatrix4f;
-    'u_terrain_unpack': Uniform4f;
-    'u_terrain_exaggeration': Uniform1f;
 };
 
 export type TerrainUniformsType = {
@@ -38,11 +33,7 @@ export type TerrainDepthUniformsType = {
 
 const terrainPreludeUniforms = (context: Context, locations: UniformLocations): TerrainPreludeUniformsType => ({
     'u_depth': new Uniform1i(context, locations.u_depth),
-    'u_terrain': new Uniform1i(context, locations.u_terrain),
-    'u_terrain_dim': new Uniform1f(context, locations.u_terrain_dim),
-    'u_terrain_matrix': new UniformMatrix4f(context, locations.u_terrain_matrix),
-    'u_terrain_unpack': new Uniform4f(context, locations.u_terrain_unpack),
-    'u_terrain_exaggeration': new Uniform1f(context, locations.u_terrain_exaggeration)
+    'u_terrain': new Uniform1i(context, locations.u_terrain)
 });
 
 const terrainUniforms = (context: Context, locations: UniformLocations): TerrainUniformsType => ({

--- a/src/webgl/terrain_uniform_buffer.ts
+++ b/src/webgl/terrain_uniform_buffer.ts
@@ -1,0 +1,29 @@
+import {UBO_BINDINGS, UniformBuffer, std140Layout} from './uniform_buffer.ts';
+import type {Context} from './context.ts';
+import type {TerrainData} from '../render/terrain.ts';
+
+const layout = std140Layout([
+    {name: 'u_terrain_matrix', type: 'mat4'},
+    {name: 'u_terrain_unpack', type: 'vec4'},
+    {name: 'u_terrain_dim', type: 'float'},
+    {name: 'u_terrain_exaggeration', type: 'float'},
+]);
+
+const offsets = layout.offsets;
+
+/**
+ * @internal
+ * The buffer behind the `TerrainUBO` block in the vertex prelude, written by `Program.draw` for every draw with terrain.
+ */
+export function createTerrainUniformBuffer(context: Context): UniformBuffer {
+    return new UniformBuffer(context, UBO_BINDINGS.TerrainUBO, layout);
+}
+
+export function updateTerrainUniformBuffer(buffer: UniformBuffer, terrain: TerrainData): void {
+    const f32 = buffer.pending;
+    f32.set(terrain.u_terrain_matrix, offsets.u_terrain_matrix);
+    f32.set(terrain.u_terrain_unpack, offsets.u_terrain_unpack);
+    f32[offsets.u_terrain_dim] = terrain.u_terrain_dim;
+    f32[offsets.u_terrain_exaggeration] = terrain.u_terrain_exaggeration;
+    buffer.upload();
+}

--- a/src/webgl/uniform_buffer.ts
+++ b/src/webgl/uniform_buffer.ts
@@ -2,6 +2,7 @@ import type {Context} from './context.ts';
 
 export const UBO_BINDINGS = {
     ProjectionUBO: 0,
+    TerrainUBO: 1,
 };
 
 export function applyUBOBindings(gl: WebGL2RenderingContext, program: WebGLProgram): void {

--- a/test/build/bundle_size.json
+++ b/test/build/bundle_size.json
@@ -1,7 +1,7 @@
 {
     "dist/maplibre-gl.mjs": {
-        "raw": 581523,
-        "gzip": 147103
+        "raw": 581988,
+        "gzip": 147195
     },
     "dist/maplibre-gl-worker.mjs": {
         "raw": 19181,


### PR DESCRIPTION
Part of below as Milestone 2.3

- #7640

Simliar to the ProjectionUBO,  instead of passing four uniforms ( e.g. the exaggeration ) into the terrain shader on each draw call, they're packed into a small TerrainUBO.

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] If you changed code in a file that has a benchmark file next to it (`*.bench.ts`), post before/after results of `npm run bench` (the compare workflow is in `test/bench/README.md`).
 - [ ] Add an entry to `CHANGELOG.md` under the `## main` section.
 - [x] Confirm you have read our AI policy [here](https://github.com/maplibre/maplibre/blob/main/AI_POLICY.md).
<!--
  Add one of:    Assisted-By: | Generated-By:     and the model/version
-->
