### PR TITLE
fix: stop re-opening sky and light transitions on every style update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Fix a `Not implemented.` error that broke panning and zooming when the projection was changed while the camera was moving, on maps with terrain enabled or a `transformCameraUpdate` callback ([#8351](https://github.com/maplibre/maplibre-gl-js/issues/8351)) (by [@lazerg](https://github.com/lazerg))
 - Fix a map created inside a hidden container staying at the `400x300` fallback size when the container is shown before the resize observer's first notification is delivered ([#8277](https://github.com/maplibre/maplibre-gl-js/issues/8277)) (by [@spliffone](https://github.com/spliffone))
 - Fix `MercatorTransform` throwing when it is resized to a zero width, and skip the matrix calculation of every projection while the transform has a zero width or height ([#8374](https://github.com/maplibre/maplibre-gl-js/pull/8374)) (by [@avosa](https://github.com/avosa))
+- Fix every style update opening a redundant sky and light transition, which kept `idle` from firing for the transition duration after the map was otherwise done, and could ease the sky and the light on a different curve from the layers ([#8348](https://github.com/maplibre/maplibre-gl-js/issues/8348)) (by [@cherenkov](https://github.com/cherenkov))
 - _...Add new stuff here..._
 
 ## 6.8.0

--- a/src/style/style.test.ts
+++ b/src/style/style.test.ts
@@ -13,7 +13,7 @@ import {OverscaledTileID} from '../tile/tile_id.ts';
 import {fakeServer, type FakeServer} from 'nise';
 import {ImageRequest} from '../util/image_request.ts';
 
-import {type EvaluationParameters} from './evaluation_parameters.ts';
+import {EvaluationParameters} from './evaluation_parameters.ts';
 import {Color, type Feature, type LayerSpecification, type GeoJSONSourceSpecification, type FilterSpecification, type SourceSpecification, type StyleSpecification, type SymbolLayerSpecification, type SkySpecification, type CameraFunctionSpecification} from '@maplibre/maplibre-gl-style-spec';
 import {type GeoJSONSource} from '../source/geojson_source.ts';
 import {StubMap, sleep, waitForEvent} from '../util/test/util.ts';
@@ -3744,6 +3744,55 @@ describe('Style.hasTransitions', () => {
         style.setPaintProperty('background', 'background-color', 'blue');
         style.update({transition: {duration: 0, delay: 0}} as EvaluationParameters);
         expect(style.hasTransitions()).toBe(false);
+    });
+
+    test('does not transition a sky or a light that has not changed', async () => {
+        const style = new Style(getStubMap());
+        style.loadJSON(createStyleJSON({
+            sky: {'sky-color': 'red'},
+            light: {color: '#ff0000'},
+            layers: [{id: 'background', type: 'background'}]
+        }));
+
+        await style.once('style.load');
+        style.setPaintProperty('background', 'background-color', 'blue');
+        style.update({transition: {duration: 300, delay: 0}} as EvaluationParameters);
+
+        expect(style.sky.hasTransition()).toBe(false);
+        expect(style.light.hasTransition()).toBe(false);
+    });
+
+    test('transitions the sky and the light when they are set', async () => {
+        const style = new Style(getStubMap());
+        style.loadJSON(createStyleJSON());
+
+        await style.once('style.load');
+        style.setSky({'sky-color': 'magenta'});
+        style.setLight({color: '#ff0000'});
+        style.update({transition: {duration: 300, delay: 0}} as EvaluationParameters);
+
+        expect(style.sky.hasTransition()).toBe(true);
+        expect(style.light.hasTransition()).toBe(true);
+    });
+
+    // A `global-state` expression reads the live global state object, so both ends of a transition
+    // evaluate to the same new value and there is nothing to interpolate. Opening one would only
+    // hold `idle` off. The new value still reaches the sky, through the recalculation that the
+    // global state change triggers anyway.
+    test('does not transition the sky when a global state property it reads changes, but still applies the value', async () => {
+        const style = new Style(getStubMap());
+        style.loadJSON(createStyleJSON({
+            state: {c: {default: '#ff0000'}},
+            sky: {'sky-color': ['global-state', 'c']}
+        }));
+
+        await style.once('style.load');
+        style.setGlobalStateProperty('c', '#0000ff');
+        style.update({transition: {duration: 300, delay: 0}} as EvaluationParameters);
+        style.sky.recalculate(new EvaluationParameters(0));
+
+        expect(style.sky.hasTransition()).toBe(false);
+        expect(style.sky.properties.get('sky-color')).toEqual(Color.parse('#0000ff'));
     });
 });
 

--- a/src/style/style.test.ts
+++ b/src/style/style.test.ts
@@ -3775,11 +3775,7 @@ describe('Style.hasTransitions', () => {
         expect(style.light.hasTransition()).toBe(true);
     });
 
-    // A `global-state` expression reads the live global state object, so both ends of a transition
-    // evaluate to the same new value and there is nothing to interpolate. Opening one would only
-    // hold `idle` off. The new value still reaches the sky, through the recalculation that the
-    // global state change triggers anyway.
-    test('does not transition the sky when a global state property it reads changes, but still applies the value', async () => {
+    test('applies a global state change to the sky without opening a transition', async () => {
         const style = new Style(getStubMap());
         style.loadJSON(createStyleJSON({
             state: {c: {default: '#ff0000'}},

--- a/src/style/style.ts
+++ b/src/style/style.ts
@@ -737,9 +737,6 @@ export class Style extends Evented<MapEventType> {
                 this._layers[id].updateTransitions(parameters);
             }
 
-            this.light.updateTransitions(parameters);
-            this.sky.updateTransitions(parameters);
-
             this._resetUpdates();
         }
 


### PR DESCRIPTION
- Fixes #8348

`Style.update()` called `sky.updateTransitions()` and `light.updateTransitions()` for any
`_changed`, unlike the layers above them, which are gated by `_updatedPaintProps`. Both
setters already open the transition after a `deepEqual` check, so this only added a
redundant second one — a transition from a value to itself on every style update, which
`hasTransition()` counts for its full duration, holding `idle` off. `setLayoutProperty`
reached `idle` in 321ms and 17 renders, against 38ms and 2 without these calls; a plain
load of `basic-v9.json` wastes ~15 `render()` passes.

Removing them also puts the sky and the light back on the same easing curve as the layers,
which the doubled call had skewed when they changed in the same frame as something else.

3 tests added to `Style.hasTransitions`: one fails without the fix, the other two guard the
paths that must still transition. Render suite unchanged.

## Launch Checklist

- [x] Confirm **your changes do not include backports from Mapbox projects**
- [x] Briefly describe the changes in this PR.
- [x] Link to related issues.
- [x] Write tests for all new functionality.
- [x] Add an entry to `CHANGELOG.md` under the `## main` section.
- [x] Confirm you have read our AI policy [here](https://github.com/maplibre/maplibre/blob/main/AI_POLICY.md).

Assisted-By: Claude Opus 5
