### PR TITLE
Validate sky before writing it, and route sky errors to the map

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -6,6 +6,7 @@
     "ACAC",
     "adiff",
     "afterjs",
+    "Ameur",
     "APAB",
     "APAC",
     "APNG",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes
+- Fix `map.setSky()` silently keeping the old sky and firing no `error` event when the value included a `-transition` key ([#8375](https://github.com/maplibre/maplibre-gl-js/issues/8375)) (by [@Yasser-Ameur](https://github.com/Yasser-Ameur))
 - Fix queued GeoJSON `updateData` property removals throwing after geometry-only updates or retaining previously updated values ([#8372](https://github.com/maplibre/maplibre-gl-js/pull/8372)) (by [@jokrasno](https://github.com/jokrasno))
 - Treat camera options passed as `undefined` as not given in `jumpTo`, `easeTo` and `flyTo`; they were coerced to NaN ([#8373](https://github.com/maplibre/maplibre-gl-js/pull/8373)) (by [@vlumi](https://github.com/vlumi))
 - Fix a `Not implemented.` error that broke panning and zooming when the projection was changed while the camera was moving, on maps with terrain enabled or a `transformCameraUpdate` callback ([#8351](https://github.com/maplibre/maplibre-gl-js/issues/8351)) (by [@lazerg](https://github.com/lazerg))

--- a/src/style/style.test.ts
+++ b/src/style/style.test.ts
@@ -1484,6 +1484,28 @@ describe('Style.setSky', () => {
         expect(inputJson.sky).toBe(inputSky);
         expect(inputJsonString).toEqual(JSON.stringify(inputJson));
     });
+
+    test('fires an error on the style when given an invalid property', async () => {
+        const style = new Style(getStubMap());
+        style.loadJSON(createStyleJSON({sky: {'sky-color': 'red'}}));
+        await style.once('style.load');
+
+        const promise = style.once('error');
+        style.setSky({'sky-color': 'blue', 'not-a-sky-property': 1} as any);
+        const event = await promise;
+        expect(event.error.message).toContain('not-a-sky-property');
+    });
+
+    test('keeps the previous value from getSky() after a rejected setSky', async () => {
+        const style = new Style(getStubMap());
+        style.loadJSON(createStyleJSON({sky: {'sky-color': 'red'}}));
+        await style.once('style.load');
+
+        style.on('error', () => {});
+        style.setSky({'sky-color': 'blue', 'not-a-sky-property': 1} as any);
+
+        expect(style.getSky()).toEqual({'sky-color': 'red'});
+    });
 });
 
 describe('Style.setGlyphs', () => {

--- a/src/style/style.ts
+++ b/src/style/style.ts
@@ -499,6 +499,7 @@ export class Style extends Evented<MapEventType> {
         this._setProjectionInternal(this.stylesheet.projection?.type || 'mercator');
 
         this.sky = new Sky(this.stylesheet.sky, this._globalState);
+        this.sky.setEventedParent(this);
 
         // The stylesheet's terrain was already validated as part of the style itself.
         this.map.setTerrain(this.stylesheet.terrain ?? null, {validate: false});
@@ -1744,6 +1745,8 @@ export class Style extends Evented<MapEventType> {
         }
         if (!update) return;
 
+        if (this._validate(validateStyle.sky, 'sky', skyOptions, null, options)) return;
+
         const parameters = {
             now: now(),
             transition: extend({
@@ -1753,7 +1756,7 @@ export class Style extends Evented<MapEventType> {
         };
 
         this.stylesheet.sky = skyOptions;
-        this.sky.setSky(skyOptions, options);
+        this.sky.setSky(skyOptions, {...options, validate: false});
         this.sky.updateTransitions(parameters);
     }
 

--- a/src/style/style.ts
+++ b/src/style/style.ts
@@ -1726,6 +1726,8 @@ export class Style extends Evented<MapEventType> {
 
     setSky(skyOptions?: SkySpecification, options: StyleSetterOptions = {}): void {
         this._checkLoaded();
+        if (this._validate(validateStyle.sky, 'sky', skyOptions, null, options)) return;
+
         const sky = this.getSky();
 
         let update = false;
@@ -1744,8 +1746,6 @@ export class Style extends Evented<MapEventType> {
             }
         }
         if (!update) return;
-
-        if (this._validate(validateStyle.sky, 'sky', skyOptions, null, options)) return;
 
         const parameters = {
             now: now(),

--- a/test/build/bundle_size.json
+++ b/test/build/bundle_size.json
@@ -1,14 +1,14 @@
 {
     "dist/maplibre-gl.mjs": {
-        "raw": 584162,
-        "gzip": 148605
+        "raw": 585203,
+        "gzip": 148843
     },
     "dist/maplibre-gl-worker.mjs": {
         "raw": 19002,
         "gzip": 6024
     },
     "dist/maplibre-gl-shared.mjs": {
-        "raw": 493279,
-        "gzip": 138574
+        "raw": 493281,
+        "gzip": 138576
     }
 }


### PR DESCRIPTION
`map.setSky()` left the rendered sky unchanged when the value carried a `-transition` key, while `getSky()` reported the new value and no `error` event fired (#8375).

**Cause.** Two gaps on this side, one in the style spec. `Style.setSky` wrote `stylesheet.sky` before `Sky.setSky` validated the value, so a rejected call still changed what `getSky()` returned. `Sky` was never made a child of the style's event chain, so the `error` that `Sky._validate` fires stayed on the `Sky` instance and never reached `map.on('error')`. The spec's `validateSky` has no `-transition` branch, unlike `validateLight`; that half is maplibre/maplibre-style-spec#1867.

**Change.** `Style.setSky` validates with the style's own `_validate` before touching `stylesheet.sky`, the same order `setGlyphs` and `setSprite` use, and passes `validate: false` down so the value is not checked twice. `Style._load` parents the `Sky` into the style's event chain. Changelog entry under `## main`.

**Proof.** Two tests in `src/style/style.test.ts`: an unknown sky property makes the style fire `error` naming that property, and `getSky()` still returns the previous value afterwards. Both fail on `main` (the first times out waiting for the event, the second sees the rejected value) and pass here. `npm run lint`, `npm run typecheck` and the unit suite for `style.test.ts` and `sky.test.ts` are green.

Fixes #8375

## Launch Checklist

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] If you changed code in a file that has a benchmark file next to it (`*.bench.ts`), post before/after results of `npm run bench` (the compare workflow is in `test/bench/README.md`).
 - [x] Add an entry to `CHANGELOG.md` under the `## main` section.
 - [x] Confirm you have read our AI policy [here](https://github.com/maplibre/maplibre/blob/main/AI_POLICY.md).

Disclosure per the MapLibre AI policy: the change was prepared with AI assistance under my direction; I reviewed every line and am responsible for it.

