### PR TITLE
fix: treat camera options given as undefined as not given

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes
-- Treat camera options given as `undefined` (`{bearing: undefined}` and the like, as optional fields often produce) as not given in `jumpTo`, `easeTo` and `flyTo`, instead of coercing them to NaN and breaking the transform; `calculateCameraOptionsFromCameraLngLatAltRotation` without a roll produced such an object ([#8373](https://github.com/maplibre/maplibre-gl-js/pull/8373)) (by [@vlumi](https://github.com/vlumi))
+- Treat camera options passed as `undefined` as not given in `jumpTo`, `easeTo` and `flyTo`; they were coerced to NaN ([#8373](https://github.com/maplibre/maplibre-gl-js/pull/8373)) (by [@vlumi](https://github.com/vlumi))
 - _...Add new stuff here..._
 
 ## 6.8.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes
+- Treat camera options given as `undefined` (`{bearing: undefined}` and the like, as optional fields often produce) as not given in `jumpTo`, `easeTo` and `flyTo`, instead of coercing them to NaN and breaking the transform; `calculateCameraOptionsFromCameraLngLatAltRotation` without a roll produced such an object ([#8373](https://github.com/maplibre/maplibre-gl-js/pull/8373)) (by [@vlumi](https://github.com/vlumi))
 - _...Add new stuff here..._
 
 ## 6.8.0

--- a/src/ui/camera.test.ts
+++ b/src/ui/camera.test.ts
@@ -3960,3 +3960,45 @@ describe('zoomSnap', () => {
         expect(camera.getZoom()).toBe(10.0);
     });
 });
+
+describe('camera options given as undefined are treated as absent', () => {
+    const state = (camera: Camera) => ({
+        zoom: camera.getZoom(),
+        bearing: camera.getBearing(),
+        pitch: camera.getPitch(),
+        roll: camera.getRoll(),
+        elevation: camera.transform.elevation
+    });
+    const start = {zoom: 3, bearing: 30, pitch: 40, roll: 5, elevation: 100};
+    function cameraAtStart() {
+        const {camera} = createCamera({maxPitch: 60});
+        camera.jumpTo({center: [10, 20], ...start});
+        return camera;
+    }
+    const undefinedOptions = {zoom: undefined, bearing: undefined, pitch: undefined, roll: undefined, elevation: undefined, padding: undefined};
+
+    test('jumpTo', () => {
+        const camera = cameraAtStart();
+        camera.jumpTo(undefinedOptions);
+        expect(state(camera)).toEqual(start);
+    });
+
+    test('jumpTo with zoom snapping', () => {
+        const {camera} = createCamera({zoomSnap: 1});
+        camera.jumpTo({zoom: 3});
+        camera.jumpTo({zoom: undefined});
+        expect(camera.getZoom()).toBe(3);
+    });
+
+    test('easeTo', () => {
+        const camera = cameraAtStart();
+        camera.easeTo({...undefinedOptions, duration: 0});
+        expect(state(camera)).toEqual(start);
+    });
+
+    test('flyTo', () => {
+        const camera = cameraAtStart();
+        camera.flyTo({...undefinedOptions, center: [10, 20], animate: false});
+        expect(state(camera)).toEqual(start);
+    });
+});

--- a/src/ui/camera.test.ts
+++ b/src/ui/camera.test.ts
@@ -94,8 +94,7 @@ describe('calculateCameraOptionsFromCameraLngLatAltRotation', () => {
         expect(cameraOptions.roll).toBeUndefined();
     });
 
-    test('the result can be jumped to when no roll was given', () => {
-        // Its own camera: the jump below moves it, and the other tests here read the shared one from its start.
+    test('a fresh camera can be jumped to the result when no roll was given', () => {
         const {camera: own} = createCamera({maxPitch: 180}, false, {zoom: 1});
         const cameraOptions: CameraOptions = own.calculateCameraOptionsFromCameraLngLatAltRotation({lng: 1, lat: 0}, 1000, 30, 60);
         expect(() => own.jumpTo(cameraOptions)).not.toThrow();

--- a/src/ui/camera.test.ts
+++ b/src/ui/camera.test.ts
@@ -94,6 +94,16 @@ describe('calculateCameraOptionsFromCameraLngLatAltRotation', () => {
         expect(cameraOptions.roll).toBeUndefined();
     });
 
+    test('the result can be jumped to when no roll was given', () => {
+        // Its own camera: the jump below moves it, and the other tests here read the shared one from its start.
+        const {camera: own} = createCamera({maxPitch: 180}, false, {zoom: 1});
+        const cameraOptions: CameraOptions = own.calculateCameraOptionsFromCameraLngLatAltRotation({lng: 1, lat: 0}, 1000, 30, 60);
+        expect(() => own.jumpTo(cameraOptions)).not.toThrow();
+        expect(own.getRoll()).toBe(0);
+        expect(own.getBearing()).toBeCloseTo(30);
+        expect(own.getPitch()).toBeCloseTo(60);
+    });
+
     test('look level', () => {
         const cameraOptions: CameraOptions = camera.calculateCameraOptionsFromCameraLngLatAltRotation({lng: 1, lat: 0}, 0, 0, 90);
         expect(cameraOptions).toBeDefined();

--- a/src/ui/camera.ts
+++ b/src/ui/camera.ts
@@ -636,7 +636,7 @@ export class Camera extends Evented<MapEventType> {
     jumpTo(options: JumpToOptions, eventData?: any): this {
         this.stop();
 
-        if ('zoom' in options && this._zoomSnap) {
+        if (options.zoom !== undefined && this._zoomSnap) {
             options.zoom = evaluateZoomSnap(options.zoom, this._zoomSnap);
         }
 
@@ -653,21 +653,21 @@ export class Camera extends Evented<MapEventType> {
 
         const zoomChanged = tr.zoom !== oldZoom;
 
-        if ('elevation' in options && tr.elevation !== +options.elevation) {
+        if (options.elevation !== undefined && tr.elevation !== +options.elevation) {
             tr.setElevation(+options.elevation);
         }
 
-        if ('bearing' in options && tr.bearing !== +options.bearing) {
+        if (options.bearing !== undefined && tr.bearing !== +options.bearing) {
             bearingChanged = true;
             tr.setBearing(+options.bearing);
         }
 
-        if ('pitch' in options && tr.pitch !== +options.pitch) {
+        if (options.pitch !== undefined && tr.pitch !== +options.pitch) {
             pitchChanged = true;
             tr.setPitch(+options.pitch);
         }
 
-        if ('roll' in options && tr.roll !== +options.roll) {
+        if (options.roll !== undefined && tr.roll !== +options.roll) {
             rollChanged = true;
             tr.setRoll(+options.roll);
         }
@@ -728,7 +728,7 @@ export class Camera extends Evented<MapEventType> {
             easing: defaultEasing
         }, options);
 
-        if ('zoom' in options && this._zoomSnap) {
+        if (options.zoom !== undefined && this._zoomSnap) {
             options.zoom = evaluateZoomSnap(options.zoom, this._zoomSnap);
         }
 
@@ -740,10 +740,10 @@ export class Camera extends Evented<MapEventType> {
         const startBearing = this.getBearing(),
             startPitch = tr.pitch,
             startRoll = tr.roll,
-            bearing = 'bearing' in options ? this._normalizeBearing(options.bearing, startBearing) : startBearing,
-            pitch = 'pitch' in options ? +options.pitch : startPitch,
-            roll = 'roll' in options ? this._normalizeBearing(options.roll, startRoll) : startRoll,
-            padding = ('padding' in options ? options.padding : tr.padding) as PaddingOptions;
+            bearing = options.bearing !== undefined ? this._normalizeBearing(options.bearing, startBearing) : startBearing,
+            pitch = options.pitch !== undefined ? +options.pitch : startPitch,
+            roll = options.roll !== undefined ? this._normalizeBearing(options.roll, startRoll) : startRoll,
+            padding = (options.padding !== undefined ? options.padding : tr.padding) as PaddingOptions;
         const offsetAsPoint = Point.convert(options.offset);
 
         let around, aroundPoint;
@@ -1009,7 +1009,7 @@ export class Camera extends Evented<MapEventType> {
             easing: defaultEasing
         }, options);
 
-        if ('zoom' in options && this._zoomSnap) {
+        if (options.zoom !== undefined && this._zoomSnap) {
             options.zoom = evaluateZoomSnap(options.zoom, this._zoomSnap);
         }
 
@@ -1019,10 +1019,10 @@ export class Camera extends Evented<MapEventType> {
             startRoll = tr.roll,
             startPadding = tr.padding;
 
-        const bearing = 'bearing' in options ? this._normalizeBearing(options.bearing, startBearing) : startBearing;
-        const pitch = 'pitch' in options ? +options.pitch : startPitch;
-        const roll = 'roll' in options ? this._normalizeBearing(options.roll, startRoll) : startRoll;
-        const padding = ('padding' in options ? options.padding : tr.padding) as PaddingOptions;
+        const bearing = options.bearing !== undefined ? this._normalizeBearing(options.bearing, startBearing) : startBearing;
+        const pitch = options.pitch !== undefined ? +options.pitch : startPitch;
+        const roll = options.roll !== undefined ? this._normalizeBearing(options.roll, startRoll) : startRoll;
+        const padding = (options.padding !== undefined ? options.padding : tr.padding) as PaddingOptions;
 
         const offsetAsPoint = Point.convert(options.offset);
         let pointAtOffset = tr.centerPoint.add(offsetAsPoint);
@@ -1104,10 +1104,10 @@ export class Camera extends Evented<MapEventType> {
             w = (s) => Math.exp(k * rho * s);
         }
 
-        if ('duration' in options) {
+        if (options.duration !== undefined) {
             options.duration = +options.duration;
         } else {
-            const V = 'screenSpeed' in options ? +options.screenSpeed / rho : +options.speed;
+            const V = options.screenSpeed !== undefined ? +options.screenSpeed / rho : +options.speed;
             options.duration = 1000 * S / V;
         }
 


### PR DESCRIPTION
## Launch Checklist

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [ ] Link to related issues. (None filed; this PR carries the report.)
 - [ ] Include before/after visuals or gifs if this PR includes visual changes. (No visual change.)
 - [x] Write tests for all new functionality.
 - [ ] Document any changes to public APIs. (No API change; undefined options were never documented to break the map.)
 - [ ] If you changed code in a file that has a benchmark file next to it (`*.bench.ts`), post before/after results of `npm run bench` (the compare workflow is in `test/bench/README.md`). (No benchmark beside `camera.ts`.)
 - [x] Add an entry to `CHANGELOG.md` under the `## main` section.
 - [x] Confirm you have read our AI policy [here](https://github.com/maplibre/maplibre/blob/main/AI_POLICY.md).

Assisted-By: Claude Fable 5.1 (Anthropic), via Claude Code

## What

`jumpTo`, `easeTo` and `flyTo` decide which camera options to apply by key presence (`'roll' in options`) and then coerce the value with a unary plus or the bearing normalizer. An option built from an optional field, `{roll: options.roll}` with `roll?: number`, is present with the value `undefined`, `+undefined` is NaN, and the transform takes it: every matrix is NaN from then on and the jump, or the next camera call, throws `Cannot read properties of null (reading '0')` from a null inverse. The map cannot recover.

The seventeen presence checks become definedness checks, `options.roll !== undefined`, the idiom this file's constructor already uses for its options: `zoom` (the snap step in all three methods), `elevation`, `bearing`, `pitch`, `roll` in `jumpTo`; `bearing`, `pitch`, `roll`, `padding` in `easeTo` and `flyTo`; `duration`, `screenSpeed` in `flyTo`. `center` and `padding` in `jumpTo` were already guarded by value. No new helper: the tree checks definedness inline in some eighty places and had the `in` idiom only here. No behavior change for callers who pass values, `0` and `null` included; nobody can have relied on the old behavior, since its only result was a broken map.

## How it was found

`calculateCameraOptionsFromCameraLngLatAltRotation` returns exactly such an object when called without a roll (`roll: undefined`). Placing a camera on a moving satellite with its result every frame worked once and then failed on every call. The attached [repro.html](https://github.com/user-attachments/files/31933137/repro.html) shows it on 6.8.0 in both projections with an empty style. The helper still returns the key as `undefined`, harmless now; if you would rather it left the key out, that is a one-line follow-up I can open.

## Tests

In a commit of their own before the fix, so CI shows them red first: with the camera at a known zoom, bearing, pitch, roll and elevation, `jumpTo`, `easeTo` (duration 0) and `flyTo` (animate false) given every option as `undefined` leave it there; `jumpTo({zoom: undefined})` with zoom snapping on leaves the zoom; and the helper's result without a roll can be jumped to.

## AI disclosure

Code and tests were written with Claude Fable 5.1 in Claude Code, prompted by me with the observed failure and the direction to take at each step: find why every camera call failed after the first, bisect the helper's result against a hand-written one, survey the presence checks in the three methods, prefer the file's existing idiom over a new helper, split the tests from the fix. I reviewed every line and ran the unit tests, lint and type check locally.
