### PR TITLE
fix: Remove flat varyings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes
+- Remove the `flat` interpolation qualifier from shader varyings: ANGLE's Metal backend emulates GL's provoking-vertex rule for flat shading by rewriting the index buffer and syncing GPU→CPU on every draw, which on iPadOS 16 Safari hangs the GPU process outright and turns the map blank with an unresponsive page ([#8002](https://github.com/maplibre/maplibre-gl-js/issues/8002), reverts [#7661](https://github.com/maplibre/maplibre-gl-js/pull/7661))
 - Fix a marker's popup jumping to another world copy when the marker is moved across the antimeridian on a zoomed-out map ([#5655](https://github.com/maplibre/maplibre-gl-js/issues/5655), [#8326](https://github.com/maplibre/maplibre-gl-js/pull/8326), continues [#5956](https://github.com/maplibre/maplibre-gl-js/pull/5956)) (by [@yuiseki](https://github.com/yuiseki))
 - Fix terrain drape textures not being refreshed after zoom changes, causing stale rendering at the new zoom level ([#8251](https://github.com/maplibre/maplibre-gl-js/issues/8251))
 - Fix a gap between the sky and the ground at high pitch while globe transitions to mercator ([#7382](https://github.com/maplibre/maplibre-gl-js/issues/7382)) (by [@birkskyum](https://github.com/birkskyum))

--- a/src/shaders/flat_varyings.test.ts
+++ b/src/shaders/flat_varyings.test.ts
@@ -1,0 +1,23 @@
+import {describe, expect, test} from 'vitest';
+import {shaders} from './shaders';
+
+/**
+ * No shader may declare a `flat` varying.
+ *
+ * ANGLE's Metal backend cannot express OpenGL's provoking-vertex rule for
+ * flat shading directly (GL takes the last vertex of a primitive, Metal the
+ * first), so for every draw that uses a `flat` varying it rewrites the index
+ * buffer and maps it straight back — a GPU→CPU sync per draw
+ * (https://issues.chromium.org/issues/40286880). On iPadOS 16 Safari that
+ * hangs the GPU process outright (#8002). Every varying this library passes
+ * is constant across its primitive anyway, so interpolating it costs nothing
+ * and changes nothing.
+ */
+describe('shader varyings', () => {
+    test('are never declared flat', () => {
+        for (const [name, {vertexSource, fragmentSource}] of Object.entries(shaders)) {
+            expect(vertexSource, `${name} vertex shader`).not.toMatch(/\bflat\s+(in|out)\b/);
+            expect(fragmentSource, `${name} fragment shader`).not.toMatch(/\bflat\s+(in|out)\b/);
+        }
+    });
+});

--- a/src/shaders/glsl/circle.fragment.glsl
+++ b/src/shaders/glsl/circle.fragment.glsl
@@ -1,5 +1,5 @@
 in vec3 v_data;
-flat in float v_visibility;
+in float v_visibility;
 
 #pragma maplibre: define highp vec4 color
 #pragma maplibre: define mediump float radius

--- a/src/shaders/glsl/circle.vertex.glsl
+++ b/src/shaders/glsl/circle.vertex.glsl
@@ -7,7 +7,7 @@ uniform vec2 u_translate;
 layout(location = 0) in ivec2 a_pos;
 
 out vec3 v_data;
-flat out float v_visibility;
+out float v_visibility;
 
 #pragma maplibre: define highp vec4 color
 #pragma maplibre: define mediump float radius

--- a/src/shaders/glsl/collision_box.fragment.glsl
+++ b/src/shaders/glsl/collision_box.fragment.glsl
@@ -1,5 +1,5 @@
-flat in float v_placed;
-flat in float v_notUsed;
+in float v_placed;
+in float v_notUsed;
 
 void main() {
 

--- a/src/shaders/glsl/collision_box.vertex.glsl
+++ b/src/shaders/glsl/collision_box.vertex.glsl
@@ -1,8 +1,8 @@
 layout(location = 0) in vec2 a_anchor_pos;
 layout(location = 1) in vec2 a_placed;
 layout(location = 2) in vec2 a_box_real;
-flat out float v_placed;
-flat out float v_notUsed;
+out float v_placed;
+out float v_notUsed;
 
 void main() {
     gl_Position = projectTileWithElevation(a_anchor_pos, get_elevation(a_anchor_pos));

--- a/src/shaders/glsl/collision_circle.fragment.glsl
+++ b/src/shaders/glsl/collision_circle.fragment.glsl
@@ -1,6 +1,6 @@
-flat in float v_radius;
+in float v_radius;
 in vec2 v_extrude;
-flat in float v_collision;
+in float v_collision;
 
 void main() {
     float alpha = 0.5;

--- a/src/shaders/glsl/collision_circle.vertex.glsl
+++ b/src/shaders/glsl/collision_circle.vertex.glsl
@@ -1,9 +1,9 @@
 layout(location = 0) in vec2 a_pos;
 layout(location = 1) in float a_radius;
 layout(location = 2) in vec2 a_flags;
-flat out float v_radius;
+out float v_radius;
 out vec2 v_extrude;
-flat out float v_collision;
+out float v_collision;
 
 void main() {
     float radius = a_radius;

--- a/src/shaders/glsl/line.fragment.glsl
+++ b/src/shaders/glsl/line.fragment.glsl
@@ -1,4 +1,4 @@
-flat in vec2 v_width2;
+in vec2 v_width2;
 in vec2 v_normal;
 in float v_gamma_scale;
 #ifdef GLOBE

--- a/src/shaders/glsl/line.vertex.glsl
+++ b/src/shaders/glsl/line.vertex.glsl
@@ -12,7 +12,7 @@ layout(location = 1) in uvec4 a_data;
 uniform vec2 u_translation;
 uniform mediump float u_ratio;
 out vec2 v_normal;
-flat out vec2 v_width2;
+out vec2 v_width2;
 out float v_gamma_scale;
 out highp float v_linesofar;
 #ifdef GLOBE

--- a/src/shaders/glsl/line_gradient.fragment.glsl
+++ b/src/shaders/glsl/line_gradient.fragment.glsl
@@ -1,6 +1,6 @@
 uniform sampler2D u_image;
 
-flat in vec2 v_width2;
+in vec2 v_width2;
 in vec2 v_normal;
 in float v_gamma_scale;
 in highp vec2 v_uv;

--- a/src/shaders/glsl/line_gradient.vertex.glsl
+++ b/src/shaders/glsl/line_gradient.vertex.glsl
@@ -16,7 +16,7 @@ uniform mediump float u_ratio;
 uniform float u_image_height;
 
 out vec2 v_normal;
-flat out vec2 v_width2;
+out vec2 v_width2;
 out float v_gamma_scale;
 out highp vec2 v_uv;
 #ifdef GLOBE

--- a/src/shaders/glsl/line_gradient_sdf.fragment.glsl
+++ b/src/shaders/glsl/line_gradient_sdf.fragment.glsl
@@ -4,7 +4,7 @@ uniform float u_mix;
 uniform lowp float u_lineatlas_width;
 
 in vec2 v_normal;
-flat in vec2 v_width2;
+in vec2 v_width2;
 in vec2 v_tex_a;
 in vec2 v_tex_b;
 in float v_gamma_scale;

--- a/src/shaders/glsl/line_gradient_sdf.vertex.glsl
+++ b/src/shaders/glsl/line_gradient_sdf.vertex.glsl
@@ -24,7 +24,7 @@ uniform float u_crossfade_to;
 uniform float u_lineatlas_height;
 
 out vec2 v_normal;
-flat out vec2 v_width2;
+out vec2 v_width2;
 out float v_gamma_scale;
 out highp vec2 v_uv;
 out vec2 v_tex_a;

--- a/src/shaders/glsl/line_pattern.fragment.glsl
+++ b/src/shaders/glsl/line_pattern.fragment.glsl
@@ -8,10 +8,10 @@ uniform mediump vec3 u_scale;
 uniform sampler2D u_image;
 
 in vec2 v_normal;
-flat in vec2 v_width2;
+in vec2 v_width2;
 in float v_linesofar;
 in float v_gamma_scale;
-flat in float v_width;
+in float v_width;
 #ifdef GLOBE
 in float v_depth;
 #endif

--- a/src/shaders/glsl/line_pattern.vertex.glsl
+++ b/src/shaders/glsl/line_pattern.vertex.glsl
@@ -16,10 +16,10 @@ layout(location = 1) in uvec4 a_data;
 uniform vec2 u_translation;
 uniform mediump float u_ratio;
 out vec2 v_normal;
-flat out vec2 v_width2;
+out vec2 v_width2;
 out float v_linesofar;
 out float v_gamma_scale;
-flat out float v_width;
+out float v_width;
 #ifdef GLOBE
 out float v_depth;
 #endif

--- a/src/shaders/glsl/line_sdf.fragment.glsl
+++ b/src/shaders/glsl/line_sdf.fragment.glsl
@@ -3,7 +3,7 @@ uniform sampler2D u_image;
 uniform float u_mix;
 
 in vec2 v_normal;
-flat in vec2 v_width2;
+in vec2 v_width2;
 in vec2 v_tex_a;
 in vec2 v_tex_b;
 in float v_gamma_scale;

--- a/src/shaders/glsl/line_sdf.vertex.glsl
+++ b/src/shaders/glsl/line_sdf.vertex.glsl
@@ -21,7 +21,7 @@ uniform float u_crossfade_to;
 uniform float u_lineatlas_height;
 
 out vec2 v_normal;
-flat out vec2 v_width2;
+out vec2 v_width2;
 out vec2 v_tex_a;
 out vec2 v_tex_b;
 out float v_gamma_scale;

--- a/src/shaders/glsl/symbol_icon.fragment.glsl
+++ b/src/shaders/glsl/symbol_icon.fragment.glsl
@@ -1,7 +1,7 @@
 uniform sampler2D u_texture;
 
 in vec2 v_tex;
-flat in float v_total_opacity;
+in float v_total_opacity;
 
 void main() {
     fragColor = texture(u_texture, v_tex) * v_total_opacity;

--- a/src/shaders/glsl/symbol_icon.vertex.glsl
+++ b/src/shaders/glsl/symbol_icon.vertex.glsl
@@ -23,7 +23,7 @@ uniform bool u_is_offset;
 uniform bool u_height_anchor_ground;
 
 out vec2 v_tex;
-flat out float v_total_opacity;
+out float v_total_opacity;
 
 #pragma maplibre: define lowp float opacity
 

--- a/src/shaders/glsl/symbol_text_and_icon.fragment.glsl
+++ b/src/shaders/glsl/symbol_text_and_icon.fragment.glsl
@@ -10,7 +10,7 @@ uniform sampler2D u_texture_icon;
 uniform highp float u_gamma_scale;
 in vec4 v_data0;
 in vec3 v_data1;
-flat in float v_is_sdf;
+in float v_is_sdf;
 
 #pragma maplibre: define highp vec4 fill_color
 #pragma maplibre: define highp vec4 halo_color

--- a/src/shaders/glsl/symbol_text_and_icon.vertex.glsl
+++ b/src/shaders/glsl/symbol_text_and_icon.vertex.glsl
@@ -31,7 +31,7 @@ uniform bool u_height_anchor_ground;
 
 out vec4 v_data0;
 out vec3 v_data1;
-flat out float v_is_sdf;
+out float v_is_sdf;
 
 #pragma maplibre: define highp vec4 fill_color
 #pragma maplibre: define highp vec4 halo_color


### PR DESCRIPTION
## Summary

Removes the `flat` interpolation qualifier from the 26 shader varyings that #7661 (6.0.0-11) added it to. The qualifier adds nothing visible and, on ANGLE's Metal backend, makes every draw of a line, circle, collision or symbol bucket pay a GPU→CPU sync; on iPadOS 16 Safari that hangs the GPU process outright.

Fixes #8002 (same symptom: 6.0.0 "breaks map on real iOS devices without error message").

## The symptom

On an iPad on iPadOS 16.5.1, zooming a vector map in and out a few times makes the canvas go blank (the container background shows through), the page's main thread stops answering for ~5 s at a time and then for good, nothing is logged, `webglcontextlost` never fires, a reload does not recover, and only force-quitting Safari does. openfreemap.org (MapLibre 5.24) and other sites on 4.x are fine on the same device; the maplibre.org examples that draw tiles past ~z6 die.

## The bisect

Same static page, same OpenMapTiles style, same automated 7 ↔ 16.5 zoom, same device:

| version | result |
|---|---|
| 5.24.0 | runs |
| 6.0.0 | dies |
| 6.0.0-10 | runs |
| **6.0.0-11** | **dies** |
| 6.7.0 | dies |
| 6.7.0 with `flat` stripped from the bundle at load time | **runs** |

Three PRs landed between 6.0.0-10 and 6.0.0-11: a benchmark (#7664), a terrain-only framebuffer change (#7637), and #7661.

## Why

OpenGL takes the *last* vertex of a triangle as the provoking vertex for flat shading; Metal takes the *first*. To honour GL semantics, ANGLE's Metal backend rewrites the index buffer for any draw that uses a `flat` varying and maps it straight back, forcing a GPU→CPU sync per draw. This is a known ANGLE issue — [angleproject 40286880](https://issues.chromium.org/issues/40286880) — and was discussed on webgl-dev-list ([Performance problem on Safari, Chrome with ANGLE/Metal](https://groups.google.com/g/webgl-dev-list/c/UO1dTL6wo78)), where Ken Russell pointed at `flat` as the cause of "a few seconds per frame" and the fix was to remove the qualifiers. ANGLE-over-Metal is Safari on every iPhone, iPad and Mac, and Chrome on macOS; iPadOS 16 is the last WebKit its iPads will ever get.

Every varying #7661 touched is constant across the primitive (`v_width2`, `v_is_sdf`, `v_radius`, the collision flags…), so interpolating it yields the same value: no rendering changes. The PR's own description called the gain "arguably correctness" and its benchmark box was left unticked. The `v_data1`/`v_is_sdf` split from #7661 is kept; only the qualifier goes.

## Tests

- `src/shaders/flat_varyings.test.ts`: every shader's vertex and fragment source is asserted free of `flat in` / `flat out`, with the reason in the test. Fails against `main`, passes here.
- Render suite: 1684 of 1694 pass on this branch. The 10 that fail (`debug/*`, `text-local-glyphs/*`, `text-local-ideographs/cjk-symbols`, `font-faces/complex-scripts`, `text-field/formatted-grapheme-sections`, `raster-masking/overlapping-zoom`) fail identically on `main` with the same headless Chrome on the same machine — local-font and SwiftShader differences, not this change. Every line, circle, collision and symbol test renders pixel-identical before and after, which is the "no visual change" claim above, tested.

## Benchmark

`npm run bench-e2e`, both artifacts built locally from the same checkout (`main`'s shaders against this branch's), 16 runs each, headless Chrome on SwiftShader:

| | main | this branch | delta |
|---|---|---|---|
| bundleImport | 3.8 ms | 3.7 ms | −3.6% |
| styleLoad | 15.5 ms | 17.7 ms | +14.4% |
| firstTile | 206.7 ms | 200.0 ms | −3.2% |
| mapLoad | 291.6 ms | 282.2 ms | −3.2% |
| mapIdle | 340.7 ms | 351.0 ms | +3.0% |

All within the same-session noise the bench README warns about (the styleLoad delta is 2 ms on a step that never touches a shader). This is a software renderer, so it says the CPU side is unchanged; the GPU-side effect on ANGLE/Metal is the device table above, and the micro benchmarks do not cover shaders.

## Public API

None changed. The shaders are internal; the varyings keep their names and types, only the qualifier goes.

## Launch Checklist

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [x] Include before/after visuals or gifs if this PR includes visual changes. (no visual changes; the render suite is the evidence — see Tests)
 - [x] Write tests for all new functionality.
 - [x] Document any changes to public APIs. (none)
 - [x] Post benchmark scores.
 - [x] Add an entry to `CHANGELOG.md` under the `## main` section.
 - [x] Confirm you have read our AI policy [here](https://github.com/maplibre/maplibre/blob/main/AI_POLICY.md).