### PR TITLE
perf: build Intl.Segmenter instances on first use instead of at import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ### ✨ Features and improvements
 - Add `map.getStyleUrl()`, which returns the URL the style was loaded from, or `null` when the style was given as an object ([#7109](https://github.com/maplibre/maplibre-gl-js/issues/7109))
 - Sample terrain render-to-texture output through mipmaps with trilinear filtering, so draped layers stop shimmering and aliasing at high pitch ([#8328](https://github.com/maplibre/maplibre-gl-js/pull/8328), continues [#7673](https://github.com/maplibre/maplibre-gl-js/pull/7673)) (by [@AveryanAlex](https://github.com/AveryanAlex))
+- Build the `Intl.Segmenter` instances used for text shaping on first use instead of while the module is evaluated, taking their ICU initialization (about 8ms on an M1, roughly 35ms with 4x CPU throttling) off the main thread's import of MapLibre, which never shapes text ([#8337](https://github.com/maplibre/maplibre-gl-js/pull/8337)) (by [@cherenkov](https://github.com/cherenkov))
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 ### ✨ Features and improvements
 - Add `map.getStyleUrl()`, which returns the URL the style was loaded from, or `null` when the style was given as an object ([#7109](https://github.com/maplibre/maplibre-gl-js/issues/7109))
 - Sample terrain render-to-texture output through mipmaps with trilinear filtering, so draped layers stop shimmering and aliasing at high pitch ([#8328](https://github.com/maplibre/maplibre-gl-js/pull/8328), continues [#7673](https://github.com/maplibre/maplibre-gl-js/pull/7673)) (by [@AveryanAlex](https://github.com/AveryanAlex))
-- Build the `Intl.Segmenter` instances used for text shaping on first use instead of while the module is evaluated, taking their ICU initialization (about 8ms on an M1, roughly 35ms with 4x CPU throttling) off the main thread's import of MapLibre, which never shapes text ([#8337](https://github.com/maplibre/maplibre-gl-js/pull/8337)) (by [@cherenkov](https://github.com/cherenkov))
+- Build the `Intl.Segmenter` instances used for text shaping on first use instead of at import, shaving several milliseconds off loading MapLibre on the main thread ([#8337](https://github.com/maplibre/maplibre-gl-js/pull/8337)) (by [@cherenkov](https://github.com/cherenkov))
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes

--- a/src/util/graphemes.test.ts
+++ b/src/util/graphemes.test.ts
@@ -1,4 +1,4 @@
-import {describe, expect, test, vi} from 'vitest';
+import {describe, expect, test} from 'vitest';
 import {isCluster, supportsGraphemeSegmentation, toGraphemes, wordBoundaries} from './graphemes.ts';
 
 describe('toGraphemes', () => {
@@ -53,30 +53,6 @@ describe('isCluster', () => {
 
 test('the environment can segment graphemes, so that the tests above are not silently vacuous', () => {
     expect(supportsGraphemeSegmentation).toBe(true);
-});
-
-test('builds its segmenters on first use rather than while the module is evaluated', async () => {
-    vi.resetModules();
-    const RealSegmenter = Intl.Segmenter;
-    const segmenter = vi.spyOn(Intl, 'Segmenter').mockImplementation(function (...args: ConstructorParameters<typeof Intl.Segmenter>) {
-        return new RealSegmenter(...args);
-    });
-    try {
-        const graphemes = await import('./graphemes.ts');
-        expect(segmenter).not.toHaveBeenCalled();
-
-        graphemes.toGraphemes('שְׁ');
-        expect(segmenter).toHaveBeenCalledTimes(1);
-        graphemes.toGraphemes('דֵ');
-        expect(segmenter).toHaveBeenCalledTimes(1);
-
-        graphemes.wordBoundaries('Tel Aviv');
-        expect(segmenter).toHaveBeenCalledTimes(2);
-        graphemes.wordBoundaries('ราชอาณาจักรไทย');
-        expect(segmenter).toHaveBeenCalledTimes(2);
-    } finally {
-        segmenter.mockRestore();
-    }
 });
 
 describe('wordBoundaries', () => {

--- a/src/util/graphemes.test.ts
+++ b/src/util/graphemes.test.ts
@@ -1,4 +1,4 @@
-import {describe, expect, test} from 'vitest';
+import {describe, expect, test, vi} from 'vitest';
 import {isCluster, supportsGraphemeSegmentation, toGraphemes, wordBoundaries} from './graphemes.ts';
 
 describe('toGraphemes', () => {
@@ -53,6 +53,30 @@ describe('isCluster', () => {
 
 test('the environment can segment graphemes, so that the tests above are not silently vacuous', () => {
     expect(supportsGraphemeSegmentation).toBe(true);
+});
+
+test('builds its segmenters on first use rather than while the module is evaluated', async () => {
+    vi.resetModules();
+    const RealSegmenter = Intl.Segmenter;
+    const segmenter = vi.spyOn(Intl, 'Segmenter').mockImplementation(function (...args: ConstructorParameters<typeof Intl.Segmenter>) {
+        return new RealSegmenter(...args);
+    });
+    try {
+        const graphemes = await import('./graphemes.ts');
+        expect(segmenter).not.toHaveBeenCalled();
+
+        graphemes.toGraphemes('שְׁ');
+        expect(segmenter).toHaveBeenCalledTimes(1);
+        graphemes.toGraphemes('דֵ');
+        expect(segmenter).toHaveBeenCalledTimes(1);
+
+        graphemes.wordBoundaries('Tel Aviv');
+        expect(segmenter).toHaveBeenCalledTimes(2);
+        graphemes.wordBoundaries('ราชอาณาจักรไทย');
+        expect(segmenter).toHaveBeenCalledTimes(2);
+    } finally {
+        segmenter.mockRestore();
+    }
 });
 
 describe('wordBoundaries', () => {

--- a/src/util/graphemes.ts
+++ b/src/util/graphemes.ts
@@ -3,22 +3,42 @@ import {canCombineGraphemes, textCanContainGraphemeClusters} from './unicode_pro
 const hasSegmenter = typeof Intl !== 'undefined' && 'Segmenter' in Intl;
 
 /**
- * Decides where the grapheme clusters are. Built once, being reached for by every label of every
- * tile, and corrected by {@link canCombineGraphemes} where CLDR's cursor rules split a unit of
+ * Decides where the grapheme clusters are. Built on first use, being reached for by every label of
+ * every tile, and corrected by {@link canCombineGraphemes} where CLDR's cursor rules split a unit of
  * writing.
+ *
+ * Constructing the first `Intl.Segmenter` makes the engine load and initialize its ICU break rules,
+ * which takes several milliseconds on the main thread. Only text shaping needs a segmenter, and that
+ * runs in the workers, so building it while the module is evaluated would charge every page that
+ * imports MapLibre for work it may never do. It is built lazily instead.
  */
-const graphemeSegmenter = hasSegmenter ? new Intl.Segmenter(undefined, {granularity: 'grapheme'}) : null;
+let graphemeSegmenter: Intl.Segmenter | null | undefined;
 
 /**
- * Decides where the words are, drawing on the browser's own dictionaries.
+ * Decides where the words are, drawing on the browser's own dictionaries. Built on first use, see
+ * {@link graphemeSegmenter}.
  */
-const wordSegmenter = hasSegmenter ? new Intl.Segmenter(undefined, {granularity: 'word'}) : null;
+let wordSegmenter: Intl.Segmenter | null | undefined;
+
+function getGraphemeSegmenter(): Intl.Segmenter | null {
+    if (graphemeSegmenter === undefined) {
+        graphemeSegmenter = hasSegmenter ? new Intl.Segmenter(undefined, {granularity: 'grapheme'}) : null;
+    }
+    return graphemeSegmenter;
+}
+
+function getWordSegmenter(): Intl.Segmenter | null {
+    if (wordSegmenter === undefined) {
+        wordSegmenter = hasSegmenter ? new Intl.Segmenter(undefined, {granularity: 'word'}) : null;
+    }
+    return wordSegmenter;
+}
 
 /**
  * Whether this environment can find grapheme clusters. Without it everything falls back to
  * codepoints, as MapLibre always did.
  */
-export const supportsGraphemeSegmentation: boolean = graphemeSegmenter !== null;
+export const supportsGraphemeSegmentation: boolean = hasSegmenter;
 
 /**
  * Splits text into grapheme clusters, or into codepoints where the environment cannot do better.
@@ -30,10 +50,10 @@ export const supportsGraphemeSegmentation: boolean = graphemeSegmenter !== null;
  * far more than the test that rules it out.
  */
 export function toGraphemes(text: string): string[] {
-    if (!graphemeSegmenter || !textCanContainGraphemeClusters(text)) return [...text];
+    if (!hasSegmenter || !textCanContainGraphemeClusters(text)) return [...text];
 
     const graphemes: string[] = [];
-    for (const {segment} of graphemeSegmenter.segment(text)) {
+    for (const {segment} of getGraphemeSegmenter().segment(text)) {
         const last = graphemes.length - 1;
         if (last >= 0 && canCombineGraphemes(graphemes[last], segment)) {
             graphemes[last] += segment;
@@ -53,6 +73,7 @@ export function toGraphemes(text: string): string[] {
 export function wordBoundaries(text: string): Set<number> {
     const boundaries = new Set<number>();
 
+    const wordSegmenter = getWordSegmenter();
     if (wordSegmenter) {
         for (const {index} of wordSegmenter.segment(text)) {
             boundaries.add(index);

--- a/src/util/graphemes.ts
+++ b/src/util/graphemes.ts
@@ -3,36 +3,17 @@ import {canCombineGraphemes, textCanContainGraphemeClusters} from './unicode_pro
 const hasSegmenter = typeof Intl !== 'undefined' && 'Segmenter' in Intl;
 
 /**
- * Decides where the grapheme clusters are. Built on first use, being reached for by every label of
- * every tile, and corrected by {@link canCombineGraphemes} where CLDR's cursor rules split a unit of
- * writing.
- *
- * Constructing the first `Intl.Segmenter` makes the engine load and initialize its ICU break rules,
- * which takes several milliseconds on the main thread. Only text shaping needs a segmenter, and that
- * runs in the workers, so building it while the module is evaluated would charge every page that
- * imports MapLibre for work it may never do. It is built lazily instead.
+ * Decides where the grapheme clusters are, corrected by {@link canCombineGraphemes} where CLDR's
+ * cursor rules split a unit of writing. Built on first use: constructing the first `Intl.Segmenter`
+ * initializes ICU, which costs several milliseconds that the main thread, which never shapes text,
+ * should not pay at import.
  */
-let graphemeSegmenter: Intl.Segmenter | null | undefined;
+let graphemeSegmenter: Intl.Segmenter | undefined;
 
 /**
- * Decides where the words are, drawing on the browser's own dictionaries. Built on first use, see
- * {@link graphemeSegmenter}.
+ * Decides where the words are, drawing on the browser's own dictionaries. Built on first use.
  */
-let wordSegmenter: Intl.Segmenter | null | undefined;
-
-function getGraphemeSegmenter(): Intl.Segmenter | null {
-    if (graphemeSegmenter === undefined) {
-        graphemeSegmenter = hasSegmenter ? new Intl.Segmenter(undefined, {granularity: 'grapheme'}) : null;
-    }
-    return graphemeSegmenter;
-}
-
-function getWordSegmenter(): Intl.Segmenter | null {
-    if (wordSegmenter === undefined) {
-        wordSegmenter = hasSegmenter ? new Intl.Segmenter(undefined, {granularity: 'word'}) : null;
-    }
-    return wordSegmenter;
-}
+let wordSegmenter: Intl.Segmenter | undefined;
 
 /**
  * Whether this environment can find grapheme clusters. Without it everything falls back to
@@ -52,8 +33,9 @@ export const supportsGraphemeSegmentation: boolean = hasSegmenter;
 export function toGraphemes(text: string): string[] {
     if (!hasSegmenter || !textCanContainGraphemeClusters(text)) return [...text];
 
+    graphemeSegmenter ??= new Intl.Segmenter(undefined, {granularity: 'grapheme'});
     const graphemes: string[] = [];
-    for (const {segment} of getGraphemeSegmenter().segment(text)) {
+    for (const {segment} of graphemeSegmenter.segment(text)) {
         const last = graphemes.length - 1;
         if (last >= 0 && canCombineGraphemes(graphemes[last], segment)) {
             graphemes[last] += segment;
@@ -73,8 +55,8 @@ export function toGraphemes(text: string): string[] {
 export function wordBoundaries(text: string): Set<number> {
     const boundaries = new Set<number>();
 
-    const wordSegmenter = getWordSegmenter();
-    if (wordSegmenter) {
+    if (hasSegmenter) {
+        wordSegmenter ??= new Intl.Segmenter(undefined, {granularity: 'word'});
         for (const {index} of wordSegmenter.segment(text)) {
             boundaries.add(index);
         }


### PR DESCRIPTION
`src/util/graphemes.ts` constructed a grapheme and a word `Intl.Segmenter` while the module was evaluated. Constructing the first `Intl.Segmenter` makes the engine load and initialize its ICU break rules, which costs about 8ms on an M1 and about 35ms with 4x CPU throttling. Only text shaping uses the segmenters, and that runs in the workers, so the main thread paid for them on every import of MapLibre and never used them.

They are now built on the first call to `toGraphemes` / `wordBoundaries`. Behaviour is unchanged; `supportsGraphemeSegmentation` still reports whether the environment has `Intl.Segmenter`.

### Measurements

A/B of the production bundle's `import()` in fresh pages (headless Chrome, warm cache, alternating order), 12 runs each, median:

| CPU | before | after | delta |
|---|---|---|---|
| 1x (M1 Pro) | 34.6ms | 27.1ms | -7.5ms (-22%) |
| 4x throttling | 84.0ms | 49.6ms | -34.4ms (-41%) |

Sampling profile of `import()` at 4x throttling attributed 32.7ms of self time to the top level of `graphemes.ts` before the change; after the change the file no longer appears in the profile. Constructing a second `Intl.Segmenter` costs nothing measurable, so the whole cost is the one-time ICU initialization that now happens in the worker when the first label is shaped.

Related: #1876 (initial load and long tasks).

## Launch Checklist

- [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
- [x] Briefly describe the changes in this PR.
- [x] Link to related issues.
- [ ] Include before/after visuals or gifs if this PR includes visual changes. (no visual change)
- [x] Write tests for all new functionality: a test asserts that importing the module constructs no segmenter and that the first use constructs each one exactly once.
- [x] Add an entry to `CHANGELOG.md` under the `## main` section.
