### PR TITLE
GM2.5 Extract shared render state into RenderOptions

### DIFF
--- a/src/render/painter.test.ts
+++ b/src/render/painter.test.ts
@@ -1,7 +1,9 @@
 import {describe, beforeEach, test, expect, vi, afterEach} from 'vitest';
 import {Painter} from './painter.ts';
 import {MercatorTransform} from '../geo/projection/mercator_transform.ts';
+import {GlobeProjection} from '../geo/projection/globe_projection.ts';
 import {Style} from '../style/style.ts';
+import {CustomStyleLayer} from '../style/style_layer/custom_style_layer.ts';
 import {StubMap} from '../util/test/util.ts';
 import {Texture} from '../webgl/texture.ts';
 import {createNullGL} from '../util/test/null_gl.ts';
@@ -47,7 +49,7 @@ describe('render', () => {
     test('must not fail with incompletely loaded style', () => {
         painter.render(style, renderOptions);
 
-        expect(painter.renderPass).toBe('translucent');
+        expect(painter.renderOptions.currentPass).toBe('translucent');
     });
 
     test('calls terrainDepth', () => {
@@ -80,6 +82,38 @@ describe('render', () => {
         expect(painter.getTerrainDataForTile(tileID, true)).toBe(terrainData);
         expect(getTerrainData).toHaveBeenCalledWith(tileID);
     });
+
+    test('builds render options from the transform, globe projection and terrain', () => {
+        const terrain = {tileManager: {anyTilesAfterTime: () => false}};
+        map.terrain = terrain;
+        style.projection = new GlobeProjection({type: 'vertical-perspective'}, {});
+        vi.spyOn(painter.drawFunctions, 'terrainDepth').mockImplementation(() => {});
+        vi.spyOn(painter.drawFunctions, 'atmosphere').mockImplementation(() => {});
+
+        painter.render(style, renderOptions);
+
+        expect(painter.renderOptions.transform).toBe(painter.transform);
+        expect(painter.renderOptions.terrain).toBe(terrain);
+        expect(painter.renderOptions.projectionTransition).toBe(1);
+        expect(painter.renderOptions.isRenderingGlobe).toBe(true);
+    });
+
+    test('uses render options for depth and blending when drawing a custom layer', () => {
+        painter.render(style, renderOptions);
+        const options = painter.renderOptions;
+        options.depthRangeFor3D = [0.1, 0.8];
+        const render = vi.fn((gl: WebGL2RenderingContext) => {
+            expect(painter.context.depthRange.get()).toEqual([0.1, 0.8]);
+            expect(painter.context.blend.get()).toBe(true);
+            expect(painter.context.blendFunc.get()).toEqual([gl.ONE, gl.ONE_MINUS_SRC_ALPHA]);
+        });
+        const layer = new CustomStyleLayer({id: 'custom', type: 'custom', renderingMode: '3d', render}, {});
+
+        painter.renderLayer(painter, null, layer, [], options);
+
+        expect(render).toHaveBeenCalledTimes(1);
+    });
+
     describe('terrain render time', () => {
         beforeEach(() => {
             vi.spyOn(painter.drawFunctions, 'terrainDepth').mockImplementation(() => {});

--- a/src/render/painter.ts
+++ b/src/render/painter.ts
@@ -33,10 +33,11 @@ import type {PatternAtlas} from './pattern_atlas.ts';
 import type {GlyphManager} from './glyph_manager.ts';
 import type {VertexBuffer} from '../webgl/vertex_buffer.ts';
 import type {IndexBuffer} from '../webgl/index_buffer.ts';
-import type {DepthRangeType, DepthMaskType, DepthFuncType} from '../webgl/types.ts';
+import type {DepthMaskType, DepthFuncType} from '../webgl/types.ts';
 import type {ResolvedImage} from '@maplibre/maplibre-gl-style-spec';
 import type {IRenderToTexture} from './render_to_texture_interface.ts';
 import type {TerrainData} from './terrain.ts';
+import {RenderOptions} from './render_options.ts';
 import type {ProjectionData} from '../geo/projection/projection_data.ts';
 import type {Framebuffer} from '../webgl/framebuffer.ts';
 import {updateFrameUniformBuffer} from '../webgl/frame_uniform_buffer.ts';
@@ -53,8 +54,6 @@ import {isRasterStyleLayer} from '../style/style_layer/raster_style_layer.ts';
 import {isBackgroundStyleLayer} from '../style/style_layer/background_style_layer.ts';
 import {isCustomStyleLayer} from '../style/style_layer/custom_style_layer.ts';
 
-export type RenderPass = 'offscreen' | 'opaque' | 'translucent';
-
 type PainterOptions = {
     showOverdrawInspector: boolean;
     showTileBoundaries: boolean;
@@ -64,11 +63,6 @@ type PainterOptions = {
     moving: boolean;
     fadeDuration: number;
     anisotropicFilterPitch: number;
-};
-
-export type RenderOptions = {
-    isRenderingToTexture: boolean;
-    isRenderingGlobe: boolean;
 };
 
 /**
@@ -144,10 +138,7 @@ export class Painter {
     imageManager: ImageManager;
     patternAtlas: PatternAtlas;
     glyphManager: GlyphManager;
-    depthRangeFor3D: DepthRangeType;
-    opaquePassCutoff: number;
-    renderPass: RenderPass;
-    currentLayer: number;
+    renderOptions: RenderOptions;
     currentStencilSource: string;
     nextStencilID: number;
     id: string;
@@ -487,7 +478,7 @@ export class Painter {
             const a = 1 / numOverdrawSteps;
 
             return new ColorMode([gl.CONSTANT_COLOR, gl.ONE], new Color(a, a, a, 0), [true, true, true, true]);
-        } else if (this.renderPass === 'opaque') {
+        } else if (this.renderOptions.currentPass === 'opaque') {
             return ColorMode.unblended;
         } else {
             return ColorMode.alphaBlended;
@@ -496,12 +487,12 @@ export class Painter {
 
     getDepthModeForSublayer(n: number, mask: DepthMaskType, func?: DepthFuncType | null): Readonly<DepthMode> {
         if (!this.opaquePassEnabledForLayer()) return DepthMode.disabled;
-        const depth = 1 - ((1 + this.currentLayer) * this.numSublayers + n) * this.depthEpsilon;
+        const depth = 1 - ((1 + this.renderOptions.currentLayer) * this.numSublayers + n) * this.depthEpsilon;
         return new DepthMode(func || this.context.gl.LEQUAL, mask, [depth, depth]);
     }
 
     getDepthModeFor3D(): Readonly<DepthMode> {
-        return new DepthMode(this.context.gl.LEQUAL, DepthMode.ReadWrite, this.depthRangeFor3D);
+        return new DepthMode(this.context.gl.LEQUAL, DepthMode.ReadWrite, this.renderOptions.depthRangeFor3D);
     }
 
     /*
@@ -512,12 +503,13 @@ export class Painter {
      * opaque pass.
      */
     opaquePassEnabledForLayer(): boolean {
-        return this.currentLayer < this.opaquePassCutoff;
+        return this.renderOptions.currentLayer < this.renderOptions.opaquePassCutoff;
     }
 
     render(style: Style, options: PainterOptions): void {
         this.style = style;
         this.options = options;
+        const renderOptions = this.renderOptions = new RenderOptions(this.transform, style.projection, style.map.terrain ?? null);
 
         this.lineAtlas = style.lineAtlas;
         this.imageManager = style.imageManager;
@@ -535,7 +527,6 @@ export class Painter {
         const coordsAscending: {[_: string]: OverscaledTileID[]} = {};
         const coordsDescending: {[_: string]: OverscaledTileID[]} = {};
         const coordsDescendingSymbol: {[_: string]: OverscaledTileID[]} = {};
-        const renderOptions: RenderOptions = {isRenderingToTexture: false, isRenderingGlobe: style.projection?.transitionState > 0};
 
         for (const id in tileManagers) {
             const tileManager = tileManagers[id];
@@ -548,11 +539,11 @@ export class Painter {
             coordsDescendingSymbol[id] = tileManager.getVisibleCoordinates(true).reverse();
         }
 
-        this.opaquePassCutoff = Infinity;
+        renderOptions.opaquePassCutoff = Infinity;
         for (let i = 0; i < layerIds.length; i++) {
             const layerId = layerIds[i];
             if (this.style._layers[layerId].is3D()) {
-                this.opaquePassCutoff = i;
+                renderOptions.opaquePassCutoff = i;
                 break;
             }
         }
@@ -562,14 +553,14 @@ export class Painter {
         if (this.renderToTexture) {
             this.renderToTexture.prepareForRender(this.style, this.transform.zoom);
             // this is disabled, because render-to-texture is rendering all layers from bottom to top.
-            this.opaquePassCutoff = 0;
+            renderOptions.opaquePassCutoff = 0;
         }
 
         // Offscreen pass ===============================================
         // We first do all rendering that requires rendering to a separate
         // framebuffer, and then save those for rendering back to the map
         // later: in doing this we avoid doing expensive framebuffer restores.
-        this.renderPass = 'offscreen';
+        renderOptions.currentPass = 'offscreen';
 
         for (const layerId of layerIds) {
             const layer = this.style._layers[layerId];
@@ -593,15 +584,15 @@ export class Painter {
         if (this.style.sky) this.drawFunctions.sky(this, this.style.sky);
 
         this._showOverdrawInspector = options.showOverdrawInspector;
-        this.depthRangeFor3D = [0, 1 - ((style._order.length + 2) * this.numSublayers * this.depthEpsilon)];
+        renderOptions.depthRangeFor3D = [0, 1 - ((style._order.length + 2) * this.numSublayers * this.depthEpsilon)];
 
         // Opaque pass ===============================================
         // Draw opaque layers top-to-bottom first.
         if (!this.renderToTexture) {
-            this.renderPass = 'opaque';
+            renderOptions.currentPass = 'opaque';
 
-            for (this.currentLayer = layerIds.length - 1; this.currentLayer >= 0; this.currentLayer--) {
-                const layer = this.style._layers[layerIds[this.currentLayer]];
+            for (renderOptions.currentLayer = layerIds.length - 1; renderOptions.currentLayer >= 0; renderOptions.currentLayer--) {
+                const layer = this.style._layers[layerIds[renderOptions.currentLayer]];
                 const tileManager = tileManagers[layer.source];
                 const coords = coordsAscending[layer.source];
 
@@ -612,12 +603,12 @@ export class Painter {
 
         // Translucent pass ===============================================
         // Draw all other layers bottom-to-top.
-        this.renderPass = 'translucent';
+        renderOptions.currentPass = 'translucent';
 
         let globeDepthRendered = false;
 
-        for (this.currentLayer = 0; this.currentLayer < layerIds.length; this.currentLayer++) {
-            const layer = this.style._layers[layerIds[this.currentLayer]];
+        for (renderOptions.currentLayer = 0; renderOptions.currentLayer < layerIds.length; renderOptions.currentLayer++) {
+            const layer = this.style._layers[layerIds[renderOptions.currentLayer]];
             const tileManager = tileManagers[layer.source];
 
             if (this.renderToTexture?.renderLayer(layer, renderOptions)) continue;

--- a/src/render/render_options.ts
+++ b/src/render/render_options.ts
@@ -1,0 +1,30 @@
+import type {IReadonlyTransform} from '../geo/transform_interface.ts';
+import type {Projection} from '../geo/projection/projection.ts';
+import type {Terrain} from './terrain.ts';
+import type {DepthRangeType} from '../webgl/types.ts';
+
+export type RenderPass = 'offscreen' | 'opaque' | 'translucent';
+
+/**
+ * @internal
+ * Shared draw state, created per render and updated as rendering proceeds.
+ * Corresponds to part of MapLibre Native's `PaintParameters`.
+ */
+export class RenderOptions {
+    currentPass: RenderPass = 'offscreen';
+    currentLayer: number = 0;
+    opaquePassCutoff: number = Infinity;
+    depthRangeFor3D: DepthRangeType = [0, 1];
+    isRenderingToTexture: boolean = false;
+    readonly transform: IReadonlyTransform;
+    readonly terrain: Terrain | null;
+    readonly projectionTransition: number;
+    readonly isRenderingGlobe: boolean;
+
+    constructor(transform: IReadonlyTransform, projection: Projection | undefined, terrain: Terrain | null) {
+        this.transform = transform;
+        this.terrain = terrain;
+        this.projectionTransition = projection?.transitionState ?? 0;
+        this.isRenderingGlobe = this.projectionTransition > 0;
+    }
+}

--- a/src/render/render_to_texture_interface.ts
+++ b/src/render/render_to_texture_interface.ts
@@ -1,7 +1,7 @@
 import type {Style} from '../style/style.ts';
 import type {StyleLayer} from '../style/style_layer.ts';
 import type {Tile} from '../tile/tile.ts';
-import type {RenderOptions} from './painter.ts';
+import type {RenderOptions} from './render_options.ts';
 
 /**
  * Interface for render-to-texture implementations.

--- a/src/webgl/draw/draw_background.ts
+++ b/src/webgl/draw/draw_background.ts
@@ -6,7 +6,8 @@ import {
     backgroundPatternUniformValues
 } from '../program/background_program.ts';
 
-import type {Painter, RenderOptions} from '../../render/painter.ts';
+import type {Painter} from '../../render/painter.ts';
+import type {RenderOptions} from '../../render/render_options.ts';
 import type {TileManager} from '../../tile/tile_manager.ts';
 import type {BackgroundStyleLayer} from '../../style/style_layer/background_style_layer.ts';
 import {type OverscaledTileID} from '../../tile/tile_id.ts';
@@ -29,7 +30,7 @@ export function drawBackground(painter: Painter, tileManager: TileManager, layer
     if (painter.isPatternMissing(image)) return;
 
     const pass = (!image && color.a === 1 && opacity === 1 && painter.opaquePassEnabledForLayer()) ? 'opaque' : 'translucent';
-    if (painter.renderPass !== pass) return;
+    if (renderOptions.currentPass !== pass) return;
 
     const stencilMode = StencilMode.disabled;
     const depthMode = painter.getDepthModeForSublayer(0, pass === 'opaque' ? DepthMode.ReadWrite : DepthMode.ReadOnly);

--- a/src/webgl/draw/draw_circle.ts
+++ b/src/webgl/draw/draw_circle.ts
@@ -6,7 +6,8 @@ import {circleUniformValues} from '../program/circle_program.ts';
 import {SegmentVector} from '../../data/segment.ts';
 import {type OverscaledTileID} from '../../tile/tile_id.ts';
 
-import type {Painter, RenderOptions} from '../../render/painter.ts';
+import type {Painter} from '../../render/painter.ts';
+import type {RenderOptions} from '../../render/render_options.ts';
 import type {TileManager} from '../../tile/tile_manager.ts';
 import type {CircleStyleLayer} from '../../style/style_layer/circle_style_layer.ts';
 import type {CircleBucket} from '../../data/bucket/circle_bucket.ts';
@@ -36,7 +37,7 @@ type SegmentsTileRenderState = {
 };
 
 export function drawCircles(painter: Painter, tileManager: TileManager, layer: CircleStyleLayer, coords: OverscaledTileID[], renderOptions: RenderOptions): void {
-    if (painter.renderPass !== 'translucent') return;
+    if (renderOptions.currentPass !== 'translucent') return;
 
     const {isRenderingToTexture} = renderOptions;
     const opacity = layer.paint.get('circle-opacity');

--- a/src/webgl/draw/draw_color_relief.ts
+++ b/src/webgl/draw/draw_color_relief.ts
@@ -7,13 +7,14 @@ import {
     colorReliefUniformValues
 } from '../program/color_relief_program.ts';
 
-import type {Painter, RenderOptions} from '../../render/painter.ts';
+import type {Painter} from '../../render/painter.ts';
+import type {RenderOptions} from '../../render/render_options.ts';
 import type {TileManager} from '../../tile/tile_manager.ts';
 import type {ColorReliefStyleLayer} from '../../style/style_layer/color_relief_style_layer.ts';
 import type {OverscaledTileID} from '../../tile/tile_id.ts';
 
 export function drawColorRelief(painter: Painter, tileManager: TileManager, layer: ColorReliefStyleLayer, tileIDs: OverscaledTileID[], renderOptions: RenderOptions): void {
-    if (painter.renderPass !== 'translucent') return;
+    if (renderOptions.currentPass !== 'translucent') return;
     if (!tileIDs.length) return;
 
     const {isRenderingToTexture} = renderOptions;

--- a/src/webgl/draw/draw_custom.test.ts
+++ b/src/webgl/draw/draw_custom.test.ts
@@ -2,7 +2,8 @@ import {describe, test, expect, vi} from 'vitest';
 import {OverscaledTileID} from '../../tile/tile_id.ts';
 import {TileManager} from '../../tile/tile_manager.ts';
 import {Tile} from '../../tile/tile.ts';
-import {Painter, type RenderOptions} from '../../render/painter.ts';
+import {Painter} from '../../render/painter.ts';
+import {RenderOptions} from '../../render/render_options.ts';
 import type {Map} from '../../ui/map.ts';
 import {drawCustom} from './draw_custom.ts';
 import {CustomStyleLayer} from '../../style/style_layer/custom_style_layer.ts';
@@ -33,8 +34,10 @@ describe('drawCustom', () => {
         mockPainter.style = {
             projection: new MercatorProjection(),
         } as any;
-        mockPainter.renderPass = 'translucent';
         mockPainter.transform = transform;
+        const renderOptions = new RenderOptions(transform, mockPainter.style.projection, null);
+        renderOptions.currentPass = 'translucent';
+        mockPainter.renderOptions = renderOptions;
         mockPainter.context = {
             gl: {},
             setColorMode: () => {},
@@ -70,7 +73,6 @@ describe('drawCustom', () => {
                 };
             },
         }, {});
-        const renderOptions: RenderOptions = {isRenderingToTexture: false, isRenderingGlobe: false};
         drawCustom(mockPainter, tileManagerMock, mockLayer, renderOptions);
         expect(result.gl).toBeDefined();
         expect(result.args.farZ).toBeCloseTo(804.8028169246645, 6);

--- a/src/webgl/draw/draw_custom.ts
+++ b/src/webgl/draw/draw_custom.ts
@@ -1,7 +1,8 @@
 import {DepthMode} from '../depth_mode.ts';
 import {StencilMode} from '../stencil_mode.ts';
 
-import type {Painter, RenderOptions} from '../../render/painter.ts';
+import type {Painter} from '../../render/painter.ts';
+import type {RenderOptions} from '../../render/render_options.ts';
 import type {TileManager} from '../../tile/tile_manager.ts';
 import type {CustomLayerProjectionDataParams, CustomRenderMethodInput, CustomStyleLayer} from '../../style/style_layer/custom_style_layer.ts';
 import {OverscaledTileID} from '../../tile/tile_id.ts';
@@ -46,7 +47,7 @@ export function drawCustom(painter: Painter, tileManager: TileManager, layer: Cu
 
     const renderingMode = implementation.renderingMode ? implementation.renderingMode : '2d';
 
-    if (painter.renderPass === 'offscreen') {
+    if (renderOptions.currentPass === 'offscreen') {
         const prerender = implementation.prerender;
         if (prerender) {
             painter.setCustomLayerDefaults();
@@ -57,7 +58,7 @@ export function drawCustom(painter: Painter, tileManager: TileManager, layer: Cu
             context.setDirty();
             painter.setBaseState();
         }
-    } else if (painter.renderPass === 'translucent') {
+    } else if (renderOptions.currentPass === 'translucent') {
 
         painter.setCustomLayerDefaults();
 

--- a/src/webgl/draw/draw_fill.test.ts
+++ b/src/webgl/draw/draw_fill.test.ts
@@ -3,7 +3,8 @@ import {mat4} from 'gl-matrix';
 import {OverscaledTileID} from '../../tile/tile_id.ts';
 import {TileManager} from '../../tile/tile_manager.ts';
 import {Tile} from '../../tile/tile.ts';
-import {Painter, type RenderOptions} from '../../render/painter.ts';
+import {Painter} from '../../render/painter.ts';
+import {RenderOptions} from '../../render/render_options.ts';
 import {Program} from '../program.ts';
 import type {ZoomHistory} from '../../style/zoom_history.ts';
 import type {Map} from '../../ui/map.ts';
@@ -45,8 +46,7 @@ describe('drawFill', () => {
         (vi.mocked(tileManagerMock.getTile)).mockReturnValue(mockTile);
         tileManagerMock.map = {showCollisionBoxes: false} as any as Map;
 
-        const renderOptions: RenderOptions = {isRenderingToTexture: false, isRenderingGlobe: false};
-        drawFill(painterMock, tileManagerMock, layer, [mockTile.tileID], renderOptions);
+        drawFill(painterMock, tileManagerMock, layer, [mockTile.tileID], painterMock.renderOptions);
 
         // twice: first for fill, second for stroke
         expect(programMock.draw).toHaveBeenCalledTimes(2);
@@ -91,7 +91,6 @@ describe('drawFill', () => {
                 set: () => {}
             }
         } as any;
-        painterMock.renderPass = 'translucent';
         painterMock.transform = {
             pitch: 0,
             labelPlaneMatrix: mat4.create(),
@@ -108,6 +107,8 @@ describe('drawFill', () => {
                 };
             },
         } as any as IReadonlyTransform;
+        painterMock.renderOptions = new RenderOptions(painterMock.transform, undefined, null);
+        painterMock.renderOptions.currentPass = 'translucent';
         painterMock.options = {} as any;
         painterMock.style = {
             map: {

--- a/src/webgl/draw/draw_fill.ts
+++ b/src/webgl/draw/draw_fill.ts
@@ -12,7 +12,8 @@ import {translatePosition} from '../../util/util.ts';
 import {drawLayerOpacity, prepareDrawLayerOpacity} from './draw_layer_opacity.ts';
 
 import type {ColorMode} from '../color_mode.ts';
-import type {Painter, RenderOptions} from '../../render/painter.ts';
+import type {Painter} from '../../render/painter.ts';
+import type {RenderOptions} from '../../render/render_options.ts';
 import type {TileManager} from '../../tile/tile_manager.ts';
 import type {FillStyleLayer} from '../../style/style_layer/fill_style_layer.ts';
 import type {FillBucket} from '../../data/bucket/fill_bucket.ts';
@@ -25,7 +26,7 @@ export function drawFill(painter: Painter, tileManager: TileManager, layer: Fill
     if (opacity.constantOr(1) === 0 || layerOpacity === 0) return;
 
     if (layerOpacity < 1) {
-        if (painter.renderPass !== 'translucent') return;
+        if (renderOptions.currentPass !== 'translucent') return;
         const useTerrain = !!painter.style.map.terrain;
 
         const results = prepareDrawLayerOpacity(painter,layer, coords, useTerrain);
@@ -40,7 +41,7 @@ export function drawFill(painter: Painter, tileManager: TileManager, layer: Fill
         color.constantOr(Color.transparent).a === 1 &&
         opacity.constantOr(0) === 1;
 
-    if (fillEligibleForOpaque && painter.renderPass === 'opaque') {
+    if (fillEligibleForOpaque && renderOptions.currentPass === 'opaque') {
         // Opaque-eligible fill draws standalone in the opaque pass with ReadWrite depth;
         // its outline (always translucent) runs in the translucent pass below.
         const {isRenderingToTexture} = renderOptions;
@@ -49,12 +50,12 @@ export function drawFill(painter: Painter, tileManager: TileManager, layer: Fill
         drawFillTiles(painter, tileManager, layer, coords, depthMode, colorMode, false, isRenderingToTexture);
         return;
     }
-    if (fillEligibleForOpaque && painter.renderPass === 'translucent') {
+    if (fillEligibleForOpaque && renderOptions.currentPass === 'translucent') {
         // Fill already drew in the opaque pass; just draw the outline here.
         drawOutline(painter, tileManager, layer, coords, renderOptions);
         return;
     }
-    if (painter.renderPass === 'translucent') {
+    if (renderOptions.currentPass === 'translucent') {
         drawFillAndOutline(painter, tileManager, layer, coords, renderOptions);
     }
 }

--- a/src/webgl/draw/draw_fill_extrusion.ts
+++ b/src/webgl/draw/draw_fill_extrusion.ts
@@ -7,7 +7,8 @@ import {
     fillExtrusionPatternUniformValues,
 } from '../program/fill_extrusion_program.ts';
 
-import type {Painter, RenderOptions} from '../../render/painter.ts';
+import type {Painter} from '../../render/painter.ts';
+import type {RenderOptions} from '../../render/render_options.ts';
 import type {TileManager} from '../../tile/tile_manager.ts';
 import type {FillExtrusionStyleLayer} from '../../style/style_layer/fill_extrusion_style_layer.ts';
 import type {FillExtrusionBucket} from '../../data/bucket/fill_extrusion_bucket.ts';
@@ -23,8 +24,8 @@ export function drawFillExtrusion(painter: Painter, tileManager: TileManager, la
     }
 
     const {isRenderingToTexture} = renderOptions;
-    if (painter.renderPass === 'translucent') {
-        const depthMode = new DepthMode(painter.context.gl.LEQUAL, DepthMode.ReadWrite, painter.depthRangeFor3D);
+    if (renderOptions.currentPass === 'translucent') {
+        const depthMode = new DepthMode(painter.context.gl.LEQUAL, DepthMode.ReadWrite, renderOptions.depthRangeFor3D);
 
         if (opacity === 1 && !layer.paint.get('fill-extrusion-pattern').constantOr(1 as any)) {
             const colorMode = painter.colorModeForRenderPass();

--- a/src/webgl/draw/draw_heatmap.ts
+++ b/src/webgl/draw/draw_heatmap.ts
@@ -13,7 +13,8 @@ import {
 } from '../program/heatmap_program.ts';
 import {HEATMAP_FULL_RENDER_FBO_KEY} from '../../style/style_layer/heatmap_style_layer.ts';
 
-import type {Painter, RenderOptions} from '../../render/painter.ts';
+import type {Painter} from '../../render/painter.ts';
+import type {RenderOptions} from '../../render/render_options.ts';
 import type {TileManager} from '../../tile/tile_manager.ts';
 import type {HeatmapStyleLayer} from '../../style/style_layer/heatmap_style_layer.ts';
 import type {HeatmapBucket} from '../../data/bucket/heatmap_bucket.ts';
@@ -33,17 +34,17 @@ export function drawHeatmap(painter: Painter, tileManager: TileManager, layer: H
             // to use complex tile masking here because the change between zoom levels is subtle,
             // so it's fine to simply render the parent until all its 4 children are loaded
             if (tileManager.hasRenderableParent(coord)) continue;
-            if (painter.renderPass === 'offscreen') {
+            if (renderOptions.currentPass === 'offscreen') {
                 prepareHeatmapTerrain(painter, tile, layer, coord, isRenderingGlobe);
-            } else if (painter.renderPass === 'translucent') {
+            } else if (renderOptions.currentPass === 'translucent') {
                 renderHeatmapTerrain(painter, layer, coord, isRenderingToTexture, isRenderingGlobe);
             }
         }
         context.viewport.set([0, 0, painter.width, painter.height]);
     } else {
-        if (painter.renderPass === 'offscreen') {
+        if (renderOptions.currentPass === 'offscreen') {
             prepareHeatmapFlat(painter, tileManager, layer, tileIDs);
-        } else if (painter.renderPass === 'translucent') {
+        } else if (renderOptions.currentPass === 'translucent') {
             renderHeatmapFlat(painter, layer);
         }
 

--- a/src/webgl/draw/draw_hillshade.ts
+++ b/src/webgl/draw/draw_hillshade.ts
@@ -8,13 +8,14 @@ import {
     hillshadeUniformPrepareValues
 } from '../program/hillshade_program.ts';
 
-import type {Painter, RenderOptions} from '../../render/painter.ts';
+import type {Painter} from '../../render/painter.ts';
+import type {RenderOptions} from '../../render/render_options.ts';
 import type {TileManager} from '../../tile/tile_manager.ts';
 import type {HillshadeStyleLayer} from '../../style/style_layer/hillshade_style_layer.ts';
 import type {OverscaledTileID} from '../../tile/tile_id.ts';
 
 export function drawHillshade(painter: Painter, tileManager: TileManager, layer: HillshadeStyleLayer, tileIDs: OverscaledTileID[], renderOptions: RenderOptions): void {
-    if (painter.renderPass !== 'offscreen' && painter.renderPass !== 'translucent') return;
+    if (renderOptions.currentPass !== 'offscreen' && renderOptions.currentPass !== 'translucent') return;
 
     const {isRenderingToTexture} = renderOptions;
     const context = painter.context;
@@ -24,11 +25,11 @@ export function drawHillshade(painter: Painter, tileManager: TileManager, layer:
     const depthMode = painter.getDepthModeForSublayer(0, DepthMode.ReadOnly);
     const colorMode = painter.colorModeForRenderPass();
 
-    if (painter.renderPass === 'offscreen') {
+    if (renderOptions.currentPass === 'offscreen') {
         // Prepare tiles
         prepareHillshade(painter, tileManager, tileIDs, layer, depthMode, StencilMode.disabled, colorMode);
         context.viewport.set([0, 0, painter.width, painter.height]);
-    } else if (painter.renderPass === 'translucent') {
+    } else if (renderOptions.currentPass === 'translucent') {
         // Globe (or any projection with subdivision) needs two-pass rendering to avoid artifacts when rendering texture tiles.
         // See comments in draw_raster.ts for more details.
         if (useSubdivision) {

--- a/src/webgl/draw/draw_line.ts
+++ b/src/webgl/draw/draw_line.ts
@@ -13,7 +13,8 @@ import {renderColorRamp} from '../../util/color_ramp.ts';
 import {EXTENT} from '../../data/extent.ts';
 import {drawLayerOpacity, prepareDrawLayerOpacity} from './draw_layer_opacity.ts';
 
-import type {Painter, RenderOptions} from '../../render/painter.ts';
+import type {Painter} from '../../render/painter.ts';
+import type {RenderOptions} from '../../render/render_options.ts';
 import type {TileManager} from '../../tile/tile_manager.ts';
 import type {LineStyleLayer} from '../../style/style_layer/line_style_layer.ts';
 import type {LineBucket} from '../../data/bucket/line_bucket.ts';
@@ -140,7 +141,7 @@ function bindGradientAndDashTextures(
 }
 
 export function drawLine(painter: Painter, tileManager: TileManager, layer: LineStyleLayer, coords: OverscaledTileID[], renderOptions: RenderOptions): void {
-    if (painter.renderPass !== 'translucent') return;
+    if (renderOptions.currentPass !== 'translucent') return;
 
     const opacity = layer.paint.get('line-opacity');
     const width = layer.paint.get('line-width');

--- a/src/webgl/draw/draw_raster.ts
+++ b/src/webgl/draw/draw_raster.ts
@@ -14,7 +14,8 @@ import {EXTENT} from '../../data/extent.ts';
 import {FadingDirections} from '../../tile/tile.ts';
 import Point from '@mapbox/point-geometry';
 
-import type {Painter, RenderOptions} from '../../render/painter.ts';
+import type {Painter} from '../../render/painter.ts';
+import type {RenderOptions} from '../../render/render_options.ts';
 import type {TileManager} from '../../tile/tile_manager.ts';
 import type {RasterStyleLayer} from '../../style/style_layer/raster_style_layer.ts';
 import type {OverscaledTileID} from '../../tile/tile_id.ts';
@@ -42,7 +43,7 @@ const cornerCoords = [
 ];
 
 export function drawRaster(painter: Painter, tileManager: TileManager, layer: RasterStyleLayer, tileIDs: OverscaledTileID[], renderOptions: RenderOptions): void {
-    if (painter.renderPass !== 'translucent') return;
+    if (renderOptions.currentPass !== 'translucent') return;
     if (layer.paint.get('raster-opacity') === 0) return;
     if (!tileIDs.length) return;
 

--- a/src/webgl/draw/draw_symbol.test.ts
+++ b/src/webgl/draw/draw_symbol.test.ts
@@ -5,7 +5,8 @@ import {SymbolBucket} from '../../data/bucket/symbol_bucket.ts';
 import {TileManager} from '../../tile/tile_manager.ts';
 import {Tile} from '../../tile/tile.ts';
 import {SymbolStyleLayer} from '../../style/style_layer/symbol_style_layer.ts';
-import {Painter, type RenderOptions} from '../../render/painter.ts';
+import {Painter} from '../../render/painter.ts';
+import {RenderOptions} from '../../render/render_options.ts';
 import {Program} from '../program.ts';
 import {drawSymbols} from './draw_symbol.ts';
 import * as symbolProjection from '../../symbol/projection.ts';
@@ -55,9 +56,9 @@ function createMockTransform() {
 describe('drawSymbol', () => {
     test('should not do anything', () => {
         const mockPainter = new Painter(null, null);
-        mockPainter.renderPass = 'opaque';
+        const renderOptions = new RenderOptions(null, undefined, null);
+        renderOptions.currentPass = 'opaque';
 
-        const renderOptions: RenderOptions = {isRenderingToTexture: false, isRenderingGlobe: false};
         drawSymbols(mockPainter, null, null, null, null, renderOptions);
 
         expect(mockPainter.colorModeForRenderPass).not.toHaveBeenCalled();
@@ -71,8 +72,9 @@ describe('drawSymbol', () => {
                 set: () => { }
             }
         } as any;
-        painterMock.renderPass = 'translucent';
         painterMock.transform = createMockTransform();
+        painterMock.renderOptions = new RenderOptions(painterMock.transform, undefined, null);
+        painterMock.renderOptions.currentPass = 'translucent';
         painterMock.options = {} as any;
         painterMock.style = {
             map: {},
@@ -119,8 +121,7 @@ describe('drawSymbol', () => {
         tileManagerMock.map = {showCollisionBoxes: false} as any as Map;
         tileManagerMock.getTile = (_a) => tile;
 
-        const renderOptions: RenderOptions = {isRenderingToTexture: false, isRenderingGlobe: false};
-        drawSymbols(painterMock, tileManagerMock, layer, [tileId], null, renderOptions);
+        drawSymbols(painterMock, tileManagerMock, layer, [tileId], null, painterMock.renderOptions);
 
         expect(programMock.draw).toHaveBeenCalledTimes(1);
     });
@@ -134,8 +135,9 @@ describe('drawSymbol', () => {
                 set: () => { }
             }
         } as any;
-        painterMock.renderPass = 'translucent';
         painterMock.transform = createMockTransform();
+        painterMock.renderOptions = new RenderOptions(painterMock.transform, undefined, null);
+        painterMock.renderOptions.currentPass = 'translucent';
         painterMock.options = {} as any;
 
         const layerSpec = {
@@ -187,8 +189,7 @@ describe('drawSymbol', () => {
         } as any as Style;
 
         const spy = vi.spyOn(symbolProjection, 'updateLineLabels');
-        const renderOptions: RenderOptions = {isRenderingToTexture: false, isRenderingGlobe: false};
-        drawSymbols(painterMock, tileManagerMock, layer, [tileId], null, renderOptions);
+        drawSymbols(painterMock, tileManagerMock, layer, [tileId], null, painterMock.renderOptions);
 
         expect(spy.mock.calls[0][7]).toBeFalsy(); // rotateToLine === false
     });
@@ -202,8 +203,9 @@ describe('drawSymbol', () => {
                 set: () => { }
             }
         } as any;
-        painterMock.renderPass = 'translucent';
         painterMock.transform = createMockTransform();
+        painterMock.renderOptions = new RenderOptions(painterMock.transform, undefined, null);
+        painterMock.renderOptions.currentPass = 'translucent';
         painterMock.options = {} as any;
         painterMock.style = {
             projection: new MercatorProjection()
@@ -249,8 +251,7 @@ describe('drawSymbol', () => {
         (vi.mocked(tileManagerMock.getTile)).mockReturnValue(tile);
         tileManagerMock.map = {showCollisionBoxes: false} as any as Map;
 
-        const renderOptions: RenderOptions = {isRenderingToTexture: false, isRenderingGlobe: false};
-        drawSymbols(painterMock, tileManagerMock, layer, [tileId], null, renderOptions);
+        drawSymbols(painterMock, tileManagerMock, layer, [tileId], null, painterMock.renderOptions);
 
         expect(programMock.draw).toHaveBeenCalledTimes(0);
     });

--- a/src/webgl/draw/draw_symbol.ts
+++ b/src/webgl/draw/draw_symbol.ts
@@ -22,7 +22,8 @@ import {
     symbolTextAndIconUniformValues
 } from '../program/symbol_program.ts';
 
-import type {Painter, RenderOptions} from '../../render/painter.ts';
+import type {Painter} from '../../render/painter.ts';
+import type {RenderOptions} from '../../render/render_options.ts';
 import type {TileManager} from '../../tile/tile_manager.ts';
 import type {SymbolStyleLayer} from '../../style/style_layer/symbol_style_layer.ts';
 import type {Texture, TextureFilter} from '../texture.ts';
@@ -62,7 +63,7 @@ const identityMat4 = mat4.identity(new Float32Array(16));
 export function drawSymbols(painter: Painter, tileManager: TileManager, layer: SymbolStyleLayer, coords: OverscaledTileID[], variableOffsets: {
     [_ in CrossTileID]: VariableOffset;
 }, renderOptions: RenderOptions): void {
-    if (painter.renderPass !== 'translucent') return;
+    if (renderOptions.currentPass !== 'translucent') return;
 
     const {isRenderingToTexture} = renderOptions;
     // Disable the stencil test so that labels aren't clipped to tile boundaries.

--- a/src/webgl/draw/draw_terrain.ts
+++ b/src/webgl/draw/draw_terrain.ts
@@ -1,7 +1,8 @@
 import {StencilMode} from '../stencil_mode.ts';
 import {DepthMode} from '../depth_mode.ts';
 import {terrainUniformValues, terrainDepthUniformValues} from '../program/terrain_program.ts';
-import type {Painter, RenderOptions} from '../../render/painter.ts';
+import type {Painter} from '../../render/painter.ts';
+import type {RenderOptions} from '../../render/render_options.ts';
 import type {Tile} from '../../tile/tile.ts';
 import {CullFaceMode} from '../cull_face_mode.ts';
 import {Color} from '@maplibre/maplibre-gl-style-spec';

--- a/src/webgl/render_to_texture.test.ts
+++ b/src/webgl/render_to_texture.test.ts
@@ -1,6 +1,7 @@
 import {beforeEach, describe, test, expect, vi} from 'vitest';
 import {RenderToTexture} from './render_to_texture.ts';
 import {RTTFingerprint} from './rtt_fingerprint.ts';
+import {RenderOptions} from '../render/render_options.ts';
 import type {Painter, RTTObject} from '../render/painter.ts';
 import type {LineStyleLayer} from '../style/style_layer/line_style_layer.ts';
 import type {SymbolStyleLayer} from '../style/style_layer/symbol_style_layer.ts';
@@ -132,7 +133,7 @@ describe('render to texture', () => {
         const renderLayerSpy = vi.spyOn(painter, 'renderLayer');
         rtt.prepareForRender(style, 0);
 
-        const renderOptions = {isRenderingToTexture: false, isRenderingGlobe: false};
+        const renderOptions = new RenderOptions(painter.transform, undefined, terrain);
         for (const layerId of style._order) {
             const layer = style._layers[layerId];
             rtt.renderLayer(layer, renderOptions);
@@ -178,7 +179,7 @@ describe('render to texture', () => {
         style._order = ['maine-fill', 'maine-symbol'];
         rtt.prepareForRender(style, 0);
         layersDrawn = 0;
-        const renderOptions = {isRenderingToTexture: false, isRenderingGlobe: false};
+        const renderOptions = new RenderOptions(painter.transform, undefined, terrain);
         expect(rtt._renderableLayerIds).toStrictEqual(['maine-fill', 'maine-symbol']);
         expect(rtt.renderLayer(fillLayer, renderOptions)).toBeTruthy();
         expect(rtt.renderLayer(symbolLayer, renderOptions)).toBeFalsy();
@@ -189,7 +190,7 @@ describe('render to texture', () => {
         style._order = ['maine-background', 'maine-fill', 'maine-raster', 'maine-hillshade', 'maine-symbol', 'maine-line', 'maine-symbol'];
         rtt.prepareForRender(style, 0);
         layersDrawn = 0;
-        const renderOptions = {isRenderingToTexture: false, isRenderingGlobe: false};
+        const renderOptions = new RenderOptions(painter.transform, undefined, terrain);
         expect(rtt._renderableLayerIds).toStrictEqual(['maine-background', 'maine-fill', 'maine-raster', 'maine-hillshade', 'maine-symbol', 'maine-line', 'maine-symbol']);
         expect(rtt.renderLayer(backgroundLayer, renderOptions)).toBeTruthy();
         expect(rtt.renderLayer(fillLayer, renderOptions)).toBeTruthy();
@@ -205,7 +206,7 @@ describe('render to texture', () => {
         style._order = ['maine-background', 'maine-symbol', 'maine-hillshade', 'maine-symbol', 'maine-line', 'maine-symbol'];
         rtt.prepareForRender(style, 0);
         layersDrawn = 0;
-        const renderOptions = {isRenderingToTexture: false, isRenderingGlobe: false};
+        const renderOptions = new RenderOptions(painter.transform, undefined, terrain);
         expect(rtt._renderableLayerIds).toStrictEqual(['maine-background', 'maine-symbol', 'maine-hillshade', 'maine-symbol', 'maine-line', 'maine-symbol']);
         expect(rtt.renderLayer(backgroundLayer, renderOptions)).toBeTruthy();
         expect(rtt.renderLayer(symbolLayer, renderOptions)).toBeFalsy();
@@ -238,7 +239,7 @@ describe('render to texture', () => {
         const acquireSpy = vi.spyOn(painter, 'acquireRTT');
         acquireSpy.mockClear();
 
-        const renderOptions = {isRenderingToTexture: false, isRenderingGlobe: false};
+        const renderOptions = new RenderOptions(painter.transform, undefined, terrain);
         rtt.renderLayer(fillLayer, renderOptions);
         rtt.renderLayer(symbolLayer, renderOptions);
 
@@ -257,7 +258,7 @@ describe('render to texture', () => {
         const acquireSpy = vi.spyOn(painter, 'acquireRTT');
         acquireSpy.mockClear();
 
-        const renderOptions = {isRenderingToTexture: false, isRenderingGlobe: false};
+        const renderOptions = new RenderOptions(painter.transform, undefined, terrain);
         rtt.renderLayer(fillLayer, renderOptions);
         rtt.renderLayer(symbolLayer, renderOptions);
 
@@ -270,7 +271,7 @@ describe('render to texture', () => {
         style._order = ['maine-fill', 'maine-symbol'];
         rtt.prepareForRender(style, 0);
 
-        const renderOptions = {isRenderingToTexture: false, isRenderingGlobe: false};
+        const renderOptions = new RenderOptions(painter.transform, undefined, terrain);
         rtt.renderLayer(fillLayer, renderOptions);
         rtt.renderLayer(symbolLayer, renderOptions);
 

--- a/src/webgl/render_to_texture.ts
+++ b/src/webgl/render_to_texture.ts
@@ -1,4 +1,5 @@
-import {type Painter, type RenderOptions} from '../render/painter.ts';
+import {type Painter} from '../render/painter.ts';
+import type {RenderOptions} from '../render/render_options.ts';
 import {type Tile} from '../tile/tile.ts';
 import {Color} from '@maplibre/maplibre-gl-style-spec';
 import {type OverscaledTileID} from '../tile/tile_id.ts';

--- a/test/build/bundle_size.json
+++ b/test/build/bundle_size.json
@@ -1,7 +1,7 @@
 {
     "dist/maplibre-gl.mjs": {
-        "raw": 580688,
-        "gzip": 147278
+        "raw": 581361,
+        "gzip": 147564
     },
     "dist/maplibre-gl-worker.mjs": {
         "raw": 19181,


### PR DESCRIPTION
Part of below as Milestone 2.5

- #7640

The draw functions already receive RenderOptions, but they also pick up shared rendering state directly from Painter. So it's a bit unclear what the inputs to drawing actually are.

This PR extracts all shared render state from painter so it's now consolidated in RenderOptions. That includes the render pass, layer index, depth settings, transform, terrain and projection state. This makes the inputs clearer ahead of the drawable work.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items that are not relevant. -->


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] If you changed code in a file that has a benchmark file next to it (`*.bench.ts`), post before/after results of `npm run bench` (the compare workflow is in `test/bench/README.md`).
 - [ ] Add an entry to `CHANGELOG.md` under the `## main` section.
 - [x] Confirm you have read our AI policy [here](https://github.com/maplibre/maplibre/blob/main/AI_POLICY.md).
<!--
  Add one of:    Assisted-By: | Generated-By:     and the model/version
-->
