### PR TITLE
refactor: unify bucket dependency finalization through addFeatures

### DIFF
--- a/src/data/bucket.ts
+++ b/src/data/bucket.ts
@@ -11,7 +11,8 @@ import type {SubdivisionGranularitySetting} from '../render/subdivision_granular
 import type {DashEntry} from '../render/line_atlas.ts';
 import type {Feature as StyleFeature} from '@maplibre/maplibre-gl-style-spec';
 import type {VectorTileFeatureLike, VectorTileLayerLike} from '@maplibre/vt-pbf';
-import type {GetImagesResponse} from '../util/actor_messages.ts';
+import type {GetGlyphsResponse, GetImagesResponse} from '../util/actor_messages.ts';
+import type {GlyphPositions} from '../render/glyph_atlas.ts';
 
 export type BucketParameters<Layer extends TypedStyleLayer> = {
     index: number;
@@ -45,9 +46,14 @@ export type PopulateParameters = {
 export type BucketDependencyParameters = {
     options: PopulateParameters;
     canonical: CanonicalTileID;
-    imagePositions: Record<string, ImagePosition>;
+    glyphMap: GetGlyphsResponse;
+    glyphPositions: GlyphPositions;
+    iconMap: GetImagesResponse;
+    iconPositions: Record<string, ImagePosition>;
+    patternMap: GetImagesResponse;
+    patternPositions: Record<string, ImagePosition>;
     dashPositions: Record<string, DashEntry>;
-    imageMap: GetImagesResponse;
+    showCollisionBoxes: boolean;
 };
 
 export type IndexedFeature = {

--- a/src/data/bucket.ts
+++ b/src/data/bucket.ts
@@ -43,6 +43,13 @@ export type PopulateParameters = {
     subdivisionGranularity: SubdivisionGranularitySetting;
 };
 
+/**
+ * The asynchronously loaded tile content a bucket may need to finalize its
+ * features. Every image, glyph, and dash entry referenced by the bucket's
+ * layers arrives here after the worker has fetched it; pattern maps belong to
+ * fill, fill-extrusion, and line buckets, icon maps and glyph maps to symbol
+ * buckets.
+ */
 export type BucketDependencyParameters = {
     options: PopulateParameters;
     canonical: CanonicalTileID;

--- a/src/data/bucket/fill_bucket.test.ts
+++ b/src/data/bucket/fill_bucket.test.ts
@@ -35,13 +35,18 @@ function createFillBucketWithLayers(layerSpecifications: LayerSpecification[], a
     return new FillBucket({layers, zoom: 0, overscaling: 0, index: 0} as BucketParameters<FillStyleLayer>);
 }
 
-function createDependencyParameters(imageMap: Record<string, StyleImage>): BucketDependencyParameters {
+function createDependencyParameters(patternMap: Record<string, StyleImage>): BucketDependencyParameters {
     return {
-        options: createPopulateOptions(Object.keys(imageMap)),
+        options: createPopulateOptions(Object.keys(patternMap)),
         canonical: new CanonicalTileID(0, 0, 0),
-        imagePositions: {},
+        glyphMap: {},
+        glyphPositions: {},
+        iconMap: {},
+        iconPositions: {},
+        patternMap,
+        patternPositions: {},
         dashPositions: {},
-        imageMap
+        showCollisionBoxes: false
     };
 }
 

--- a/src/data/bucket/fill_bucket.ts
+++ b/src/data/bucket/fill_bucket.ts
@@ -142,10 +142,10 @@ export class FillBucket implements Bucket {
         });
     }
 
-    addFeatures({options, canonical, imagePositions, imageMap}: BucketDependencyParameters): void {
-        this.detectSdfPatterns(imageMap);
+    addFeatures({options, canonical, patternPositions, patternMap}: BucketDependencyParameters): void {
+        this.detectSdfPatterns(patternMap);
         for (const feature of this.patternFeatures) {
-            this.addFeature(feature, feature.geometry, feature.index, canonical, imagePositions, options.subdivisionGranularity);
+            this.addFeature(feature, feature.geometry, feature.index, canonical, patternPositions, options.subdivisionGranularity);
         }
     }
 

--- a/src/data/bucket/fill_extrusion_bucket.ts
+++ b/src/data/bucket/fill_extrusion_bucket.ts
@@ -137,10 +137,10 @@ export class FillExtrusionBucket implements Bucket {
         }
     }
 
-    addFeatures({options, canonical, imagePositions}: BucketDependencyParameters): void {
+    addFeatures({options, canonical, patternPositions}: BucketDependencyParameters): void {
         for (const feature of this.features) {
             const {geometry} = feature;
-            this.addFeature(feature, geometry, feature.index, canonical, imagePositions, options.subdivisionGranularity);
+            this.addFeature(feature, geometry, feature.index, canonical, patternPositions, options.subdivisionGranularity);
         }
     }
 

--- a/src/data/bucket/line_bucket.ts
+++ b/src/data/bucket/line_bucket.ts
@@ -214,9 +214,9 @@ export class LineBucket implements Bucket {
         });
     }
 
-    addFeatures({options, canonical, imagePositions, dashPositions}: BucketDependencyParameters): void {
+    addFeatures({options, canonical, patternPositions, dashPositions}: BucketDependencyParameters): void {
         for (const feature of this.patternFeatures) {
-            this.addFeature(feature, feature.geometry, feature.index, canonical, imagePositions, dashPositions, options.subdivisionGranularity);
+            this.addFeature(feature, feature.geometry, feature.index, canonical, patternPositions, dashPositions, options.subdivisionGranularity);
         }
     }
 

--- a/src/data/bucket/symbol_bucket.test.ts
+++ b/src/data/bucket/symbol_bucket.test.ts
@@ -1,5 +1,4 @@
 import {describe, test, expect, vi, beforeAll} from 'vitest';
-import {SymbolBucket} from './symbol_bucket.ts';
 import {CollisionBoxArray} from '../../data/array_types.g.ts';
 import {performSymbolLayout} from '../../symbol/symbol_layout.ts';
 import {Placement} from '../../symbol/placement.ts';

--- a/src/data/bucket/symbol_bucket.test.ts
+++ b/src/data/bucket/symbol_bucket.test.ts
@@ -130,9 +130,9 @@ describe('SymbolBucket', () => {
 
     test('SymbolBucket integer overflow', () => {
         const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-        SymbolBucket.MAX_GLYPHS = 5;
-
         const bucket = bucketSetup();
+        bucket.maxGlyphs = 5;
+
         const options = {iconDependencies: {}, glyphDependencies: {}} as PopulateParameters;
 
         bucket.populate(features, options, undefined);

--- a/src/data/bucket/symbol_bucket.ts
+++ b/src/data/bucket/symbol_bucket.ts
@@ -32,7 +32,7 @@ import {toEvaluationFeature} from '../evaluation_feature.ts';
 import {VectorTileFeature} from '@mapbox/vector-tile';
 import {verticalizedCharacterMap} from '../../util/verticalize_punctuation.ts';
 import {type Anchor} from '../../symbol/anchor.ts';
-import {getSizeData, MAX_PACKED_SIZE} from '../../symbol/symbol_size.ts';
+import {getSizeData, MAX_PACKED_SIZE, MAX_GLYPHS} from '../../symbol/symbol_size.ts';
 import {performSymbolLayout} from '../../symbol/symbol_layout.ts';
 
 import {register} from '../../util/web_worker_transfer.ts';
@@ -311,7 +311,6 @@ register('CollisionBuffers', CollisionBuffers);
  *    using a dynamic "OpacityVertexArray".
  */
 export class SymbolBucket implements Bucket {
-    static MAX_GLYPHS: number;
     static addDynamicAttributes: typeof addDynamicAttributes;
 
     collisionBoxArray: CollisionBoxArray;
@@ -334,6 +333,11 @@ export class SymbolBucket implements Bucket {
     iconSizeData: SizeData;
 
     glyphOffsetArray: GlyphOffsetArray;
+    /**
+     * The glyph cap for this bucket, normally {@link MAX_GLYPHS}. Tests lower it to
+     * exercise the overflow warning without filling a bucket with 65,535 glyphs.
+     */
+    maxGlyphs: number;
     lineVertexArray: SymbolLineVertexArray;
     features: SymbolFeature[];
     symbolInstances: SymbolInstanceArray;
@@ -378,6 +382,7 @@ export class SymbolBucket implements Bucket {
         this.sortKeyRanges = [];
 
         this.collisionCircleArray = [];
+        this.maxGlyphs = MAX_GLYPHS;
 
         const layer = this.layers[0];
         const unevaluatedLayoutValues = layer._unevaluatedLayout._values;
@@ -1001,14 +1006,6 @@ export class SymbolBucket implements Bucket {
 register('SymbolBucket', SymbolBucket, {
     omit: ['layers', 'collisionBoxArray', 'features', 'compareText']
 });
-
-// this constant is based on the size of StructArray indexes used in a symbol
-// bucket--namely, glyphOffsetArrayStart
-// eg the max valid UInt16 is 65,535
-// See https://github.com/mapbox/mapbox-gl-js/issues/2907 for motivation
-// lineStartIndex and textBoxStartIndex could potentially be concerns
-// but we expect there to be many fewer boxes/lines than glyphs
-SymbolBucket.MAX_GLYPHS = 65535;
 
 SymbolBucket.addDynamicAttributes = addDynamicAttributes;
 

--- a/src/data/bucket/symbol_bucket.ts
+++ b/src/data/bucket/symbol_bucket.ts
@@ -311,8 +311,6 @@ register('CollisionBuffers', CollisionBuffers);
  *    using a dynamic "OpacityVertexArray".
  */
 export class SymbolBucket implements Bucket {
-    static addDynamicAttributes: typeof addDynamicAttributes;
-
     collisionBoxArray: CollisionBoxArray;
     zoom: number;
     overscaling: number;
@@ -1006,7 +1004,5 @@ export class SymbolBucket implements Bucket {
 register('SymbolBucket', SymbolBucket, {
     omit: ['layers', 'collisionBoxArray', 'features', 'compareText']
 });
-
-SymbolBucket.addDynamicAttributes = addDynamicAttributes;
 
 export {addDynamicAttributes};

--- a/src/data/bucket/symbol_bucket.ts
+++ b/src/data/bucket/symbol_bucket.ts
@@ -33,6 +33,7 @@ import {VectorTileFeature} from '@mapbox/vector-tile';
 import {verticalizedCharacterMap} from '../../util/verticalize_punctuation.ts';
 import {type Anchor} from '../../symbol/anchor.ts';
 import {getSizeData, MAX_PACKED_SIZE} from '../../symbol/symbol_size.ts';
+import {performSymbolLayout} from '../../symbol/symbol_layout.ts';
 
 import {register} from '../../util/web_worker_transfer.ts';
 import {EvaluationParameters} from '../../style/evaluation_parameters.ts';
@@ -292,11 +293,10 @@ register('CollisionBuffers', CollisionBuffers);
  *    stores the feature data for use in subsequent step (this.features).
  *
  * 2. WorkerTile asynchronously requests from the main thread all of the glyphs
- *    and icons needed (by this bucket and any others). When glyphs and icons
- *    have been received, the WorkerTile creates a CollisionIndex and invokes:
+ *    and icons needed (by this bucket and any others).
  *
- * 3. performSymbolLayout(bucket, stacks, icons) perform texts shaping and
- *    layout on a Symbol Bucket. This step populates:
+ * 3. WorkerTile calls SymbolBucket.addFeatures(), which delegates text shaping
+ *    and layout to performSymbolLayout(). This step populates:
  *      `this.symbolInstances`: metadata on generated symbols
  *      `this.collisionBoxArray`: collision data for use by foreground
  *      `this.text`: SymbolBuffers for text symbols
@@ -373,7 +373,7 @@ export class SymbolBucket implements Bucket {
         this.index = options.index;
         this.pixelRatio = options.pixelRatio;
         this.sourceLayerIndex = options.sourceLayerIndex;
-        this.hasDependencies = false;
+        this.hasDependencies = true;
         this.hasRTLText = false;
         this.sortKeyRanges = [];
 
@@ -591,7 +591,18 @@ export class SymbolBucket implements Bucket {
         });
     }
 
-    addFeatures(_parameters: BucketDependencyParameters): void {}
+    addFeatures({options, canonical, glyphMap, glyphPositions, iconMap, iconPositions, showCollisionBoxes}: BucketDependencyParameters): void {
+        performSymbolLayout({
+            bucket: this,
+            glyphMap,
+            glyphPositions,
+            imageMap: iconMap,
+            imagePositions: iconPositions,
+            showCollisionBoxes,
+            canonical,
+            subdivisionGranularity: options.subdivisionGranularity
+        });
+    }
 
     isEmpty(): boolean {
         // When the bucket encounters only rtl-text but the plugin isn't loaded, no symbol instances will be created.

--- a/src/source/worker_tile.test.ts
+++ b/src/source/worker_tile.test.ts
@@ -227,8 +227,9 @@ describe('worker tile', () => {
         const actorMock = {
             sendAsync
         };
-        const result = await tile.parse(data, layerIndex, ['hello'], actorMock, SubdivisionGranularitySetting.noSubdivision);
+        const result = await tile.parse(data, layerIndex, ['hello'], actorMock, SubdivisionGranularitySetting.noSubdivision) as WorkerTileWithData;
         expect(result).toBeDefined();
+        expect(result.buckets.some((bucket) => bucket.layerIds.includes('test'))).toBe(true);
         expect(sendAsync).toHaveBeenCalledTimes(4); // icons, patterns, glyphs, dashes
         expect(sendAsync).toHaveBeenCalledWith(expect.objectContaining({type: 'GI', data: expect.objectContaining({'icons': ['hello'], 'type': 'icons'})}), expect.any(Object));
         expect(sendAsync).toHaveBeenCalledWith(expect.objectContaining({type: 'GI', data: expect.objectContaining({'icons': ['hello'], 'type': 'patterns'})}), expect.any(Object));

--- a/src/source/worker_tile.ts
+++ b/src/source/worker_tile.ts
@@ -1,8 +1,6 @@
 import {FeatureIndex} from '../data/feature_index.ts';
-import {performSymbolLayout} from '../symbol/symbol_layout.ts';
 import {CollisionBoxArray} from '../data/array_types.g.ts';
 import {DictionaryCoder} from '../util/dictionary_coder.ts';
-import {SymbolBucket} from '../data/bucket/symbol_bucket.ts';
 import {warnOnce, mapObject} from '../util/util.ts';
 import {ImageAtlas} from '../render/image_atlas.ts';
 import {GlyphAtlas} from '../render/glyph_atlas.ts';
@@ -172,28 +170,21 @@ export class WorkerTile {
 
         for (const key in buckets) {
             const bucket = buckets[key];
-            if (bucket instanceof SymbolBucket) {
-                recalculateLayers(bucket.layers, this.zoom, availableImages);
-                performSymbolLayout({
-                    bucket,
-                    glyphMap,
-                    glyphPositions: glyphAtlas.positions,
-                    imageMap: iconMap,
-                    imagePositions: imageAtlas.iconPositions,
-                    showCollisionBoxes: this.showCollisionBoxes,
-                    canonical: this.tileID.canonical,
-                    subdivisionGranularity: options.subdivisionGranularity
-                });
-            } else if (bucket.hasDependencies) {
-                recalculateLayers(bucket.layers, this.zoom, availableImages);
-                bucket.addFeatures({
-                    options,
-                    canonical: this.tileID.canonical,
-                    imagePositions: imageAtlas.patternPositions,
-                    dashPositions,
-                    imageMap: patternMap
-                });
-            }
+            if (!bucket.hasDependencies) continue;
+
+            recalculateLayers(bucket.layers, this.zoom, availableImages);
+            bucket.addFeatures({
+                options,
+                canonical: this.tileID.canonical,
+                glyphMap,
+                glyphPositions: glyphAtlas.positions,
+                iconMap,
+                iconPositions: imageAtlas.iconPositions,
+                patternMap,
+                patternPositions: imageAtlas.patternPositions,
+                dashPositions,
+                showCollisionBoxes: this.showCollisionBoxes
+            });
         }
 
         return {

--- a/src/symbol/symbol_layout.ts
+++ b/src/symbol/symbol_layout.ts
@@ -1,21 +1,23 @@
+import murmur3 from 'murmurhash-js';
+import ONE_EM from './one_em.ts';
 import {Anchor} from './anchor.ts';
-
 import {getAnchors, getCenterAnchor} from './get_anchors.ts';
 import {clipLine} from './clip_line.ts';
 import {shapeText, shapeIcon, WritingMode, fitIconToText} from './shaping.ts';
 import {getGlyphQuads, getIconQuads} from './quads.ts';
 import {CollisionFeature} from './collision_feature.ts';
 import {warnOnce} from '../util/util.ts';
-import {
-    allowsVerticalWritingMode,
-    allowsLetterSpacing
-} from '../util/script_detection.ts';
+import {allowsVerticalWritingMode, allowsLetterSpacing} from '../util/script_detection.ts';
 import {findPoleOfInaccessibility} from '../util/find_pole_of_inaccessibility.ts';
 import {EXTENT} from '../data/extent.ts';
-import type {SymbolBucket} from '../data/bucket/symbol_bucket.ts';
 import {EvaluationParameters} from '../style/evaluation_parameters.ts';
 import {SIZE_PACK_FACTOR, MAX_PACKED_SIZE, MAX_GLYPH_ICON_SIZE} from './symbol_size.ts';
-import ONE_EM from './one_em.ts';
+import {getIconPadding, type SymbolPadding} from '../style/style_layer/symbol_style_layer.ts';
+import {getTextVariableAnchorOffset, evaluateVariableOffset, INVALID_TEXT_OFFSET, type TextAnchor, TextAnchorEnum} from '../style/style_layer/variable_text_anchor.ts';
+import {type VariableAnchorOffsetCollection, classifyRings} from '@maplibre/maplibre-gl-style-spec';
+import {subdivideVertexLine} from '../render/subdivision.ts';
+import type Point from '@mapbox/point-geometry';
+import type {SymbolBucket} from '../data/bucket/symbol_bucket.ts';
 import type {CanonicalTileID} from '../tile/tile_id.ts';
 import type {Shaping, PositionedIcon, TextJustify} from './shaping.ts';
 import type {CollisionBoxArray, TextAnchorOffsetArray} from '../data/array_types.g.ts';
@@ -26,13 +28,6 @@ import type {SymbolStyleLayer} from '../style/style_layer/symbol_style_layer.ts'
 import type {ImagePosition} from '../render/image_atlas.ts';
 import type {GlyphPosition} from '../render/glyph_atlas.ts';
 import type {PossiblyEvaluatedPropertyValue} from '../style/properties.ts';
-
-import type Point from '@mapbox/point-geometry';
-import murmur3 from 'murmurhash-js';
-import {getIconPadding, type SymbolPadding} from '../style/style_layer/symbol_style_layer.ts';
-import {type VariableAnchorOffsetCollection, classifyRings} from '@maplibre/maplibre-gl-style-spec';
-import {getTextVariableAnchorOffset, evaluateVariableOffset, INVALID_TEXT_OFFSET, type TextAnchor, TextAnchorEnum} from '../style/style_layer/variable_text_anchor.ts';
-import {subdivideVertexLine} from '../render/subdivision.ts';
 import type {SubdivisionGranularitySetting} from '../render/subdivision_granularity_settings.ts';
 
 // The symbol layout process needs `text-size` evaluated at up to five different zoom levels, and

--- a/src/symbol/symbol_layout.ts
+++ b/src/symbol/symbol_layout.ts
@@ -12,7 +12,7 @@ import {
 } from '../util/script_detection.ts';
 import {findPoleOfInaccessibility} from '../util/find_pole_of_inaccessibility.ts';
 import {EXTENT} from '../data/extent.ts';
-import {SymbolBucket} from '../data/bucket/symbol_bucket.ts';
+import type {SymbolBucket} from '../data/bucket/symbol_bucket.ts';
 import {EvaluationParameters} from '../style/evaluation_parameters.ts';
 import {SIZE_PACK_FACTOR, MAX_PACKED_SIZE, MAX_GLYPH_ICON_SIZE} from './symbol_size.ts';
 import ONE_EM from './one_em.ts';
@@ -695,7 +695,7 @@ function addSymbol(bucket: SymbolBucket,
     if (useRuntimeCollisionCircles)
         collisionCircleDiameter *= layoutTextSize / ONE_EM;
 
-    if (bucket.glyphOffsetArray.length >= SymbolBucket.MAX_GLYPHS) warnOnce(
+    if (bucket.glyphOffsetArray.length >= bucket.maxGlyphs) warnOnce(
         'Too many glyphs being rendered in a tile. See https://github.com/mapbox/mapbox-gl-js/issues/2907'
     );
 

--- a/src/symbol/symbol_size.ts
+++ b/src/symbol/symbol_size.ts
@@ -8,6 +8,14 @@ import type {InterpolationType, StylePropertyExpression} from '@maplibre/maplibr
 const MAX_GLYPH_ICON_SIZE = 255;
 const SIZE_PACK_FACTOR = 128;
 const MAX_PACKED_SIZE: number = MAX_GLYPH_ICON_SIZE * SIZE_PACK_FACTOR;
+/**
+ * The maximum number of glyphs per symbol bucket. UInt16 `glyphOffsetArrayStart`
+ * is the first index that can overflow at 65,535; see
+ * https://github.com/mapbox/mapbox-gl-js/issues/2907 for the motivation.
+ * Line and text-box starts could in theory overflow too, but there are far
+ * fewer boxes and lines than glyphs.
+ */
+export const MAX_GLYPHS = 65535;
 
 export {getSizeData, evaluateSizeForFeature, evaluateSizeForZoom, SIZE_PACK_FACTOR, MAX_GLYPH_ICON_SIZE, MAX_PACKED_SIZE};
 

--- a/src/webgl/draw/draw_custom.test.ts
+++ b/src/webgl/draw/draw_custom.test.ts
@@ -19,7 +19,7 @@ vi.mock(import('../../tile/tile'));
 vi.mock(import('../../data/bucket/symbol_bucket'), () => {
     return {
         SymbolBucket: vi.fn()
-    } as any;
+    };
 });
 vi.mock(import('../../symbol/projection'));
 

--- a/src/webgl/draw/draw_fill.test.ts
+++ b/src/webgl/draw/draw_fill.test.ts
@@ -27,7 +27,7 @@ vi.mock(import('../../tile/tile'));
 vi.mock(import('../../data/bucket/symbol_bucket'), () => {
     return {
         SymbolBucket: vi.fn()
-    } as any;
+    };
 });
 vi.mock(import('../../symbol/projection'));
 

--- a/src/webgl/draw/draw_symbol.test.ts
+++ b/src/webgl/draw/draw_symbol.test.ts
@@ -27,7 +27,7 @@ vi.mock(import('../../tile/tile'));
 vi.mock(import('../../data/bucket/symbol_bucket'), () => {
     return {
         SymbolBucket: vi.fn()
-    } as any;
+    };
 });
 
 vi.mock(import('../../symbol/projection'));


### PR DESCRIPTION
Follow-up to #8239 (Add SDF rendering support for fill patterns). This takes the last open review thread from that PR — unifying `performSymbolLayout` and `addFeatures` behind the `Bucket` interface — and lands it as its own change.

- Removes the `instanceof SymbolBucket` branch from `WorkerTile.parse`. Every bucket now finalizes the same way: `hasDependencies` gates the work, `recalculateLayers` runs once per bucket, and `addFeatures` receives one `BucketDependencyParameters` object carrying glyphs, icons, patterns, and dashes.
- `SymbolBucket.addFeatures()` (previously a no-op) now delegates to `performSymbolLayout`, so the symbol path drops its special-case call site.
- `BucketDependencyParameters` is widened into a params object, so adding symbol-only inputs costs nothing at the interface.

Behavior is unchanged: the same set of buckets runs `recalculateLayers` and finalization as before — circle/heatmap and dependency-free buckets are still skipped via `hasDependencies === false`.

Verified with `npm run typecheck` and the focused unit suites (`fill_bucket`, `symbol_bucket`, `worker_tile`).

Honestly, I was surprised how few changes this actually took once the `Bucket` interface was there — the hard part (keeping dependencies bucket-polymorphic) had already been done in #8239.