### PR TITLE
Add showButton option to GeolocateControl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## main
 ### ✨ Features and improvements
+- Add a `showButton` option to `GeolocateControl` to hide the default geolocate button and allow using a custom button with `trigger()` ([#3103](https://github.com/maplibre/maplibre-gl-js/issues/3103))
 - Improved support for drawing the letters of Devanagari, Khmer, Burmese and the other complex scripts and also draws Arabic and Hebrew labels correctly without loading a right-to-left text plugin, which deprecates `setRTLTextPlugin` and `getRTLTextPluginStatus` ([#8343](https://github.com/maplibre/maplibre-gl-js/pull/8343)) (by [@HarelM](https://github.com/HarelM))
 - Read sprite and image pixels back through an `OffscreenCanvas` where available, removing a main-thread stall of tens of milliseconds on GPU-accelerated browsers when a sprite loads ([#8339](https://github.com/maplibre/maplibre-gl-js/pull/8339)) (by [@cherenkov](https://github.com/cherenkov))
 - Skip clipping masks for layers hidden at the current zoom and stop re-binding dynamic buffers on cached vertex array binds, removing redundant WebGL calls every frame ([#8369](https://github.com/maplibre/maplibre-gl-js/pull/8369))

--- a/src/ui/control/geolocate_control.test.ts
+++ b/src/ui/control/geolocate_control.test.ts
@@ -886,4 +886,34 @@ describe('GeolocateControl with no options', () => {
         const geolocateUIelem = await geolocateControl._container.getElementsByClassName('maplibregl-ctrl-geolocate');
         expect(geolocateUIelem).toHaveLength(1);
     });
+
+    test('does not attach the geolocate button to the container when showButton is false', async () => {
+        const geolocate = new GeolocateControl({showButton: false});
+        map.addControl(geolocate);
+        await sleep(0);
+
+        const buttons = geolocate._container.getElementsByClassName('maplibregl-ctrl-geolocate');
+        expect(buttons).toHaveLength(0);
+
+        // the button is detached from the DOM but kept as an internal node for the geolocate state machine,
+        // so the empty control group renders no visible box
+        expect(geolocate._geolocateButton.parentElement).toBeNull();
+    });
+
+    test('still triggers geolocation when the button is hidden', async () => {
+        const geolocate = new GeolocateControl({showButton: false});
+        map.addControl(geolocate);
+        await sleep(0);
+
+        // hide the default button (showButton is false), then drive the control through the public API
+        expect(geolocate._geolocateButton.parentElement).toBeNull();
+
+        const geolocatePromise = geolocate.once('geolocate');
+        geolocate.trigger();
+        geolocation.send({latitude: 10, longitude: 20, accuracy: 30, timestamp: 40});
+        const position = await geolocatePromise;
+
+        expect(position.coords.latitude).toBe(10);
+        expect(position.coords.longitude).toBe(20);
+    });
 });

--- a/src/ui/control/geolocate_control.ts
+++ b/src/ui/control/geolocate_control.ts
@@ -38,6 +38,11 @@ export type GeolocateControlOptions = {
      * @defaultValue true
      */
     showUserLocation?: boolean;
+    /**
+     * If `false` the default geolocate button is not rendered on the map, allowing the use of a custom button that calls {@link GeolocateControl.trigger}.
+     * @defaultValue true
+     */
+    showButton?: boolean;
 };
 
 const defaultOptions: GeolocateControlOptions = {
@@ -51,7 +56,8 @@ const defaultOptions: GeolocateControlOptions = {
     },
     trackUserLocation: false,
     showAccuracyCircle: true,
-    showUserLocation: true
+    showUserLocation: true,
+    showButton: true
 };
 
 let numberOfWatches = 0;
@@ -651,6 +657,12 @@ export class GeolocateControl extends Evented<GeolocateControlEventType> impleme
         DOM.create('span', 'maplibregl-ctrl-icon', this._geolocateButton).setAttribute('aria-hidden', 'true');
         this._geolocateButton.type = 'button';
         this._geolocateButton.disabled = true;
+
+        // The button is kept anyway as an internal node so the state machine toggling its classes
+        // keeps working unchanged; it is simply not attached to the container when it is hidden.
+        if (!this.options.showButton) {
+            this._geolocateButton.remove();
+        }
     };
 
     _finishSetupUI = (supported: boolean): void => {


### PR DESCRIPTION
Closes #3103

### Description

Add a `showButton` option to `GeolocateControl` to allow applications to hide the default geolocate button and use a custom UI with the public `trigger()` API.

### Changes

- Add `showButton?: boolean` to `GeolocateControlOptions`
- Default `showButton` to `true` for backward compatibility
- Remove the button from the control container when `showButton` is `false`, while keeping the internal button node for the existing control state handling
- Add tests covering the hidden-button behavior and triggering geolocation without the default button
- Update `CHANGELOG.md`

### Testing

- `npm run test-unit -- geolocate_control.test.ts`
- `npm run typecheck`
- `npm run lint`

### AI Assistance

This PR was developed with significant assistance from Claude Code. I reviewed and verified the implementation, tests, and behavior before submission.