### PR TITLE
fix: preserve property removals when merging GeoJSON updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes
+- Fix queued GeoJSON `updateData` property removals throwing after geometry-only updates or retaining previously updated values.
 - _...Add new stuff here..._
 
 ## 6.8.0

--- a/src/source/geojson_source_diff.test.ts
+++ b/src/source/geojson_source_diff.test.ts
@@ -636,6 +636,65 @@ describe('mergeSourceDiffs', () => {
         expect(merged.update[0].removeProperties).toHaveLength(1);
     });
 
+    test('removes properties after a geometry-only update', () => {
+        const point: GeoJSON.Feature = {
+            type: 'Feature',
+            id: 'point',
+            geometry: {type: 'Point', coordinates: [0, 0]},
+            properties: {remove: 'old', keep: 'unchanged'}
+        };
+        const diff1 = {
+            update: [{id: 'point', newGeometry: {type: 'Point', coordinates: [1, 1]}}]
+        } satisfies GeoJSONSourceDiff;
+        const diff2 = {
+            update: [{id: 'point', removeProperties: ['remove']}]
+        } satisfies GeoJSONSourceDiff;
+        const sequential = toUpdateable(point);
+        applySourceDiff(sequential, diff1);
+        applySourceDiff(sequential, diff2);
+
+        const merged = toUpdateable(point);
+        applySourceDiff(merged, mergeSourceDiffs(diff1, diff2));
+
+        expect(merged).toEqual(sequential);
+        expect(merged.get('point')).toEqual({
+            ...point,
+            geometry: {type: 'Point', coordinates: [1, 1]},
+            properties: {keep: 'unchanged'}
+        });
+    });
+
+    test('removes all queued updates for a property while retaining other updates', () => {
+        const point: GeoJSON.Feature = {
+            type: 'Feature',
+            id: 'point',
+            geometry: {type: 'Point', coordinates: [0, 0]},
+            properties: {remove: 'old', keep: 'old'}
+        };
+        const diff1 = {
+            update: [{id: 'point', addOrUpdateProperties: [{key: 'remove', value: 'first'}]}]
+        } satisfies GeoJSONSourceDiff;
+        const diff2 = {
+            update: [{id: 'point', addOrUpdateProperties: [
+                {key: 'remove', value: 'second'},
+                {key: 'keep', value: 'updated'}
+            ]}]
+        } satisfies GeoJSONSourceDiff;
+        const diff3 = {
+            update: [{id: 'point', removeProperties: ['remove']}]
+        } satisfies GeoJSONSourceDiff;
+        const sequential = toUpdateable(point);
+        applySourceDiff(sequential, diff1);
+        applySourceDiff(sequential, diff2);
+        applySourceDiff(sequential, diff3);
+
+        const merged = toUpdateable(point);
+        applySourceDiff(merged, mergeSourceDiffs(mergeSourceDiffs(diff1, diff2), diff3));
+
+        expect(merged).toEqual(sequential);
+        expect(merged.get('point').properties).toEqual({keep: 'updated'});
+    });
+
     test('merges two diffs remove feature properties then update feature properties - retains both operations', () => {
         const diff1 = {
             update: [{id: 'feature1', removeProperties: ['prop1']}]

--- a/src/source/geojson_source_diff.ts
+++ b/src/source/geojson_source_diff.ts
@@ -293,11 +293,9 @@ function mergeFeatureDiffs(prev: GeoJSONFeatureDiff, next: GeoJSONFeatureDiff): 
         delete next.removeProperties;
     }
     // Removing properties that were added or updated in previous
-    if (next.removeProperties) {
-        for (const key of next.removeProperties) {
-            const index = prev.addOrUpdateProperties.findIndex(prop => prop.key === key);
-            if (index > -1) prev.addOrUpdateProperties.splice(index, 1);
-        }
+    if (next.removeProperties && prev.addOrUpdateProperties) {
+        const removedProperties = new Set(next.removeProperties);
+        prev.addOrUpdateProperties = prev.addOrUpdateProperties.filter(prop => !removedProperties.has(prop.key));
     }
 
     // Merge the two diffs


### PR DESCRIPTION
Queued `GeoJSONSource.updateData` calls can throw when a property removal follows a geometry-only update: the previous diff has no `addOrUpdateProperties` array. Removing a property after repeatedly updating it can also leave an older queued value behind because only the first matching update is removed.

Guard the optional array and filter out every superseded update for the removed keys. Two regressions compare the resulting feature data from merged updates with sequentially applied updates. Related to #6339; that original report was already fixed separately.

Validation:
- `npm run test-unit -- src/source/geojson_source_diff.test.ts --maxWorkers=1 --no-file-parallelism` — 43 passed; the two new regressions fail before the fix.
- `npx --no-install eslint src/source/geojson_source_diff.ts src/source/geojson_source_diff.test.ts` and `git diff --check` pass.
- Tested on Windows with Node 24.11.1; the repository requests Node 26. No full build or rendering suite was run.

Launch checklist:
- [x] No Mapbox backports; changes were developed from this repository's implementation.
- [x] Changes and related issue described above.
- [x] Regression tests added.
- [x] Changelog entry added; no public API changes.
- [x] AI policy read; assistance disclosed below.
- [x] Human contributor code review before marking ready.

Generated-By: OpenAI Codex (GPT-6), implementation, tests, and draft description. The task was to identify a bounded, reproducible bug, check for duplicate PRs, and validate a focused fix without heavy local workloads. This PR remains a draft pending the human contributor's review as required by the AI policy.
