### PR TITLE
fix: emit an error event when queryRenderedFeatures receives more than two points

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Treat an empty tile response (e.g. HTTP 204) as no data: raster-DEM tiles now load without elevation instead of failing with a `dem dimension mismatch` error, and empty raster tiles render as transparent ([#1551](https://github.com/maplibre/maplibre-gl-js/issues/1551)) (by [@clement-igonet](https://github.com/clement-igonet))
 - Fix the map freezing when a render task throws an error ([#6093](https://github.com/maplibre/maplibre-gl-js/issues/6093))
 - Draw an elevated symbol on globe when the symbol itself is in view but the ground under it is behind the horizon; occlusion now follows the line of sight to the elevated point ([#8253](https://github.com/maplibre/maplibre-gl-js/issues/8253)) (by [@clement-igonet](https://github.com/clement-igonet))
+- Emit an error event when `Map#queryRenderedFeatures` receives more than two screen points ([#5685](https://github.com/maplibre/maplibre-gl-js/issues/5685)) (by [@isjiajia01](https://github.com/isjiajia01))
 - _...Add new stuff here..._
 
 ## 6.7.0

--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -2489,6 +2489,7 @@ export class Map extends Evented<MapEventType> {
      * or with only a `options` argument) is equivalent to passing a bounding box encompassing the entire
      * map viewport.
      * The geometryOrOptions can receive a {@link QueryRenderedFeaturesOptions} only to support a situation where the function receives only one parameter which is the options parameter.
+     * More than two points is not a valid geometry: an `error` event is fired and an empty array is returned.
      * @param options - (optional) Options object.
      *
      * @returns An array of MapGeoJSONFeature objects.

--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -2559,6 +2559,10 @@ export class Map extends Evented<MapEventType> {
      * @see [Get features under the mouse pointer](https://maplibre.org/maplibre-gl-js/docs/examples/get-features-under-the-mouse-pointer/)
      */
     queryRenderedFeatures(geometryOrOptions?: PointLike | [PointLike, PointLike] | QueryRenderedFeaturesOptions, options?: QueryRenderedFeaturesOptions): MapGeoJSONFeature[] {
+        if (Array.isArray(geometryOrOptions) && typeof geometryOrOptions[0] !== 'number' && geometryOrOptions.length > 2) {
+            this.fire(new ErrorEvent(new Error('queryRenderedFeatures only accepts a single point or a bounding box of two points.')));
+            return [];
+        }
         if (!this.style) {
             return [];
         }

--- a/src/ui/map_tests/map_query_rendered_features.test.ts
+++ b/src/ui/map_tests/map_query_rendered_features.test.ts
@@ -75,26 +75,25 @@ describe('queryRenderedFeatures', () => {
     test('fires an error when geometry contains more than two points', async () => {
         const map = createMap();
         await map.once('load');
-        const errorListener = vi.fn();
-        map.on('error', errorListener);
+        const onError = vi.fn();
+        map.on('error', onError);
 
         const result = map.queryRenderedFeatures([[0, 0], [10, 10], [20, 20]] as any);
 
         expect(result).toEqual([]);
-        expect(errorListener).toHaveBeenCalledTimes(1);
-        expect(errorListener.mock.calls[0][0].error.message).toBe('queryRenderedFeatures only accepts a single point or a bounding box of two points.');
+        expect(onError).toHaveBeenCalledTimes(1);
+        expect(onError.mock.calls[0][0].error.message).toBe('queryRenderedFeatures only accepts a single point or a bounding box of two points.');
     });
 
     test('fires an error for more than two points when no style is loaded', () => {
         const map = createMap({style: undefined});
-        const errorListener = vi.fn();
-        map.on('error', errorListener);
+        const onError = vi.fn();
+        map.on('error', onError);
 
         const result = map.queryRenderedFeatures([[0, 0], [10, 10], [20, 20]] as any);
 
         expect(result).toEqual([]);
-        expect(errorListener).toHaveBeenCalledTimes(1);
-        expect(errorListener.mock.calls[0][0].error.message).toBe('queryRenderedFeatures only accepts a single point or a bounding box of two points.');
+        expect(onError).toHaveBeenCalledTimes(1);
     });
 
     test('returns an empty array when no style is loaded', () => {

--- a/src/ui/map_tests/map_query_rendered_features.test.ts
+++ b/src/ui/map_tests/map_query_rendered_features.test.ts
@@ -76,7 +76,6 @@ describe('queryRenderedFeatures', () => {
         const map = createMap();
         await map.once('load');
         const errorListener = vi.fn();
-        const queryListener = vi.spyOn(map.style, 'queryRenderedFeatures');
         map.on('error', errorListener);
 
         const result = map.queryRenderedFeatures([[0, 0], [10, 10], [20, 20]] as any);
@@ -84,7 +83,6 @@ describe('queryRenderedFeatures', () => {
         expect(result).toEqual([]);
         expect(errorListener).toHaveBeenCalledTimes(1);
         expect(errorListener.mock.calls[0][0].error.message).toBe('queryRenderedFeatures only accepts a single point or a bounding box of two points.');
-        expect(queryListener).not.toHaveBeenCalled();
     });
 
     test('fires an error for more than two points when no style is loaded', () => {

--- a/src/ui/map_tests/map_query_rendered_features.test.ts
+++ b/src/ui/map_tests/map_query_rendered_features.test.ts
@@ -72,6 +72,33 @@ describe('queryRenderedFeatures', () => {
         expect(spy.mock.calls[0][0]).toEqual([{x: 612, y: 100}]);
     });
 
+    test('fires an error when geometry contains more than two points', async () => {
+        const map = createMap();
+        await map.once('load');
+        const errorListener = vi.fn();
+        const queryListener = vi.spyOn(map.style, 'queryRenderedFeatures');
+        map.on('error', errorListener);
+
+        const result = map.queryRenderedFeatures([[0, 0], [10, 10], [20, 20]] as any);
+
+        expect(result).toEqual([]);
+        expect(errorListener).toHaveBeenCalledTimes(1);
+        expect(errorListener.mock.calls[0][0].error.message).toBe('queryRenderedFeatures only accepts a single point or a bounding box of two points.');
+        expect(queryListener).not.toHaveBeenCalled();
+    });
+
+    test('fires an error for more than two points when no style is loaded', () => {
+        const map = createMap({style: undefined});
+        const errorListener = vi.fn();
+        map.on('error', errorListener);
+
+        const result = map.queryRenderedFeatures([[0, 0], [10, 10], [20, 20]] as any);
+
+        expect(result).toEqual([]);
+        expect(errorListener).toHaveBeenCalledTimes(1);
+        expect(errorListener.mock.calls[0][0].error.message).toBe('queryRenderedFeatures only accepts a single point or a bounding box of two points.');
+    });
+
     test('returns an empty array when no style is loaded', () => {
         const map = createMap({style: undefined});
         expect(map.queryRenderedFeatures()).toEqual([]);


### PR DESCRIPTION
- Closes #5685

- Continues #8115 by @isjiajia01. 

`queryRenderedFeatures` takes a point or a two-point box; three or more points were silently read as a box from the first two, so a polygon ring returned features that had nothing to do with the ring. The method now fires an `error` event naming the accepted shapes and returns an empty array, before the style check so a styleless map behaves the same. That follows how the other style and query methods report bad input (`addLayer`, `setPaintProperty`, `isSourceLoaded`, and `queryRenderedFeatures` itself for an unknown layer id all fire `error`); the camera methods are the ones that throw.

## Launch Checklist

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [x] Write tests for all new functionality.
 - [x] Document any changes to public APIs.
 - [x] Add an entry to `CHANGELOG.md` under the `## main` section.
 - [x] Confirm you have read our AI policy [here](https://github.com/maplibre/maplibre/blob/main/AI_POLICY.md).

Assisted-By: Claude Fable 5.1
