### PR TITLE
Use a type for RenderOptions

### DIFF
--- a/src/render/painter.ts
+++ b/src/render/painter.ts
@@ -37,7 +37,7 @@ import type {DepthMaskType, DepthFuncType} from '../webgl/types.ts';
 import type {ResolvedImage} from '@maplibre/maplibre-gl-style-spec';
 import type {IRenderToTexture} from './render_to_texture_interface.ts';
 import type {TerrainData} from './terrain.ts';
-import {RenderOptions} from './render_options.ts';
+import {createRenderOptions, type RenderOptions} from './render_options.ts';
 import type {ProjectionData} from '../geo/projection/projection_data.ts';
 import type {Framebuffer} from '../webgl/framebuffer.ts';
 import {updateFrameUniformBuffer} from '../webgl/frame_uniform_buffer.ts';
@@ -509,7 +509,7 @@ export class Painter {
     render(style: Style, options: PainterOptions): void {
         this.style = style;
         this.options = options;
-        const renderOptions = this.renderOptions = new RenderOptions(this.transform, style.projection, style.map.terrain ?? null);
+        const renderOptions = this.renderOptions = createRenderOptions(this.transform, style.projection, style.map.terrain ?? null);
 
         this.lineAtlas = style.lineAtlas;
         this.imageManager = style.imageManager;

--- a/src/render/render_options.ts
+++ b/src/render/render_options.ts
@@ -10,21 +10,29 @@ export type RenderPass = 'offscreen' | 'opaque' | 'translucent';
  * Shared draw state, created per render and updated as rendering proceeds.
  * Corresponds to part of MapLibre Native's `PaintParameters`.
  */
-export class RenderOptions {
-    currentPass: RenderPass = 'offscreen';
-    currentLayer: number = 0;
-    opaquePassCutoff: number = Infinity;
-    depthRangeFor3D: DepthRangeType = [0, 1];
-    isRenderingToTexture: boolean = false;
+export type RenderOptions = {
+    currentPass: RenderPass;
+    currentLayer: number;
+    opaquePassCutoff: number;
+    depthRangeFor3D: DepthRangeType;
+    isRenderingToTexture: boolean;
     readonly transform: IReadonlyTransform;
     readonly terrain: Terrain | null;
     readonly projectionTransition: number;
     readonly isRenderingGlobe: boolean;
+};
 
-    constructor(transform: IReadonlyTransform, projection: Projection | undefined, terrain: Terrain | null) {
-        this.transform = transform;
-        this.terrain = terrain;
-        this.projectionTransition = projection?.transitionState ?? 0;
-        this.isRenderingGlobe = this.projectionTransition > 0;
-    }
+export function createRenderOptions(transform: IReadonlyTransform, projection: Projection | undefined, terrain: Terrain | null): RenderOptions {
+    const projectionTransition = projection?.transitionState ?? 0;
+    return {
+        currentPass: 'offscreen',
+        currentLayer: 0,
+        opaquePassCutoff: Infinity,
+        depthRangeFor3D: [0, 1],
+        isRenderingToTexture: false,
+        transform,
+        terrain,
+        projectionTransition,
+        isRenderingGlobe: projectionTransition > 0
+    };
 }

--- a/src/webgl/draw/draw_custom.test.ts
+++ b/src/webgl/draw/draw_custom.test.ts
@@ -3,7 +3,7 @@ import {OverscaledTileID} from '../../tile/tile_id.ts';
 import {TileManager} from '../../tile/tile_manager.ts';
 import {Tile} from '../../tile/tile.ts';
 import {Painter} from '../../render/painter.ts';
-import {RenderOptions} from '../../render/render_options.ts';
+import {createRenderOptions} from '../../render/render_options.ts';
 import type {Map} from '../../ui/map.ts';
 import {drawCustom} from './draw_custom.ts';
 import {CustomStyleLayer} from '../../style/style_layer/custom_style_layer.ts';
@@ -35,7 +35,7 @@ describe('drawCustom', () => {
             projection: new MercatorProjection(),
         } as any;
         mockPainter.transform = transform;
-        const renderOptions = new RenderOptions(transform, mockPainter.style.projection, null);
+        const renderOptions = createRenderOptions(transform, mockPainter.style.projection, null);
         renderOptions.currentPass = 'translucent';
         mockPainter.renderOptions = renderOptions;
         mockPainter.context = {

--- a/src/webgl/draw/draw_fill.test.ts
+++ b/src/webgl/draw/draw_fill.test.ts
@@ -4,7 +4,7 @@ import {OverscaledTileID} from '../../tile/tile_id.ts';
 import {TileManager} from '../../tile/tile_manager.ts';
 import {Tile} from '../../tile/tile.ts';
 import {Painter} from '../../render/painter.ts';
-import {RenderOptions} from '../../render/render_options.ts';
+import {createRenderOptions} from '../../render/render_options.ts';
 import {Program} from '../program.ts';
 import type {ZoomHistory} from '../../style/zoom_history.ts';
 import type {Map} from '../../ui/map.ts';
@@ -107,7 +107,7 @@ describe('drawFill', () => {
                 };
             },
         } as any as IReadonlyTransform;
-        painterMock.renderOptions = new RenderOptions(painterMock.transform, undefined, null);
+        painterMock.renderOptions = createRenderOptions(painterMock.transform, undefined, null);
         painterMock.renderOptions.currentPass = 'translucent';
         painterMock.options = {} as any;
         painterMock.style = {

--- a/src/webgl/draw/draw_symbol.test.ts
+++ b/src/webgl/draw/draw_symbol.test.ts
@@ -6,7 +6,7 @@ import {TileManager} from '../../tile/tile_manager.ts';
 import {Tile} from '../../tile/tile.ts';
 import {SymbolStyleLayer} from '../../style/style_layer/symbol_style_layer.ts';
 import {Painter} from '../../render/painter.ts';
-import {RenderOptions} from '../../render/render_options.ts';
+import {createRenderOptions} from '../../render/render_options.ts';
 import {Program} from '../program.ts';
 import {drawSymbols} from './draw_symbol.ts';
 import * as symbolProjection from '../../symbol/projection.ts';
@@ -56,7 +56,7 @@ function createMockTransform() {
 describe('drawSymbol', () => {
     test('should not do anything', () => {
         const mockPainter = new Painter(null, null);
-        const renderOptions = new RenderOptions(null, undefined, null);
+        const renderOptions = createRenderOptions(null, undefined, null);
         renderOptions.currentPass = 'opaque';
 
         drawSymbols(mockPainter, null, null, null, null, renderOptions);
@@ -73,7 +73,7 @@ describe('drawSymbol', () => {
             }
         } as any;
         painterMock.transform = createMockTransform();
-        painterMock.renderOptions = new RenderOptions(painterMock.transform, undefined, null);
+        painterMock.renderOptions = createRenderOptions(painterMock.transform, undefined, null);
         painterMock.renderOptions.currentPass = 'translucent';
         painterMock.options = {} as any;
         painterMock.style = {
@@ -136,7 +136,7 @@ describe('drawSymbol', () => {
             }
         } as any;
         painterMock.transform = createMockTransform();
-        painterMock.renderOptions = new RenderOptions(painterMock.transform, undefined, null);
+        painterMock.renderOptions = createRenderOptions(painterMock.transform, undefined, null);
         painterMock.renderOptions.currentPass = 'translucent';
         painterMock.options = {} as any;
 
@@ -204,7 +204,7 @@ describe('drawSymbol', () => {
             }
         } as any;
         painterMock.transform = createMockTransform();
-        painterMock.renderOptions = new RenderOptions(painterMock.transform, undefined, null);
+        painterMock.renderOptions = createRenderOptions(painterMock.transform, undefined, null);
         painterMock.renderOptions.currentPass = 'translucent';
         painterMock.options = {} as any;
         painterMock.style = {

--- a/src/webgl/render_to_texture.test.ts
+++ b/src/webgl/render_to_texture.test.ts
@@ -1,7 +1,7 @@
 import {beforeEach, describe, test, expect, vi} from 'vitest';
 import {RenderToTexture} from './render_to_texture.ts';
 import {RTTFingerprint} from './rtt_fingerprint.ts';
-import {RenderOptions} from '../render/render_options.ts';
+import {createRenderOptions} from '../render/render_options.ts';
 import type {Painter, RTTObject} from '../render/painter.ts';
 import type {LineStyleLayer} from '../style/style_layer/line_style_layer.ts';
 import type {SymbolStyleLayer} from '../style/style_layer/symbol_style_layer.ts';
@@ -133,7 +133,7 @@ describe('render to texture', () => {
         const renderLayerSpy = vi.spyOn(painter, 'renderLayer');
         rtt.prepareForRender(style, 0);
 
-        const renderOptions = new RenderOptions(painter.transform, undefined, terrain);
+        const renderOptions = createRenderOptions(painter.transform, undefined, terrain);
         for (const layerId of style._order) {
             const layer = style._layers[layerId];
             rtt.renderLayer(layer, renderOptions);
@@ -179,7 +179,7 @@ describe('render to texture', () => {
         style._order = ['maine-fill', 'maine-symbol'];
         rtt.prepareForRender(style, 0);
         layersDrawn = 0;
-        const renderOptions = new RenderOptions(painter.transform, undefined, terrain);
+        const renderOptions = createRenderOptions(painter.transform, undefined, terrain);
         expect(rtt._renderableLayerIds).toStrictEqual(['maine-fill', 'maine-symbol']);
         expect(rtt.renderLayer(fillLayer, renderOptions)).toBeTruthy();
         expect(rtt.renderLayer(symbolLayer, renderOptions)).toBeFalsy();
@@ -190,7 +190,7 @@ describe('render to texture', () => {
         style._order = ['maine-background', 'maine-fill', 'maine-raster', 'maine-hillshade', 'maine-symbol', 'maine-line', 'maine-symbol'];
         rtt.prepareForRender(style, 0);
         layersDrawn = 0;
-        const renderOptions = new RenderOptions(painter.transform, undefined, terrain);
+        const renderOptions = createRenderOptions(painter.transform, undefined, terrain);
         expect(rtt._renderableLayerIds).toStrictEqual(['maine-background', 'maine-fill', 'maine-raster', 'maine-hillshade', 'maine-symbol', 'maine-line', 'maine-symbol']);
         expect(rtt.renderLayer(backgroundLayer, renderOptions)).toBeTruthy();
         expect(rtt.renderLayer(fillLayer, renderOptions)).toBeTruthy();
@@ -206,7 +206,7 @@ describe('render to texture', () => {
         style._order = ['maine-background', 'maine-symbol', 'maine-hillshade', 'maine-symbol', 'maine-line', 'maine-symbol'];
         rtt.prepareForRender(style, 0);
         layersDrawn = 0;
-        const renderOptions = new RenderOptions(painter.transform, undefined, terrain);
+        const renderOptions = createRenderOptions(painter.transform, undefined, terrain);
         expect(rtt._renderableLayerIds).toStrictEqual(['maine-background', 'maine-symbol', 'maine-hillshade', 'maine-symbol', 'maine-line', 'maine-symbol']);
         expect(rtt.renderLayer(backgroundLayer, renderOptions)).toBeTruthy();
         expect(rtt.renderLayer(symbolLayer, renderOptions)).toBeFalsy();
@@ -239,7 +239,7 @@ describe('render to texture', () => {
         const acquireSpy = vi.spyOn(painter, 'acquireRTT');
         acquireSpy.mockClear();
 
-        const renderOptions = new RenderOptions(painter.transform, undefined, terrain);
+        const renderOptions = createRenderOptions(painter.transform, undefined, terrain);
         rtt.renderLayer(fillLayer, renderOptions);
         rtt.renderLayer(symbolLayer, renderOptions);
 
@@ -258,7 +258,7 @@ describe('render to texture', () => {
         const acquireSpy = vi.spyOn(painter, 'acquireRTT');
         acquireSpy.mockClear();
 
-        const renderOptions = new RenderOptions(painter.transform, undefined, terrain);
+        const renderOptions = createRenderOptions(painter.transform, undefined, terrain);
         rtt.renderLayer(fillLayer, renderOptions);
         rtt.renderLayer(symbolLayer, renderOptions);
 
@@ -271,7 +271,7 @@ describe('render to texture', () => {
         style._order = ['maine-fill', 'maine-symbol'];
         rtt.prepareForRender(style, 0);
 
-        const renderOptions = new RenderOptions(painter.transform, undefined, terrain);
+        const renderOptions = createRenderOptions(painter.transform, undefined, terrain);
         rtt.renderLayer(fillLayer, renderOptions);
         rtt.renderLayer(symbolLayer, renderOptions);
 


### PR DESCRIPTION
Convert RenderOptions from class to type with factory function.

Follow up to 
- #8318 

GM2.6 will build on this with two helper functions that take the renderOptions object and a tile ID

```
getProjectionData(renderOptions, tileID); // returns proj matrices, tile bounds and globe settings
getTerrainData(renderOptions, tileID); // returns terrain uniforms and textures
```

wita class this would have been methods on RenderOptions

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items that are not relevant. -->


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] If you changed code in a file that has a benchmark file next to it (`*.bench.ts`), post before/after results of `npm run bench` (the compare workflow is in `test/bench/README.md`).
 - [ ] Add an entry to `CHANGELOG.md` under the `## main` section.
 - [x] Confirm you have read our AI policy [here](https://github.com/maplibre/maplibre/blob/main/AI_POLICY.md).
<!--
  Add one of:    Assisted-By: | Generated-By:     and the model/version
-->
