### PR TITLE
feat: add map.getStyleUrl() returning the URL the style was loaded from

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## main
 ### ✨ Features and improvements
-- _...Add new stuff here..._
+- Add `map.getStyleUrl()`, which returns the URL the style was loaded from, or `null` when the style was given as an object ([#7109](https://github.com/maplibre/maplibre-gl-js/issues/7109))
 
 ### 🐞 Bug fixes
 - Fix terrain drape textures not being refreshed after zoom changes, causing stale rendering at the new zoom level ([#8251](https://github.com/maplibre/maplibre-gl-js/issues/8251))

--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -633,6 +633,7 @@ export class Map extends Evented<MapEventType> {
     _mapId: number = uniqueId();
     _localIdeographFontFamily: string | false;
     _validateStyle: boolean;
+    _styleUrl: string | null = null;
     _requestManager: RequestManager;
     _locale: Record<string, string>;
     _removed: boolean;
@@ -2665,6 +2666,7 @@ export class Map extends Evented<MapEventType> {
                 localIdeographFontFamily: this._localIdeographFontFamily,
                 validate: this._validateStyle
             }, options);
+        this._styleUrl = typeof style === 'string' ? style : null;
 
         if ((options.diff !== false && options.localIdeographFontFamily === this._localIdeographFontFamily) && this.style && style) {
             this._diffStyle(style, options);
@@ -2804,6 +2806,20 @@ export class Map extends Evented<MapEventType> {
         if (this.style) {
             return this.style.serialize();
         }
+    }
+
+    /**
+     * Returns the URL the map's style was loaded from.
+     *
+     * @returns The URL given to {@link Map.setStyle} or the `style` map option, or `null` when the style was given as an object or the map has no style.
+     *
+     * @example
+     * ```ts
+     * const styleUrl = map.getStyleUrl();
+     * ```
+     */
+    getStyleUrl(): string | null {
+        return this._styleUrl;
     }
 
     /**

--- a/src/ui/map_tests/map_style.test.ts
+++ b/src/ui/map_tests/map_style.test.ts
@@ -419,6 +419,35 @@ describe('setStyle', () => {
     });
 });
 
+describe('getStyleUrl', () => {
+    test('returns the URL given to setStyle', () => {
+        const map = createMap();
+        map.setStyle('/styles/streets.json');
+
+        expect(map.getStyleUrl()).toBe('/styles/streets.json');
+    });
+
+    test('returns the URL given in the map options', () => {
+        const map = createMap({style: '/styles/streets.json'});
+
+        expect(map.getStyleUrl()).toBe('/styles/streets.json');
+    });
+
+    test('returns null when the style is given as an object', () => {
+        const map = createMap({style: '/styles/streets.json'});
+        map.setStyle(createStyle());
+
+        expect(map.getStyleUrl()).toBeNull();
+    });
+
+    test('returns null after the style is removed', () => {
+        const map = createMap({style: '/styles/streets.json'});
+        map.setStyle(null);
+
+        expect(map.getStyleUrl()).toBeNull();
+    });
+});
+
 describe('getStyle', () => {
     test('returns undefined if the style has not loaded yet', () => {
         const style = createStyle();


### PR DESCRIPTION
Continues #7110 by @giswqs.

Closes #7109

Adds `map.getStyleUrl()`, which returns the URL given to `setStyle` or the `style` map option, and `null` when the style was given as an object or the map has no style. The use case in #7109 is a layer control that needs to tell the basemap's layers from the ones the app added, which today means keeping the URL somewhere outside the map.

The review on #7110 asked not to have the map and the style both writing an internal field on the style, and not to thread a source URL through the diff path. The URL is decided in exactly one place, `setStyle`, so the map records it there and the style class is untouched. A diff that falls back to a full reload keeps the same URL because the style still came from it.

## Launch Checklist

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [x] Write tests for all new functionality.
 - [x] Document any changes to public APIs.
 - [x] Add an entry to `CHANGELOG.md` under the `## main` section.
 - [x] Confirm you have read our AI policy [here](https://github.com/maplibre/maplibre/blob/main/AI_POLICY.md).

Assisted-By: Claude Fable 5.1
