### PR TITLE
perf: skip hidden layers before their clipping masks and drop the dynamic buffer rebinds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## main
 ### ✨ Features and improvements
 - Read sprite and image pixels back through an `OffscreenCanvas` where available, removing a main-thread stall of tens of milliseconds on GPU-accelerated browsers when a sprite loads ([#8339](https://github.com/maplibre/maplibre-gl-js/pull/8339)) (by [@cherenkov](https://github.com/cherenkov))
+- Skip layers that are hidden at the current zoom before rendering their tile clipping masks, and stop re-binding dynamic vertex buffers on every cached vertex array bind; on a terrain style with layers outside their zoom range this removes about a fifth of the WebGL calls per frame
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## main
 ### ✨ Features and improvements
 - Read sprite and image pixels back through an `OffscreenCanvas` where available, removing a main-thread stall of tens of milliseconds on GPU-accelerated browsers when a sprite loads ([#8339](https://github.com/maplibre/maplibre-gl-js/pull/8339)) (by [@cherenkov](https://github.com/cherenkov))
-- Skip layers that are hidden at the current zoom before rendering their tile clipping masks, and stop re-binding dynamic vertex buffers on every cached vertex array bind; on a terrain style with layers outside their zoom range this removes about a fifth of the WebGL calls per frame
+- Skip layers that are hidden at the current zoom before rendering their tile clipping masks, and stop re-binding dynamic vertex buffers on every cached vertex array bind; on a terrain style with layers outside their zoom range this removes about a fifth of the WebGL calls per frame ([#8369](https://github.com/maplibre/maplibre-gl-js/pull/8369))
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## main
 ### ✨ Features and improvements
 - Read sprite and image pixels back through an `OffscreenCanvas` where available, removing a main-thread stall of tens of milliseconds on GPU-accelerated browsers when a sprite loads ([#8339](https://github.com/maplibre/maplibre-gl-js/pull/8339)) (by [@cherenkov](https://github.com/cherenkov))
-- Skip layers that are hidden at the current zoom before rendering their tile clipping masks, and stop re-binding dynamic vertex buffers on every cached vertex array bind; on a terrain style with layers outside their zoom range this removes about a fifth of the WebGL calls per frame ([#8369](https://github.com/maplibre/maplibre-gl-js/pull/8369))
+- Skip clipping masks for layers hidden at the current zoom and stop re-binding dynamic buffers on cached vertex array binds, removing redundant WebGL calls every frame ([#8369](https://github.com/maplibre/maplibre-gl-js/pull/8369))
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes

--- a/src/render/painter.test.ts
+++ b/src/render/painter.test.ts
@@ -9,7 +9,6 @@ import {Texture} from '../webgl/texture.ts';
 import {createNullGL} from '../util/test/null_gl.ts';
 import {restoreNow, setNow} from '../util/time_control.ts';
 import {OverscaledTileID} from '../tile/tile_id.ts';
-import {createStyleLayer} from '../style/create_style_layer.ts';
 
 describe('render', () => {
     let painter: Painter;
@@ -51,17 +50,6 @@ describe('render', () => {
         painter.render(style, renderOptions);
 
         expect(painter.renderOptions.currentPass).toBe('translucent');
-    });
-
-    test('does not set up tile clipping for a layer hidden at the current zoom', () => {
-        const coord = new OverscaledTileID(0, 0, 0, 0, 0);
-        style.tileManagers = {source: {used: false, prepare: vi.fn(), getVisibleCoordinates: () => [coord]}} as any;
-        style._layers = {hidden: createStyleLayer({id: 'hidden', type: 'fill', source: 'source', minzoom: 10}, {})};
-        style._order = ['hidden'];
-
-        painter.render(style, renderOptions);
-
-        expect(painter.currentStencilSource).toBeUndefined();
     });
 
     test('calls terrainDepth', () => {

--- a/src/render/painter.test.ts
+++ b/src/render/painter.test.ts
@@ -9,6 +9,7 @@ import {Texture} from '../webgl/texture.ts';
 import {createNullGL} from '../util/test/null_gl.ts';
 import {restoreNow, setNow} from '../util/time_control.ts';
 import {OverscaledTileID} from '../tile/tile_id.ts';
+import {createStyleLayer} from '../style/create_style_layer.ts';
 
 describe('render', () => {
     let painter: Painter;
@@ -50,6 +51,23 @@ describe('render', () => {
         painter.render(style, renderOptions);
 
         expect(painter.renderOptions.currentPass).toBe('translucent');
+    });
+
+    test('skips clipping masks and drawing for layers hidden at the current zoom', () => {
+        const coord = new OverscaledTileID(0, 0, 0, 0, 0);
+        style.tileManagers = {source: {used: false, prepare: vi.fn(), getVisibleCoordinates: () => [coord]}} as any;
+        style._layers = {
+            hidden: createStyleLayer({id: 'hidden', type: 'fill', source: 'source', minzoom: 10}, {}),
+            visible: createStyleLayer({id: 'visible', type: 'fill', source: 'source'}, {}),
+        };
+        style._order = ['hidden', 'visible'];
+        const renderTileClippingMasks = vi.spyOn(painter, 'renderTileClippingMasks').mockImplementation(() => {});
+        const renderLayer = vi.spyOn(painter, 'renderLayer').mockImplementation(() => {});
+
+        painter.render(style, renderOptions);
+
+        expect(renderTileClippingMasks.mock.calls.map(([layer]) => layer.id)).toEqual(['visible', 'visible']);
+        expect(renderLayer.mock.calls.map(([, , layer]) => layer.id)).toEqual(['visible', 'visible']);
     });
 
     test('calls terrainDepth', () => {

--- a/src/render/painter.test.ts
+++ b/src/render/painter.test.ts
@@ -56,7 +56,7 @@ describe('render', () => {
     test('does not set up tile clipping for a layer hidden at the current zoom', () => {
         const coord = new OverscaledTileID(0, 0, 0, 0, 0);
         style.tileManagers = {source: {used: false, prepare: vi.fn(), getVisibleCoordinates: () => [coord]}} as any;
-        style._layers = {hidden: createStyleLayer({id: 'hidden', type: 'fill', source: 'source', minzoom: 10}, {})} as any;
+        style._layers = {hidden: createStyleLayer({id: 'hidden', type: 'fill', source: 'source', minzoom: 10}, {})};
         style._order = ['hidden'];
 
         painter.render(style, renderOptions);

--- a/src/render/painter.test.ts
+++ b/src/render/painter.test.ts
@@ -53,21 +53,15 @@ describe('render', () => {
         expect(painter.renderOptions.currentPass).toBe('translucent');
     });
 
-    test('skips clipping masks and drawing for layers hidden at the current zoom', () => {
+    test('does not set up tile clipping for a layer hidden at the current zoom', () => {
         const coord = new OverscaledTileID(0, 0, 0, 0, 0);
         style.tileManagers = {source: {used: false, prepare: vi.fn(), getVisibleCoordinates: () => [coord]}} as any;
-        style._layers = {
-            hidden: createStyleLayer({id: 'hidden', type: 'fill', source: 'source', minzoom: 10}, {}),
-            visible: createStyleLayer({id: 'visible', type: 'fill', source: 'source'}, {}),
-        };
-        style._order = ['hidden', 'visible'];
-        const renderTileClippingMasks = vi.spyOn(painter, 'renderTileClippingMasks').mockImplementation(() => {});
-        const renderLayer = vi.spyOn(painter, 'renderLayer').mockImplementation(() => {});
+        style._layers = {hidden: createStyleLayer({id: 'hidden', type: 'fill', source: 'source', minzoom: 10}, {})} as any;
+        style._order = ['hidden'];
 
         painter.render(style, renderOptions);
 
-        expect(renderTileClippingMasks.mock.calls.map(([layer]) => layer.id)).toEqual(['visible', 'visible']);
-        expect(renderLayer.mock.calls.map(([, , layer]) => layer.id)).toEqual(['visible', 'visible']);
+        expect(painter.currentStencilSource).toBeUndefined();
     });
 
     test('calls terrainDepth', () => {

--- a/src/render/painter.ts
+++ b/src/render/painter.ts
@@ -593,6 +593,7 @@ export class Painter {
 
             for (renderOptions.currentLayer = layerIds.length - 1; renderOptions.currentLayer >= 0; renderOptions.currentLayer--) {
                 const layer = this.style._layers[layerIds[renderOptions.currentLayer]];
+                if (layer.isHidden(this.transform.zoom)) continue;
                 const tileManager = tileManagers[layer.source];
                 const coords = coordsAscending[layer.source];
 
@@ -609,6 +610,7 @@ export class Painter {
 
         for (renderOptions.currentLayer = 0; renderOptions.currentLayer < layerIds.length; renderOptions.currentLayer++) {
             const layer = this.style._layers[layerIds[renderOptions.currentLayer]];
+            if (layer.isHidden(this.transform.zoom)) continue;
             const tileManager = tileManagers[layer.source];
 
             if (this.renderToTexture?.renderLayer(layer, renderOptions)) continue;

--- a/src/ui/map_tests/map_render.test.ts
+++ b/src/ui/map_tests/map_render.test.ts
@@ -258,12 +258,17 @@ describe('hidden layers', () => {
             layers: [
                 {id: 'shared-fill', type: 'fill', source: 'shared'},
                 {id: 'other-fill', type: 'fill', source: 'other'},
-                {id: 'shared-hidden-fill', type: 'fill', source: 'shared', minzoom: 10}
+                {id: 'shared-fill-hidden-below-zoom-10', type: 'fill', source: 'shared', minzoom: 10}
             ]
         }});
-        await map.once('idle');
+        const lastSourceToRenderClippingMasks = () => map.painter.currentStencilSource;
 
-        expect(map.painter.currentStencilSource).toBe('other');
+        await map.once('idle');
+        expect(lastSourceToRenderClippingMasks()).toBe('other');
+
+        map.setLayerZoomRange('shared-fill-hidden-below-zoom-10', 0, 24);
+        await map.once('idle');
+        expect(lastSourceToRenderClippingMasks()).toBe('shared');
         map.remove();
     });
 });

--- a/src/ui/map_tests/map_render.test.ts
+++ b/src/ui/map_tests/map_render.test.ts
@@ -248,3 +248,22 @@ describe('render-to-texture follow-up frame', () => {
         map.remove();
     });
 });
+
+describe('hidden layers', () => {
+    test('a layer hidden at the current zoom does not render tile clipping masks for its source', async () => {
+        const square: GeoJSON.Feature = {type: 'Feature', geometry: {type: 'Polygon', coordinates: [[[-10, -10], [10, -10], [10, 10], [-10, 10], [-10, -10]]]}, properties: {}};
+        const map = createMap({style: {
+            version: 8,
+            sources: {shared: {type: 'geojson', data: square}, other: {type: 'geojson', data: square}},
+            layers: [
+                {id: 'shared-fill', type: 'fill', source: 'shared'},
+                {id: 'other-fill', type: 'fill', source: 'other'},
+                {id: 'shared-hidden-fill', type: 'fill', source: 'shared', minzoom: 10}
+            ]
+        }});
+        await map.once('idle');
+
+        expect(map.painter.currentStencilSource).toBe('other');
+        map.remove();
+    });
+});

--- a/src/webgl/index_buffer.ts
+++ b/src/webgl/index_buffer.ts
@@ -38,8 +38,8 @@ export class IndexBuffer {
     updateData(array: StructArray): void {
         const gl = this.context.gl;
         if (!this.dynamicDraw) throw new Error('Attempted to update data while not in dynamic mode.');
-        // The right VAO will get this buffer re-bound later in VertexArrayObject.bind
-        // See https://github.com/mapbox/mapbox-gl-js/issues/5620
+        // As in the constructor, leave the bound vertex array's element array binding alone; vertex arrays
+        // using this buffer read the new data through their own binding. See https://github.com/mapbox/mapbox-gl-js/issues/5620
         this.context.unbindVAO();
         this.bind();
         gl.bufferSubData(gl.ELEMENT_ARRAY_BUFFER, 0, array.arrayBuffer);

--- a/src/webgl/vertex_array_object.ts
+++ b/src/webgl/vertex_array_object.ts
@@ -65,23 +65,6 @@ export class VertexArrayObject {
             this.freshBind(program, layoutVertexBuffer, paintVertexBuffers, indexBuffer, vertexOffset, dynamicVertexBuffer, dynamicVertexBuffer2, dynamicVertexBuffer3);
         } else {
             context.bindVertexArray.set(this.vao);
-
-            if (dynamicVertexBuffer) {
-                // The buffer may have been updated. Rebind to upload data.
-                dynamicVertexBuffer.bind();
-            }
-
-            if (indexBuffer?.dynamicDraw) {
-                indexBuffer.bind();
-            }
-
-            if (dynamicVertexBuffer2) {
-                dynamicVertexBuffer2.bind();
-            }
-
-            if (dynamicVertexBuffer3) {
-                dynamicVertexBuffer3.bind();
-            }
         }
     }
 

--- a/test/build/bundle_size.json
+++ b/test/build/bundle_size.json
@@ -1,14 +1,14 @@
 {
     "dist/maplibre-gl.mjs": {
-        "raw": 584162,
-        "gzip": 148605
+        "raw": 585124,
+        "gzip": 148792
     },
     "dist/maplibre-gl-worker.mjs": {
         "raw": 19002,
         "gzip": 6024
     },
     "dist/maplibre-gl-shared.mjs": {
-        "raw": 493279,
-        "gzip": 138574
+        "raw": 493281,
+        "gzip": 138576
     }
 }


### PR DESCRIPTION
Two wasted-command paths in the render loop, found while attributing the per-frame WebGL command stream of a terrain style on a Galaxy S24.

**Hidden layers still rendered clipping masks.** Both render passes call `renderTileClippingMasks` before `renderLayer`, and only `renderLayer` checks `isHidden`. A fill or line layer outside its zoom range therefore still switches the stencil source and re-renders a clipping mask for every tile, on every frame, whenever its source differs from the layer before it. With the mapeak style at zoom 12 (one such line layer with `minzoom` 15), that is 19 to 40 stencil draws per frame, each with its own uniform buffer uploads. The loops now skip hidden layers up front, in both passes; the render-to-texture path already returns `false` for hidden layers without touching its stack bookkeeping, so the draped stacks are unchanged.

**Cached vertex array binds re-bound the dynamic buffers.** `VertexArrayObject.bind` re-bound the dynamic layout, opacity and index buffers on every cached bind, with a comment saying the buffer may have been updated. An `ARRAY_BUFFER` binding is not vertex array state and `updateData` binds the buffer it writes, so those calls did nothing. Symbol draws paid two or three extra `bindBuffer` calls each.

Measured on the mapeak style (264 layers, 63 of them symbol, terrain on) at a 980x2109 viewport, steady moving frame, with a GL call census in headless Chrome:

| | main | this branch |
|---|---|---|
| WebGL calls per frame | 3729 | 3067 |
| draws per frame | 281 | 240 |
| clipping mask draws | 40 | 1 |
| `bindBuffer` calls | 885 | 373 |
| `stencilFunc` calls | 41 | 0 |

On the S24 itself (Chrome 152, desktop-site layout) the GPU-side frame time moved by less than the run-to-run noise; this branch does not fix that device's steady frame, it removes work that should not be there. Symbol draws are what that frame is spent on (about 5 ms of a 17 ms frame, 214 draws for 63 layers times 13 tiles); that lane is separate.

Tests: a map test renders two GeoJSON sources, a fill on each and a third fill on the first source hidden by its `minzoom`, and checks that the clipping masks in place at the end of the frame are the second source's (`painter.currentStencilSource`); on main the hidden layer switches them back to the first source. Full unit and render suites pass.

## Launch Checklist

 - [x] No backports from Mapbox projects
 - [x] Changes described above
 - [x] Tests for the new behavior
 - [x] No file with a `*.bench.ts` sibling touched
 - [x] `CHANGELOG.md` entry under `## main`
 - [x] AI policy read

Assisted-By: Claude Fable 5.1

