### PR TITLE
fix: markers judder in Firefox during camera animations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Treat an empty tile response (e.g. HTTP 204) as no data: raster-DEM tiles now load without elevation instead of failing with a `dem dimension mismatch` error, and empty raster tiles render as transparent ([#1551](https://github.com/maplibre/maplibre-gl-js/issues/1551)) (by [@clement-igonet](https://github.com/clement-igonet))
 - Fix the map freezing when a render task throws an error ([#6093](https://github.com/maplibre/maplibre-gl-js/issues/6093))
 - Draw an elevated symbol on globe when the symbol itself is in view but the ground under it is behind the horizon; occlusion now follows the line of sight to the elevated point ([#8253](https://github.com/maplibre/maplibre-gl-js/issues/8253)) (by [@clement-igonet](https://github.com/clement-igonet))
+- Fix markers juddering in Firefox during camera animations ([#7522](https://github.com/maplibre/maplibre-gl-js/issues/7522)) (by [@johncarmack1984](https://github.com/johncarmack1984))
 - _...Add new stuff here..._
 
 ## 6.7.0

--- a/src/ui/marker.test.ts
+++ b/src/ui/marker.test.ts
@@ -1464,17 +1464,6 @@ describe('marker', () => {
             .toContain('translate(262px, 236px) rotateX(0deg) rotateZ(0deg)');
     });
 
-    test('keeps rotateZ(0deg) at rest when subpixel positioning leaves the position fractional', () => {
-        const map = createMap();
-        const marker = new Marker()
-            .setLngLat([4.5, 4.5])
-            .setSubpixelPositioning(true)
-            .addTo(map);
-
-        expect(marker.getElement().style.transform)
-            .toContain('translate(262.4px, 235.5934100987358px) rotateX(0deg) rotateZ(0deg)');
-    });
-
     test('keeps rotateZ(0deg) when a terrain change repositions a resting marker', () => {
         const map = createMap();
         const marker = new Marker()
@@ -1484,17 +1473,6 @@ describe('marker', () => {
         map.fire('terrain');
 
         expect(marker.getElement().style.transform).toContain('rotateZ(0deg)');
-    });
-
-    test('keeps an explicit marker rotation while the map moves', () => {
-        const map = createMap();
-        const marker = new Marker({rotation: 30})
-            .setLngLat([4.5, 4.5])
-            .addTo(map);
-
-        map.fire('move');
-
-        expect(marker.getElement().style.transform).toContain('rotateZ(30deg)');
     });
 
     test('Sets opacity according to options.opacity when provided a number', async () => {

--- a/src/ui/marker.test.ts
+++ b/src/ui/marker.test.ts
@@ -1464,7 +1464,7 @@ describe('marker', () => {
             .toContain('translate(262px, 236px) rotateX(0deg) rotateZ(0deg)');
     });
 
-    test('rotates the marker by 0.05 degrees at rest when subpixel positioning is enabled', () => {
+    test('keeps rotateZ(0deg) at rest when subpixel positioning leaves the position fractional', () => {
         const map = createMap();
         const marker = new Marker()
             .setLngLat([4.5, 4.5])
@@ -1472,7 +1472,18 @@ describe('marker', () => {
             .addTo(map);
 
         expect(marker.getElement().style.transform)
-            .toContain('translate(262.4px, 235.5934100987358px) rotateX(0deg) rotateZ(0.05deg)');
+            .toContain('translate(262.4px, 235.5934100987358px) rotateX(0deg) rotateZ(0deg)');
+    });
+
+    test('keeps rotateZ(0deg) when a terrain change repositions a resting marker', () => {
+        const map = createMap();
+        const marker = new Marker()
+            .setLngLat([4.5, 4.5])
+            .addTo(map);
+
+        map.fire('terrain');
+
+        expect(marker.getElement().style.transform).toContain('rotateZ(0deg)');
     });
 
     test('keeps an explicit marker rotation while the map moves', () => {

--- a/src/ui/marker.test.ts
+++ b/src/ui/marker.test.ts
@@ -1439,6 +1439,53 @@ describe('marker', () => {
             .toContain('translate(262.4px, 235.5934100987358px)');
     });
 
+    test('rotates the marker by 0.05 degrees while the map moves and its position is fractional', () => {
+        const map = createMap();
+        const marker = new Marker()
+            .setLngLat([4.5, 4.5])
+            .addTo(map);
+
+        map.fire('move');
+
+        expect(marker.getElement().style.transform)
+            .toContain('translate(262.4px, 235.5934100987358px) rotateX(0deg) rotateZ(0.05deg)');
+    });
+
+    test('returns to rotateZ(0deg) once the map stops moving and the position is rounded again', () => {
+        const map = createMap();
+        const marker = new Marker()
+            .setLngLat([4.5, 4.5])
+            .addTo(map);
+
+        map.fire('move');
+        map.fire('moveend');
+
+        expect(marker.getElement().style.transform)
+            .toContain('translate(262px, 236px) rotateX(0deg) rotateZ(0deg)');
+    });
+
+    test('rotates the marker by 0.05 degrees at rest when subpixel positioning is enabled', () => {
+        const map = createMap();
+        const marker = new Marker()
+            .setLngLat([4.5, 4.5])
+            .setSubpixelPositioning(true)
+            .addTo(map);
+
+        expect(marker.getElement().style.transform)
+            .toContain('translate(262.4px, 235.5934100987358px) rotateX(0deg) rotateZ(0.05deg)');
+    });
+
+    test('keeps an explicit marker rotation while the map moves', () => {
+        const map = createMap();
+        const marker = new Marker({rotation: 30})
+            .setLngLat([4.5, 4.5])
+            .addTo(map);
+
+        map.fire('move');
+
+        expect(marker.getElement().style.transform).toContain('rotateZ(30deg)');
+    });
+
     test('Sets opacity according to options.opacity when provided a number', async () => {
         const map = createMap();
         const marker = new Marker({opacity: 0.7})

--- a/src/ui/marker.ts
+++ b/src/ui/marker.ts
@@ -32,6 +32,13 @@ const KEYBOARD_DRAG_SMALL_STEP = 1;
 const KEYBOARD_DRAG_LARGE_STEP = 10;
 
 /**
+ * Firefox snaps an element to whole device pixels when its CSS transform is axis-aligned, so a marker at a
+ * fractional position judders while the camera animates (#7522). A rotation this small is invisible (0.036 px
+ * at the corner of the default pin) and is past that alignment tolerance, which 0.01 degrees is not.
+ */
+const SUBPIXEL_ROTATION_DEGREES = 0.05;
+
+/**
  * The {@link Marker} options object
  */
 export type MarkerOptions = {
@@ -765,11 +772,9 @@ export class Marker extends Evented<MarkerEventType> {
             this._flatPos = this._map._camera.transform.locationToScreenPoint(this._lngLat)._add(this._offset);
         }
 
-        let rotation = '';
-        if (this._rotationAlignment === 'viewport' || this._rotationAlignment === 'auto') {
-            rotation = `rotateZ(${this._rotation}deg)`;
-        } else if (this._rotationAlignment === 'map') {
-            rotation = `rotateZ(${this._rotation - this._map.getBearing()}deg)`;
+        let rotationDegrees = this._rotation;
+        if (this._rotationAlignment === 'map') {
+            rotationDegrees = this._rotation - this._map.getBearing();
         }
 
         let pitch = '';
@@ -782,11 +787,14 @@ export class Marker extends Evented<MarkerEventType> {
         // because rounding the coordinates at every `move` event causes stuttered zooming
         // we only round them when _update is called with `moveend` or when its called with
         // no arguments (when the Marker is initialized or Marker.setLngLat is invoked).
-        if (!this._subpixelPositioning && (!e || e.type === 'moveend')) {
+        const roundToWholePixels = !this._subpixelPositioning && (!e || e.type === 'moveend');
+        if (roundToWholePixels) {
             this._pos = this._pos.round();
+        } else if (rotationDegrees === 0) {
+            rotationDegrees = SUBPIXEL_ROTATION_DEGREES;
         }
 
-        this._element.style.transform = `${anchorTranslate[this._anchor]} translate(${this._pos.x}px, ${this._pos.y}px) ${pitch} ${rotation}`;
+        this._element.style.transform = `${anchorTranslate[this._anchor]} translate(${this._pos.x}px, ${this._pos.y}px) ${pitch} rotateZ(${rotationDegrees}deg)`;
 
         browser.frameAsync(new AbortController(), this._map._ownerWindow).then(() => { // Run _updateOpacity only after painter.render and drawDepth
             this._updateOpacity(e?.type === 'moveend');

--- a/src/ui/marker.ts
+++ b/src/ui/marker.ts
@@ -32,10 +32,8 @@ const KEYBOARD_DRAG_SMALL_STEP = 1;
 const KEYBOARD_DRAG_LARGE_STEP = 10;
 
 /**
- * Firefox snaps an element to whole device pixels when its CSS transform is axis-aligned, so a marker judders
- * while the camera animates (#7522). While the map moves, a marker with no rotation of its own is rotated by
- * this much instead: invisible (0.036 px at the corner of the default pin) but past that alignment tolerance,
- * which 0.01 degrees is not. At rest the transform is left exactly as it was.
+ * Rotation given to an unrotated marker while the map moves.
+ * Works around Firefox snapping axis-aligned transforms to whole pixels, which makes markers judder (#7522).
  */
 const MOVING_MARKER_ROTATION_DEGREES = 0.05;
 

--- a/src/ui/marker.ts
+++ b/src/ui/marker.ts
@@ -32,11 +32,12 @@ const KEYBOARD_DRAG_SMALL_STEP = 1;
 const KEYBOARD_DRAG_LARGE_STEP = 10;
 
 /**
- * Firefox snaps an element to whole device pixels when its CSS transform is axis-aligned, so a marker at a
- * fractional position judders while the camera animates (#7522). A rotation this small is invisible (0.036 px
- * at the corner of the default pin) and is past that alignment tolerance, which 0.01 degrees is not.
+ * Firefox snaps an element to whole device pixels when its CSS transform is axis-aligned, so a marker judders
+ * while the camera animates (#7522). While the map moves, a marker with no rotation of its own is rotated by
+ * this much instead: invisible (0.036 px at the corner of the default pin) but past that alignment tolerance,
+ * which 0.01 degrees is not. At rest the transform is left exactly as it was.
  */
-const SUBPIXEL_ROTATION_DEGREES = 0.05;
+const MOVING_MARKER_ROTATION_DEGREES = 0.05;
 
 /**
  * The {@link Marker} options object
@@ -787,11 +788,12 @@ export class Marker extends Evented<MarkerEventType> {
         // because rounding the coordinates at every `move` event causes stuttered zooming
         // we only round them when _update is called with `moveend` or when its called with
         // no arguments (when the Marker is initialized or Marker.setLngLat is invoked).
-        const roundToWholePixels = !this._subpixelPositioning && (!e || e.type === 'moveend');
-        if (roundToWholePixels) {
+        if (!this._subpixelPositioning && (!e || e.type === 'moveend')) {
             this._pos = this._pos.round();
-        } else if (rotationDegrees === 0) {
-            rotationDegrees = SUBPIXEL_ROTATION_DEGREES;
+        }
+
+        if (e?.type === 'move' && rotationDegrees === 0) {
+            rotationDegrees = MOVING_MARKER_ROTATION_DEGREES;
         }
 
         this._element.style.transform = `${anchorTranslate[this._anchor]} translate(${this._pos.x}px, ${this._pos.y}px) ${pitch} rotateZ(${rotationDegrees}deg)`;


### PR DESCRIPTION
Closes #7522

Firefox snaps an element to whole device pixels when its CSS transform is axis-aligned, and a default marker's is (`translate(...) rotateX(0deg) rotateZ(0deg)`), so markers judder while the camera animates. On `move` frames a marker with no rotation of its own now gets `rotateZ(0.05deg)`, which is invisible (0.036 px at a corner of the default pin) but keeps Firefox from snapping it; 0.01 degrees is inside Firefox's tolerance and still snaps. Every other update leaves the transform exactly as before, because a resting rotation changes how text in custom markers rasterizes. Measured on Firefox 154 and 155 with Chrome as control: the default marker snapped in every run, the rotated one never did.

Left is `main`, right is this branch: Firefox 155, the default marker in red and a `rotation: 1` control in blue, the map turning at 10 degrees per second, recorded from the screen and shown at 2x.

![Firefox marker judder, before and after](https://raw.githubusercontent.com/johncarmack1984/maplibre-gl-js/gh-pages/7522/compare.gif)

The same clip as [mp4](https://raw.githubusercontent.com/johncarmack1984/maplibre-gl-js/gh-pages/7522/compare.mp4).

## Launch Checklist

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [x] Write tests for all new functionality.
 - [x] Add an entry to `CHANGELOG.md` under the `## main` section.
 - [x] Confirm you have read our AI policy [here](https://github.com/maplibre/maplibre/blob/main/AI_POLICY.md).

Assisted-By: Claude Fable 5.1
