### PR TITLE
docs: add PR link and author to GeoJSON changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes
-- Fix queued GeoJSON `updateData` property removals throwing after geometry-only updates or retaining previously updated values.
+- Fix queued GeoJSON `updateData` property removals throwing after geometry-only updates or retaining previously updated values ([#8372](https://github.com/maplibre/maplibre-gl-js/pull/8372)) (by [@jokrasno](https://github.com/jokrasno))
 - Treat camera options passed as `undefined` as not given in `jumpTo`, `easeTo` and `flyTo`; they were coerced to NaN ([#8373](https://github.com/maplibre/maplibre-gl-js/pull/8373)) (by [@vlumi](https://github.com/vlumi))
 - _...Add new stuff here..._
 


### PR DESCRIPTION
Adds the PR link and author to the changelog entry for #8372, as Harel requested. Changelog only, no code changes.