### PR TITLE
Skip the tile scan for constant symbol-height-offset, name the elevated culling helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## main
 ### ✨ Features and improvements
 - Stop the scale control forcing a synchronous layout and rewriting its DOM on every frame of a pan or zoom ([#8403](https://github.com/maplibre/maplibre-gl-js/pull/8403)) (by [@cherenkov](https://github.com/cherenkov))
+- Skip the loaded-tile scan for constant `symbol-height-offset` layers when computing tile coverage, and name the elevated culling helper ([#8424](https://github.com/maplibre/maplibre-gl-js/pull/8424)) (by [@clement-igonet](https://github.com/clement-igonet))
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes

--- a/src/geo/projection/covering_tiles.test.ts
+++ b/src/geo/projection/covering_tiles.test.ts
@@ -1,7 +1,9 @@
 import {beforeEach, describe, expect, test} from 'vitest';
 import {GlobeTransform} from './globe_transform.ts';
 import {LngLat} from '../lng_lat.ts';
-import {coveringTiles, coveringZoomLevel, createCalculateTileZoomFunction, type CoveringTilesOptions} from './covering_tiles.ts';
+import {coveringTiles, coveringZoomLevel, createCalculateTileZoomFunction, expandCullingToContentElevation, type CoveringTilesOptions} from './covering_tiles.ts';
+import {earthRadius} from '../lng_lat.ts';
+import type {vec4} from 'gl-matrix';
 import {OverscaledTileID} from '../../tile/tile_id.ts';
 import {MercatorTransform} from './mercator_transform.ts';
 
@@ -865,5 +867,33 @@ describe('coveringZoomLevel', () => {
         options.roundZoom = true;
         transform.setZoom(11.5);
         expect(coveringZoomLevel(transform, options)).toBe(13);
+    });
+});
+describe('expandCullingToContentElevation', () => {
+    test('pushes the horizon plane and the far plane back by the elevated shell', () => {
+        const transform = new GlobeTransform();
+        transform.resize(512, 512);
+        transform.setCenter(new LngLat(0, 0));
+        transform.setZoom(2);
+        const frustum = transform.getCameraFrustum();
+        const plane = transform.getClippingPlane();
+        const shellRadius = 1 + 500000 / earthRadius;
+
+        const expanded = expandCullingToContentElevation(frustum, plane, transform.cameraPosition, 500000);
+
+        const len = Math.hypot(plane[0], plane[1], plane[2]);
+        const expectedCos = Math.cos(Math.acos(-plane[3] / len) + Math.acos(1 / shellRadius));
+        expect([expanded.plane[0], expanded.plane[1], expanded.plane[2]]).toEqual([plane[0], plane[1], plane[2]]);
+        expect(expanded.plane[3]).toBeCloseTo(-expectedCos * len, 10);
+        expect(expanded.frustum.planes[1][3] - frustum.planes[1][3]).toBeCloseTo(Math.sqrt(shellRadius * shellRadius - 1), 10);
+    });
+
+    test('leaves a degenerate plane alone', () => {
+        const transform = new GlobeTransform();
+        transform.resize(512, 512);
+        const frustum = transform.getCameraFrustum();
+        const plane: vec4 = [0, 0, 0, 1];
+
+        expect(expandCullingToContentElevation(frustum, plane, transform.cameraPosition, 500000)).toEqual({frustum, plane});
     });
 });

--- a/src/geo/projection/covering_tiles.ts
+++ b/src/geo/projection/covering_tiles.ts
@@ -248,14 +248,33 @@ function pushFrustumFarPlane(frustum: Frustum, distance: number, cameraPos: vec3
 }
 
 /**
+ * The horizon culling plane and the frustum's far plane both assume content sits on the
+ * surface. Content elevated to radius r (in planet radii) stays visible up to acos(1/r)
+ * beyond the surface horizon and up to sqrt(r^2-1) farther away, so both are pushed back
+ * accordingly; without this, tiles under highly elevated symbols would be dropped while
+ * the symbols are still in view.
+ * @param frustum - The covering frustum, fitted to the surface horizon.
+ * @param plane - The horizon culling plane used by globe transform.
+ * @param cameraPos - The camera position, in the frustum's space.
+ * @param maxContentElevation - The highest elevation the content may reach, in meters.
+ */
+export function expandCullingToContentElevation(frustum: Frustum, plane: vec4, cameraPos: vec3, maxContentElevation: number): {frustum: Frustum; plane: vec4} {
+    const len = Math.hypot(plane[0], plane[1], plane[2]);
+    if (len === 0) {
+        return {frustum, plane};
+    }
+    const shellRadius = 1.0 + maxContentElevation / earthRadius;
+    const horizonCos = clamp(-plane[3] / len, -1, 1);
+    const shellCos = Math.cos(Math.acos(horizonCos) + Math.acos(1.0 / shellRadius));
+    return {
+        frustum: pushFrustumFarPlane(frustum, Math.sqrt(shellRadius * shellRadius - 1.0), cameraPos),
+        plane: [plane[0], plane[1], plane[2], -shellCos * len] as vec4,
+    };
+}
+
+/**
  * Returns a list of tiles that optimally covers the screen. Adapted for globe projection.
  * Correctly handles LOD when moving over the antimeridian.
- *
- * The horizon culling plane and the frustum's far plane both assume content sits on the
- * surface. When `options.maxContentElevation` is set, a point elevated to radius r (in planet
- * radii) stays visible up to acos(1/r) beyond the surface horizon and up to sqrt(r^2-1)
- * farther away, so both are pushed back accordingly; without this, tiles under highly
- * elevated symbols would be dropped while the symbols are still in view.
  * @param transform - The transform instance.
  * @param frustum - The covering frustum.
  * @param plane - The clipping plane used by globe transform, or null.
@@ -269,14 +288,7 @@ export function coveringTiles(transform: IReadonlyTransform, options: CoveringTi
     let frustum = transform.getCameraFrustum();
     let plane = transform.getClippingPlane();
     if (plane && options.maxContentElevation > 0) {
-        const len = Math.hypot(plane[0], plane[1], plane[2]);
-        if (len > 0) {
-            const shellRadius = 1.0 + options.maxContentElevation / earthRadius;
-            const horizonCos = clamp(-plane[3] / len, -1, 1);
-            const shellCos = Math.cos(Math.acos(horizonCos) + Math.acos(1.0 / shellRadius));
-            plane = [plane[0], plane[1], plane[2], -shellCos * len] as vec4;
-            frustum = pushFrustumFarPlane(frustum, Math.sqrt(shellRadius * shellRadius - 1.0), transform.cameraPosition);
-        }
+        ({frustum, plane} = expandCullingToContentElevation(frustum, plane, transform.cameraPosition, options.maxContentElevation));
     }
     const cameraCoord = cameraMercatorCoordinate(transform);
     const centerCoord = MercatorCoordinate.fromLngLat(transform.center, transform.elevation);

--- a/src/tile/tile_manager.test.ts
+++ b/src/tile/tile_manager.test.ts
@@ -2698,6 +2698,20 @@ describe('TileManager / etag', () => {
 });
 
 describe('TileManager content elevation', () => {
+    test('scans loaded tiles only for data-driven symbol-height-offset', () => {
+        const tileManager = createTileManager();
+        const getBucket = vi.fn().mockReturnValue({maxHeightOffset: 0});
+        const constantLayer = {type: 'symbol', source: tileManager.id, isHidden: () => false, layout: {get: () => ({constantOr: () => 100, isConstant: () => true})}};
+        const dataDrivenLayer = {type: 'symbol', source: tileManager.id, isHidden: () => false, layout: {get: () => ({constantOr: () => 0, isConstant: () => false})}};
+        tileManager.map = {style: {_layers: {constantLayer, dataDrivenLayer}}} as any;
+        tileManager.transform = new MercatorTransform();
+        tileManager._inViewTiles.getAllTiles = () => [{getBucket}] as any;
+
+        expect(tileManager._updateMaxContentElevation()).toBe(100);
+        expect(getBucket).toHaveBeenCalledTimes(1);
+        expect(getBucket).toHaveBeenCalledWith(dataDrivenLayer);
+    });
+
     test.each(['resetMaxContentElevation', 'clearTiles'] as const)(
         'preserves expanded tile coverage after unloading until %s', async (reset) => {
             const map = globalCreateMap({

--- a/src/tile/tile_manager.ts
+++ b/src/tile/tile_manager.ts
@@ -499,7 +499,8 @@ export class TileManager extends Evented<SourceEventType> {
     /**
      * The highest elevation this source's symbols may reach, in meters: `symbol-height-offset`
      * constants read from the visible symbol layers, data-driven maxima tracked by the loaded
-     * buckets at layout time. The value is a high-water mark: a maximum seen once is kept even
+     * buckets at layout time. Only data-driven layers scan the loaded tiles, so styles without
+     * them pay nothing beyond the layer loop. The value is a high-water mark: a maximum seen once is kept even
      * after its tile unloads, otherwise dropping the tile would also drop the reason to keep it,
      * and the tile could not come back while its content is still visible. The mark resets with
      * the tiles in `clearTiles`.
@@ -514,7 +515,9 @@ export class TileManager extends Evented<SourceEventType> {
             if (layer.type !== 'symbol' || layer.source !== this.id || layer.isHidden(this.transform.zoom)) continue;
             const symbolLayer = layer as SymbolStyleLayer;
             if (!symbolLayer.layout) continue;
-            maxElevation = Math.max(maxElevation, symbolLayer.layout.get('symbol-height-offset').constantOr(0));
+            const heightOffset = symbolLayer.layout.get('symbol-height-offset');
+            maxElevation = Math.max(maxElevation, heightOffset.constantOr(0));
+            if (heightOffset.isConstant()) continue;
             for (const tile of tiles) {
                 const bucket = tile.getBucket(layer) as SymbolBucket;
                 if (bucket && bucket.maxHeightOffset > maxElevation) {


### PR DESCRIPTION
Follow-up on #8319, addressing @HarelM's two post-merge comments. Fixes #8423.

- `_updateMaxContentElevation` only scans loaded tiles for layers with a data-driven `symbol-height-offset`; constant layers are read once, so styles without elevated symbols pay a layer loop and nothing else.
- The horizon and far-plane relaxation moves out of `coveringTiles` into `expandCullingToContentElevation`, with the math explained on the helper.

No behavior change; existing render test `symbol-height-offset-tile-retention` still passes.

**Launch Checklist**
- [x] Confirm your changes do not include backports from Mapbox projects (unless with compliant license)
- [x] Briefly describe the changes in this PR.
- [x] Link to related issues.
- [x] Include before/after visuals or gifs if this PR includes visual changes. (none: no visual change)
- [x] Write tests for all new functionality.
- [x] Add an entry to `CHANGELOG.md` under the `## main` section.

Assisted-By: Claude
