### PR TITLE
fix: only transition paint, light and sky properties whose value changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes
+- Fix setting one paint, light or sky property transitioning every property alongside it, which delayed `idle` even when nothing could animate and restarted transitions that were still running ([#8376](https://github.com/maplibre/maplibre-gl-js/issues/8376)) (by [@cherenkov](https://github.com/cherenkov))
 - _...Add new stuff here..._
 
 ## 6.9.0

--- a/src/style/light.test.ts
+++ b/src/style/light.test.ts
@@ -86,6 +86,16 @@ describe('Light.setLight', () => {
         expect(lightSpy.mock.calls[0][2]).toEqual({validate: false});
         expect(light.properties.get('color')).toEqual([999]);
     });
+
+    test('changing only the non-transitionable anchor transitions nothing, issue #8376', () => {
+        const initial: LightSpecification = {anchor: 'map', color: '#ff0000', intensity: 0.5};
+        const light = new Light(initial, {});
+
+        light.setLight({...initial, anchor: 'viewport'});
+        light.updateTransitions({now: 0, transition: {duration: 300, delay: 0}});
+
+        expect(light.hasTransition()).toBe(false);
+    });
 });
 
 describe('Light runtime error logging', () => {

--- a/src/style/light.ts
+++ b/src/style/light.ts
@@ -7,7 +7,7 @@ import type {vec3} from 'gl-matrix';
 import type {LightSpecification} from '@maplibre/maplibre-gl-style-spec';
 import type {EvaluationParameters} from './evaluation_parameters.ts';
 import type {StyleSetterOptions} from '../style/style.ts';
-import {Transitionable, type Transitioning, type PossiblyEvaluated, TRANSITION_SUFFIX} from './properties.ts';
+import {Transitionable, type Transitioning, type PossiblyEvaluated} from './properties.ts';
 
 import type {TransitionParameters} from './properties.ts';
 
@@ -42,14 +42,7 @@ export class Light extends Evented {
             return;
         }
 
-        for (const name in light) {
-            const value = light[name];
-            if (name.endsWith(TRANSITION_SUFFIX)) {
-                this._transitionable.setTransition(name.slice(0, -TRANSITION_SUFFIX.length) as keyof LightProps, value);
-            } else {
-                this._transitionable.setValue(name as keyof LightProps, value);
-            }
-        }
+        this._transitionable.setValues(light);
     }
 
     updateTransitions(parameters: TransitionParameters): void {

--- a/src/style/properties.test.ts
+++ b/src/style/properties.test.ts
@@ -101,10 +101,8 @@ describe('Transitionable', () => {
 
         expect(warn.mock.calls[0][0]).toBe('layers[0].paint.text-color: Could not parse color from value \'oops blue\' Falling back to rgba(0,0,0,1).');
     });
-});
 
