### PR TITLE
ci: cancel superseded pull request runs

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -20,6 +20,10 @@ on:
   schedule:
     - cron: '17 0 * * 6'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   checks: write
   pull-requests: write


### PR DESCRIPTION
A push to an open pull request starts another 21 jobs, 12 of them render-test shards with a two hour timeout, while the previous run keeps going. This is the concurrency block maplibre-tile-spec and martin use: pull request runs are keyed by number and cancelled when superseded; runs on main and the scheduled CodeQL run queue behind each other and are never cancelled.

## Launch Checklist

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Confirm you have read our AI policy [here](https://github.com/maplibre/maplibre/blob/main/AI_POLICY.md).
<!--
  Add one of:    Assisted-By: | Generated-By:     and the model/version
-->

Assisted-By: Claude Fable 5 was used to diagnose CI bottlenecks across the MapLibre org, this solution was worked out in [this Slack thread](https://osmus.slack.com/archives/C01G3D28DAB/p1788530857324559)