### PR TITLE
Add Meteosat to the spell check dictionary

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -119,6 +119,7 @@
     "mediump",
     "Merc",
     "merp",
+    "Meteosat",
     "mguide",
     "MIERUNE",
     "mihalyi",


### PR DESCRIPTION
Adds **Meteosat** (the EUMETSAT geostationary satellite family) to `.cspell.json`.

Context: the awesome-maplibre CI fetches this dictionary, and [maplibre/awesome-maplibre#192](https://github.com/maplibre/awesome-maplibre/pull/192) (adding kanari, a real-time wildfire map built on MapLibre) fails the spell check on this one word. Requested by @HarelM in that PR.

No code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)