### PR TITLE
fix: set source.tiles synchronously in setTiles so a same-frame loadTile uses the new URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Fix visible seams between hillshade tiles when using linear interpolation. ([#8302](https://github.com/maplibre/maplibre-gl-js/pull/8302)) (by [@Turbo87](https://github.com/Turbo87))
 - Fix the map freezing when a render task throws an error ([#6093](https://github.com/maplibre/maplibre-gl-js/issues/6093))
 - Draw an elevated symbol on globe when the symbol itself is in view but the ground under it is behind the horizon; occlusion now follows the line of sight to the elevated point ([#8253](https://github.com/maplibre/maplibre-gl-js/issues/8253)) (by [@clement-igonet](https://github.com/clement-igonet))
+- Fix `setTiles` producing stale tile URLs when `loadTile` runs in the same frame ([#7910](https://github.com/maplibre/maplibre-gl-js/pull/7910)) (by [@nostrorom](https://github.com/nostrorom))
 - _...Add new stuff here..._
 
 ## 6.7.0

--- a/src/source/raster_tile_source.test.ts
+++ b/src/source/raster_tile_source.test.ts
@@ -261,7 +261,7 @@ describe('RasterTileSource', () => {
         expect(source.tiles[0]).toBe('http://example.com/{z}/{x}/{y}.png?updated=true');
     });
 
-    test('setTiles updates this.tiles used by loadTile', () => {
+    test('loadTile requests the new URLs right after setTiles, before the source reloads', () => {
         const source = createSource({tiles: ['http://example.com/{z}/{x}/{y}.png']});
         const transformSpy = vi.spyOn(source.map._requestManager, 'transformRequest');
 

--- a/src/source/raster_tile_source.test.ts
+++ b/src/source/raster_tile_source.test.ts
@@ -261,6 +261,20 @@ describe('RasterTileSource', () => {
         expect(source.tiles[0]).toBe('http://example.com/{z}/{x}/{y}.png?updated=true');
     });
 
+    test('setTiles updates this.tiles used by loadTile', () => {
+        const source = createSource({tiles: ['http://example.com/{z}/{x}/{y}.png']});
+        const transformSpy = vi.spyOn(source.map._requestManager, 'transformRequest');
+
+        source.setTiles(['http://example2.com/{z}/{x}/{y}.png']);
+
+        source.loadTile({
+            tileID: new OverscaledTileID(10, 0, 10, 5, 5),
+            state: 'loading'
+        } as any as Tile);
+
+        expect(transformSpy.mock.calls[0][0]).toBe('http://example2.com/10/5/5.png');
+    });
+
     test('cancels TileJSON request if removed', async () => {
         const source = createSource({url: '/source.json'});
         await sleep(0);

--- a/src/source/raster_tile_source.ts
+++ b/src/source/raster_tile_source.ts
@@ -155,6 +155,7 @@ export class RasterTileSource extends Evented<SourceEventType> implements Source
      */
     setTiles(tiles: string[]): this {
         this.setSourceProperty(() => {
+            this.tiles = tiles;
             this._options.tiles = tiles;
         });
 

--- a/src/source/vector_tile_source.test.ts
+++ b/src/source/vector_tile_source.test.ts
@@ -480,7 +480,7 @@ describe('VectorTileSource', () => {
         });
     });
 
-    test('setTiles updates this.tiles used by loadTile', async () => {
+    test('loadTile requests the new URLs right after setTiles, before the source reloads', async () => {
         const source = createSource({
             tiles: ['http://example.com/{z}/{x}/{y}.png']
         });

--- a/src/source/vector_tile_source.test.ts
+++ b/src/source/vector_tile_source.test.ts
@@ -480,6 +480,31 @@ describe('VectorTileSource', () => {
         });
     });
 
+    test('setTiles updates this.tiles used by loadTile', async () => {
+        const source = createSource({
+            tiles: ['http://example.com/{z}/{x}/{y}.png']
+        });
+
+        let receivedMessage: ActorMessage<MessageType> = null;
+
+        source.dispatcher = getWrapDispatcher()({
+            sendAsync(message) {
+                receivedMessage = message;
+                return Promise.resolve({});
+            }
+        });
+
+        source.setTiles(['http://example2.com/{z}/{x}/{y}.png']);
+
+        await source.loadTile({
+            loadVectorData() {},
+            tileID: new OverscaledTileID(10, 0, 10, 5, 5)
+        } as any as Tile);
+
+        expect((receivedMessage.data as WorkerTileParameters).request.url)
+            .toBe('http://example2.com/10/5/5.png');
+    });
+
     test('setTiles updates tiles without clearing the cache', async () => {
         const clearTiles = vi.fn();
         const source = createSource({tiles: ['http://example.com/{z}/{x}/{y}.pbf']}, undefined, clearTiles);

--- a/src/source/vector_tile_source.ts
+++ b/src/source/vector_tile_source.ts
@@ -171,6 +171,7 @@ export class VectorTileSource extends Evented<SourceEventType> implements Source
      */
     setTiles(tiles: string[]): this {
         this.setSourceProperty(() => {
+            this.tiles = tiles;
             this._options.tiles = tiles;
         });
 


### PR DESCRIPTION
- Continues #7910 by @nostrorom.

Bug fix. `setTiles` wrote the new URLs to `_options.tiles` and started the async reload, but `loadTile` reads `this.tiles`, which only caught up when the reload finished, so a tile requested in the same frame still went to the old URLs. `setTiles` now sets `this.tiles` too, the same way `setUrl` already sets both `url` and `_options.url`. On the review question about keeping tiles in two places: `_options.tiles` is the configured value that `serialize` and a TileJSON reload read, `this.tiles` is the resolved value that `loadTile` uses (from `_options` for inline tiles, from the TileJSON for a `url` source), and `load` reconciles them on every reload; merging them means changing how `load` applies TileJSON for every source type, which is a separate change.

## Launch Checklist

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [x] Write tests for all new functionality.
 - [x] Add an entry to `CHANGELOG.md` under the `## main` section.
 - [x] Confirm you have read our AI policy [here](https://github.com/maplibre/maplibre/blob/main/AI_POLICY.md).

Assisted-By: Claude Fable 5.1
