### PR TITLE
fix: free the pooled terrain drape textures once the map is at rest and when terrain is removed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes
+- Free the pooled terrain drape textures once the map is at rest and when terrain is removed, instead of keeping every drape allocated during a pan resident for the life of the map (by [@johncarmack1984](https://github.com/johncarmack1984))
 - _...Add new stuff here..._
 
 ## 6.9.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes
-- Free the pooled terrain drape textures once the map is at rest and when terrain is removed, instead of keeping every drape allocated during a pan resident for the life of the map (by [@johncarmack1984](https://github.com/johncarmack1984))
+- Free the pooled terrain drape textures once the map is at rest and when terrain is removed, instead of keeping every drape allocated during a pan resident for the life of the map ([#8400](https://github.com/maplibre/maplibre-gl-js/pull/8400)) (by [@johncarmack1984](https://github.com/johncarmack1984))
 - _...Add new stuff here..._
 
 ## 6.9.0

--- a/src/render/painter.test.ts
+++ b/src/render/painter.test.ts
@@ -220,6 +220,35 @@ describe('RTT pool', () => {
         expect(painter._rttSharedFbo.size).toBe(512);
     });
 
+    test('clearRTTPool destroys the pooled textures and leaves the ones tiles hold', () => {
+        const pooled = painter.acquireRTT(256);
+        const held = painter.acquireRTT(256);
+        vi.spyOn(pooled.texture, 'destroy');
+        vi.spyOn(held.texture, 'destroy');
+        painter.releaseRTT(pooled);
+
+        painter.clearRTTPool();
+
+        expect(pooled.texture.destroy).toHaveBeenCalledTimes(1);
+        expect(held.texture.destroy).not.toHaveBeenCalled();
+        expect(painter.acquireRTT(256)).not.toBe(pooled);
+    });
+
+    test('destroyRTTResources frees the pool and the shared FBO, and both come back on the next acquire', () => {
+        const obj = painter.acquireRTT(256);
+        vi.spyOn(obj.texture, 'destroy');
+        painter.bindRTT(obj);
+        painter.releaseRTT(obj);
+
+        painter.destroyRTTResources();
+
+        expect(obj.texture.destroy).toHaveBeenCalledTimes(1);
+        expect(painter._rttSharedFbo).toBeNull();
+
+        painter.bindRTT(painter.acquireRTT(256));
+        expect(painter._rttSharedFbo.size).toBe(256);
+    });
+
     test('painter.destroy cleans up pooled RTT textures and shared FBO', () => {
         const objs = [];
         for (let i = 0; i < 10; i++) {

--- a/src/render/painter.ts
+++ b/src/render/painter.ts
@@ -649,6 +649,9 @@ export class Painter {
             this.drawFunctions.debugPadding(this);
         }
 
+        // a frame at rest has reused every pooled drape it needs; the rest stay resident until freed here
+        if (this.renderToTexture && !this.options.moving) this.clearRTTPool();
+
         // Set defaults for most GL values so that anyone using the state after the render
         // encounters more expected values.
         this.context.setDefault();
@@ -787,6 +790,35 @@ export class Painter {
     }
 
     /**
+     * Destroys the pooled {@link RTTObject}s, the drapes no tile holds. Called at the end of a frame at rest,
+     * when they would otherwise stay resident until the next gesture reuses them.
+     */
+    clearRTTPool(): void {
+        for (const obj of this._rttObjectRecyclePool) {
+            obj.texture.destroy();
+        }
+        this._rttObjectRecyclePool.length = 0;
+    }
+
+    /**
+     * Frees the pooled drapes and the shared render-to-texture FBO. Called when terrain is removed, after its tiles
+     * released their drapes.
+     */
+    destroyRTTResources(): void {
+        this.clearRTTPool();
+        if (this._rttSharedFbo) {
+            // Detach so Framebuffer.destroy() doesn't delete the texture/renderbuffer
+            // that we already manage separately.
+            this._rttSharedFbo.fbo.colorAttachment.set(null);
+            this._rttSharedFbo.fbo.depthAttachment.set(null);
+            const gl = this.context.gl;
+            gl.deleteRenderbuffer(this._rttSharedFbo.depthRenderbuffer);
+            gl.deleteFramebuffer(this._rttSharedFbo.fbo.framebuffer);
+            this._rttSharedFbo = null;
+        }
+    }
+
+    /**
      * Checks whether a pattern image is needed, and if it is, whether it is not loaded.
      *
      * @returns true if a needed image is missing and rendering needs to be skipped.
@@ -880,21 +912,7 @@ export class Painter {
             this._tileTextures = {};
         }
 
-        for (const obj of this._rttObjectRecyclePool) {
-            obj.texture.destroy();
-        }
-        this._rttObjectRecyclePool = [];
-
-        if (this._rttSharedFbo) {
-            // Detach so Framebuffer.destroy() doesn't delete the texture/renderbuffer
-            // that we already manage separately.
-            this._rttSharedFbo.fbo.colorAttachment.set(null);
-            this._rttSharedFbo.fbo.depthAttachment.set(null);
-            const gl = this.context.gl;
-            gl.deleteRenderbuffer(this._rttSharedFbo.depthRenderbuffer);
-            gl.deleteFramebuffer(this._rttSharedFbo.fbo.framebuffer);
-            this._rttSharedFbo = null;
-        }
+        this.destroyRTTResources();
 
         this.layerOpacityFbo?.destroy();
         this.layerOpacityFbo = null;

--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -2960,6 +2960,7 @@ export class Map extends Evented<MapEventType> {
             }
             this.terrain = null;
             this.painter.renderToTexture = null;
+            this.painter.destroyRTTResources();
             this._camera.terrain = null;
             this._camera.transform.setMinElevationForCurrentTile(0);
             if (this.getCenterClampedToGround()) {

--- a/src/ui/map_tests/map_terrain.test.ts
+++ b/src/ui/map_tests/map_terrain.test.ts
@@ -7,6 +7,7 @@ import {type Terrain} from '../../render/terrain.ts';
 import {MercatorTransform} from '../../geo/projection/mercator_transform.ts';
 import {AttributionControl, defaultAttributionControlOptions} from '../control/attribution_control.ts';
 import {type Map} from '../map.ts';
+import {ImageRequest} from '../../util/image_request.ts';
 
 let server: FakeServer;
 let map: Map;
@@ -68,6 +69,42 @@ describe('setTerrain', () => {
 
         expect(errorSpy).not.toHaveBeenCalled();
         expect(map.getTerrain()).toEqual({source: 'dem', exaggeration: 2});
+    });
+
+    test('removing terrain frees the pooled drape textures and the shared framebuffer', async () => {
+        await map.once('style.load');
+        map.addSource('dem', {type: 'raster-dem', tiles: ['http://example.com/{z}/{x}/{y}.png'], tileSize: 256});
+        map.setTerrain({source: 'dem'});
+        const drape = map.painter.acquireRTT(512);
+        vi.spyOn(drape.texture, 'destroy');
+        map.painter.bindRTT(drape);
+        map.painter.releaseRTT(drape);
+
+        map.setTerrain(null);
+
+        expect(drape.texture.destroy).toHaveBeenCalledTimes(1);
+        expect(map.painter._rttSharedFbo).toBeNull();
+    });
+
+    test('frees the drapes a zoom out leaves unused once the map is at rest', async () => {
+        vi.spyOn(ImageRequest, 'getImage').mockResolvedValue({data: null});
+        map = createMap({zoom: 14, style: {
+            version: 8,
+            sources: {
+                dem: {type: 'raster-dem', tiles: ['http://example.com/{z}/{x}/{y}.png'], tileSize: 256},
+                land: {type: 'geojson', data: {type: 'Feature', properties: {}, geometry: {type: 'Polygon', coordinates: [[[-1, -1], [1, -1], [1, 1], [-1, 1], [-1, -1]]]}}}
+            },
+            layers: [{id: 'land', type: 'fill', source: 'land'}],
+            terrain: {source: 'dem'}
+        }});
+        await map.once('idle');
+        const terrainTilesAtZoom14 = map.terrain.tileManager.getRenderableTiles().length;
+
+        map.jumpTo({zoom: 0});
+        await map.once('idle');
+
+        expect(map.terrain.tileManager.getRenderableTiles().length).toBeLessThan(terrainTilesAtZoom14);
+        expect(map.painter._rttObjectRecyclePool).toHaveLength(0);
     });
 
     test('drops the previous source attribution when switching terrain to a new source', async () => {


### PR DESCRIPTION
- Fixes #8377

Every terrain drape is a `tileSize * 2 * qualityFactor` RGBA texture with a mip chain, 21 MB for a 512 px DEM source, and the mapeak style needs two per terrain tile (its symbol layers split the draped layers into two stacks). Since #7549 (6.0.0) a tile leaving view returns its drapes to `Painter._rttObjectRecyclePool`, and nothing ever takes them out again: the pool holds the high-water mark of every gesture for the life of the map, and `setTerrain(null)` leaves it and the shared RTT framebuffer behind too. At iPhone 12 mini geometry (375x812 css px at 3x) the map holds 10 drapes at load and 12 to 14 after the first pans, so the resident texture set sits at 276 MB after 20 pans with 4 drapes actually on screen, and 323 MB at pitch 60. 6.8.0 holds the same set; 6.6.0 held a third less, since #8328 added the mip chain.

mapeak (Israel Hiking Map) turned terrain on for its mobile layout on 6.9.0, and on an iPhone 12 mini (4 GB) the WebView white-screens after a few pans while an iPhone 17 is fine. Whether the drape set alone is what the device kills is for the device to say; the pool is a memory bug either way.

This frees the pool at the end of every frame rendered at rest (`Painter.clearRTTPool`, called from `render` when `options.moving` is false), and frees the pool and the shared framebuffer when terrain is removed (`Painter.destroyRTTResources`, shared with `destroy`). Within a gesture nothing changes: the tiles leaving view refill the pool and the tiles entering reuse it, the clear only runs once the map has stopped. A tile entering view when the pool is empty allocates its drape instead of popping one, in the frame that renders the drape from scratch anyway; the allocation itself is under 0.1 ms of main-thread time on an M-series Mac.

Measured with the mapeak style at exaggeration 2, pitch 45, zoom 13, 20 flicks in an expanding spiral, GL allocations counted by wrapping the context (RGBA8 bytes including mip levels):

| resident textures at rest | 6.9.0 | this branch |
|---|---|---|
| after 20 pans, Chrome (ANGLE Metal) | 276 MB, 4 drapes held + 8 pooled | 106 MB, 4 held + 0 pooled |
| after 20 pans, Safari on an iPhone 12 mini simulator (iOS 26.5) | 276 MB | 105 MB |
| after 8 pans at pitch 60, Chrome | 323 MB, 8 held + 6 pooled | 195 MB, 8 held + 0 pooled |
| after 12 pans with the zoom cycling 12.2 to 14.2, Chrome | 296 MB | 122 MB |
| same, Safari on the simulator | 297 MB | 126 MB |

The peak during a gesture is unchanged (every drape in view has to exist); what changes is what stays resident between gestures.

Hot-path check on a Galaxy S24 (SM-S921B, Chrome 152 at 120 Hz, phone layout 1080x1926, SurfaceFlinger presented frames on Chrome's surface, six 800 ms swipes per run, runs interleaved release/branch, three pairs at pitch 45 and one at pitch 60; the once-a-second HUD tick at rest shows up as intervals over one second and is excluded):

| frames during motion | 6.9.0 | this branch |
|---|---|---|
| off the 8.3 ms vsync, pitch 45 (three pairs) | 26 to 28 percent | 21 to 25 percent |
| off the vsync, pitch 60 | 27 percent | 18 percent |
| over 25 ms, all runs | 3.6 to 4.8 percent | 3.0 to 4.3 percent |

Allocating a drape as a tile enters view costs nothing the counter can see; every pair had this branch at or above the release.

Tests: `clearRTTPool` destroys pooled textures and leaves held ones; `destroyRTTResources` frees the pool and deletes the shared FBO, and both come back on the next acquire; `setTerrain(null)` frees a pooled drape; a map that zooms out from four terrain tiles to one destroys the three drapes the remaining tile does not hold once idle. All four fail on main.

## Launch Checklist

 - [x] No backports from Mapbox projects
 - [x] Changes described above
 - [x] Tests for the new behavior
 - [x] No file with a `*.bench.ts` sibling touched
 - [x] `CHANGELOG.md` entry under `## main`
 - [x] AI policy read

Assisted-By: Claude


