### PR TITLE
docs: explain the missing data past the mercator edge on globe

### DIFF
--- a/developer-guides/globe.md
+++ b/developer-guides/globe.md
@@ -173,6 +173,10 @@ that were drawn in the first pass.
 This ensures that no pixel is drawn twice, and that the stretched borders
 are only drawn in regions between tiles. 
 
+## Data near the poles
+
+Web mercator sources carry no data beyond about 85.05 degrees of latitude, so a globe has nothing to draw between that edge and the pole. MapLibre fills the gap by extending the edge of each pole-adjacent tile to the pole: subdivision adds a fan of pole triangles to every tile in the first or last mercator row, and whatever crosses the mercator edge in that tile, a fill polygon or the last row of a raster texture, is stretched all the way to the pole. Both vector and raster sources show this, most visibly around Antarctica, where an ocean polygon that crosses the edge becomes a spike reaching the pole. There is no source data to draw there, so this is the expected result rather than a rendering bug ([#5433](https://github.com/maplibre/maplibre-gl-js/issues/5433)).
+
 ## Symbols
 
 Symbol rendering also had to be adapted for globe, as well as collision detection and placement.


### PR DESCRIPTION
Adds a "Data near the poles" section to `developer-guides/globe.md`: web mercator sources stop at about 85.05 degrees, subdivision adds pole triangles to every edge-row tile, and whatever crosses the edge (a fill polygon, the last row of a raster texture) is stretched to the pole. That is the spike over Antarctica, as @kubapelc explained on the issue.

- Closes #5433

## Launch Checklist

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [ ] Write tests for all new functionality.
 - [ ] Add an entry to `CHANGELOG.md` under the `## main` section.
 - [x] Confirm you have read our AI policy [here](https://github.com/maplibre/maplibre/blob/main/AI_POLICY.md).

Assisted-By: Claude Fable 5.1
