### PR TITLE
Limit memory retained by recycled terrain RTT textures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## main
 ### ✨ Features and improvements
+- Reduce memory retained by unused terrain render-to-texture targets while preserving reuse during rendering ([#8370](https://github.com/maplibre/maplibre-gl-js/pull/8370)) (by [@DoFabien](https://github.com/DoFabien))
 - Add `map.getStyleUrl()`, which returns the URL the style was loaded from, or `null` when the style was given as an object ([#7109](https://github.com/maplibre/maplibre-gl-js/issues/7109))
 - Sample terrain render-to-texture output through mipmaps with trilinear filtering, so draped layers stop shimmering and aliasing at high pitch ([#8328](https://github.com/maplibre/maplibre-gl-js/pull/8328), continues [#7673](https://github.com/maplibre/maplibre-gl-js/pull/7673)) (by [@AveryanAlex](https://github.com/AveryanAlex))
 - Build the `Intl.Segmenter` instances used for text shaping on first use instead of at import, shaving several milliseconds off loading MapLibre on the main thread ([#8337](https://github.com/maplibre/maplibre-gl-js/pull/8337)) (by [@cherenkov](https://github.com/cherenkov))

--- a/src/render/painter.test.ts
+++ b/src/render/painter.test.ts
@@ -1,5 +1,5 @@
 import {describe, beforeEach, test, expect, vi, afterEach} from 'vitest';
-import {Painter} from './painter.ts';
+import {Painter, type RTTObject} from './painter.ts';
 import {MercatorTransform} from '../geo/projection/mercator_transform.ts';
 import {GlobeProjection} from '../geo/projection/globe_projection.ts';
 import {Style} from '../style/style.ts';
@@ -50,6 +50,28 @@ describe('render', () => {
         painter.render(style, renderOptions);
 
         expect(painter.renderOptions.currentPass).toBe('translucent');
+    });
+
+    test('render allows RTT reuse before destroying excess textures at the end of the frame', () => {
+        const oversizedRTT = painter.acquireRTT(8192);
+        painter.releaseRTT(oversizedRTT);
+
+        let rttUsedDuringRender: RTTObject;
+        style.loadEmpty();
+        style.addLayer({
+            id: 'reuses-rtt',
+            type: 'custom',
+            render() {
+                rttUsedDuringRender = painter.acquireRTT(8192);
+                painter.releaseRTT(rttUsedDuringRender);
+            }
+        });
+
+        painter.render(style, renderOptions);
+
+        expect(rttUsedDuringRender).toBe(oversizedRTT);
+        expect(oversizedRTT.texture.texture).toBeNull();
+        painter.destroy();
     });
 
     test('calls terrainDepth', () => {
@@ -172,6 +194,7 @@ describe('RTT pool', () => {
     let painter: Painter;
 
     beforeEach(() => {
+        vi.useFakeTimers();
         const gl = createNullGL();
         const transform = new MercatorTransform({minZoom: 0, maxZoom: 22, minPitch: 0, maxPitch: 60, renderWorldCopies: true});
         painter = new Painter(gl, transform);
@@ -179,6 +202,7 @@ describe('RTT pool', () => {
 
     afterEach(() => {
         painter.destroy();
+        vi.useRealTimers();
     });
 
     test('acquireRTT creates on miss, recycles on hit', () => {
@@ -202,6 +226,64 @@ describe('RTT pool', () => {
         expect(b.texture.size).toEqual([512, 512]);
     });
 
+    test('destroys a resized RTT that exceeds the memory budget', () => {
+        const rtt = painter.acquireRTT(2048);
+        painter.releaseRTT(rtt);
+
+        const resizedRTT = painter.acquireRTT(8192);
+        painter.releaseRTT(resizedRTT);
+        vi.runOnlyPendingTimers();
+
+        expect(resizedRTT.texture.texture).toBeNull();
+    });
+
+    test('trims to twelve 2048px mipmapped textures when no render follows', () => {
+        const retainedRTTs = Array.from({length: 12}, () => painter.acquireRTT(2048));
+        const excessRTT = painter.acquireRTT(2048);
+
+        for (const rtt of retainedRTTs) painter.releaseRTT(rtt);
+        painter.releaseRTT(excessRTT);
+        expect(excessRTT.texture.texture).not.toBeNull();
+
+        vi.advanceTimersByTime(100);
+
+        for (const rtt of retainedRTTs) expect(rtt.texture.texture).not.toBeNull();
+        expect(excessRTT.texture.texture).toBeNull();
+    });
+
+    test('keeps a reused RTT alive until it is released again', () => {
+        const oversizedRTT = painter.acquireRTT(8192);
+        painter.releaseRTT(oversizedRTT);
+
+        const reusedRTT = painter.acquireRTT(8192);
+        expect(reusedRTT).toBe(oversizedRTT);
+
+        vi.runOnlyPendingTimers();
+
+        expect(reusedRTT.texture.texture).not.toBeNull();
+
+        painter.releaseRTT(reusedRTT);
+        vi.runOnlyPendingTimers();
+
+        expect(reusedRTT.texture.texture).toBeNull();
+    });
+
+    test('trimming detaches an oversized texture without changing the bound framebuffer', () => {
+        const gl = painter.context.gl;
+        const oversizedRTT = painter.acquireRTT(8192);
+        painter.bindRTT(oversizedRTT);
+        const otherFramebuffer = painter.context.createFramebuffer(16, 16, false, false);
+        painter.context.bindFramebuffer.set(otherFramebuffer.framebuffer);
+
+        painter.releaseRTT(oversizedRTT);
+        vi.runOnlyPendingTimers();
+
+        expect(oversizedRTT.texture.texture).toBeNull();
+        expect(gl.framebufferTexture2D).toHaveBeenLastCalledWith(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, null, 0);
+        expect(painter.context.bindFramebuffer.get()).toBe(otherFramebuffer.framebuffer);
+        otherFramebuffer.destroy();
+    });
+
     test('bindRTT lazily creates shared FBO and binds texture', () => {
         expect(painter._rttSharedFbo).toBeNull();
         const obj = painter.acquireRTT(256);
@@ -218,6 +300,16 @@ describe('RTT pool', () => {
         const b = painter.acquireRTT(512);
         painter.bindRTT(b);
         expect(painter._rttSharedFbo.size).toBe(512);
+    });
+
+    test('painter.destroy cancels a pending RTT cleanup', () => {
+        const rtt = painter.acquireRTT(8192);
+        painter.releaseRTT(rtt);
+        expect(vi.getTimerCount()).toBe(1);
+
+        painter.destroy();
+
+        expect(vi.getTimerCount()).toBe(0);
     });
 
     test('painter.destroy cleans up pooled RTT textures and shared FBO', () => {

--- a/src/render/painter.ts
+++ b/src/render/painter.ts
@@ -93,6 +93,10 @@ export class Painter {
      * A pool of recyclable {@link RTTObject}s (textures only; the FBO is shared).
      */
     _rttObjectRecyclePool: RTTObject[];
+    /** Estimated RGBA8 storage retained by the pool, including all mip levels. */
+    _rttObjectRecyclePoolBytes: number;
+    /** Fallback cleanup when released textures are not followed by another render. */
+    private _rttRecyclePoolTimer: ReturnType<typeof setTimeout>;
     /**
      * Shared FBO used by all RTT render passes. The color attachment is
      * swapped to the target RTTObject's texture via {@link bindRTT}.
@@ -160,6 +164,7 @@ export class Painter {
         this.layerOpacityFbo = null;
         this._tileTextures = {};
         this._rttObjectRecyclePool = [];
+        this._rttObjectRecyclePoolBytes = 0;
         this._rttSharedFbo = null;
         this.terrainFacilitator = {depthDirty: true, matrix: mat4.identity(new Float64Array(16)), renderTime: 0};
 
@@ -650,6 +655,7 @@ export class Painter {
         // Set defaults for most GL values so that anyone using the state after the render
         // encounters more expected values.
         this.context.setDefault();
+        this._trimRTTRecyclePool();
     }
 
     /**
@@ -709,6 +715,8 @@ export class Painter {
     }
 
     static readonly MAX_TEXTURE_POOL_SIZE_PER_BUCKET = 50;
+    /** Retain up to twelve 2048px RGBA8 mip chains after rendering; active textures are not capped. */
+    static readonly MAX_RTT_RECYCLE_POOL_BYTES: number = 256 * 1024 * 1024;
 
     saveTileTexture(texture: Texture): void {
         const textures = this._tileTextures[texture.size[0]];
@@ -730,6 +738,7 @@ export class Painter {
         const gl = this.context.gl;
         const obj = this._rttObjectRecyclePool.pop();
         if (obj) {
+            this._rttObjectRecyclePoolBytes -= this._rttTextureByteSize(obj.size);
             if (obj.size !== size) {
                 obj.texture.update({width: size, height: size, data: null}, {premultiply: false, useMipmap: true});
                 obj.texture.bind(gl.LINEAR, gl.CLAMP_TO_EDGE, gl.LINEAR_MIPMAP_LINEAR);
@@ -780,8 +789,45 @@ export class Painter {
         this.context.bindFramebuffer.set(this._rttSharedFbo.fbo.framebuffer);
     }
 
+    /**
+     * Returns a texture for reuse before trimming the reserve at the end of rendering.
+     * A 100 ms fallback trims the reserve if no render follows.
+     */
     releaseRTT(obj: RTTObject): void {
         this._rttObjectRecyclePool.push(obj);
+        this._rttObjectRecyclePoolBytes += this._rttTextureByteSize(obj.size);
+        if (this._rttObjectRecyclePoolBytes <= Painter.MAX_RTT_RECYCLE_POOL_BYTES || this._rttRecyclePoolTimer !== undefined) return;
+
+        this._rttRecyclePoolTimer = setTimeout(() => this._trimRTTRecyclePool(), 100);
+    }
+
+    /**
+     * Frees unused textures above the reserve budget and cancels the fallback cleanup.
+     * Detaches the color target before deletion because even an unbound framebuffer can
+     * keep the texture's storage alive, preserving the caller's framebuffer binding.
+     */
+    private _trimRTTRecyclePool(): void {
+        clearTimeout(this._rttRecyclePoolTimer);
+        this._rttRecyclePoolTimer = undefined;
+        while (this._rttObjectRecyclePoolBytes > Painter.MAX_RTT_RECYCLE_POOL_BYTES) {
+            const obj = this._rttObjectRecyclePool.pop();
+            this._rttObjectRecyclePoolBytes -= this._rttTextureByteSize(obj.size);
+            if (this._rttSharedFbo?.fbo.colorAttachment.get() === obj.texture.texture) {
+                const framebuffer = this.context.bindFramebuffer.get();
+                this._rttSharedFbo.fbo.colorAttachment.set(null);
+                this.context.bindFramebuffer.set(framebuffer);
+            }
+            obj.texture.destroy();
+        }
+    }
+
+    /** Estimates square RGBA8 texture storage, including every mip level down to 1 × 1. */
+    private _rttTextureByteSize(size: number): number {
+        let bytes = 0;
+        for (let levelSize = size; levelSize >= 1; levelSize = Math.floor(levelSize / 2)) {
+            bytes += levelSize * levelSize * 4;
+        }
+        return bytes;
     }
 
     /**
@@ -866,6 +912,8 @@ export class Painter {
     }
 
     destroy(): void {
+        clearTimeout(this._rttRecyclePoolTimer);
+        this._rttRecyclePoolTimer = undefined;
         if (this._tileTextures) {
             for (const size in this._tileTextures) {
                 const textures = this._tileTextures[size];
@@ -882,6 +930,7 @@ export class Painter {
             obj.texture.destroy();
         }
         this._rttObjectRecyclePool = [];
+        this._rttObjectRecyclePoolBytes = 0;
 
         if (this._rttSharedFbo) {
             // Detach so Framebuffer.destroy() doesn't delete the texture/renderbuffer


### PR DESCRIPTION
Currently, released terrain RTT textures are pooled without a memory budget. After a demanding view, the pool can retain several hundred MiB of unused textures, even after terrain is disabled, adding memory pressure on resource-constrained devices. There is no automatic eviction to reclaim excess textures once peak demand has passed. The mipmaps recently added increase that storage cost by roughly one third.

This PR trims the unused reserve to **256 MiB**, including mipmaps, at the end of rendering so textures can be reused within the same frame. A **100 ms fallback timer** handles cleanup when no render follows. The budget accommodates 12  2048² RGBA8 textures with mipmaps; active textures remain outside it, and temporary overshoots are possible before cleanup. Rendering quality is unchanged.

Desktop and mobil diagnostics retained the same RTT creation count as main, while the estimated reserve after disabling terrain fell from **469–725 MiB to 256 MiB**. No general FPS improvement is established by these measurements.

## Launch Checklist

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [ ] Link to related issues.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] If you changed code in a file that has a benchmark file next to it (`*.bench.ts`), post before/after results of `npm run bench` (the compare workflow is in `test/bench/README.md`).
 - [x] Add an entry to `CHANGELOG.md` under the `## main` section.
 - [x] Confirm you have read our AI policy [here](https://github.com/maplibre/maplibre/blob/main/AI_POLICY.md).

 Assisted-By: GPT 5.6

