### PR TITLE
fix: apply the setTerrain style-diff operation to the map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### 🐞 Bug fixes
 - Fix setting one paint, light or sky property transitioning every property alongside it, which delayed `idle` even when nothing could animate and restarted transitions that were still running ([#8376](https://github.com/maplibre/maplibre-gl-js/issues/8376)) (by [@cherenkov](https://github.com/cherenkov))
+- Fix `setStyle(style, {diff: true})` throwing on every terrain change, which made it fall back to a full style rebuild ([#8404](https://github.com/maplibre/maplibre-gl-js/issues/8404)) (by [@jadhavgaurav](https://github.com/jadhavgaurav))
 - _...Add new stuff here..._
 
 ## 6.9.0

--- a/src/style/style.test.ts
+++ b/src/style/style.test.ts
@@ -1260,6 +1260,26 @@ describe('Style.setState', () => {
         expect(() => style.setState(targetStyle)).not.toThrow();
     });
 
+    test('setState applies a terrain change to the map', async () => {
+        const sources = {
+            'terrain-source': {
+                type: 'raster-dem',
+                tiles: ['http://example.com/{z}/{x}/{y}.png'],
+                tileSize: 256
+            } as SourceSpecification
+        };
+        const map = getStubMap();
+        const style = new Style(map);
+        style.loadJSON(createStyleJSON({sources}));
+        await style.once('style.load');
+
+        const terrain = {source: 'terrain-source', exaggeration: 2};
+        const didChange = style.setState(createStyleJSON({sources, terrain}));
+
+        expect(didChange).toBeTruthy();
+        expect(map.getTerrain()).toEqual(terrain);
+    });
+
     test('setState preserves serialized style when target has no projection', async () => {
         const style = createStyle();
         const initialStyle = createStyleJSON({

--- a/src/style/style.ts
+++ b/src/style/style.ts
@@ -927,7 +927,7 @@ export class Style extends Evented<MapEventType> {
                     operations.push(() => this.setSprite.apply(this, op.args));
                     break;
                 case 'setTerrain':
-                    operations.push(() => this.map.setTerrain.apply(this, op.args));
+                    operations.push(() => this.map.setTerrain.apply(this.map, op.args));
                     break;
                 case 'setSky':
                     operations.push(() => this.setSky.apply(this, op.args));


### PR DESCRIPTION
## Launch Checklist

- [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
- [x] Briefly describe the changes in this PR.
- [x] Link to related issues.
- [ ] Include before/after visuals or gifs if this PR includes visual changes.
- [x] Write tests for all new functionality.
- [ ] Document any changes to public APIs.
- [ ] If you changed code in a file that has a benchmark file next to it (`*.bench.ts`), post before/after results of `npm run bench`.
- [x] Add an entry to `CHANGELOG.md` under the `## main` section.
- [x] Confirm you have read our AI policy.

Assisted-By: Claude Opus (Claude Code)

### What this changes

`Style._getOperationsToPerform` builds the `setTerrain` operation as:

```ts
operations.push(() => this.map.setTerrain.apply(this, op.args));
```

It looks up a `Map` method but applies it with a `Style` receiver. `Map.setTerrain` starts with `this.style._checkLoaded()`, and a `Style` has no `.style`, so the operation throws `TypeError: Cannot read properties of undefined (reading '_checkLoaded')` every time it runs. `Style.setState` lets the error out, `Map._updateDiff` catches it, and `setStyle(style, {diff: true})` falls back to `_updateStyle`, a full teardown and rebuild of the style. Every other case in the switch binds the operation to the object that owns the method.

The fix binds it to the map, matching `Style._load`, which already calls `this.map.setTerrain(...)` directly.

### Test

`setState applies a terrain change to the map` in `src/style/style.test.ts` sets a style whose only change is a new `terrain`, over a `raster-dem` source that exists in both states, and asserts the map received it. On the unmodified source the call writes to the wrong object and the map's terrain stays unset, so the test fails before the change and passes after it.

### Scope

This is bug 1 of the two in the issue. Bug 2, the ordering of `setTerrain` against the `addSource` it depends on, is in the diff algorithm in maplibre-style-spec and needs a separate PR there, so a terrain change that also introduces the DEM source still falls back to a rebuild.

- Fixes #8404