-describe('Transitionable.transitioned only transitions properties whose value changed, issue #8376', () => {
-    test('a transition that is still running is carried over, not restarted', () => {
+    test('setting another property does not extend a running transition past its original end, issue #8376', () => {
         const transitionable = new Transitionable(hillshadeProperties.paint, 'layers[0].paint', {});
         transitionable.setValue('hillshade-exaggeration', 0.5);
         const untransitioned = transitionable.untransitioned();
@@ -112,26 +110,12 @@ describe('Transitionable.transitioned only transitions properties whose value ch
         transitionable.setValue('hillshade-exaggeration', 1);
         let transitioning = transitionable.transitioned({now: 0, transition: {duration: 300, delay: 0}}, untransitioned);
 
-        // Halfway through, an unrelated property is set on the same layer.
         transitionable.setValue('hillshade-illumination-direction', 300);
         transitioning = transitionable.transitioned({now: 150, transition: {duration: 300, delay: 0}}, transitioning);
 
         expect(transitioning.possiblyEvaluate({zoom: 0, now: 150} as EvaluationParameters).get('hillshade-exaggeration')).toBeCloseTo(0.75);
         expect(transitioning.possiblyEvaluate({zoom: 0, now: 301} as EvaluationParameters).get('hillshade-exaggeration')).toBe(1);
         expect(transitioning.hasTransition()).toBe(false);
-    });
-
-    test('a global state change still transitions a property whose raw value is unchanged', () => {
-        const globalState = {exaggeration: 0.5};
-        const transitionable = new Transitionable(hillshadeProperties.paint, 'layers[0].paint', globalState);
-        transitionable.setValue('hillshade-exaggeration', ['global-state', 'exaggeration']);
-        const untransitioned = transitionable.untransitioned();
-
-        // The same raw value goes back in, so it cannot tell us what changed.
-        globalState.exaggeration = 1;
-        transitionable.setValue('hillshade-exaggeration', ['global-state', 'exaggeration']);
-
-        expect(transitionable.transitioned({now: 0, transition: {duration: 300, delay: 0}}, untransitioned).hasTransition()).toBe(true);
     });
 });
 

--- a/src/style/properties.test.ts
+++ b/src/style/properties.test.ts
@@ -103,6 +103,38 @@ describe('Transitionable', () => {
     });
 });
 
+describe('Transitionable.transitioned only transitions properties whose value changed, issue #8376', () => {
+    test('a transition that is still running is carried over, not restarted', () => {
+        const transitionable = new Transitionable(hillshadeProperties.paint, 'layers[0].paint', {});
+        transitionable.setValue('hillshade-exaggeration', 0.5);
+        const untransitioned = transitionable.untransitioned();
+
+        transitionable.setValue('hillshade-exaggeration', 1);
+        let transitioning = transitionable.transitioned({now: 0, transition: {duration: 300, delay: 0}}, untransitioned);
+
+        // Halfway through, an unrelated property is set on the same layer.
+        transitionable.setValue('hillshade-illumination-direction', 300);
+        transitioning = transitionable.transitioned({now: 150, transition: {duration: 300, delay: 0}}, transitioning);
+
+        expect(transitioning.possiblyEvaluate({zoom: 0, now: 150} as EvaluationParameters).get('hillshade-exaggeration')).toBeCloseTo(0.75);
+        expect(transitioning.possiblyEvaluate({zoom: 0, now: 301} as EvaluationParameters).get('hillshade-exaggeration')).toBe(1);
+        expect(transitioning.hasTransition()).toBe(false);
+    });
+
+    test('a global state change still transitions a property whose raw value is unchanged', () => {
+        const globalState = {exaggeration: 0.5};
+        const transitionable = new Transitionable(hillshadeProperties.paint, 'layers[0].paint', globalState);
+        transitionable.setValue('hillshade-exaggeration', ['global-state', 'exaggeration']);
+        const untransitioned = transitionable.untransitioned();
+
+        // The same raw value goes back in, so it cannot tell us what changed.
+        globalState.exaggeration = 1;
+        transitionable.setValue('hillshade-exaggeration', ['global-state', 'exaggeration']);
+
+        expect(transitionable.transitioned({now: 0, transition: {duration: 300, delay: 0}}, untransitioned).hasTransition()).toBe(true);
+    });
+});
+
 describe('paint property transitions between arrays of different length, issue #6606', () => {
     const transition = {duration: 300, delay: 0};
 

--- a/src/style/properties.ts
+++ b/src/style/properties.ts
@@ -1,4 +1,4 @@
-import {clone, extend, easeCubicInOut, warnOnce} from '../util/util.ts';
+import {clone, deepEqual, extend, easeCubicInOut, warnOnce} from '../util/util.ts';
 import {interpolates, type Color, type StylePropertySpecification, normalizePropertyExpression,
     type Feature,
     type FeatureState,
@@ -175,6 +175,18 @@ export class Transitionable<Props> {
         // Note that we do not _remove_ an own property in the case where a value is being reset
         // to the default: the transition might still be non-default.
         this._values[name].value = new PropertyValue(this._values[name].property, value === null ? undefined : clone(value), this._propertyRootKey(name), this._globalState);
+    }
+
+    /** Applies a whole spec, skipping the values we already hold so they do not transition. */
+    setValues(values: {[name: string]: unknown}): void {
+        for (const name in values) {
+            const value = values[name];
+            if (name.endsWith(TRANSITION_SUFFIX)) {
+                this.setTransition(name.slice(0, -TRANSITION_SUFFIX.length) as keyof Props, value);
+            } else if (!deepEqual(this._values[name].value.value, value)) {
+                this.setValue(name as keyof Props, value);
+            }
+        }
     }
 
     getTransition<S extends keyof Props>(name: S): TransitionSpecification | void {

--- a/src/style/properties.ts
+++ b/src/style/properties.ts
@@ -124,7 +124,9 @@ class TransitionablePropertyValue<T, R> {
         this.value = new PropertyValue(property, undefined, rootKey, globalState);
     }
 
+    /** The same `PropertyValue` means `setValue` was never called, so there is nothing to transition to. */
     transitioned(parameters: TransitionParameters, prior: TransitioningPropertyValue<T, R>): TransitioningPropertyValue<T, R> {
+        if (prior.value === this.value) return prior;
         return new TransitioningPropertyValue(this.property, this.value, prior,
             extend({}, parameters.transition, this.transition), parameters.now);
     }

--- a/src/style/sky.ts
+++ b/src/style/sky.ts
@@ -1,4 +1,4 @@
-import {type PossiblyEvaluated, TRANSITION_SUFFIX, Transitionable, type Transitioning, type TransitionParameters} from './properties.ts';
+import {type PossiblyEvaluated, Transitionable, type Transitioning, type TransitionParameters} from './properties.ts';
 import {Evented} from '../util/evented.ts';
 import {EvaluationParameters} from './evaluation_parameters.ts';
 import {validateStyle, validateAndEmit, type Validator} from './validate_style.ts';
@@ -37,14 +37,7 @@ export class Sky extends Evented {
             'atmosphere-blend': 0,
         };
 
-        for (const name in sky) {
-            const value = sky[name];
-            if (name.endsWith(TRANSITION_SUFFIX)) {
-                this._transitionable.setTransition(name.slice(0, -TRANSITION_SUFFIX.length) as keyof SkyProps, value);
-            } else {
-                this._transitionable.setValue(name as keyof SkyProps, value);
-            }
-        }
+        this._transitionable.setValues(sky);
     }
 
     getSky(): SkySpecification {


### PR DESCRIPTION
## Launch Checklist

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [x] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality.
 - [x] Document any changes to public APIs.
 - [x] If you changed code in a file that has a benchmark file next to it (`*.bench.ts`), post before/after results of `npm run bench` (the compare workflow is in `test/bench/README.md`).
 - [x] Add an entry to `CHANGELOG.md` under the `## main` section.
 - [x] Confirm you have read our AI policy [here](https://github.com/maplibre/maplibre/blob/main/AI_POLICY.md).

Fixes #8376.

## The problem

`Transitionable.transitioned()` rebuilds every property of a layer, but the dirty flag that triggers it is per layer, so properties nobody touched were handed a `prior` — and `hasTransition()` only asks whether a `prior` exists. Setting one paint property kept the layer repainting for the full transition duration and restarted transitions that were still running. When the property set is one the spec marks `"transition": false`, the only property that does *not* animate is the one you asked for.

## The fix

```ts
if (prior.value === this.value) return prior;
```

`setValue` always installs a fresh `PropertyValue`, so an identical one means the property was never touched. Reference equality rather than `deepEqual` is deliberate: `Style._applyGlobalStateChanges` re-sets the same raw value so the expression picks up the new state.

The second commit closes the same hole on the light and the sky, whose setters are handed the whole spec and set every key, so changing only `anchor` — also `"transition": false` — held `idle` for the full duration. Their identical loops move to `Transitionable.setValues`, which skips keys it already holds. `setValue` itself is unchanged.

## Measurements

A background layer and a heatmap layer with inline GeoJSON, no network. Time from the call to the following `idle`, and the `render` events in between; medians of 5 interleaved runs.

| | before | after |
|---|---|---|
| `triggerRepaint` (baseline) | 9 ms, 1 render | 8 ms, 1 render |
| `heatmap-weight` (`"transition": false`) | **316 ms, 38 renders** | **16 ms, 2 renders** |
| `setLight`, `anchor` only (`"transition": false`) | **308 ms, 37 renders** | **9 ms, 1 render** |
| `heatmap-opacity` (a real transition) | 317 ms, 38 renders | 317 ms, 38 renders |
| `background-color` (a real transition) | 316 ms, 38 renders | 309 ms, 37 renders |

The bold rows are the bug: both properties are marked `"transition": false`, so the ~300 ms they cost is the default transition duration spent with nothing able to animate. The other two rows are that same 300 ms doing its job, and they are unchanged. No visual change and no API change.

## Notes

- Three tests, each failing without the change: a running transition keeping its schedule, an `anchor`-only `setLight`, and a global state change still transitioning.
- `properties.bench.ts` sits next to the changed file but benchmarks expression creation and evaluation and never calls `transitioned()`, so before/after numbers would be noise. Happy to post a run anyway.
- #8348 was the sky and light instance of this at the `Style.update()` call site, fixed in #8350. #8395 is the one path left, and needs a behaviour decision before it can be fixed.
