### PR TITLE
Fix MercatorTransform throwing when resized to a zero width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Treat camera options passed as `undefined` as not given in `jumpTo`, `easeTo` and `flyTo`; they were coerced to NaN ([#8373](https://github.com/maplibre/maplibre-gl-js/pull/8373)) (by [@vlumi](https://github.com/vlumi))
 - Fix a `Not implemented.` error that broke panning and zooming when the projection was changed while the camera was moving, on maps with terrain enabled or a `transformCameraUpdate` callback ([#8351](https://github.com/maplibre/maplibre-gl-js/issues/8351)) (by [@lazerg](https://github.com/lazerg))
 - Fix a map created inside a hidden container staying at the `400x300` fallback size when the container is shown before the resize observer's first notification is delivered ([#8277](https://github.com/maplibre/maplibre-gl-js/issues/8277)) (by [@spliffone](https://github.com/spliffone))
+- Fix `MercatorTransform` throwing when it is resized to a zero width, and skip the matrix calculation of every projection while the transform has a zero width or height ([#8374](https://github.com/maplibre/maplibre-gl-js/pull/8374)) (by [@avosa](https://github.com/avosa))
 - _...Add new stuff here..._
 
 ## 6.8.0

--- a/src/geo/projection/globe_transform.test.ts
+++ b/src/geo/projection/globe_transform.test.ts
@@ -36,6 +36,34 @@ function createGlobeTransform() {
 }
 
 describe('GlobeTransform', () => {
+    describe('zero size', () => {
+        test('does not throw when cloned at a zero size', () => {
+            for (const [width, height] of [[0, 480], [640, 0]]) {
+                const globeTransform = new GlobeTransform();
+                globeTransform.resize(width, height);
+                expect(() => globeTransform.clone()).not.toThrow();
+            }
+        });
+
+        test('calculates matrices again once a zero width becomes a real size', () => {
+            const globeTransform = new GlobeTransform();
+            globeTransform.resize(0, 480);
+            globeTransform.setZoom(3);
+            globeTransform.setCenter(new LngLat(10, 20));
+            const resized = globeTransform.clone();
+            resized.resize(640, 480, true);
+
+            const expected = new GlobeTransform();
+            expected.resize(640, 480);
+            expected.setZoom(3);
+            expected.setCenter(new LngLat(10, 20));
+
+            expect([...resized.modelViewProjectionMatrix]).toEqual([...expected.modelViewProjectionMatrix]);
+            expect(resized.screenPointToLocation(new Point(320, 240)).lng).toBeCloseTo(10, 6);
+            expect(resized.screenPointToLocation(new Point(320, 240)).lat).toBeCloseTo(20, 6);
+        });
+    });
+
     describe('getProjectionData', () => {
         const globeTransform = createGlobeTransform();
         test('mercator tile extents are set', () => {

--- a/src/geo/projection/mercator_transform.test.ts
+++ b/src/geo/projection/mercator_transform.test.ts
@@ -68,6 +68,44 @@ describe('transform', () => {
         }).not.toThrow();
     });
 
+    test('does not throw on a zero size', () => {
+        for (const [width, height] of [[0, 500], [500, 0], [0, 0]]) {
+            const transform = new MercatorTransform({minZoom: 0, maxZoom: 22, minPitch: 0, maxPitch: 60, renderWorldCopies: true});
+            expect(() => transform.resize(width, height)).not.toThrow();
+            expect(transform.width).toBe(width);
+            expect(transform.height).toBe(height);
+        }
+    });
+
+    test('does not throw when a sized transform is resized to a zero width', () => {
+        const transform = new MercatorTransform({minZoom: 0, maxZoom: 22, minPitch: 0, maxPitch: 60, renderWorldCopies: true});
+        transform.resize(500, 500);
+        expect(() => transform.resize(0, 500)).not.toThrow();
+        expect(() => transform.setZoom(3)).not.toThrow();
+    });
+
+    test('calculates matrices again once a zero width becomes a real size', () => {
+        const transform = new MercatorTransform({minZoom: 0, maxZoom: 22, minPitch: 0, maxPitch: 60, renderWorldCopies: true});
+        transform.resize(0, 500);
+        transform.setZoom(5);
+        transform.setPitch(30);
+        transform.setBearing(45);
+        transform.setCenter(new LngLat(10, 20));
+        transform.resize(500, 500);
+
+        const expected = new MercatorTransform({minZoom: 0, maxZoom: 22, minPitch: 0, maxPitch: 60, renderWorldCopies: true});
+        expected.resize(500, 500);
+        expected.setZoom(5);
+        expected.setPitch(30);
+        expected.setBearing(45);
+        expected.setCenter(new LngLat(10, 20));
+
+        expect([...transform.modelViewProjectionMatrix]).toEqual([...expected.modelViewProjectionMatrix]);
+        expect([...transform.cameraPosition]).toEqual([...expected.cameraPosition]);
+        expect(fixedLngLat(transform.screenPointToLocation(new Point(250, 250)))).toEqual({lng: 10, lat: 20});
+        expect(fixedCoord(transform.screenPointToMercatorCoordinate(new Point(250, 250)))).toEqual(fixedCoord(expected.screenPointToMercatorCoordinate(new Point(250, 250))));
+    });
+
     test('setLocationAt', () => {
         const transform = new MercatorTransform({minZoom: 0, maxZoom: 22, minPitch: 0, maxPitch: 60, renderWorldCopies: true});
         transform.resize(500, 500);

--- a/src/geo/projection/mercator_transform.ts
+++ b/src/geo/projection/mercator_transform.ts
@@ -715,8 +715,6 @@ export class MercatorTransform implements ITransform {
     }
 
     _calcMatrices(): void {
-        if (!this._helper._height) return;
-
         const offset = this.centerOffset;
         const point = projectToWorldCoordinates(this.worldSize, this.center);
         const x = point.x, y = point.y;

--- a/src/geo/projection/vertical_perspective_transform.ts
+++ b/src/geo/projection/vertical_perspective_transform.ts
@@ -463,10 +463,6 @@ export class VerticalPerspectiveTransform implements ITransform {
     }
 
     private _calcMatrices(): void {
-        if (!this._helper._width || !this._helper._height) {
-            return;
-        }
-
         const globeRadiusPixels = getGlobeRadiusPixels(this.worldSize, this.center.lat);
 
         // Construct a completely separate matrix for globe view

--- a/src/geo/transform_helper.test.ts
+++ b/src/geo/transform_helper.test.ts
@@ -12,6 +12,17 @@ const emptyCallbacks = {
 };
 
 describe('TransformHelper', () => {
+    test('does not calculate the projection matrices while the width or height is zero', () => {
+        let calls = 0;
+        const helper = new TransformHelper({...emptyCallbacks, calcMatrices: () => { calls++; }});
+        helper.resize(0, 480, false);
+        helper.resize(640, 0, false);
+        helper.resize(0, 0, false);
+        expect(calls).toBe(0);
+        helper.resize(640, 480, false);
+        expect(calls).toBe(1);
+    });
+
     test('apply', () => {
         const original = new TransformHelper(emptyCallbacks);
         original.setConstrainOverride((lngLat, zoom) => {

--- a/src/geo/transform_helper.ts
+++ b/src/geo/transform_helper.ts
@@ -565,25 +565,27 @@ export class TransformHelper implements ITransformGetters {
      * This function is called every time one of the transform's defining properties (center, pitch, etc.) changes.
      * This function should update the transform's internal data, such as matrices.
      * Any derived `_calcMatrices` function should also call the base function first. The base function only depends on the `_width` and `_height` fields.
+     * While either dimension is zero there is no view to build, so the derived function is not called at all.
      */
     private _calcMatrices(): void {
-        if (this._width && this._height) {
-            this._pixelsToGLUnits = [2 / this._width, -2 / this._height];
-
-            let m = mat4.identity(new Float64Array(16));
-            mat4.scale(m, m, [this._width / 2, -this._height / 2, 1]);
-            mat4.translate(m, m, [1, -1, 0]);
-            this._clipSpaceToPixelsMatrix = m;
-
-            m = mat4.identity(new Float64Array(16));
-            mat4.scale(m, m, [1, -1, 1]);
-            mat4.translate(m, m, [-1, -1, 0]);
-            mat4.scale(m, m, [2 / this._width, 2 / this._height, 1]);
-            this._pixelsToClipSpaceMatrix = m;
-            const halfFov = this.fovInRadians / 2;
-            this._cameraToCenterDistance = 0.5 / Math.tan(halfFov) * this._height;
-        }
         this._pixelPerMeter = mercatorZfromAltitude(1, this.center.lat) * this.worldSize;
+        if (!this._width || !this._height) {
+            return;
+        }
+        this._pixelsToGLUnits = [2 / this._width, -2 / this._height];
+
+        let m = mat4.identity(new Float64Array(16));
+        mat4.scale(m, m, [this._width / 2, -this._height / 2, 1]);
+        mat4.translate(m, m, [1, -1, 0]);
+        this._clipSpaceToPixelsMatrix = m;
+
+        m = mat4.identity(new Float64Array(16));
+        mat4.scale(m, m, [1, -1, 1]);
+        mat4.translate(m, m, [-1, -1, 0]);
+        mat4.scale(m, m, [2 / this._width, 2 / this._height, 1]);
+        this._pixelsToClipSpaceMatrix = m;
+        const halfFov = this.fovInRadians / 2;
+        this._cameraToCenterDistance = 0.5 / Math.tan(halfFov) * this._height;
         this._callbacks.calcMatrices();
     }
 


### PR DESCRIPTION
## Launch Checklist

`MercatorTransform._calcMatrices` skipped only a zero height. With a zero width and a real height it built the perspective matrix from an aspect ratio of zero, which put `Infinity` and `NaN` into every matrix. A transform that had never been sized then threw a `TypeError` in `mat4.multiply` on its first use, and a transform that had a real size and was resized to zero width threw in `vec4.transformMat4` on the null inverse.

`TransformHelper._calcMatrices` guarded only its own pixel matrices and then always called the projection's. Globe and vertical perspective each carried a copy of the check and mercator checked height alone. The check now lives once in the helper, which skips the projection's calculation while either dimension is zero, and the two copies are gone. Globe keeps its own check because `setTransitionState` calls its `_calcMatrices` directly. A transform with a real size computes exactly what it did before, and a transform that was zero wide computes its matrices from the current camera state on its first real resize. Constant time, no allocation.

Tests cover the helper never calling the projection while either dimension is zero, a zero size in each dimension, a sized transform resized to a zero width, recovery once the width is real again (matrices, camera position and unprojection match a transform that was never zero), and a globe transform cloned at a zero size and recovering the same way.

The benched function, `screenTerrainPointToMercatorCoordinate`, does not run `_calcMatrices`; the guard runs once per camera change in the bench setup. The compare workflow in `test/bench/README.md` puts both trees within noise of each other on p75 for every case.

* [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license). If you are not sure about this, please ask!
* [x] Briefly describe the changes in this PR.
* [x] Write tests for all new functionality.
* [x] If you changed code in a file that has a benchmark file next to it (`*.bench.ts`), post before/after results of `npm run bench` (the compare workflow is in `test/bench/README.md`).
* [x] Add an entry to `CHANGELOG.md` under the `## main` section.
* [x] Confirm you have read our AI policy [here](https://github.com/maplibre/maplibre/blob/main/AI_POLICY.md).

