### PR TITLE
fix: keep a marker's popup on the marker's world copy when the marker is moved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes
+- Fix a marker's popup jumping to another world copy when the marker is moved across the antimeridian on a zoomed-out map ([#5655](https://github.com/maplibre/maplibre-gl-js/issues/5655))
 - Fix terrain drape textures not being refreshed after zoom changes, causing stale rendering at the new zoom level ([#8251](https://github.com/maplibre/maplibre-gl-js/issues/8251))
 - Fix a gap between the sky and the ground at high pitch while globe transitions to mercator ([#7382](https://github.com/maplibre/maplibre-gl-js/issues/7382)) (by [@birkskyum](https://github.com/birkskyum))
 - Treat an empty tile response (e.g. HTTP 204) as no data: raster-DEM tiles now load without elevation instead of failing with a `dem dimension mismatch` error, and empty raster tiles render as transparent ([#1551](https://github.com/maplibre/maplibre-gl-js/issues/1551)) (by [@clement-igonet](https://github.com/clement-igonet))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes
-- Fix a marker's popup jumping to another world copy when the marker is moved across the antimeridian on a zoomed-out map ([#5655](https://github.com/maplibre/maplibre-gl-js/issues/5655))
+- Fix a marker's popup jumping to another world copy when the marker is moved across the antimeridian on a zoomed-out map ([#5655](https://github.com/maplibre/maplibre-gl-js/issues/5655), [#8326](https://github.com/maplibre/maplibre-gl-js/pull/8326), continues [#5956](https://github.com/maplibre/maplibre-gl-js/pull/5956)) (by [@yuiseki](https://github.com/yuiseki))
 - Fix terrain drape textures not being refreshed after zoom changes, causing stale rendering at the new zoom level ([#8251](https://github.com/maplibre/maplibre-gl-js/issues/8251))
 - Fix a gap between the sky and the ground at high pitch while globe transitions to mercator ([#7382](https://github.com/maplibre/maplibre-gl-js/issues/7382)) (by [@birkskyum](https://github.com/birkskyum))
 - Treat an empty tile response (e.g. HTTP 204) as no data: raster-DEM tiles now load without elevation instead of failing with a `dem dimension mismatch` error, and empty raster tiles render as transparent ([#1551](https://github.com/maplibre/maplibre-gl-js/issues/1551)) (by [@clement-igonet](https://github.com/clement-igonet))

--- a/src/ui/marker.test.ts
+++ b/src/ui/marker.test.ts
@@ -477,6 +477,20 @@ describe('marker', () => {
         map.remove();
     });
 
+    test('Popup follows its marker onto the same world copy when the marker crosses the antimeridian', () => {
+        const map = createMap({width: 1024});
+        const marker = new Marker()
+            .setLngLat([179, 0])
+            .setPopup(new Popup().setText('Test'))
+            .addTo(map)
+            .togglePopup();
+
+        marker.setLngLat([-179, 0]);
+
+        expect(marker.getPopup().getLngLat().lng).toBe(marker.getLngLat().lng);
+        map.remove();
+    });
+
     test('Marker drag functionality can be added with drag option', () => {
         const map = createMap();
         const marker = new Marker({draggable: true})

--- a/src/ui/marker.ts
+++ b/src/ui/marker.ts
@@ -516,7 +516,6 @@ export class Marker extends Evented<MarkerEventType> {
         this._lngLat = LngLat.convert(lnglat);
         this._pos = null;
         this._update();
-        // _update has wrapped the location onto the world copy the marker is drawn on, so the popup lands on the same copy
         if (this._popup) this._popup.setLngLat(this._lngLat);
         return this;
     }

--- a/src/ui/marker.ts
+++ b/src/ui/marker.ts
@@ -515,8 +515,9 @@ export class Marker extends Evented<MarkerEventType> {
     setLngLat(lnglat: LngLatLike): this {
         this._lngLat = LngLat.convert(lnglat);
         this._pos = null;
-        if (this._popup) this._popup.setLngLat(this._lngLat);
         this._update();
+        // _update has wrapped the location onto the world copy the marker is drawn on, so the popup lands on the same copy
+        if (this._popup) this._popup.setLngLat(this._lngLat);
         return this;
     }
 


### PR DESCRIPTION
Continues #5956 by @yuiseki, with the diagnosis from @sankichi92 on #5655.

Closes #5655

When a marker with an open popup is moved with `setLngLat`, the marker hands the popup its location before it has wrapped that location itself. The marker then picks the world copy nearest to where it was drawn last frame, the popup picks the copy nearest the map center, and on a zoomed-out map the two end up 360 degrees apart. Passing the location to the popup after the marker's own update means both land on the same copy. The popup keeps its own `setLngLat` reset, so opening a popup on a marker that has been dragged onto another world copy still lands on the marker (#3712, both existing tests unchanged).

Measured in a headless browser with a marker animated across the antimeridian at zoom 0.4 for 600 frames: main has the popup one world away in 279 frames, this branch in 0. Closing the popup, dragging the map one world over and reopening puts the popup on the marker in both.

## Launch Checklist

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [x] Write tests for all new functionality.
 - [x] Add an entry to `CHANGELOG.md` under the `## main` section.
 - [x] Confirm you have read our AI policy [here](https://github.com/maplibre/maplibre/blob/main/AI_POLICY.md).

Assisted-By: Claude Fable 5.1
