### PR TITLE
Stop the scale control doing per-frame layout and DOM work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## main
 ### ✨ Features and improvements
+- Stop the scale control forcing a synchronous layout and rewriting its DOM on every frame of a pan or zoom ([#8403](https://github.com/maplibre/maplibre-gl-js/pull/8403)) (by [@cherenkov](https://github.com/cherenkov))
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes

--- a/src/ui/control/scale_control.ts
+++ b/src/ui/control/scale_control.ts
@@ -101,13 +101,14 @@ function updateScale(map: Map, container: HTMLElement, options: ScaleControlOpti
     // found between the two coordinates.
     // Minimum maxWidth is calculated for the scale box.
     const optWidth = options?.maxWidth || 100;
-    const y = map._container.clientHeight / 2;
-    const x = map._container.clientWidth / 2;
+    const {width: containerWidth, height: containerHeight} = map._camera.transform;
+    const y = containerHeight / 2;
+    const x = containerWidth / 2;
     const left = map.unproject([x - optWidth / 2, y]);
     const right = map.unproject([x + optWidth / 2, y]);
 
     const globeWidth = Math.round(map.project(right).x - map.project(left).x);
-    const maxWidth = Math.min(optWidth, globeWidth, map._container.clientWidth);
+    const maxWidth = Math.min(optWidth, globeWidth, containerWidth);
 
     const maxMeters = left.distanceTo(right);
     // The real distance corresponding to 100px scale length is rounded off to

--- a/src/ui/control/scale_control.ts
+++ b/src/ui/control/scale_control.ts
@@ -135,7 +135,8 @@ function setScale(container: HTMLElement, maxWidth: number, maxDistance: number,
     const distance = getRoundNum(maxDistance);
     const ratio = distance / maxDistance;
     container.style.width = `${maxWidth * ratio}px`;
-    container.innerHTML = `${distance}&nbsp;${unit}`;
+    const label = `${distance}\u00a0${unit}`;
+    if (container.textContent !== label) container.textContent = label;
 }
 
 function getDecimalRoundNum(d) {


### PR DESCRIPTION
`ScaleControl` recomputes on every `move` event, which fires once per frame during
a pan or zoom. Two things there are wasteful:

- it reads `clientWidth`/`clientHeight` off the map container three times, each
  forcing a synchronous layout
- it assigns `innerHTML`, reparsing the string and rebuilding the container's
  children even when the label has not changed

This reads the dimensions from the transform instead — `Popup._update` already
does the same — and writes `textContent` only when the label changes.

Measured while panning and zooming for ~5s:

|  | before | after |
| --- | ---: | ---: |
| container size reads | 3 per move | 0 |
| DOM writes | 222 / 222 moves | 6 |

No visual change. `textContent` holding ` ` serialises back to `&nbsp;`
through the `innerHTML` getter, so the existing assertions pass unchanged.

## Launch Checklist

- [x] Confirm **your changes do not include backports from Mapbox projects**
- [x] Briefly describe the changes in this PR.
- [ ] Link to related issues. — none
- [ ] Include before/after visuals — no visual change
- [ ] Write tests for all new functionality — no new functionality; existing tests cover the output
- [ ] Document any changes to public APIs — none
- [x] Add an entry to `CHANGELOG.md` under the `## main` section.
- [x] Confirm you have read our AI policy

Assisted-By: Claude Opus 5
