### PR TITLE
perf: build the script-detection regular expressions on first use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Add `map.getStyleUrl()`, which returns the URL the style was loaded from, or `null` when the style was given as an object ([#7109](https://github.com/maplibre/maplibre-gl-js/issues/7109))
 - Sample terrain render-to-texture output through mipmaps with trilinear filtering, so draped layers stop shimmering and aliasing at high pitch ([#8328](https://github.com/maplibre/maplibre-gl-js/pull/8328), continues [#7673](https://github.com/maplibre/maplibre-gl-js/pull/7673)) (by [@AveryanAlex](https://github.com/AveryanAlex))
 - Build the `Intl.Segmenter` instances used for text shaping on first use instead of at import, shaving several milliseconds off loading MapLibre on the main thread ([#8337](https://github.com/maplibre/maplibre-gl-js/pull/8337)) (by [@cherenkov](https://github.com/cherenkov))
+- Build the Unicode script regular expressions used by text shaping on first use instead of at import, trimming a little more from loading MapLibre on the main thread ([#8341](https://github.com/maplibre/maplibre-gl-js/pull/8341)) (by [@cherenkov](https://github.com/cherenkov))
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes

--- a/src/util/script_detection.ts
+++ b/src/util/script_detection.ts
@@ -59,9 +59,11 @@ const cursiveScriptCodes = [
     'Syrc', // Syriac
 ];
 
-const cursiveScriptRegExp = sanitizedRegExpFromScriptCodes(cursiveScriptCodes);
+/** Built on first use: compiling `\\p{sc=…}` escapes is not free, and most pages never shape text on the main thread. */
+let cursiveScriptRegExp: RegExp | undefined;
 
 export function charAllowsLetterSpacing(char: number): boolean {
+    cursiveScriptRegExp ??= sanitizedRegExpFromScriptCodes(cursiveScriptCodes);
     return !cursiveScriptRegExp.test(String.fromCodePoint(char));
 }
 
@@ -126,9 +128,11 @@ const rtlScriptCodes = [
     'Yezi', // Yezidi
 ];
 
-const rtlScriptRegExp = sanitizedRegExpFromScriptCodes(rtlScriptCodes);
+/** Built on first use, see {@link cursiveScriptRegExp}. */
+let rtlScriptRegExp: RegExp | undefined;
 
 export function charInRTLScript(char: number): boolean {
+    rtlScriptRegExp ??= sanitizedRegExpFromScriptCodes(rtlScriptCodes);
     return rtlScriptRegExp.test(String.fromCodePoint(char));
 }
 


### PR DESCRIPTION
`script_detection.ts` built two Unicode-property regular expressions (`cursiveScriptRegExp`, `rtlScriptRegExp`) while the module was evaluated, probing 41 `\\p{sc=…}` escapes with `new RegExp` each. Like the `Intl.Segmenter` instances in #8337, they are only needed by text shaping, so they are now built on the first call to `charAllowsLetterSpacing` / `charInRTLScript` with `??=`.

Sampling profile of `import()` of the production bundle at 4x CPU throttling attributed about 3ms of self time to `sanitizedRegExpFromScriptCodes` at import; after this change it no longer runs at import. Hot-path cost is one `undefined` check per character in front of a `RegExp.test`.

Related: #1876.

## Launch Checklist

- [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
- [x] Briefly describe the changes in this PR.
- [x] Link to related issues.
- [ ] Include before/after visuals or gifs if this PR includes visual changes. (no visual change)
- [x] Write tests for all new functionality.
- [x] Add an entry to `CHANGELOG.md` under the `## main` section.